### PR TITLE
Improve error handlers in the up command

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/k8s/exec"
 	"github.com/okteto/okteto/pkg/k8s/pods"
-	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
@@ -21,10 +19,7 @@ import (
 //Exec executes a command on the CND container
 func Exec() *cobra.Command {
 	var devPath string
-	var pod string
-	var container string
 	var namespace string
-	var port int
 
 	cmd := &cobra.Command{
 		Use:   "exec COMMAND",
@@ -33,18 +28,6 @@ func Exec() *cobra.Command {
 			devPath = getFullPath(devPath)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-
-			if port != 0 {
-				go func() {
-					http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-						log.Debug("canceling process due to a request")
-						cancel()
-					})
-
-					log.Error(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
-					panic("webserver stopped handling requests")
-				}()
-			}
 
 			if _, err := os.Stat(devPath); os.IsNotExist(err) {
 				return fmt.Errorf("'%s' does not exist", devPath)
@@ -57,7 +40,7 @@ func Exec() *cobra.Command {
 			if namespace != "" {
 				dev.Namespace = namespace
 			}
-			err = executeExec(ctx, pod, container, dev, args)
+			err = executeExec(ctx, dev, args)
 			return err
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -70,17 +53,11 @@ func Exec() *cobra.Command {
 
 	cmd.Flags().StringVarP(&devPath, "file", "f", config.ManifestFileName(), "path to the manifest file")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the exec command is executed")
-	cmd.Flags().StringVarP(&pod, "pod", "p", "", "pod where it is executed")
-	cmd.Flags().MarkHidden("pod")
-	cmd.Flags().StringVarP(&container, "container", "c", "", "container where it is executed")
-	cmd.Flags().MarkHidden("container")
-	cmd.Flags().IntVar(&port, "port", 0, "port to listen to signals")
-	cmd.Flags().MarkHidden("port")
 
 	return cmd
 }
 
-func executeExec(ctx context.Context, pod, container string, dev *model.Dev, args []string) error {
+func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 	client, cfg, namespace, err := k8Client.GetLocal()
 	if err != nil {
 		return err
@@ -90,20 +67,14 @@ func executeExec(ctx context.Context, pod, container string, dev *model.Dev, arg
 		dev.Namespace = namespace
 	}
 
-	if len(pod) == 0 {
-		p, err := pods.GetDevPod(ctx, dev, client)
-		if err != nil {
-			return err
-		}
-
-		pod = p.Name
-		if len(dev.Container) == 0 {
-			dev.Container = p.Spec.Containers[0].Name
-		}
+	p, err := pods.GetDevPod(ctx, dev, client)
+	if err != nil {
+		return err
 	}
 
-	if len(container) > 0 {
-		dev.Container = container
+	if len(dev.Container) == 0 {
+		dev.Container = p.Spec.Containers[0].Name
 	}
-	return exec.Exec(ctx, client, cfg, dev.Namespace, pod, dev.Container, true, os.Stdin, os.Stdout, os.Stderr, args)
+
+	return exec.Exec(ctx, client, cfg, dev.Namespace, p.Name, dev.Container, true, os.Stdin, os.Stdout, os.Stderr, args)
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -166,7 +166,10 @@ func (up *UpContext) Activate() {
 		}()
 
 		prevError := up.WaitUntilExitOrInterrupt()
-		term.RestoreTerminal(inFd, state)
+		if err := term.RestoreTerminal(inFd, state); err != nil {
+			log.Debugf("failed to restore terminal: %s", err)
+		}
+
 		if prevError != nil {
 			if prevError == errors.ErrLostConnection || (prevError == errors.ErrCommandFailed && !up.Sy.IsConnected()) {
 				log.Yellow("\nConnection lost to your Okteto Environment, reconnecting...\n")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
 	github.com/cheggaaa/pb v1.0.27
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/docker/docker v0.0.0-20180612054059-a9fbbdc8dd87 // indirect
+	github.com/docker/docker v0.0.0-20180612054059-a9fbbdc8dd87
 	github.com/docker/spdystream v0.0.0-20170912183627-bc6354cbbc29 // indirect
 	github.com/dukex/mixpanel v0.0.0-20180925151559-f8d5594f958e
 	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,6 +331,7 @@ k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kubernetes v1.13.4 h1:gQqFv/pH8hlbznLXQUsi8s5zqYnv0slmUDl/yVA0EWc=
 k8s.io/kubernetes v1.13.4/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/kubernetes v1.14.2 h1:Gdq2hPpttbaJBoClIanCE6WSu4IZReA54yhkZtvPUOo=
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 h1:8r+l4bNWjRlsFYlQJnKJ2p7s1YQPj4XyXiJVqDHRx7c=
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -118,6 +118,7 @@ func translate(d *appsv1.Deployment, dev *model.Dev) (*appsv1.Deployment, *apiv1
 	d.Spec.Replicas = &devReplicas
 
 	devContainer := getDevContainer(d, dev.Container)
+	dev.Container = devContainer.Name
 	if devContainer == nil {
 		return nil, nil, fmt.Errorf("container/%s doesn't exist in deployment/%s", dev.Container, d.Name)
 	}

--- a/pkg/syncthing/monitor.go
+++ b/pkg/syncthing/monitor.go
@@ -21,16 +21,20 @@ func (s *Syncthing) IsConnected() bool {
 func (s *Syncthing) Monitor(ctx context.Context, wg *sync.WaitGroup, disconnect chan struct{}) {
 	wg.Add(1)
 	defer wg.Done()
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(3 * time.Second)
+	connected := true
 	for {
 		select {
 		case <-ticker.C:
-			if !s.IsConnected() {
-				if !s.IsConnected() {
+			if s.IsConnected() {
+				connected = true
+			} else {
+				if !connected {
 					log.Debug("not connected to syncthing, sending disconnect signal")
 					disconnect <- struct{}{}
 					return
 				}
+				connected = false
 			}
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
## Proposed changes
- execute `kill -- -1` before `exec` to clean previous command executions. It cleans everything but the INIT process.
- restore the terminal when the connection fails.
