### PR TITLE
track userID for new user

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -81,12 +81,12 @@ func runDown(dev *model.Dev, image string, removeVolumes bool) error {
 		if err := volumes.Destroy(volumes.GetVolumeName(dev), dev, client); err != nil {
 			return err
 		}
-	
+
 		for i := range dev.Volumes {
 			if err := volumes.Destroy(volumes.GetVolumeDataName(dev, i), dev, client); err != nil {
 				return err
 			}
-		}	
+		}
 	}
 
 	d, err := deployments.Get(dev.Name, dev.Namespace, client)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -85,13 +85,13 @@ func Login() *cobra.Command {
 
 			fmt.Printf("Received code=%s\n", code)
 			fmt.Println("Getting an access token...")
-			user, err := okteto.Auth(handler.ctx, code, oktetoURL)
+			user, new, err := okteto.Auth(handler.ctx, code, oktetoURL)
 			if err != nil {
 				return err
 			}
 
 			log.Success("Logged in as %s", user)
-			analytics.TrackLogin(VersionString)
+			analytics.TrackLogin(VersionString, new)
 			return nil
 		},
 	}

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -79,7 +79,18 @@ func TrackDown(image, version string) {
 }
 
 // TrackLogin sends a tracking event to mixpanel when the user logs in
-func TrackLogin(version string) {
+func TrackLogin(version string, isNew bool) {
+	if isNew {
+		trackID := okteto.GetUserID()
+		if len(trackID) == 0 {
+			log.Errorf("userID wasn't set for a new user")
+		} else {
+			if err := mixpanelClient.Alias(machineID, trackID); err != nil {
+				log.Errorf("failed to alias %s to %s", machineID, trackID)
+			}
+		}
+	}
+
 	track(loginEvent, version, "")
 }
 


### PR DESCRIPTION
Before a user logs in, we track her with the machineID. Once she logs in, we can start using the ID so we can correlate actions between we and CLI

