### PR TITLE
override the pull policy with an env var

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -81,12 +81,12 @@ func runDown(dev *model.Dev, image string, removeVolumes bool) error {
 		if err := volumes.Destroy(volumes.GetVolumeName(dev), dev, client); err != nil {
 			return err
 		}
-	
+
 		for i := range dev.Volumes {
 			if err := volumes.Destroy(volumes.GetVolumeDataName(dev, i), dev, client); err != nil {
 				return err
 			}
-		}	
+		}
 	}
 
 	d, err := deployments.Get(dev.Name, dev.Namespace, client)

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -1,6 +1,8 @@
 package deployments
 
 import (
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -142,6 +144,29 @@ func Test_translateResources(t *testing.T) {
 
 			if a.Cmp(b) != 0 {
 				t.Errorf("limits %s: expected %s, got %s", apiv1.ResourceCPU, b.String(), a.String())
+			}
+		})
+	}
+}
+
+func Test_getPullPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want apiv1.PullPolicy
+	}{
+		{name: "empty", env: "", want: apiv1.PullAlways},
+		{name: "bad", env: "badvalue", want: apiv1.PullAlways},
+		{name: "always", env: "always", want: apiv1.PullAlways},
+		{name: "never", env: "never", want: apiv1.PullNever},
+		{name: "ifnotpresent", env: "ifnotpresent", want: apiv1.PullIfNotPresent},
+		{name: "ifnotpresent-casing", env: "IfNotPresent", want: apiv1.PullIfNotPresent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("OKTETO_PULLPOLICY", tt.env)
+			if got := getPullPolicy(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getPullPolicy() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #234

Doing it as an env var since it's only required for minikube development, hopefully the real bug will be fixed soon enough.