### PR TITLE
Improve error when doing incompatible changes with previous statefulset

### DIFF
--- a/pkg/syncthing/k8s/crud.go
+++ b/pkg/syncthing/k8s/crud.go
@@ -21,6 +21,9 @@ func Deploy(dev *model.Dev, d *appsv1.Deployment, c *apiv1.Container, client *ku
 
 	if exists(ss, client) {
 		if err := update(ss, client); err != nil {
+			if strings.Contains(err.Error(), "updates to statefulset spec for fields other than") {
+				return fmt.Errorf("You have done an incompatible change with your previous okteto configuration. Run 'okteto down -v' and execute 'okteto up' again")
+			}
 			return err
 		}
 	} else {


### PR DESCRIPTION
For some changes, kubernetes cannot redeploy the syncthing statefulset and it gives this error:
```
error updating kubernetes syncthing statefulset: StatefulSet.apps "okteto-math" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```
This PR guides the user on how to solve this issue.
