### PR TITLE
Upload okteto binaries to google cloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,12 @@ jobs:
           echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
           gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-          gsutil -h x-goog-meta-version:${TAG} rsync ./artifacts/bin gs://downloads.okteto.com/cli
-          gsutil -h x-goog-meta-version:${TAG} rsync ./artifacts/bin gs://downloads.okteto.com/cli/${CIRCLE_TAG}
+          
+          gsutil -m -h x-goog-meta-version:${TAG} rsync ./artifacts/bin gs://downloads.okteto.com/cli/${CIRCLE_TAG}
+          
+          echo "${TAG}" > latest
+          gsutil -m -h x-goog-meta-version:${TAG} rsync ./artifacts/bin gs://downloads.okteto.com/cli
+        
           
           # legacy
           gsutil -h x-goog-meta-version:${TAG} cp ./artifacts/bin/okteto-Darwin-x86_64 gs://downloads.okteto.com/cli/okteto-Darwin-x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
           gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-          gsutil -h x-goog-meta-version:${CIRCLE_SHA1} rsync -r ./artifacts/bin gs://downloads.okteto.com/cli/master
+          gsutil -h x-goog-meta-version:${CIRCLE_SHA1} -m rsync -r ./artifacts/bin gs://downloads.okteto.com/cli/master
 workflows:
   version: 2
   build-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  aws-s3: circleci/aws-s3@1.0.6
 jobs:
   build:
     docker:
@@ -39,53 +37,20 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.12
+      - image: google/cloud-sdk
     steps:
-      - checkout
       - attach_workspace:
           at: ./artifacts
-      - aws-s3/sync:
-          from: ./artifacts/bin
-          to: "s3://downloads.okteto.com/cli"
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
-          arguments: |
-            --acl public-read \
-            --metadata version=${CIRCLE_TAG} \
-            --cache-control "max-age=86400" \
-            --exclude "*.*.*/" \
-      - aws-s3/sync:
-          from: ./artifacts/bin
-          to: "s3://downloads.okteto.com/cli/${CIRCLE_TAG}"
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
-          arguments: |
-            --acl public-read \
-            --metadata version=${CIRCLE_TAG} \
-            --cache-control "max-age=86400" \
-          overwrite: false
-      - aws-s3/copy:
-          from: "./artifacts/bin/okteto-Darwin-x86_64"
-          to: "s3://downloads.okteto.com/cloud/cli/okteto-Darwin-x86_64"
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
-          arguments: |
-            --acl public-read \
-            --metadata version=${CIRCLE_TAG} \
-            --cache-control "max-age=86400"
-      - aws-s3/copy:
-          from: "./artifacts/bin/okteto-Darwin-x86_64"
-          to: "s3://downloads.okteto.com/cli/okteto-darwin-amd64"
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
-          arguments: |
-            --acl public-read \
-            --metadata version=${CIRCLE_TAG} \
-            --cache-control "max-age=86400"
+      - run: |
+          echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+          gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+          gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+          gsutil -h x-goog-meta-version:${TAG} rsync ./artifacts/bin gs://downloads.okteto.com/cli
+          gsutil -h x-goog-meta-version:${TAG} rsync ./artifacts/bin gs://downloads.okteto.com/cli/${CIRCLE_TAG}
+          
+          # legacy
+          gsutil -h x-goog-meta-version:${TAG} cp ./artifacts/bin/okteto-Darwin-x86_64 gs://downloads.okteto.com/cli/okteto-Darwin-x86_64
+          gsutil -h x-goog-meta-version:${TAG} cp ./artifacts/bin/okteto-Darwin-x86_64 gs://downloads.okteto.com/cli/cli/okteto-darwin-amd64
       - run:
           name: "Publish Release on GitHub"
           command: |
@@ -96,7 +61,17 @@ jobs:
           command: |
             sha=$(cat ./artifacts/bin/okteto-Darwin-x86_64.sha256 | awk '{print $1}')
             bash ./update_homebrew_formula.sh $CIRCLE_TAG $GITHUB_TOKEN $sha 0
-
+  release-master:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - attach_workspace:
+          at: ./artifacts
+      - run: |
+          echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+          gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+          gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+          gsutil -h x-goog-meta-version:${CIRCLE_SHA1} rsync -r ./artifacts/bin gs://downloads.okteto.com/cli/master
 workflows:
   version: 2
   build-release:
@@ -119,4 +94,10 @@ workflows:
               only: /^\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/
+      - release-master:
+          requires:
+            - build
+          filters:
+            branches:
+              only: publish-to-gcp
       

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -36,7 +36,11 @@ func upgradeAvailable() string {
 	}
 
 	defer resp.Body.Close()
-	v := resp.Header.Get("x-amz-meta-version")
+	v := resp.Header.Get("x-goog-meta-version")
+	if len(v) == 0 {
+		v = resp.Header.Get("x-amz-meta-version")
+	}
+
 	if len(v) > 0 {
 		latest, err := semver.NewVersion(v)
 		if err != nil {


### PR DESCRIPTION
This is to standarize accounts, and use the okteto account instead of my personal one. We could also use AWS if you feel strongly against GCP.

There's a pending issue to solve:  The current CLI does a HEAD request on `https://downloads.okteto.com/cli/okteto-Darwin-x86_64` and checks the value of the `x-amz-meta-version` header to see if an upgrade is needed. This header is only available in S3, and there's no way to set it in an object stored in GCP Storage.   If we migrate, this means that the CLI won't get an update prompt until they upgrade to the next version.

We have a few options:
1. Break the upgrade mention, and notify our existing users directly
1. Stay on S3 for the CLI downloads
1. Have nginx or something similar in front of https://downloads.okteto.com/cli/okteto-Darwin-x86_64 to handle the header logic.
