### PR TITLE
add log for failed downloads

### DIFF
--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -76,7 +76,10 @@ func downloadSyncthing() error {
 
 	if err := client.Get(); err != nil {
 		log.Infof("failed to download syncthing from %s: %s", client.Src, err)
-		os.Remove(client.Dst)
+		if e := os.Remove(client.Dst); e != nil {
+			log.Infof("failed to delete partially downloaded %s: %s", client.Dst, e.Error())
+		}
+
 		return err
 	}
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -95,7 +95,7 @@ func Login() *cobra.Command {
 				log.Success("Logged in as %s @ %s", user, oktetoURL)
 			}
 
-			fmt.Println(log.BlueString("    Run `okteto namespace` to activate your Kubernetes configuration."))
+			log.Hint("    Run `okteto namespace` to activate your Kubernetes configuration.")
 			analytics.TrackLogin(config.VersionString, new)
 			return nil
 		},

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -135,11 +135,13 @@ func Errorf(format string, args ...interface{}) {
 
 // Yellow writes a line in yellow
 func Yellow(format string, args ...interface{}) {
+	log.out.Infof(format, args...)
 	fmt.Fprintln(color.Output, yellowString(format, args...))
 }
 
 // Green writes a line in green
 func Green(format string, args ...interface{}) {
+	log.out.Infof(format, args...)
 	fmt.Fprintln(color.Output, greenString(format, args...))
 }
 
@@ -150,20 +152,30 @@ func BlueString(format string, args ...interface{}) string {
 
 // Success prints a message with the success symbol first, and the text in green
 func Success(format string, args ...interface{}) {
+	log.out.Infof(format, args...)
 	fmt.Fprintf(color.Output, "%s %s\n", successSymbol, greenString(format, args...))
 }
 
 // Information prints a message with the information symbol first, and the text in blue
 func Information(format string, args ...interface{}) {
+	log.out.Infof(format, args...)
 	fmt.Fprintf(color.Output, "%s %s\n", informationSymbol, blueString(format, args...))
+}
+
+// Hint prints a message with the text in blue
+func Hint(format string, args ...interface{}) {
+	log.out.Infof(format, args...)
+	fmt.Fprintf(color.Output, "%s\n", blueString(format, args...))
 }
 
 // Fail prints a message with the error symbol first, and the text in red
 func Fail(format string, args ...interface{}) {
+	log.out.Infof(format, args...)
 	fmt.Fprintf(color.Output, "%s %s\n", errorSymbol, redString(format, args...))
 }
 
 // Println writes a line with colors
 func Println(args ...interface{}) {
+	log.out.Info(args...)
 	fmt.Fprintln(color.Output, args...)
 }

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -40,7 +40,7 @@ var (
 //Dev represents a cloud native development environment
 type Dev struct {
 	Name        string               `json:"name" yaml:"name"`
-	Labels      map[string]string    `json:"labels" yaml:"labels"`
+	Labels      map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Namespace   string               `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Container   string               `json:"container,omitempty" yaml:"container,omitempty"`
 	Image       string               `json:"image,omitempty" yaml:"image,omitempty"`


### PR DESCRIPTION
Few issues I found while testing windows:
- The blue text didn't show correctly
- On Windows, sometimes we can't delete syncthing on error due to OS issues, with this there will be a log
- Adding all the 'color'' outputs to the log as well