### PR TITLE
track the result of the operation

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -35,14 +35,13 @@ func Down() *cobra.Command {
 				dev.Namespace = namespace
 			}
 
-			analytics.TrackDown(config.VersionString)
 			err = runDown(dev, removeVolumes)
 			if err == nil {
 				log.Success("Okteto Environment deactivated")
 				log.Println()
-				return nil
 			}
 
+			analytics.TrackDown(config.VersionString, err == nil)
 			return err
 		},
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -87,7 +87,7 @@ func executeInit(devPath string) error {
 
 	if err := ioutil.WriteFile(devPath, marshalled, 0600); err != nil {
 		log.Info(err)
-		return fmt.Errorf("Failed to generate your manifest")
+		return fmt.Errorf("Failed to write your manifest")
 	}
 
 	if !fileExists(stignore) {
@@ -98,7 +98,7 @@ func executeInit(devPath string) error {
 		}
 	}
 
-	analytics.TrackInit(language, dev.Image, config.VersionString)
+	analytics.TrackInit(language, dev.Image, config.VersionString, true)
 	return nil
 }
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -86,6 +86,7 @@ func Login() *cobra.Command {
 
 			u, err := okteto.Auth(handler.ctx, code, oktetoURL)
 			if err != nil {
+				analytics.TrackLogin(u.Name, u.Email, u.ID, u.GithubID, config.VersionString, u.New, false)
 				return err
 			}
 
@@ -96,7 +97,7 @@ func Login() *cobra.Command {
 			}
 
 			fmt.Println(log.BlueString("    Run `okteto namespace` to activate your Kubernetes configuration."))
-			analytics.TrackLogin(u.Name, u.Email, u.ID, u.GithubID, config.VersionString, u.New)
+			analytics.TrackLogin(u.Name, u.Email, u.ID, u.GithubID, config.VersionString, u.New, true)
 			return nil
 		},
 	}

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -17,8 +17,9 @@ func Create() *cobra.Command {
 		Use:   "namespace <name>",
 		Short: fmt.Sprintf("Creates a namespace"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			analytics.TrackCreateNamespace(config.VersionString)
-			return executeCreateNamespace(args[0])
+			err := executeCreateNamespace(args[0])
+			analytics.TrackCreateNamespace(config.VersionString, err == nil)
+			return err
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -17,8 +17,9 @@ func Delete() *cobra.Command {
 		Use:   "namespace <name>",
 		Short: fmt.Sprintf("Deletes a namespace"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			analytics.TrackDeleteNamespace(config.VersionString)
-			return executeDeleteNamespace(args[0])
+			err := executeDeleteNamespace(args[0])
+			analytics.TrackDeleteNamespace(config.VersionString, err == nil)
+			return err
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -23,7 +23,7 @@ func Namespace() *cobra.Command {
 			}
 
 			err := RunNamespace(namespace)
-			analytics.TrackNamespace(config.VersionString)
+			analytics.TrackNamespace(config.VersionString, err == nil)
 			return err
 		},
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -92,8 +92,10 @@ func Up() *cobra.Command {
 			if namespace != "" {
 				dev.Namespace = namespace
 			}
-			analytics.TrackUp(dev.Image, config.VersionString)
-			return RunUp(dev)
+
+			err = RunUp(dev)
+			analytics.TrackUp(dev.Image, config.VersionString, err == nil)
+			return err
 		},
 	}
 


### PR DESCRIPTION
i'm adding an extra property, `success` to indicate if the event was succesful or not. This can help us understand if the users are struggling with the commands (e.g. we have a user that has run  `okteto create namespace` multiple times, but without logging in)

Also this PR changes the property for the OS, so we override Mixpanel's instead of having a different one.