### PR TITLE
Keep healthchecks in detached services

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -112,8 +112,11 @@ func translateDevContainer(c *apiv1.Container, rule *model.TranslationRule) {
 
 	c.Command = rule.Command
 	c.Args = rule.Args
-	c.ReadinessProbe = nil
-	c.LivenessProbe = nil
+
+	if !rule.Healthchecks {
+		c.ReadinessProbe = nil
+		c.LivenessProbe = nil
+	}
 
 	translateResources(c, rule.Resources)
 	translateEnvVars(c, rule.Environment)

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -236,11 +236,15 @@ func (dev *Dev) ToTranslationRule(main *Dev, d *appsv1.Deployment, nodeName stri
 	}
 
 	if main == dev {
+		rule.Healthchecks = false
 		rule.Command = []string{"tail"}
 		rule.Args = []string{"-f", "/dev/null"}
-	} else if len(dev.Command) > 0 {
-		rule.Command = dev.Command
-		rule.Args = []string{}
+	} else {
+		rule.Healthchecks = true
+		if len(dev.Command) > 0 {
+			rule.Command = dev.Command
+			rule.Args = []string{}
+		}
 	}
 
 	for i, v := range dev.Volumes {

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -14,15 +14,16 @@ type Translation struct {
 
 //TranslationRule represents how to apply a container translation in a deployment
 type TranslationRule struct {
-	Node        string               `json:"node,omitempty"`
-	Container   string               `json:"container,omitempty"`
-	Image       string               `json:"image,omitempty"`
-	Environment []EnvVar             `json:"environment,omitempty"`
-	Command     []string             `json:"command,omitempty"`
-	Args        []string             `json:"args,omitempty"`
-	WorkDir     string               `json:"workdir"`
-	Volumes     []VolumeMount        `json:"volumes,omitempty"`
-	Resources   ResourceRequirements `json:"resources,omitempty"`
+	Node         string               `json:"node,omitempty"`
+	Container    string               `json:"container,omitempty"`
+	Image        string               `json:"image,omitempty"`
+	Environment  []EnvVar             `json:"environment,omitempty"`
+	Command      []string             `json:"command,omitempty"`
+	Args         []string             `json:"args,omitempty"`
+	WorkDir      string               `json:"workdir"`
+	Healthchecks bool                 `json:"healthchecks" yaml:"healthchecks"`
+	Volumes      []VolumeMount        `json:"volumes,omitempty"`
+	Resources    ResourceRequirements `json:"resources,omitempty"`
 }
 
 //VolumeMount represents a volume mount

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -26,12 +26,13 @@ services:
 	d1 := dev.GevSandbox()
 	rule1 := dev.ToTranslationRule(dev, d1, "node")
 	rule1OK := &TranslationRule{
-		Node:        "node",
-		Container:   "dev",
-		Image:       "web:latest",
-		Command:     []string{"tail"},
-		Args:        []string{"-f", "/dev/null"},
-		Environment: make([]EnvVar, 0),
+		Node:         "node",
+		Container:    "dev",
+		Image:        "web:latest",
+		Command:      []string{"tail"},
+		Args:         []string{"-f", "/dev/null"},
+		Healthchecks: false,
+		Environment:  make([]EnvVar, 0),
 		Resources: ResourceRequirements{
 			Limits:   ResourceList{},
 			Requests: ResourceList{},
@@ -54,12 +55,13 @@ services:
 	d2 := dev2.GevSandbox()
 	rule2 := dev2.ToTranslationRule(dev, d2, "node")
 	rule2OK := &TranslationRule{
-		Node:        "node",
-		Container:   "dev",
-		Image:       "worker:latest",
-		Command:     nil,
-		Args:        nil,
-		Environment: make([]EnvVar, 0),
+		Node:         "node",
+		Container:    "dev",
+		Image:        "worker:latest",
+		Command:      nil,
+		Args:         nil,
+		Healthchecks: true,
+		Environment:  make([]EnvVar, 0),
 		Resources: ResourceRequirements{
 			Limits:   ResourceList{},
 			Requests: ResourceList{},


### PR DESCRIPTION
This functionality was removed here:
https://github.com/okteto/okteto/pull/319/files#diff-609dc08e2de9d411db9628520744417aL159

It is in-use by some users, so it has to be restored.
We could add a flag to remove them if the user wants this behavior, but let's wait for users requesting this behavior.
Added a test to avoid regressions here.