### PR TITLE
add securitycontext

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -262,11 +262,6 @@ func translateSecurityContext(c *apiv1.Container, s *model.SecurityContext) {
 		c.SecurityContext.Capabilities = &apiv1.Capabilities{}
 	}
 
-	for _, a := range s.Capabilities.Add {
-		c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, a)
-	}
-
-	for _, d := range s.Capabilities.Drop {
-		c.SecurityContext.Capabilities.Drop = append(c.SecurityContext.Capabilities.Drop, d)
-	}
+	c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, s.Capabilities.Add...)
+	c.SecurityContext.Capabilities.Drop = append(c.SecurityContext.Capabilities.Drop, s.Capabilities.Drop...)
 }

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -93,10 +93,20 @@ func translate(t *model.Translation) error {
 		TranslateDevContainer(devContainer, rule)
 		TranslateOktetoVolumes(&t.Deployment.Spec.Template.Spec, rule)
 		if rule.SecurityContext != nil {
-			t.Deployment.Spec.Template.Spec.SecurityContext = &apiv1.PodSecurityContext{
-				RunAsUser:  rule.SecurityContext.RunAsUser,
-				RunAsGroup: rule.SecurityContext.RunAsGroup,
-				FSGroup:    rule.SecurityContext.FSGroup,
+			if t.Deployment.Spec.Template.Spec.SecurityContext == nil {
+				t.Deployment.Spec.Template.Spec.SecurityContext = &apiv1.PodSecurityContext{}
+			}
+
+			if rule.SecurityContext.RunAsUser != nil {
+				t.Deployment.Spec.Template.Spec.SecurityContext.RunAsUser = rule.SecurityContext.RunAsUser
+			}
+
+			if rule.SecurityContext.RunAsGroup != nil {
+				t.Deployment.Spec.Template.Spec.SecurityContext.RunAsGroup = rule.SecurityContext.RunAsGroup
+			}
+
+			if rule.SecurityContext.FSGroup != nil {
+				t.Deployment.Spec.Template.Spec.SecurityContext.FSGroup = rule.SecurityContext.FSGroup
 			}
 		}
 

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -99,6 +99,7 @@ func translate(t *model.Translation) error {
 				FSGroup:    rule.SecurityContext.FSGroup,
 			}
 		}
+
 	}
 	return nil
 }
@@ -143,6 +144,7 @@ func TranslateDevContainer(c *apiv1.Container, rule *model.TranslationRule) {
 	translateResources(c, rule.Resources)
 	translateEnvVars(c, rule.Environment)
 	translateVolumeMounts(c, rule)
+	translateSecurityContext(c, rule.SecurityContext)
 }
 
 func translateResources(c *apiv1.Container, r model.ResourceRequirements) {
@@ -244,5 +246,27 @@ func TranslateOktetoVolumes(spec *apiv1.PodSpec, rule *model.TranslationRule) {
 			},
 		}
 		spec.Volumes = append(spec.Volumes, v)
+	}
+}
+
+func translateSecurityContext(c *apiv1.Container, s *model.SecurityContext) {
+	if s == nil || s.Capabilities == nil {
+		return
+	}
+
+	if c.SecurityContext == nil {
+		c.SecurityContext = &apiv1.SecurityContext{}
+	}
+
+	if c.SecurityContext.Capabilities == nil {
+		c.SecurityContext.Capabilities = &apiv1.Capabilities{}
+	}
+
+	for _, a := range s.Capabilities.Add {
+		c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, a)
+	}
+
+	for _, d := range s.Capabilities.Drop {
+		c.SecurityContext.Capabilities.Drop = append(c.SecurityContext.Capabilities.Drop, d)
 	}
 }

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -304,7 +304,7 @@ func Test_translateResources(t *testing.T) {
 	}
 }
 
-func Test_transalateSecurityContext(t *testing.T) {
+func Test_translateSecurityContext(t *testing.T) {
 	tests := []struct {
 		name         string
 		c            *apiv1.Container

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -1,6 +1,7 @@
 package deployments
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -298,6 +299,75 @@ func Test_translateResources(t *testing.T) {
 
 			if a.Cmp(b) != 0 {
 				t.Errorf("limits %s: expected %s, got %s", apiv1.ResourceCPU, b.String(), a.String())
+			}
+		})
+	}
+}
+
+func Test_transalateSecurityContext(t *testing.T) {
+	tests := []struct {
+		name         string
+		c            *apiv1.Container
+		s            *model.SecurityContext
+		expectedAdd  []apiv1.Capability
+		expectedDrop []apiv1.Capability
+	}{
+		{
+			name: "single-add",
+			c:    &apiv1.Container{},
+			s: &model.SecurityContext{
+				Capabilities: &model.Capabilities{
+					Add: []apiv1.Capability{"SYS_TRACE"},
+				},
+			},
+			expectedAdd: []apiv1.Capability{"SYS_TRACE"},
+		},
+		{
+			name: "add-drop",
+			c:    &apiv1.Container{},
+			s: &model.SecurityContext{
+				Capabilities: &model.Capabilities{
+					Add:  []apiv1.Capability{"SYS_TRACE"},
+					Drop: []apiv1.Capability{"SYS_NICE"},
+				},
+			},
+			expectedAdd:  []apiv1.Capability{"SYS_TRACE"},
+			expectedDrop: []apiv1.Capability{"SYS_NICE"},
+		},
+		{
+			name: "merge-uniques",
+			c: &apiv1.Container{
+				SecurityContext: &apiv1.SecurityContext{
+					Capabilities: &apiv1.Capabilities{
+						Add:  []apiv1.Capability{"SYS_FOO"},
+						Drop: []apiv1.Capability{"SYS_BAR"},
+					},
+				},
+			},
+			s: &model.SecurityContext{
+				Capabilities: &model.Capabilities{
+					Add:  []apiv1.Capability{"SYS_TRACE"},
+					Drop: []apiv1.Capability{"SYS_NICE"},
+				},
+			},
+			expectedAdd:  []apiv1.Capability{"SYS_FOO", "SYS_TRACE"},
+			expectedDrop: []apiv1.Capability{"SYS_BAR", "SYS_NICE"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			translateSecurityContext(tt.c, tt.s)
+			if tt.c.SecurityContext == nil {
+				t.Fatal("SecurityContext was nil")
+			}
+
+			if !reflect.DeepEqual(tt.c.SecurityContext.Capabilities.Add, tt.expectedAdd) {
+				t.Errorf("tt.c.SecurityContext.Capabilities.Add != tt.expectedAdd. Expected: %s, Got; %s", tt.expectedAdd, tt.c.SecurityContext.Capabilities.Add)
+			}
+
+			if !reflect.DeepEqual(tt.c.SecurityContext.Capabilities.Drop, tt.expectedDrop) {
+				t.Errorf("tt.c.SecurityContext.Capabilities.Drop != tt.expectedDrop. Expected: %s, Got; %s", tt.expectedDrop, tt.c.SecurityContext.Capabilities.Drop)
 			}
 		})
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -62,9 +62,16 @@ type Dev struct {
 
 // SecurityContext represents a pod security context
 type SecurityContext struct {
-	RunAsUser  *int64 `json:"runAsUser,omitempty" yaml:"runAsUser,omitempty"`
-	RunAsGroup *int64 `json:"runAsGroup,omitempty" yaml:"runAsGroup,omitempty"`
-	FSGroup    *int64 `json:"fsGroup,omitempty" yaml:"fsGroup,omitempty"`
+	RunAsUser    *int64        `json:"runAsUser,omitempty" yaml:"runAsUser,omitempty"`
+	RunAsGroup   *int64        `json:"runAsGroup,omitempty" yaml:"runAsGroup,omitempty"`
+	FSGroup      *int64        `json:"fsGroup,omitempty" yaml:"fsGroup,omitempty"`
+	Capabilities *Capabilities `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+}
+
+// Capabilities sets the linux capabilities of a container
+type Capabilities struct {
+	Add  []apiv1.Capability `json:"add,omitempty" yaml:"add,omitempty"`
+	Drop []apiv1.Capability `json:"drop,omitempty" yaml:"drop,omitempty"`
 }
 
 // EnvVar represents an environment value. When loaded, it will expand from the current env

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -20,6 +20,12 @@ resources:
   limits:
     memory: "128Mi"
     cpu: "500m"
+securityContext:
+  capabilities:
+    add:
+    - SYS_TRACE
+    drop:
+    - SYS_NICE
 workdir: /app`)
 	d, err := Read(manifest)
 	if err != nil {
@@ -52,6 +58,14 @@ workdir: /app`)
 	cpu = d.Resources.Limits["cpu"]
 	if cpu.String() != "500m" {
 		t.Errorf("Resources.Requests.CPU was not parsed correctly. Expected '500M', got '%s'", cpu.String())
+	}
+
+	if !reflect.DeepEqual(d.SecurityContext.Capabilities.Add, []apiv1.Capability{"SYS_TRACE"}) {
+		t.Errorf("SecurityContext.Capabilities.Add was not parsed correctly. Expected [SYS_TRACE]")
+	}
+
+	if !reflect.DeepEqual(d.SecurityContext.Capabilities.Drop, []apiv1.Capability{"SYS_NICE"}) {
+		t.Errorf("SecurityContext.Capabilities.Drop was not parsed correctly. Expected [SYS_NICE]")
 	}
 }
 

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -2,9 +2,9 @@ package okteto
 
 import (
 	"context"
-	"os"
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
@@ -76,7 +76,7 @@ func SetKubeConfig(filename, namespace string) error {
 	contextName := fmt.Sprintf("%s-context", oktetoURL)
 
 	var cfg *clientcmdapi.Config
-	cred, err :=GetCredentials(namespace)
+	cred, err := GetCredentials(namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/syncthing/k8s/crud.go
+++ b/pkg/syncthing/k8s/crud.go
@@ -26,6 +26,7 @@ func Deploy(dev *model.Dev, d *appsv1.Deployment, c *apiv1.Container, client *ku
 		ss.Spec.Template.Spec.NodeName = pods.GetSyncNode(dev, client)
 		ss.Spec.PodManagementPolicy = old.Spec.PodManagementPolicy
 		if err := update(ss, client); err != nil {
+			log.Infof("couldn't update the syncthing stateful set: %s", err)
 			if strings.Contains(err.Error(), "updates to statefulset spec for fields other than") {
 				return fmt.Errorf("You have done an incompatible change with your previous okteto configuration. Run 'okteto down -v' and execute 'okteto up' again")
 			}


### PR DESCRIPTION
Adds the ability to specify capabilities to the manifest. This will only be applied on the dev pod