### PR TITLE
check latest version from file not header

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
             - v1-pkg-cache
       - run: make test
       - run: env VERSION_STRING=$CIRCLE_TAG make -j 3 build-all
+      - run: env VERSION_STRING=$CIRCLE_TAG make latest
       - persist_to_workspace:
           root: .
           paths:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,11 @@ build-all: $(PLATFORMS)
 
 $(PLATFORMS):
 	GOOS=$(os) GOARCH=$(arch) $(BUILDCOMMAND) -o "bin/okteto-$(label)" 
-	sha256sum "bin/okteto-$(label)" > "bin/okteto-$(label).sha256"  
+	sha256sum "bin/okteto-$(label)" > "bin/okteto-$(label).sha256" 
+
+.PHONY: latest
+latest:
+	echo ${VERSION_STRING} > bin/latest
 
 .PHONY: lint
 lint:

--- a/cmd/dependencies.go
+++ b/cmd/dependencies.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	// DownloadPath is the path of the syncthing binary.
+	// SyncthingURL is the path of the syncthing binary.
 	SyncthingURL = map[string]string{
 		"linux":   "https://downloads.okteto.com/cli/syncthing/1.2.2/syncthing-Linux-x86_64",
 		"darwin":  "https://downloads.okteto.com/cli/syncthing/1.2.2/syncthing-Darwin-x86_64",

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -59,7 +59,7 @@ func upgradeAvailable() string {
 func getVersion() (string, error) {
 	resp, err := netClient.Get("https://downloads.okteto.com/cli/latest")
 	if err != nil {
-		log.Errorf("failed to get latest version: %s", err)
+		log.Infof("failed to get latest version: %s", err)
 		return "", err
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,14 +2,20 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"runtime"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/spf13/cobra"
 )
+
+var netClient = &http.Client{
+	Timeout: time.Second * 3,
+}
 
 //Version returns information about the binary
 func Version() *cobra.Command {
@@ -29,14 +35,11 @@ func upgradeAvailable() string {
 		return ""
 	}
 
-	resp, err := http.Head("https://downloads.okteto.com/cli/okteto-Darwin-x86_64")
+	v, err := getVersion()
 	if err != nil {
-		log.Errorf("failed to get latest version: %s", err)
-		return ""
+		log.Infof("failed to get the latest version from https://downloads.okteto.com/cli/latest: %s", err)
 	}
 
-	defer resp.Body.Close()
-	v := resp.Header.Get("x-amz-meta-version")
 	if len(v) > 0 {
 		latest, err := semver.NewVersion(v)
 		if err != nil {
@@ -51,6 +54,22 @@ func upgradeAvailable() string {
 	}
 
 	return ""
+}
+
+func getVersion() (string, error) {
+	resp, err := netClient.Get("https://downloads.okteto.com/cli/latest")
+	if err != nil {
+		log.Errorf("failed to get latest version: %s", err)
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
 }
 
 func shouldNotify(latest, current *semver.Version) bool {


### PR DESCRIPTION
This is more standard. Having this makes the process of moving to gcloud for storage (so we don't have anything on my personal aws account) easier.