### PR TITLE
build for linux arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,19 @@ VERSION_STRING := $(shell git rev-parse --short HEAD)
 endif
 
 BINDIR    := $(CURDIR)/bin
-PLATFORMS := linux/amd64/Linux-x86_64 darwin/amd64/Darwin-x86_64 windows/amd64/Windows-x86_64
+PLATFORMS := linux/amd64/Linux-x86_64 darwin/amd64/Darwin-x86_64 windows/amd64/Windows-x86_64 linux/arm64/Linux-arm64
 BUILDCOMMAND := go build -ldflags "-X github.com/okteto/okteto/pkg/config.VersionString=${VERSION_STRING}" -tags "osusergo netgo static_build"
 temp = $(subst /, ,$@)
 os = $(word 1, $(temp))
 arch = $(word 2, $(temp))
 label = $(word 3, $(temp))
+
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+SHACOMMAND := shasum -a 256
+else 
+SHACOMMAND := sha256sum
+endif
 
 .DEFAULT_GOAL := build
 
@@ -17,7 +24,7 @@ build-all: $(PLATFORMS)
 
 $(PLATFORMS):
 	GOOS=$(os) GOARCH=$(arch) $(BUILDCOMMAND) -o "bin/okteto-$(label)" 
-	sha256sum "bin/okteto-$(label)" > "bin/okteto-$(label).sha256" 
+	$(SHACOMMAND) "bin/okteto-$(label)" > "bin/okteto-$(label).sha256" 
 
 .PHONY: latest
 latest:


### PR DESCRIPTION
Fixes #433

Support for arm64 devices running linux. 

This request came over the weekend. I think it makes sense to support it. Still need to test the binary on an arm64 device (I think AWS has VMs).