### PR TITLE
Generate a context per server/namespace

### DIFF
--- a/pkg/okteto/auth.go
+++ b/pkg/okteto/auth.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/machinebox/graphql"
 	"github.com/okteto/okteto/pkg/config"
@@ -135,12 +134,6 @@ func GetURL() string {
 	}
 
 	return t.URL
-}
-
-// GetURLWithUnderscore returns the URL of the authenticated user with underscores
-func GetURLWithUnderscore() string {
-	u, _ := url.Parse(GetURL())
-	return strings.ReplaceAll(u.Host, ".", "_")
 }
 
 func saveToken(id, token, url string) error {

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -69,15 +69,14 @@ func isConnectionError(s string) bool {
 }
 
 //SetKubeConfig updates a kubeconfig file with okteto cluster credentials
-func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, host string) error {
-	clusterName := fmt.Sprintf("%s", host)
+func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, clusterName string) error {
 	var contextName = ""
 	if len(namespace) == 0 {
 		// don't include namespace for the personal namespace
-		contextName = fmt.Sprintf(host)
+		contextName = fmt.Sprintf(clusterName)
 		namespace = cred.Namespace
 	} else {
-		contextName = fmt.Sprintf("%s-%s", host, namespace)
+		contextName = fmt.Sprintf("%s-%s", clusterName, namespace)
 	}
 
 	var cfg *clientcmdapi.Config

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -70,14 +70,14 @@ func isConnectionError(s string) bool {
 
 //SetKubeConfig updates a kubeconfig file with okteto cluster credentials
 func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, host string) error {
-	clusterName := fmt.Sprintf("%s-cluster", host)
+	clusterName := fmt.Sprintf("%s", host)
 	var contextName = ""
 	if len(namespace) == 0 {
 		// don't include namespace for the personal namespace
-		contextName = fmt.Sprintf("%s-context", host)
+		contextName = fmt.Sprintf(host)
 		namespace = cred.Namespace
 	} else {
-		contextName = fmt.Sprintf("%s-%s-context", host, namespace)
+		contextName = fmt.Sprintf("%s-%s", host, namespace)
 	}
 
 	var cfg *clientcmdapi.Config

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -72,9 +72,10 @@ func isConnectionError(s string) bool {
 func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, host string) error {
 	clusterName := fmt.Sprintf("%s-cluster", host)
 	var contextName = ""
-	if namespace == userName {
+	if len(namespace) == 0 {
 		// don't include namespace for the personal namespace
 		contextName = fmt.Sprintf("%s-context", host)
+		namespace = cred.Namespace
 	} else {
 		contextName = fmt.Sprintf("%s-%s-context", host, namespace)
 	}

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -68,20 +68,19 @@ func isConnectionError(s string) bool {
 	return strings.Contains(s, "decoding response") || strings.Contains(s, "reading body")
 }
 
-//SetKubeConfig update a kubeconfig file with okteto cluster credentials
-func SetKubeConfig(filename, namespace string) error {
-	oktetoURL := GetURLWithUnderscore()
-	clusterName := fmt.Sprintf("%s-cluster", oktetoURL)
-	userName := GetUserID()
-	contextName := fmt.Sprintf("%s-context", oktetoURL)
-
-	var cfg *clientcmdapi.Config
-	cred, err := GetCredentials(namespace)
-	if err != nil {
-		return err
+//SetKubeConfig updates a kubeconfig file with okteto cluster credentials
+func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, host string) error {
+	clusterName := fmt.Sprintf("%s-cluster", host)
+	var contextName = ""
+	if namespace == userName {
+		// don't include namespace for the personal namespace
+		contextName = fmt.Sprintf("%s-context", host)
+	} else {
+		contextName = fmt.Sprintf("%s-%s-context", host, namespace)
 	}
 
-	_, err = os.Stat(filename)
+	var cfg *clientcmdapi.Config
+	_, err := os.Stat(kubeConfigPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			cfg = clientcmdapi.NewConfig()
@@ -89,7 +88,7 @@ func SetKubeConfig(filename, namespace string) error {
 			return err
 		}
 	} else {
-		cfg, err = clientcmd.LoadFromFile(filename)
+		cfg, err = clientcmd.LoadFromFile(kubeConfigPath)
 		if err != nil {
 			return err
 		}
@@ -100,6 +99,7 @@ func SetKubeConfig(filename, namespace string) error {
 	if !ok {
 		cluster = clientcmdapi.NewCluster()
 	}
+
 	cluster.CertificateAuthorityData = []byte(cred.Certificate)
 	cluster.Server = cred.Server
 	cfg.Clusters[clusterName] = cluster
@@ -117,14 +117,15 @@ func SetKubeConfig(filename, namespace string) error {
 	if !ok {
 		context = clientcmdapi.NewContext()
 	}
+
 	context.Cluster = clusterName
 	context.AuthInfo = userName
-	context.Namespace = cred.Namespace
+	context.Namespace = namespace
 	cfg.Contexts[contextName] = context
 
 	cfg.CurrentContext = contextName
 
-	if err := clientcmd.WriteToFile(*cfg, filename); err != nil {
+	if err := clientcmd.WriteToFile(*cfg, kubeConfigPath); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -70,10 +70,11 @@ func isConnectionError(s string) bool {
 
 //SetKubeConfig updates a kubeconfig file with okteto cluster credentials
 func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, clusterName string) error {
-	var contextName = ""
+
+	contextName := ""
 	if len(namespace) == 0 {
 		// don't include namespace for the personal namespace
-		contextName = fmt.Sprintf(clusterName)
+		contextName = clusterName
 		namespace = cred.Namespace
 	} else {
 		contextName = fmt.Sprintf("%s-%s", clusterName, namespace)

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -57,4 +57,23 @@ func TestSetKubeConfig(t *testing.T) {
 		t.Errorf("current context was not sf-okteto-com-ns-2, it was %s", cfg.CurrentContext)
 	}
 
+	// add duplicated
+
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-124", "sf-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	cfg, err = clientcmd.LoadFromFile(file.Name())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(cfg.Contexts) != 5 {
+		t.Errorf("the config file didn't have five contexts after adding the same twice: %+v", cfg.Contexts)
+	}
+
 }

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -1,0 +1,60 @@
+package okteto
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestSetKubeConfig(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	defer os.Remove(file.Name())
+	c := &Credential{}
+	if err := SetKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if err := SetKubeConfig(c, file.Name(), "ns", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if err := SetKubeConfig(c, file.Name(), "", "123-123-124", "sf-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-124", "sf-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	cfg, err := clientcmd.LoadFromFile(file.Name())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(cfg.Clusters) != 2 {
+		t.Errorf("the config file didn't have two clusters: %+v", cfg.Clusters)
+	}
+
+	if len(cfg.AuthInfos) != 2 {
+		t.Errorf("the config file didn't have two users: %+v", cfg.AuthInfos)
+	}
+
+	if len(cfg.Contexts) != 5 {
+		t.Errorf("the config file didn't have five contexts: %+v", cfg.Contexts)
+	}
+
+	if cfg.CurrentContext != "sf-okteto-com-ns-2" {
+		t.Errorf("current context was not sf-okteto-com-ns-2, it was %s", cfg.CurrentContext)
+	}
+
+}


### PR DESCRIPTION
Generate a context per server/namespace configuration, so that it's easier to switch namespaces with other kubernetes tools (like the VS Code context switcher).

I also want to remove the redundant postfixes, so that all names are shorter and easier to read. I think it's ok to leave the old ones, but we could have a migration code if you fix strongly about it.