### PR TITLE
Add a label to disallow okteto in certain namespaces

### DIFF
--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -8,6 +8,7 @@ import (
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	apiv1 "k8s.io/api/core/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -101,7 +102,7 @@ func Deploy(d *appsv1.Deployment, forceCreate bool, client *kubernetes.Clientset
 }
 
 //TraslateDevMode translates the deployment manifests to put them in dev mode
-func TraslateDevMode(tr map[string]*model.Translation, ns string, c *kubernetes.Clientset) error {
+func TraslateDevMode(tr map[string]*model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
 	for _, t := range tr {
 		err := translate(t, ns, c)
 		if err != nil {

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -39,7 +39,7 @@ var (
 	devTerminationGracePeriodSeconds int64
 )
 
-func translate(t *model.Translation, ns string, c *kubernetes.Clientset) error {
+func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
 	for _, rule := range t.Rules {
 		devContainer := GetDevContainer(&t.Deployment.Spec.Template.Spec, rule.Container)
 		if devContainer == nil {
@@ -60,7 +60,7 @@ func translate(t *model.Translation, ns string, c *kubernetes.Clientset) error {
 	delete(annotations, revisionAnnotation)
 	t.Deployment.GetObjectMeta().SetAnnotations(annotations)
 
-	if c != nil && namespaces.IsOktetoNamespace(ns, c) {
+	if c != nil && namespaces.IsOktetoNamespace(ns) {
 		_, v := os.LookupEnv("OKTETO_CLIENTSIDE_TRANSLATION")
 		if !v {
 			commonTranslation(t)

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -44,7 +44,7 @@ services:
 		Deployment:  d1,
 		Rules:       []*model.TranslationRule{rule1},
 	}
-	err = translate(tr1, "", nil)
+	err = translate(tr1, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ services:
 		Deployment:  d2,
 		Rules:       []*model.TranslationRule{rule2},
 	}
-	err = translate(tr2, "", nil)
+	err = translate(tr2, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/k8s/namespaces/crud.go
+++ b/pkg/k8s/namespaces/crud.go
@@ -35,7 +35,6 @@ func IsOktetoNamespace(ns *apiv1.Namespace) bool {
 
 //IsOktetoAllowed checks if Okteto operationos are allowed in this namespace
 func IsOktetoAllowed(ns *apiv1.Namespace) bool {
-	log.Debug("labels: %v", ns.Labels)
 	if _, ok := ns.Labels[OktetoNotAllowedLabel]; ok {
 		return false
 	}

--- a/pkg/k8s/namespaces/crud.go
+++ b/pkg/k8s/namespaces/crud.go
@@ -16,6 +16,9 @@ import (
 const (
 	//OktetoLabel represents the owner of the namespace
 	OktetoLabel = "dev.okteto.com"
+
+	// OktetoNotAllowedLabel tells Okteto to not allow operations on the namespace
+	OktetoNotAllowedLabel = "dev.okteto.com/not-allowed"
 )
 
 var (
@@ -26,13 +29,29 @@ var (
 )
 
 //IsOktetoNamespace checks if this is a namespace created by okteto
-func IsOktetoNamespace(ns string, c *kubernetes.Clientset) bool {
+func IsOktetoNamespace(ns *apiv1.Namespace) bool {
+	return ns.Labels[OktetoLabel] == "true"
+}
+
+//IsOktetoAllowed checks if Okteto operationos are allowed in this namespace
+func IsOktetoAllowed(ns *apiv1.Namespace) bool {
+	log.Debug("labels: %v", ns.Labels)
+	if _, ok := ns.Labels[OktetoNotAllowedLabel]; ok {
+		return false
+	}
+
+	return true
+}
+
+// Get returns the namespace object of ns
+func Get(ns string, c *kubernetes.Clientset) (*apiv1.Namespace, error) {
 	n, err := c.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
 	if err != nil {
 		log.Infof("error accessing namespace %s: %s", ns, err)
-		return false
+		return nil, err
 	}
-	return n.Labels[OktetoLabel] == "true"
+
+	return n, nil
 }
 
 //CheckAvailableResources checks if therre are available resources for activating the dev env


### PR DESCRIPTION
Add a label to disallow okteto in certain namespaces. Mainly to prevent me from doing `okteto up` in prod or similar namespaces.