### PR TITLE
download from github

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -95,7 +95,7 @@ func shouldNotify(latest, current *semver.Version) bool {
 
 func getUpgradeCommand() string {
 	if runtime.GOOS == "windows" {
-		return `wget https://downloads.okteto.com/cli/okteto-Windows-x86_64 -OutFile c:\windows\system32\okteto.exe`
+		return `wget https://github.com/okteto/okteto/releases/latest/download/okteto-Windows-x86_64 -OutFile c:\windows\system32\okteto.exe`
 	}
 
 	return `curl https://get.okteto.com -sSfL | sh`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,5 +15,5 @@ $ brew install okteto
 
 ## Windows:
 ```console
-$ wget https://downloads.okteto.com/cli/okteto-Windows-x86_64 -OutFile c:\windows\system32\okteto.exe
+$ wget https://github.com/okteto/okteto/releases/latest/download/okteto-Windows-x86_64 -OutFile c:\windows\system32\okteto.exe
 ```

--- a/scripts/get-okteto.sh
+++ b/scripts/get-okteto.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+{ # Prevent execution if this script was only partially downloaded
+
+set -e
+
+green="\033[32m"
+red="\033[31m"
+reset="\033[0m"
+install_path='/usr/local/bin/okteto'
+OS=$(uname | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+cmd_exists() {
+	command -v "$@" > /dev/null 2>&1
+}
+
+
+case "$OS" in
+    darwin) 
+      URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Darwin-x86_64
+      ;;
+    linux)
+      case "$ARCH" in
+        x86_64) 
+            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-x86_64
+            ;;
+        amd64) 
+            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-x86_64
+            ;;
+        armv8*) 
+            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-arm64
+            ;;
+        aarch64)
+            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-arm64
+            ;;
+        *) 
+            printf "$red> The architecture (${ARCH}) is not supported by this installation script.$reset\n" 
+            exit 1 
+            ;;
+      esac
+      ;;
+    *)
+      printf "$red> The OS (${OS}) is not supported by this installation script.$reset\n"
+      exit 1
+      ;;
+esac
+
+sh_c='sh -c'
+if [ ! -w $install_path ]; then
+    # use sudo if $user doesn't have write access to the path
+    if [ "$user" != 'root' ]; then
+        if cmd_exists sudo; then
+            sh_c='sudo -E sh -c'
+	elif cmd_exists su; then
+            sh_c='su -c'
+	else
+            echo 'This script requires to run commands as sudo. We are unable to find either "sudo" or "su".'
+            exit 1
+	fi
+    fi
+fi
+
+printf "> Installing $install_path\n"
+$sh_c "curl -fSL $URL -o $install_path"
+$sh_c "chmod +x $install_path"
+
+printf "$green> Okteto successfully installed!\n$reset"
+
+} # End of wrapping

--- a/scripts/get-okteto.sh
+++ b/scripts/get-okteto.sh
@@ -14,24 +14,25 @@ cmd_exists() {
 	command -v "$@" > /dev/null 2>&1
 }
 
+latestURL=https://github.com/okteto/okteto/releases/latest/download
 
 case "$OS" in
     darwin) 
-      URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Darwin-x86_64
+      URL=${latestURL}/okteto-Darwin-x86_64
       ;;
     linux)
       case "$ARCH" in
         x86_64) 
-            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-x86_64
+            URL=${latestURL}/okteto-Linux-x86_64
             ;;
         amd64) 
-            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-x86_64
+            URL=${latestURL}/okteto-Linux-x86_64
             ;;
         armv8*) 
-            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-arm64
+            URL=${latestURL}/okteto-Linux-arm64
             ;;
         aarch64)
-            URL=https://github.com/okteto/okteto/releases/latest/download/okteto-Linux-arm64
+            URL=${latestURL}/okteto-Linux-arm64
             ;;
         *) 
             printf "$red> The architecture (${ARCH}) is not supported by this installation script.$reset\n" 

--- a/scripts/windows.sh
+++ b/scripts/windows.sh
@@ -1,0 +1,1 @@
+wget https://github.com/okteto/okteto/releases/latest/download/okteto-Windows-x86_64 -OutFile c:\windows\system32\okteto.exe

--- a/update_homebrew_formula.sh
+++ b/update_homebrew_formula.sh
@@ -30,7 +30,7 @@ cat << EOF > Formula/okteto.rb
 class Okteto < Formula
     desc "CLI for cloud native development"
     homepage "https://okteto.com"
-    url "https://downloads.okteto.com/cli/okteto-Darwin-x86_64"
+    url "https://github.com/okteto/okteto/releases/latest/download/okteto-Darwin-x86_64"
     sha256 "$SHA"
     version "$VERSION"
     


### PR DESCRIPTION
Point all downloads to github instead of downloads.okteto.com. We still have the master build there, but we can think of other ways to post that so we can deprecate downloads.okteto.com in this repo.