### PR TITLE
Show proper error when security context is not set

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -401,7 +401,7 @@ func (up *UpContext) startLocalSyncthing() error {
 	if err := up.Sy.WaitForPing(up.Context, up.WG, false); err != nil {
 		return errors.UserError{
 			E:    fmt.Errorf("Failed to connect to the synchronization service"),
-			Hint: fmt.Sprintf("If you are using a non-root container, and the runAsUser and runAsGroup values are not specified in your Kubernetes manifest, you need to set these values in your Okteto manifest.\n    Follow this link for more information on how to do it: https://okteto.com/docs/reference/manifest/index.html#securityContext-object-optional"),
+			Hint: fmt.Sprintf("If you are using a non-root container, you need to set the securityContext.runAsUser and securityContext.runAsGroup values in your Okteto manifest (https://okteto.com/docs/reference/manifest/index.html#securityContext-object-optional)."),
 		}
 	}
 	up.Sy.SendStignoreFile(up.Context, up.WG, up.Dev)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -328,7 +328,7 @@ func (up *UpContext) devMode(isRetry bool, ns *apiv1.Namespace, d *appsv1.Deploy
 		return err
 	}
 
-	if err := deployments.TraslateDevMode(tr, ns, up.Client); err != nil {
+	if err := deployments.TranslateDevMode(tr, ns, up.Client); err != nil {
 		return err
 	}
 
@@ -400,8 +400,8 @@ func (up *UpContext) startLocalSyncthing() error {
 	}
 	if err := up.Sy.WaitForPing(up.Context, up.WG, false); err != nil {
 		return errors.UserError{
-			E:    fmt.Errorf("Failed to connect to the synchonization service"),
-			Hint: fmt.Sprintf("This is probably because your development image is not root.\n    Please, add securityContext.runAsUser and securityContext.fsGroup to your okteto manifest.\n    Follow this link for an example: https://github.com/okteto/java-gradle-getting-started/blob/master/okteto.yml"),
+			E:    fmt.Errorf("Failed to connect to the synchronization service"),
+			Hint: fmt.Sprintf("If you are using a non-root container, and the runAsUser and runAsGroup values are not specified in your Kubernetes manifest, you need to set these values in your Okteto manifest.\n    Follow this link for more information on how to do it: https://okteto.com/docs/reference/manifest/index.html#securityContext-object-optional"),
 		}
 	}
 	up.Sy.SendStignoreFile(up.Context, up.WG, up.Dev)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -398,6 +398,12 @@ func (up *UpContext) startLocalSyncthing() error {
 	if err := up.Sy.WaitForPing(up.Context, up.WG, true); err != nil {
 		return err
 	}
+	if err := up.Sy.WaitForPing(up.Context, up.WG, false); err != nil {
+		return errors.UserError{
+			E:    fmt.Errorf("Failed to connect to the synchonization service"),
+			Hint: fmt.Sprintf("This is probably because your development image is not root.\n    Please, add securityContext.runAsUser and securityContext.fsGroup to your okteto manifest.\n    Follow this link for an example: https://github.com/okteto/java-gradle-getting-started/blob/master/okteto.yml"),
+		}
+	}
 	up.Sy.SendStignoreFile(up.Context, up.WG, up.Dev)
 	if err := up.Sy.WaitForScanning(up.Context, up.WG, up.Dev, true); err != nil {
 		return err

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -103,8 +103,8 @@ func Deploy(d *appsv1.Deployment, forceCreate bool, client *kubernetes.Clientset
 	return nil
 }
 
-//TraslateDevMode translates the deployment manifests to put them in dev mode
-func TraslateDevMode(tr map[string]*model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
+//TranslateDevMode translates the deployment manifests to put them in dev mode
+func TranslateDevMode(tr map[string]*model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
 	for _, t := range tr {
 		err := translate(t, ns, c)
 		if err != nil {

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -261,7 +261,7 @@ func (s *Syncthing) Run(ctx context.Context, wg *sync.WaitGroup) error {
 func (s *Syncthing) WaitForPing(ctx context.Context, wg *sync.WaitGroup, local bool) error {
 	ticker := time.NewTicker(200 * time.Millisecond)
 	log.Infof("waiting for syncthing to be ready...")
-	for i := 0; i < 200; i++ {
+	for i := 0; i < 30; i++ {
 		_, err := s.APICall("rest/system/ping", "GET", 200, nil, local, nil)
 		if err == nil {
 			return nil
@@ -275,7 +275,7 @@ func (s *Syncthing) WaitForPing(ctx context.Context, wg *sync.WaitGroup, local b
 			return ctx.Err()
 		}
 	}
-	return fmt.Errorf("Syncthing not responding after 50s")
+	return fmt.Errorf("Syncthing not responding after 10s")
 }
 
 //SendStignoreFile sends .stignore from local to remote


### PR DESCRIPTION
Error management is not a little simpler since there are fewer moving pieces.
This is how it looks like if the user missed to set the security context:

<img width="1288" alt="Screenshot 2019-10-08 at 11 53 38" src="https://user-images.githubusercontent.com/7474696/66424335-4b6ef180-e9c2-11e9-8bc3-411d76618cc0.png">
