### PR TITLE
Add support for pod annotations

### DIFF
--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -87,6 +87,7 @@ func GetTranslations(dev *model.Dev, d *appsv1.Deployment, c *kubernetes.Clients
 			Name:        dev.Name,
 			Version:     model.TranslationVersion,
 			Deployment:  d,
+			Annotations: dev.Annotations,
 			Replicas:    *d.Spec.Replicas,
 			Rules:       []*model.TranslationRule{rule},
 		}
@@ -108,6 +109,7 @@ func GetTranslations(dev *model.Dev, d *appsv1.Deployment, c *kubernetes.Clients
 				Interactive: false,
 				Version:     model.TranslationVersion,
 				Deployment:  d,
+				Annotations: dev.Annotations,
 				Replicas:    *d.Spec.Replicas,
 				Rules:       []*model.TranslationRule{rule},
 			}

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -178,6 +178,7 @@ func DevModeOff(d *appsv1.Deployment, c *kubernetes.Clientset) error {
 		delete(annotations, oktetoVersionAnnotation)
 		d.GetObjectMeta().SetAnnotations(annotations)
 		annotations = d.Spec.Template.GetObjectMeta().GetAnnotations()
+		deleteUserAnnotations(annotations)
 		delete(annotations, okLabels.TranslationAnnotation)
 		d.Spec.Template.GetObjectMeta().SetAnnotations(annotations)
 		labels := d.GetObjectMeta().GetLabels()
@@ -210,6 +211,18 @@ func update(d *appsv1.Deployment, c *kubernetes.Clientset) error {
 	_, err := c.AppsV1().Deployments(d.Namespace).Update(d)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func deleteUserAnnotations(annotations map[string]string) error {
+	tr, err := getTranslationFromAnnotation(annotations)
+	if err != nil {
+		return err
+	}
+	userAnnotations := tr.Annotations
+	for key := range userAnnotations {
+		delete(annotations, key)
 	}
 	return nil
 }

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -178,7 +178,9 @@ func DevModeOff(d *appsv1.Deployment, c *kubernetes.Clientset) error {
 		delete(annotations, oktetoVersionAnnotation)
 		d.GetObjectMeta().SetAnnotations(annotations)
 		annotations = d.Spec.Template.GetObjectMeta().GetAnnotations()
-		deleteUserAnnotations(annotations)
+		if err := deleteUserAnnotations(annotations); err != nil {
+			return err
+		}
 		delete(annotations, okLabels.TranslationAnnotation)
 		d.Spec.Template.GetObjectMeta().SetAnnotations(annotations)
 		labels := d.GetObjectMeta().GetLabels()

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -72,6 +72,8 @@ func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientse
 	}
 	setAnnotation(t.Deployment.GetObjectMeta(), oktetoDeploymentAnnotation, string(manifestBytes))
 
+	TranslatePodAnnotations(t.Deployment.Spec.Template.GetObjectMeta(), t.Annotations)
+
 	commonTranslation(t)
 
 	setLabel(t.Deployment.Spec.Template.GetObjectMeta(), okLabels.DevLabel, "true")
@@ -122,6 +124,13 @@ func GetDevContainer(spec *apiv1.PodSpec, name string) *apiv1.Container {
 	}
 
 	return nil
+}
+
+//TranslatePodAnnotations translates the annotations of pod
+func TranslatePodAnnotations(o metav1.Object, annotations map[string]string) {
+	for key, value := range annotations {
+		setAnnotation(o, key, value)
+	}
 }
 
 //TranslatePodAffinity translates the affinity of pod to be all on the same node
@@ -365,7 +374,7 @@ func TranslateOktetoInitBinContainer(spec *apiv1.PodSpec) {
 		ImagePullPolicy: apiv1.PullIfNotPresent,
 		Command:         []string{"sh", "-c", "cp /usr/local/bin/* /okteto/bin"},
 		VolumeMounts: []apiv1.VolumeMount{
-			apiv1.VolumeMount{
+			{
 				Name:      oktetoBinName,
 				MountPath: "/okteto/bin",
 			},

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -72,7 +72,7 @@ func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientse
 	}
 	setAnnotation(t.Deployment.GetObjectMeta(), oktetoDeploymentAnnotation, string(manifestBytes))
 
-	TranslatePodAnnotations(t.Deployment.Spec.Template.GetObjectMeta(), t.Annotations)
+	TranslatePodUserAnnotations(t.Deployment.Spec.Template.GetObjectMeta(), t.Annotations)
 
 	commonTranslation(t)
 
@@ -126,8 +126,8 @@ func GetDevContainer(spec *apiv1.PodSpec, name string) *apiv1.Container {
 	return nil
 }
 
-//TranslatePodAnnotations translates the annotations of pod
-func TranslatePodAnnotations(o metav1.Object, annotations map[string]string) {
+//TranslatePodUserAnnotations translates the user provided annotations of pod
+func TranslatePodUserAnnotations(o metav1.Object, annotations map[string]string) {
 	for key, value := range annotations {
 		setAnnotation(o, key, value)
 	}

--- a/pkg/k8s/deployments/utils.go
+++ b/pkg/k8s/deployments/utils.go
@@ -42,3 +42,12 @@ func setTranslationAsAnnotation(o metav1.Object, tr *model.Translation) error {
 	setAnnotation(o, okLabels.TranslationAnnotation, string(translationBytes))
 	return nil
 }
+
+func getTranslationFromAnnotation(annotations map[string]string) (model.Translation, error) {
+	tr := model.Translation{}
+	err := json.Unmarshal([]byte(annotations[okLabels.TranslationAnnotation]), &tr)
+	if err != nil {
+		return model.Translation{}, err
+	}
+	return tr, nil
+}

--- a/pkg/k8s/deployments/utils_test.go
+++ b/pkg/k8s/deployments/utils_test.go
@@ -1,0 +1,55 @@
+package deployments
+
+import (
+	"reflect"
+	"testing"
+
+	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
+	"github.com/okteto/okteto/pkg/model"
+)
+
+func Test_set_translation_as_annotation_and_back(t *testing.T) {
+	manifest := []byte(`name: web
+container: dev
+image: web:latest
+command: ["./run_web.sh"]
+workdir: /app
+annotations:
+  key1: value1
+  key2: value2`)
+	dev, err := model.Read(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := dev.GevSandbox()
+	dev.DevPath = "okteto.yml"
+	translations, err := GetTranslations(dev, d, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr1 := translations[d.Name]
+	setTranslationAsAnnotation(d.GetObjectMeta(), tr1)
+	translationString := d.GetObjectMeta().GetAnnotations()[okLabels.TranslationAnnotation]
+	if translationString == "" {
+		t.Fatal("Marshalled translation was not found in the deployment's annotations")
+	}
+	tr2, err := getTranslationFromAnnotation(d.GetObjectMeta().GetAnnotations())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr1.Name != tr2.Name {
+		t.Fatal("Mismatching Name value between original and unmarshalled translation")
+	}
+	if tr1.Version != tr2.Version {
+		t.Fatal("Mismatching Version value between original and unmarshalled translation")
+	}
+	if tr1.Interactive != tr2.Interactive {
+		t.Fatal("Mismatching Interactive flag between original and unmarshalled translation")
+	}
+	if tr1.Replicas != tr2.Replicas {
+		t.Fatal("Mismatching Replicas count between original and unmarshalled translation")
+	}
+	if !reflect.DeepEqual(tr1.Annotations, tr2.Annotations) {
+		t.Fatal("Mismatching Annotations between original and unmarshalled translation")
+	}
+}

--- a/pkg/k8s/deployments/utils_test.go
+++ b/pkg/k8s/deployments/utils_test.go
@@ -28,7 +28,9 @@ annotations:
 		t.Fatal(err)
 	}
 	tr1 := translations[d.Name]
-	setTranslationAsAnnotation(d.GetObjectMeta(), tr1)
+	if err := setTranslationAsAnnotation(d.GetObjectMeta(), tr1); err != nil {
+		t.Fatal(err)
+	}
 	translationString := d.GetObjectMeta().GetAnnotations()[okLabels.TranslationAnnotation]
 	if translationString == "" {
 		t.Fatal("Marshalled translation was not found in the deployment's annotations")

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -53,6 +53,7 @@ var (
 type Dev struct {
 	Name            string               `json:"name" yaml:"name"`
 	Labels          map[string]string    `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations     map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Namespace       string               `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Container       string               `json:"container,omitempty" yaml:"container,omitempty"`
 	Image           string               `json:"image,omitempty" yaml:"image,omitempty"`
@@ -185,6 +186,9 @@ func (dev *Dev) setDefaults() error {
 	if dev.Labels == nil {
 		dev.Labels = map[string]string{}
 	}
+	if dev.Annotations == nil {
+		dev.Annotations = map[string]string{}
+	}
 	dev.Volumes = uniqueStrings(dev.Volumes)
 	for _, s := range dev.Services {
 		if s.MountPath == "" && s.WorkDir == "" {
@@ -199,6 +203,9 @@ func (dev *Dev) setDefaults() error {
 		}
 		if s.Labels == nil {
 			s.Labels = map[string]string{}
+		}
+		if s.Annotations == nil {
+			s.Annotations = map[string]string{}
 		}
 		if s.Name != "" && len(s.Labels) > 0 {
 			return fmt.Errorf("'name' and 'labels' cannot be defined at the same time for service '%s'", s.Name)
@@ -430,6 +437,7 @@ func (dev *Dev) GevSandbox() *appsv1.Deployment {
 					Labels: map[string]string{
 						"app": dev.Name,
 					},
+					Annotations: dev.Annotations,
 				},
 				Spec: apiv1.PodSpec{
 					TerminationGracePeriodSeconds: &devTerminationGracePeriodSeconds,

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -437,12 +437,11 @@ func (dev *Dev) GevSandbox() *appsv1.Deployment {
 					Labels: map[string]string{
 						"app": dev.Name,
 					},
-					Annotations: dev.Annotations,
 				},
 				Spec: apiv1.PodSpec{
 					TerminationGracePeriodSeconds: &devTerminationGracePeriodSeconds,
 					Containers: []apiv1.Container{
-						apiv1.Container{
+						{
 							Name:            "dev",
 							Image:           dev.Image,
 							ImagePullPolicy: apiv1.PullAlways,

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -13,6 +13,9 @@ name: deployment
 container: core
 image: code/core:0.1.8
 command: ["uwsgi"]
+annotations:
+  key1: value1
+  key2: value2
 resources:
   requests:
     memory: "64Mi"
@@ -58,6 +61,10 @@ workdir: /app`)
 	cpu = d.Resources.Limits["cpu"]
 	if cpu.String() != "500m" {
 		t.Errorf("Resources.Requests.CPU was not parsed correctly. Expected '500M', got '%s'", cpu.String())
+	}
+
+	if d.Annotations["key1"] != "value1" && d.Annotations["key2"] != "value2" {
+		t.Errorf("Annotations were not parsed correctly")
 	}
 
 	if !reflect.DeepEqual(d.SecurityContext.Capabilities.Add, []apiv1.Capability{"SYS_TRACE"}) {

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -19,6 +19,7 @@ type Translation struct {
 type TranslationRule struct {
 	Marker          string               `json:"marker"`
 	Node            string               `json:"node,omitempty"`
+	Annotations     map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Container       string               `json:"container,omitempty"`
 	Image           string               `json:"image,omitempty"`
 	ImagePullPolicy apiv1.PullPolicy     `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -11,6 +11,7 @@ type Translation struct {
 	Name        string             `json:"name"`
 	Version     string             `json:"version"`
 	Deployment  *appsv1.Deployment `json:"-"`
+	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Replicas    int32              `json:"replicas"`
 	Rules       []*TranslationRule `json:"rules"`
 }
@@ -19,7 +20,6 @@ type Translation struct {
 type TranslationRule struct {
 	Marker          string               `json:"marker"`
 	Node            string               `json:"node,omitempty"`
-	Annotations     map[string]string    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Container       string               `json:"container,omitempty"`
 	Image           string               `json:"image,omitempty"`
 	ImagePullPolicy apiv1.PullPolicy     `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`


### PR DESCRIPTION
## Proposed changes
This PR adds annotations for the deployment Pod.
This is useful in conjunction with [kube2iam](https://github.com/jtblin/kube2iam) in order to assign a role to the okteto pod.

This makes the using the following development manifest possible:

```yaml
name: okteto
image: python:3.5
annotations:
  key1: value1
  key2: value2
command:
- bash
workdir: /okteto
```

```bash
$ okteto up

 ✓  Development environment activated
 ✓  Files synchronized
    Namespace: default
    Name:      okteto
    Forward:   8080 -> 8080
               2345 -> 2345
```

```bash
$ kubectl get pod okteto-7b9fc7c989-k4jkf -o jsonpath='{.metadata.annotations}{"\n"}'
map[key1:value1 key2:value2]
```

