### PR TITLE
only delete the spawned syncthing  on shutdown

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -154,7 +154,7 @@ func stopSyncthing(dev *model.Dev) {
 		return
 	}
 
-	if err := sy.Stop(); err != nil {
+	if err := sy.Stop(true); err != nil {
 		log.Infof("failed to stop existing syncthing")
 	}
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -263,7 +263,7 @@ func (up *UpContext) WaitUntilExitOrInterrupt() error {
 		case err := <-up.Running:
 			fmt.Println()
 			if err != nil {
-				log.Infof("Command execution error: %s\n", err)
+				log.Infof("Command execution error: %s", err)
 				return errors.ErrCommandFailed
 			}
 			return nil
@@ -316,7 +316,7 @@ func (up *UpContext) devMode(isRetry bool, d *appsv1.Deployment, create bool) er
 		return err
 	}
 
-	if err := up.Sy.Stop(); err != nil {
+	if err := up.Sy.Stop(true); err != nil {
 		log.Infof("failed to stop existing syncthing: %s", err)
 	}
 
@@ -534,6 +534,10 @@ func (up *UpContext) shutdown() {
 		if err := ssh.RemoveEntry(up.Dev.Name); err != nil {
 			log.Infof("failed to remove ssh entry: %s", err)
 		}
+	}
+
+	if err := up.Sy.Stop(false); err != nil {
+		log.Info("failed to stop syncthing during shutdown: %s", err)
 	}
 
 	log.Debugf("waiting for tasks for be done")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -537,7 +537,7 @@ func (up *UpContext) shutdown() {
 	}
 
 	if err := up.Sy.Stop(false); err != nil {
-		log.Info("failed to stop syncthing during shutdown: %s", err)
+		log.Infof("failed to stop syncthing during shutdown: %s", err)
 	}
 
 	log.Debugf("waiting for tasks for be done")

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -412,7 +412,7 @@ func (s *Syncthing) Stop(force bool) error {
 
 	if !force {
 		if pid != s.pid {
-			log.Infof("syncthing pid-%d wasn't created by this command, not stopping", pid)
+			log.Infof("syncthing pid-%d wasn't created by this command, skipping", pid)
 			return nil
 		}
 	}
@@ -494,31 +494,6 @@ func getPID(pidPath string) (int, error) {
 	}
 
 	return strconv.Atoi(string(content))
-}
-
-// Exists returns true if the syncthing process exists
-func Exists(home string) bool {
-	pidPath := filepath.Join(home, syncthingPidFile)
-	pid, err := getPID(pidPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-	}
-
-	process, err := ps.FindProcess(pid)
-	if process == nil && err == nil {
-		return false
-	}
-
-	if err != nil {
-		log.Infof("error when looking up the process: %s", err)
-		return true
-	}
-
-	log.Debugf("found %s pid-%d ppid-%d", process.Executable(), process.Pid(), process.PPid())
-
-	return process.Executable() == getBinaryName()
 }
 
 // GetInstallPath returns the expected install path for syncthing


### PR DESCRIPTION
if `okteto up` dies because of a second `okteto up` command, don't kill syncthing to prevent a race condition.