### PR TITLE
template for vscode remote development

### DIFF
--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -27,6 +27,7 @@ const (
 	java       = "java"
 	ruby       = "ruby"
 	csharp     = "csharp"
+	vscode     = "vscode"
 
 	// Unrecognized is the option returned when the linguist couldn't detect a language
 	Unrecognized = "other"
@@ -128,6 +129,21 @@ func init() {
 			{
 				Local:  5000,
 				Remote: 5000,
+			},
+		},
+	}
+
+	languageDefaults[vscode] = languageDefault{
+		image:   model.DefaultImage,
+		command: []string{"bash"},
+		volumes: []string{
+			"/root/.vscode-server",
+		},
+		securityContext: &model.SecurityContext{
+			Capabilities: &model.Capabilities{
+				Add: []apiv1.Capability{
+					apiv1.Capability("SYS_PTRACE"),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
with the change in #515, I think we should at least have a template. On the `remote-kubernetes` extension we can show it as `Default VS Code dev env` or something like that.