### PR TITLE
Follow kubectl behavior for namespaces

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -35,8 +35,8 @@ func Down() *cobra.Command {
 				return err
 			}
 
-			if namespace != "" {
-				dev.Namespace = namespace
+			if err := dev.UpdateNamespace(namespace); err != nil {
+				return err
 			}
 
 			if err := runDown(dev); err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -33,8 +33,8 @@ func Exec() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if namespace != "" {
-				dev.Namespace = namespace
+			if err := dev.UpdateNamespace(namespace); err != nil {
+				return err
 			}
 			err = executeExec(ctx, dev, args)
 			analytics.TrackExec(dev.Image, config.VersionString, err == nil)

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -23,8 +23,8 @@ func Restart() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if namespace != "" {
-				dev.Namespace = namespace
+			if err := dev.UpdateNamespace(namespace); err != nil {
+				return err
 			}
 
 			if err := executeRestart(dev); err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -90,8 +90,8 @@ func Up() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if namespace != "" {
-				dev.Namespace = namespace
+			if err := dev.UpdateNamespace(namespace); err != nil {
+				return err
 			}
 
 			err = RunUp(dev, remote)

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -398,6 +398,18 @@ func (dev *Dev) ToTranslationRule(main *Dev, d *appsv1.Deployment) *TranslationR
 	return rule
 }
 
+//UpdateNamespace updates the dev namespace
+func (dev *Dev) UpdateNamespace(namespace string) error {
+	if namespace == "" {
+		return nil
+	}
+	if dev.Namespace != "" && dev.Namespace != namespace {
+		return fmt.Errorf("the namespace in the okteto manifest '%s' does not match the namespace '%s'", dev.Namespace, namespace)
+	}
+	dev.Namespace = namespace
+	return nil
+}
+
 //GevSandbox returns a deployment sandbox
 func (dev *Dev) GevSandbox() *appsv1.Deployment {
 	if dev.Image == "" {


### PR DESCRIPTION
`kubectl` prioritizes the flag or the field namespace in the k8s manifest over the context. If the user defines the namespace both, in the manifest and the flag, they must be the same or otherwise it fails with this error:
```
error: the namespace from the provided object "pepe" does not match the namespace "jose"
```