### PR TITLE
Remove unnecessary path.Base function call

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -174,8 +174,8 @@ func askForLanguage() (string, error) {
 	return supportedLanguages[i], nil
 }
 
-func getDeploymentName(name string) string {
-	deploymentName := filepath.Base(name)
+func getDeploymentName(workDir string) string {
+	deploymentName := filepath.Base(workDir)
 	deploymentName = strings.ToLower(deploymentName)
 	deploymentName = model.ValidKubeNameRegex.ReplaceAllString(deploymentName, "-")
 	log.Infof("deployment name: %s", deploymentName)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -66,7 +66,7 @@ func executeInit(devPath string, overwrite bool) error {
 		}
 	}
 
-	root, err := os.Getwd()
+	workDir, err := os.Getwd()
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func executeInit(devPath string, overwrite bool) error {
 		dev = linguist.GetDevConfig(l)
 		language = l
 	} else {
-		l, err := linguist.ProcessDirectory(root)
+		l, err := linguist.ProcessDirectory(workDir)
 		if err != nil {
 			log.Info(err)
 			return fmt.Errorf("Failed to determine the language of the current directory")
@@ -98,7 +98,7 @@ func executeInit(devPath string, overwrite bool) error {
 		dev.Image = askForImage(language, dev.Image)
 	}
 
-	dev.Name = getDeploymentName(filepath.Base(root))
+	dev.Name = getDeploymentName(filepath.Base(workDir))
 
 	marshalled, err := yaml.Marshal(dev)
 	if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -98,7 +98,7 @@ func executeInit(devPath string, overwrite bool) error {
 		dev.Image = askForImage(language, dev.Image)
 	}
 
-	dev.Name = getDeploymentName(filepath.Base(workDir))
+	dev.Name = getDeploymentName(workDir)
 
 	marshalled, err := yaml.Marshal(dev)
 	if err != nil {


### PR DESCRIPTION
# Fixes
`executeInit` in `cmd/init.go` was calling `path.Base` unnecessarily since `path.Base` is being call inside `getDeploymentName`.
## Proposed changes
- Remove the call
- Rename root to workDir
