### PR TITLE
Flag to force pull of dev images on "okteto up"

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -66,6 +66,7 @@ func Up() *cobra.Command {
 	var namespace string
 	var remote int
 	var autoDeploy bool
+	var forcePull bool
 	cmd := &cobra.Command{
 		Use:   "up",
 		Short: "Activates your development environment",
@@ -95,7 +96,7 @@ func Up() *cobra.Command {
 				return err
 			}
 
-			err = RunUp(dev, remote, autoDeploy)
+			err = RunUp(dev, remote, autoDeploy, forcePull)
 			return err
 		},
 	}
@@ -104,11 +105,12 @@ func Up() *cobra.Command {
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the up command is executed")
 	cmd.Flags().IntVarP(&remote, "remote", "r", 0, "configures remote execution on the specified port")
 	cmd.Flags().BoolVarP(&autoDeploy, "deploy", "d", false, "create deployment when it doesn't exist in a namespace")
+	cmd.Flags().BoolVarP(&forcePull, "pull", "", false, "force dev image pull")
 	return cmd
 }
 
 //RunUp starts the up sequence
-func RunUp(dev *model.Dev, remote int, autoDeploy bool) error {
+func RunUp(dev *model.Dev, remote int, autoDeploy bool, forcePull bool) error {
 	up := &UpContext{
 		Dev:        dev,
 		Exit:       make(chan error, 1),
@@ -119,6 +121,10 @@ func RunUp(dev *model.Dev, remote int, autoDeploy bool) error {
 
 	if up.remoteModeEnabled() {
 		dev.LoadRemote(int(remote))
+	}
+
+	if forcePull {
+		dev.LoadForcePull()
 	}
 
 	stop := make(chan os.Signal, 1)

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -182,12 +182,17 @@ func DevModeOff(d *appsv1.Deployment, c *kubernetes.Clientset) error {
 			return err
 		}
 		delete(annotations, okLabels.TranslationAnnotation)
+		delete(annotations, model.OktetoRestartAnnotation)
 		d.Spec.Template.GetObjectMeta().SetAnnotations(annotations)
 		labels := d.GetObjectMeta().GetLabels()
 		delete(labels, okLabels.DevLabel)
 		delete(labels, okLabels.InteractiveDevLabel)
 		delete(labels, okLabels.DetachedDevLabel)
 		d.GetObjectMeta().SetLabels(labels)
+		labels = d.Spec.Template.GetObjectMeta().GetLabels()
+		delete(labels, okLabels.InteractiveDevLabel)
+		delete(labels, okLabels.DetachedDevLabel)
+		d.Spec.Template.GetObjectMeta().SetLabels(labels)
 	}
 
 	if err := update(d, c); err != nil {

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -72,8 +72,6 @@ func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientse
 	}
 	setAnnotation(t.Deployment.GetObjectMeta(), oktetoDeploymentAnnotation, string(manifestBytes))
 
-	TranslatePodUserAnnotations(t.Deployment.Spec.Template.GetObjectMeta(), t.Annotations)
-
 	commonTranslation(t)
 
 	setLabel(t.Deployment.Spec.Template.GetObjectMeta(), okLabels.DevLabel, "true")
@@ -98,6 +96,7 @@ func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientse
 }
 
 func commonTranslation(t *model.Translation) {
+	TranslatePodUserAnnotations(t.Deployment.Spec.Template.GetObjectMeta(), t.Annotations)
 	setAnnotation(t.Deployment.GetObjectMeta(), oktetoDeveloperAnnotation, okteto.GetUserID())
 	setAnnotation(t.Deployment.GetObjectMeta(), oktetoVersionAnnotation, okLabels.Version)
 	setLabel(t.Deployment.GetObjectMeta(), okLabels.DevLabel, "true")

--- a/pkg/k8s/deployments/utils_test.go
+++ b/pkg/k8s/deployments/utils_test.go
@@ -1,7 +1,6 @@
 package deployments
 
 import (
-	"reflect"
 	"testing"
 
 	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
@@ -50,8 +49,5 @@ annotations:
 	}
 	if tr1.Replicas != tr2.Replicas {
 		t.Fatal("Mismatching Replicas count between original and unmarshalled translation")
-	}
-	if !reflect.DeepEqual(tr1.Annotations, tr2.Annotations) {
-		t.Fatal("Mismatching Annotations between original and unmarshalled translation")
 	}
 }

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -11,7 +11,7 @@ type Translation struct {
 	Name        string             `json:"name"`
 	Version     string             `json:"version"`
 	Deployment  *appsv1.Deployment `json:"-"`
-	Annotations map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Annotations map[string]string  `json:"-"`
 	Replicas    int32              `json:"replicas"`
 	Rules       []*TranslationRule `json:"rules"`
 }


### PR DESCRIPTION
Fixes #552

## Proposed changes
- Flag `--pull` overwrites the field `imagePullPolicy` and forces recreation of dev pods
