### PR TITLE
update to bin 1.0.7

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -26,7 +26,7 @@ const (
 	oktetoVolumeName           = "okteto"
 
 	//syncthing
-	oktetoBinImageTag        = "okteto/bin:1.0.6"
+	oktetoBinImageTag        = "okteto/bin:1.0.7"
 	oktetoSyncSecretVolume   = "okteto-sync-secret"
 	oktetoSyncSecretTemplate = "okteto-%s"
 )


### PR DESCRIPTION
Enables --remote support for phpstorm and pycharm. 

Fixes #571 and contributes toward #574 
