### PR TITLE
expand image name if there are env vars

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -178,6 +179,11 @@ func Read(bytes []byte) (*Dev, error) {
 		msg = strings.TrimSuffix(msg, "in type model.Dev")
 		return nil, errors.New(msg)
 	}
+
+	if len(dev.Image) > 0 {
+		dev.Image = os.ExpandEnv(dev.Image)
+	}
+
 	if err := dev.setDefaults(); err != nil {
 		return nil, err
 	}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -179,6 +181,58 @@ forward:
 				}
 			}
 
+		})
+	}
+}
+
+func Test_loadDevImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		want     string
+		image    string
+		tagValue string
+	}{
+		{
+			name:     "tag",
+			want:     "code/core:dev",
+			image:    "code/core:${tag}",
+			tagValue: "dev",
+		},
+		{
+			name:     "registry",
+			want:     "dev/core:latest",
+			image:    "${tag}/core:latest",
+			tagValue: "dev",
+		},
+		{
+			name:     "full",
+			want:     "dev/core:latest",
+			image:    "${tag}",
+			tagValue: "dev/core:latest",
+		},
+		{
+			name:     "missing",
+			want:     "code/core:",
+			image:    "code/core:${image}",
+			tagValue: "tag",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manifest := []byte(fmt.Sprintf(`
+name: deployment
+image: %s
+`, tt.image))
+			os.Setenv("tag", tt.tagValue)
+			d, err := Read(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d.Image != tt.want {
+				t.Errorf("got: %s, expected: %s", d.Image, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #576 

## Proposed changes
- Expand env vars found in the `image` key of the manifest, following the same rules as the ports.
