### PR TITLE
support remote from the manifest

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -60,7 +60,6 @@ type UpContext struct {
 	Sy         *syncthing.Syncthing
 	ErrChan    chan error
 	cleaned    chan struct{}
-	remotePort int
 	success    bool
 }
 
@@ -437,7 +436,7 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 	}
 
 	if up.remoteModeEnabled() {
-		if err := ssh.AddEntry(up.Dev.Name, up.remotePort); err != nil {
+		if err := ssh.AddEntry(up.Dev.Name, up.Dev.RemotePort); err != nil {
 			return err
 		}
 	}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/model"
 )
 
 func Test_remoteEnabled(t *testing.T) {
@@ -14,7 +15,8 @@ func Test_remoteEnabled(t *testing.T) {
 		t.Errorf("default should be remote disabled")
 	}
 
-	up.remotePort = 22000
+	up.Dev = &model.Dev{RemotePort: 22000}
+
 	if !up.remoteModeEnabled() {
 		t.Errorf("remote should be enabled after adding a port")
 	}

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -26,7 +26,7 @@ const (
 	oktetoVolumeName           = "okteto"
 
 	//syncthing
-	oktetoBinImageTag        = "okteto/bin:1.0.7"
+	oktetoBinImageTag        = "okteto/bin:1.0.8"
 	oktetoSyncSecretVolume   = "okteto-sync-secret"
 	oktetoSyncSecretTemplate = "okteto-%s"
 )

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -76,6 +76,7 @@ type Dev struct {
 	Volumes         []Volume             `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 	SecurityContext *SecurityContext     `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 	Forward         []Forward            `json:"forward,omitempty" yaml:"forward,omitempty"`
+	RemotePort      int                  `json:"remote,omitempty" yaml:"remote,omitempty"`
 	Resources       ResourceRequirements `json:"resources,omitempty" yaml:"resources,omitempty"`
 	DevPath         string               `json:"-" yaml:"-"`
 	DevDir          string               `json:"-" yaml:"-"`
@@ -280,22 +281,16 @@ func validatePullPolicy(pullPolicy apiv1.PullPolicy) error {
 }
 
 //LoadRemote configures remote execution
-func (dev *Dev) LoadRemote(localPort int) {
+func (dev *Dev) LoadRemote() {
 	dev.Command = []string{"/var/okteto/bin/remote"}
 	dev.Forward = append(
 		dev.Forward,
 		Forward{
-			Local:  localPort,
-			Remote: 22100,
+			Local:  dev.RemotePort,
+			Remote: 22,
 		},
 	)
-	dev.Environment = append(
-		dev.Environment,
-		EnvVar{
-			Name:  oktetoRemotePortVariable,
-			Value: "22100",
-		},
-	)
+
 	log.Infof("enabled remote mode")
 }
 

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -269,6 +269,7 @@ func Test_LoadRemote(t *testing.T) {
   container: core
   image: code/core:0.1.8
   command: ["uwsgi"]
+  remote: 22100
   annotations:
     key1: value1
     key2: value2
@@ -295,7 +296,7 @@ func Test_LoadRemote(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dev.LoadRemote(22100)
+	dev.LoadRemote()
 
 	if dev.Command[0] != "/var/okteto/bin/remote" {
 		t.Errorf("remote command wasn't set: %s", dev.Command)
@@ -307,14 +308,6 @@ func Test_LoadRemote(t *testing.T) {
 
 	if dev.Forward[1].Local != 22100 {
 		t.Errorf("local forward wasn't 22100 it was %d", dev.Forward[1].Local)
-	}
-
-	if len(dev.Environment) != 2 {
-		t.Errorf("Environment value wasn't injected")
-	}
-
-	if dev.Environment[1].Name != "OKTETO_REMOTE_PORT" {
-		t.Errorf("injected env var wasn't OKTETO_REMOTE_PORT it was %s", dev.Environment[1].Name)
 	}
 }
 


### PR DESCRIPTION
Fixes #570 

## Proposed changes
- Adds the key `remote` to the manifest, functioning just as the --remote parameter. 

