### PR TITLE
Support for remote forward tunnels

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -434,7 +434,7 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 
 		remoteForwardManager := ssh.NewRemoteForwardManager(up.Context, up.Dev.RemotePort)
 		for _, f := range up.Dev.RemoteForward {
-			if err := remoteForwardManager.Add(f.Local, f.Remote); err != nil {
+			if err := remoteForwardManager.Add(&f); err != nil {
 				return err
 			}
 		}
@@ -635,6 +635,12 @@ func printDisplayContext(message string, dev *model.Dev) {
 		log.Println(fmt.Sprintf("    %s   %d -> %d", log.BlueString("Forward:"), dev.Forward[0].Local, dev.Forward[0].Remote))
 		for i := 1; i < len(dev.Forward); i++ {
 			log.Println(fmt.Sprintf("               %d -> %d", dev.Forward[i].Local, dev.Forward[i].Remote))
+		}
+	}
+	if len(dev.RemoteForward) > 0 {
+		log.Println(fmt.Sprintf("    %s    %d -> %d", log.BlueString("Remote:"), dev.RemoteForward[0].Remote, dev.RemoteForward[0].Local))
+		for i := 1; i < len(dev.RemoteForward); i++ {
+			log.Println(fmt.Sprintf("               %d -> %d", dev.RemoteForward[i].Remote, dev.RemoteForward[i].Local))
 		}
 	}
 	fmt.Println()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -432,14 +432,14 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 			return err
 		}
 
-		remoteForwardManager := ssh.NewRemoteForwardManager(up.Context, up.Dev.RemotePort)
-		for _, f := range up.Dev.RemoteForward {
-			if err := remoteForwardManager.Add(&f); err != nil {
+		reverseManager := ssh.NewReverseManager(up.Context, up.Dev.RemotePort)
+		for _, f := range up.Dev.Reverse {
+			if err := reverseManager.Add(&f); err != nil {
 				return err
 			}
 		}
 
-		if err := remoteForwardManager.Start(); err != nil {
+		if err := reverseManager.Start(); err != nil {
 			return err
 		}
 	}
@@ -637,10 +637,10 @@ func printDisplayContext(message string, dev *model.Dev) {
 			log.Println(fmt.Sprintf("               %d -> %d", dev.Forward[i].Local, dev.Forward[i].Remote))
 		}
 	}
-	if len(dev.RemoteForward) > 0 {
-		log.Println(fmt.Sprintf("    %s    %d -> %d", log.BlueString("Remote:"), dev.RemoteForward[0].Remote, dev.RemoteForward[0].Local))
-		for i := 1; i < len(dev.RemoteForward); i++ {
-			log.Println(fmt.Sprintf("               %d -> %d", dev.RemoteForward[i].Remote, dev.RemoteForward[i].Local))
+	if len(dev.Reverse) > 0 {
+		log.Println(fmt.Sprintf("    %s    %d <- %d", log.BlueString("Reverse:"), dev.Reverse[0].Local, dev.Reverse[0].Remote))
+		for i := 1; i < len(dev.Reverse); i++ {
+			log.Println(fmt.Sprintf("               %d <- %d", dev.Reverse[i].Local, dev.Reverse[i].Remote))
 		}
 	}
 	fmt.Println()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -638,7 +638,7 @@ func printDisplayContext(message string, dev *model.Dev) {
 		}
 	}
 	if len(dev.Reverse) > 0 {
-		log.Println(fmt.Sprintf("    %s    %d <- %d", log.BlueString("Reverse:"), dev.Reverse[0].Local, dev.Reverse[0].Remote))
+		log.Println(fmt.Sprintf("    %s   %d <- %d", log.BlueString("Reverse:"), dev.Reverse[0].Local, dev.Reverse[0].Remote))
 		for i := 1; i < len(dev.Reverse); i++ {
 			log.Println(fmt.Sprintf("               %d <- %d", dev.Reverse[i].Local, dev.Reverse[i].Remote))
 		}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/model"
 )
 
 func TestWaitUntilExitOrInterrupt(t *testing.T) {
@@ -32,4 +33,58 @@ func TestWaitUntilExitOrInterrupt(t *testing.T) {
 	if err != errors.ErrLostConnection {
 		t.Errorf("exited with error %s instead of %s", err, errors.ErrLostConnection)
 	}
+}
+
+func Test_printDisplayContext(t *testing.T) {
+	var tests = []struct {
+		name string
+		dev  *model.Dev
+	}{
+		{
+			name: "basic",
+			dev: &model.Dev{
+				Name:      "dev",
+				Namespace: "namespace",
+			},
+		},
+		{
+			name: "single-forward",
+			dev: &model.Dev{
+				Name:      "dev",
+				Namespace: "namespace",
+				Forward:   []model.Forward{{Local: 1000, Remote: 1000}},
+			},
+		},
+		{
+			name: "multiple-forward",
+			dev: &model.Dev{
+				Name:      "dev",
+				Namespace: "namespace",
+				Forward:   []model.Forward{{Local: 1000, Remote: 1000}, {Local: 2000, Remote: 2000}},
+			},
+		},
+		{
+			name: "single-reverse",
+			dev: &model.Dev{
+				Name:      "dev",
+				Namespace: "namespace",
+				Reverse:   []model.Reverse{{Local: 1000, Remote: 1000}},
+			},
+		},
+		{
+			name: "multiple-reverse",
+			dev: &model.Dev{
+				Name:      "dev",
+				Namespace: "namespace",
+				Reverse:   []model.Reverse{{Local: 1000, Remote: 1000}, {Local: 2000, Remote: 2000}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			printDisplayContext(tt.name, tt.dev)
+		})
+	}
+
 }

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -76,7 +76,7 @@ type Dev struct {
 	Volumes         []Volume             `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 	SecurityContext *SecurityContext     `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 	Forward         []Forward            `json:"forward,omitempty" yaml:"forward,omitempty"`
-	RemoteForward   []Forward            `json:"remoteForward,omitempty" yaml:"remoteForward,omitempty"`
+	RemoteForward   []RemoteForward      `json:"remoteForward,omitempty" yaml:"remoteForward,omitempty"`
 	RemotePort      int                  `json:"remote,omitempty" yaml:"remote,omitempty"`
 	Resources       ResourceRequirements `json:"resources,omitempty" yaml:"resources,omitempty"`
 	DevPath         string               `json:"-" yaml:"-"`
@@ -114,6 +114,12 @@ type EnvVar struct {
 type Forward struct {
 	Local  int
 	Remote int
+}
+
+// RemoteForward represents a remote forward port
+type RemoteForward struct {
+	Remote int
+	Local  int
 }
 
 // ResourceRequirements describes the compute resource requirements.
@@ -234,6 +240,7 @@ func (dev *Dev) setDefaults() error {
 		}
 		s.Namespace = ""
 		s.Forward = make([]Forward, 0)
+		s.RemoteForward = make([]RemoteForward, 0)
 		s.Volumes = make([]Volume, 0)
 		s.Services = make([]*Dev, 0)
 	}
@@ -283,6 +290,10 @@ func validatePullPolicy(pullPolicy apiv1.PullPolicy) error {
 
 //LoadRemote configures remote execution
 func (dev *Dev) LoadRemote() {
+	if dev.RemotePort == 0 {
+		dev.RemotePort = 2222
+	}
+
 	dev.Forward = append(
 		dev.Forward,
 		Forward{
@@ -483,5 +494,9 @@ func (dev *Dev) RemoteModeEnabled() bool {
 		return false
 	}
 
-	return dev.RemotePort > 0
+	if dev.RemotePort > 0 {
+		return true
+	}
+
+	return len(dev.RemoteForward) > 0
 }

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -76,7 +76,7 @@ type Dev struct {
 	Volumes         []Volume             `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 	SecurityContext *SecurityContext     `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 	Forward         []Forward            `json:"forward,omitempty" yaml:"forward,omitempty"`
-	Reverse   []Reverse      `json:"reverse,omitempty" yaml:"reverse,omitempty"`
+	Reverse         []Reverse            `json:"reverse,omitempty" yaml:"reverse,omitempty"`
 	RemotePort      int                  `json:"remote,omitempty" yaml:"remote,omitempty"`
 	Resources       ResourceRequirements `json:"resources,omitempty" yaml:"resources,omitempty"`
 	DevPath         string               `json:"-" yaml:"-"`
@@ -291,7 +291,13 @@ func validatePullPolicy(pullPolicy apiv1.PullPolicy) error {
 //LoadRemote configures remote execution
 func (dev *Dev) LoadRemote() {
 	if dev.RemotePort == 0 {
-		dev.RemotePort = 2222
+		p, err := GetAvailablePort()
+		if err != nil {
+			log.Infof("failed to get random port for SSH connection: %s", err)
+			p = 2222
+		}
+
+		dev.RemotePort = p
 		log.Infof("remote port not set, using %d", dev.RemotePort)
 	}
 

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -292,6 +292,7 @@ func validatePullPolicy(pullPolicy apiv1.PullPolicy) error {
 func (dev *Dev) LoadRemote() {
 	if dev.RemotePort == 0 {
 		dev.RemotePort = 2222
+		log.Infof("remote port not set, using %d", dev.RemotePort)
 	}
 
 	dev.Forward = append(

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -76,7 +76,7 @@ type Dev struct {
 	Volumes         []Volume             `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 	SecurityContext *SecurityContext     `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 	Forward         []Forward            `json:"forward,omitempty" yaml:"forward,omitempty"`
-	RemoteForward   []RemoteForward      `json:"remoteForward,omitempty" yaml:"remoteForward,omitempty"`
+	Reverse   []Reverse      `json:"reverse,omitempty" yaml:"reverse,omitempty"`
 	RemotePort      int                  `json:"remote,omitempty" yaml:"remote,omitempty"`
 	Resources       ResourceRequirements `json:"resources,omitempty" yaml:"resources,omitempty"`
 	DevPath         string               `json:"-" yaml:"-"`
@@ -116,8 +116,8 @@ type Forward struct {
 	Remote int
 }
 
-// RemoteForward represents a remote forward port
-type RemoteForward struct {
+// Reverse represents a remote forward port
+type Reverse struct {
 	Remote int
 	Local  int
 }
@@ -240,7 +240,7 @@ func (dev *Dev) setDefaults() error {
 		}
 		s.Namespace = ""
 		s.Forward = make([]Forward, 0)
-		s.RemoteForward = make([]RemoteForward, 0)
+		s.Reverse = make([]Reverse, 0)
 		s.Volumes = make([]Volume, 0)
 		s.Services = make([]*Dev, 0)
 	}
@@ -499,5 +499,5 @@ func (dev *Dev) RemoteModeEnabled() bool {
 		return true
 	}
 
-	return len(dev.RemoteForward) > 0
+	return len(dev.Reverse) > 0
 }

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -76,6 +76,7 @@ type Dev struct {
 	Volumes         []Volume             `json:"volumes,omitempty" yaml:"volumes,omitempty"`
 	SecurityContext *SecurityContext     `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
 	Forward         []Forward            `json:"forward,omitempty" yaml:"forward,omitempty"`
+	RemoteForward   []Forward            `json:"remoteForward,omitempty" yaml:"remoteForward,omitempty"`
 	RemotePort      int                  `json:"remote,omitempty" yaml:"remote,omitempty"`
 	Resources       ResourceRequirements `json:"resources,omitempty" yaml:"resources,omitempty"`
 	DevPath         string               `json:"-" yaml:"-"`

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -311,7 +311,7 @@ func Test_LoadRemote(t *testing.T) {
 	}
 }
 
-func Test_RemoteForward(t *testing.T) {
+func Test_Reverse(t *testing.T) {
 	manifest := []byte(`
   name: deployment
   container: core
@@ -320,7 +320,7 @@ func Test_RemoteForward(t *testing.T) {
   annotations:
     key1: value1
     key2: value2
-  remoteForward:
+  reverse:
     - 8080:8080`)
 	dev, err := Read(manifest)
 	if err != nil {
@@ -341,12 +341,12 @@ func Test_RemoteForward(t *testing.T) {
 		t.Errorf("local forward wasn't 22100 it was %d", dev.Forward[0].Local)
 	}
 
-	if dev.RemoteForward[0].Local != 8080 {
-		t.Errorf("remote forward local wasn't 8080 it was %d", dev.RemoteForward[0].Local)
+	if dev.Reverse[0].Local != 8080 {
+		t.Errorf("remote forward local wasn't 8080 it was %d", dev.Reverse[0].Local)
 	}
 
-	if dev.RemoteForward[0].Remote != 8080 {
-		t.Errorf("remote forward remote wasn't 8080 it was %d", dev.RemoteForward[0].Remote)
+	if dev.Reverse[0].Remote != 8080 {
+		t.Errorf("remote forward remote wasn't 8080 it was %d", dev.Reverse[0].Remote)
 	}
 }
 
@@ -396,7 +396,7 @@ func Test_remoteEnabled(t *testing.T) {
 		t.Errorf("remote should be enabled after adding a port")
 	}
 
-	dev = &Dev{RemoteForward: []RemoteForward{{Local: 22000, Remote: 22000}}}
+	dev = &Dev{Reverse: []Reverse{{Local: 22000, Remote: 22000}}}
 
 	if !dev.RemoteModeEnabled() {
 		t.Errorf("remote should be enabled after adding a remote forward")

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -337,10 +337,6 @@ func Test_Reverse(t *testing.T) {
 		t.Errorf("forward wasn't injected")
 	}
 
-	if dev.Forward[0].Local != 2222 {
-		t.Errorf("local forward wasn't 22100 it was %d", dev.Forward[0].Local)
-	}
-
 	if dev.Reverse[0].Local != 8080 {
 		t.Errorf("remote forward local wasn't 8080 it was %d", dev.Reverse[0].Local)
 	}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -311,6 +311,45 @@ func Test_LoadRemote(t *testing.T) {
 	}
 }
 
+func Test_RemoteForward(t *testing.T) {
+	manifest := []byte(`
+  name: deployment
+  container: core
+  image: code/core:0.1.8
+  command: ["uwsgi"]
+  annotations:
+    key1: value1
+    key2: value2
+  remoteForward:
+    - 8080:8080`)
+	dev, err := Read(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dev.LoadRemote()
+
+	if dev.RemotePort == 0 {
+		t.Error("remote port was not automatically enabled")
+	}
+
+	if len(dev.Forward) != 1 {
+		t.Errorf("forward wasn't injected")
+	}
+
+	if dev.Forward[0].Local != 2222 {
+		t.Errorf("local forward wasn't 22100 it was %d", dev.Forward[0].Local)
+	}
+
+	if dev.RemoteForward[0].Local != 8080 {
+		t.Errorf("remote forward local wasn't 8080 it was %d", dev.RemoteForward[0].Local)
+	}
+
+	if dev.RemoteForward[0].Remote != 8080 {
+		t.Errorf("remote forward remote wasn't 8080 it was %d", dev.RemoteForward[0].Remote)
+	}
+}
+
 func Test_LoadForcePull(t *testing.T) {
 	manifest := []byte(`
   name: a
@@ -355,5 +394,11 @@ func Test_remoteEnabled(t *testing.T) {
 
 	if !dev.RemoteModeEnabled() {
 		t.Errorf("remote should be enabled after adding a port")
+	}
+
+	dev = &Dev{RemoteForward: []RemoteForward{{Local: 22000, Remote: 22000}}}
+
+	if !dev.RemoteModeEnabled() {
+		t.Errorf("remote should be enabled after adding a remote forward")
 	}
 }

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -46,9 +46,10 @@ func (f *Forward) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if len(parts) != 2 {
 		return fmt.Errorf("Wrong port-forward syntax '%s', must be of the form 'localPort:RemotePort'", raw)
 	}
+
 	localPort, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return fmt.Errorf("Cannot convert remote port '%s' in port-forward '%s'", parts[0], raw)
+		return fmt.Errorf("Cannot convert local port '%s' in port-forward '%s'", parts[0], raw)
 	}
 	remotePort, err := strconv.Atoi(parts[1])
 	if err != nil {
@@ -62,6 +63,38 @@ func (f *Forward) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // MarshalYAML Implements the marshaler interface of the yaml pkg.
 func (f Forward) MarshalYAML() (interface{}, error) {
 	return fmt.Sprintf("%d:%d", f.Local, f.Remote), nil
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (f *RemoteForward) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw string
+	err := unmarshal(&raw)
+	if err != nil {
+		return err
+	}
+
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("Wrong port-forward syntax '%s', must be of the form 'localPort:RemotePort'", raw)
+	}
+	remotePort, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("Cannot convert remote port '%s' in remoteForward '%s'", parts[0], raw)
+	}
+
+	localPort, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return fmt.Errorf("Cannot convert local port '%s' in remoteForward '%s'", parts[1], raw)
+	}
+
+	f.Local = localPort
+	f.Remote = remotePort
+	return nil
+}
+
+// MarshalYAML Implements the marshaler interface of the yaml pkg.
+func (f RemoteForward) MarshalYAML() (interface{}, error) {
+	return fmt.Sprintf("%d:%d", f.Remote, f.Local), nil
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -66,7 +66,7 @@ func (f Forward) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
-func (f *RemoteForward) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (f *Reverse) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var raw string
 	err := unmarshal(&raw)
 	if err != nil {
@@ -79,12 +79,12 @@ func (f *RemoteForward) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	remotePort, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return fmt.Errorf("Cannot convert remote port '%s' in remoteForward '%s'", parts[0], raw)
+		return fmt.Errorf("Cannot convert remote port '%s' in reverse '%s'", parts[0], raw)
 	}
 
 	localPort, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return fmt.Errorf("Cannot convert local port '%s' in remoteForward '%s'", parts[1], raw)
+		return fmt.Errorf("Cannot convert local port '%s' in reverse '%s'", parts[1], raw)
 	}
 
 	f.Local = localPort
@@ -93,7 +93,7 @@ func (f *RemoteForward) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML Implements the marshaler interface of the yaml pkg.
-func (f RemoteForward) MarshalYAML() (interface{}, error) {
+func (f Reverse) MarshalYAML() (interface{}, error) {
 	return fmt.Sprintf("%d:%d", f.Remote, f.Local), nil
 }
 

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -3,11 +3,129 @@ package model
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	yaml "gopkg.in/yaml.v2"
 )
 
+func TestRemoteForwardMashalling(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      string
+		expected  RemoteForward
+		expectErr bool
+	}{
+		{
+			name:     "basic",
+			data:     "8080:9090",
+			expected: RemoteForward{Local: 9090, Remote: 8080},
+		},
+		{
+			name:     "equal",
+			data:     "8080:8080",
+			expected: RemoteForward{Local: 8080, Remote: 8080},
+		},
+		{
+			name:      "missing-part",
+			data:      "8080",
+			expectErr: true,
+		},
+		{
+			name:      "non-integer",
+			data:      "8080:foo",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result RemoteForward
+			if err := yaml.Unmarshal([]byte(tt.data), &result); err != nil {
+				if tt.expectErr {
+					return
+				}
+
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("didn't unmarshal correctly. Actual '%+v', Expected '%+v'", result, tt.expected)
+			}
+
+			out, err := yaml.Marshal(result)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			outStr := string(out)
+			outStr = strings.TrimSuffix(outStr, "\n")
+
+			if !reflect.DeepEqual(outStr, tt.data) {
+				t.Errorf("didn't unmarshal correctly. Actual '%+v', Expected '%+v'", outStr, tt.data)
+			}
+		})
+	}
+}
+
+func TestForwardMashalling(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      string
+		expected  Forward
+		expectErr bool
+	}{
+		{
+			name:     "basic",
+			data:     "8080:9090",
+			expected: Forward{Local: 8080, Remote: 9090},
+		},
+		{
+			name:     "equal",
+			data:     "8080:8080",
+			expected: Forward{Local: 8080, Remote: 8080},
+		},
+		{
+			name:      "missing-part",
+			data:      "8080",
+			expectErr: true,
+		},
+		{
+			name:      "non-integer",
+			data:      "8080:foo",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result Forward
+			if err := yaml.Unmarshal([]byte(tt.data), &result); err != nil {
+				if tt.expectErr {
+					return
+				}
+
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("didn't unmarshal correctly. Actual '%+v', Expected '%+v'", result, tt.expected)
+			}
+
+			out, err := yaml.Marshal(result)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			outStr := string(out)
+			outStr = strings.TrimSuffix(outStr, "\n")
+
+			if !reflect.DeepEqual(outStr, tt.data) {
+				t.Errorf("didn't unmarshal correctly. Actual '%+v', Expected '%+v'", outStr, tt.data)
+			}
+		})
+	}
+}
 func TestEnvVarMashalling(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -117,6 +235,143 @@ func TestVolumeMashalling(t *testing.T) {
 			_, err := yaml.Marshal(&v)
 			if err != nil {
 				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestEnvVar_UnmarshalYAML(t *testing.T) {
+	type fields struct {
+		Name  string
+		Value string
+	}
+	type args struct {
+		unmarshal func(interface{}) error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &EnvVar{
+				Name:  tt.fields.Name,
+				Value: tt.fields.Value,
+			}
+			if err := e.UnmarshalYAML(tt.args.unmarshal); (err != nil) != tt.wantErr {
+				t.Errorf("EnvVar.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestForward_UnmarshalYAML(t *testing.T) {
+	type fields struct {
+		Local  int
+		Remote int
+	}
+	type args struct {
+		unmarshal func(interface{}) error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &Forward{
+				Local:  tt.fields.Local,
+				Remote: tt.fields.Remote,
+			}
+			if err := f.UnmarshalYAML(tt.args.unmarshal); (err != nil) != tt.wantErr {
+				t.Errorf("Forward.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRemoteForward_UnmarshalYAML(t *testing.T) {
+	type fields struct {
+		Remote int
+		Local  int
+	}
+	type args struct {
+		unmarshal func(interface{}) error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &RemoteForward{
+				Remote: tt.fields.Remote,
+				Local:  tt.fields.Local,
+			}
+			if err := f.UnmarshalYAML(tt.args.unmarshal); (err != nil) != tt.wantErr {
+				t.Errorf("RemoteForward.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResourceList_UnmarshalYAML(t *testing.T) {
+	type args struct {
+		unmarshal func(interface{}) error
+	}
+	tests := []struct {
+		name    string
+		r       *ResourceList
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.r.UnmarshalYAML(tt.args.unmarshal); (err != nil) != tt.wantErr {
+				t.Errorf("ResourceList.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVolume_UnmarshalYAML(t *testing.T) {
+	type fields struct {
+		SubPath   string
+		MountPath string
+	}
+	type args struct {
+		unmarshal func(interface{}) error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Volume{
+				SubPath:   tt.fields.SubPath,
+				MountPath: tt.fields.MountPath,
+			}
+			if err := v.UnmarshalYAML(tt.args.unmarshal); (err != nil) != tt.wantErr {
+				t.Errorf("Volume.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -9,22 +9,22 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func TestRemoteForwardMashalling(t *testing.T) {
+func TestReverseMashalling(t *testing.T) {
 	tests := []struct {
 		name      string
 		data      string
-		expected  RemoteForward
+		expected  Reverse
 		expectErr bool
 	}{
 		{
 			name:     "basic",
 			data:     "8080:9090",
-			expected: RemoteForward{Local: 9090, Remote: 8080},
+			expected: Reverse{Local: 9090, Remote: 8080},
 		},
 		{
 			name:     "equal",
 			data:     "8080:8080",
-			expected: RemoteForward{Local: 8080, Remote: 8080},
+			expected: Reverse{Local: 8080, Remote: 8080},
 		},
 		{
 			name:      "missing-part",
@@ -40,7 +40,7 @@ func TestRemoteForwardMashalling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var result RemoteForward
+			var result Reverse
 			if err := yaml.Unmarshal([]byte(tt.data), &result); err != nil {
 				if tt.expectErr {
 					return
@@ -298,7 +298,7 @@ func TestForward_UnmarshalYAML(t *testing.T) {
 	}
 }
 
-func TestRemoteForward_UnmarshalYAML(t *testing.T) {
+func TestReverse_UnmarshalYAML(t *testing.T) {
 	type fields struct {
 		Remote int
 		Local  int
@@ -316,12 +316,12 @@ func TestRemoteForward_UnmarshalYAML(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &RemoteForward{
+			f := &Reverse{
 				Remote: tt.fields.Remote,
 				Local:  tt.fields.Local,
 			}
 			if err := f.UnmarshalYAML(tt.args.unmarshal); (err != nil) != tt.wantErr {
-				t.Errorf("RemoteForward.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Reverse.UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -20,20 +20,20 @@ type reverse struct {
 // ReverseManager handles the lifecycle of all the remote forwards
 type ReverseManager struct {
 	reverses map[int]*reverse
-	ctx            context.Context
-	sshUser        string
-	sshHost        string
-	sshPort        int
+	ctx      context.Context
+	sshUser  string
+	sshHost  string
+	sshPort  int
 }
 
 // NewReverseManager returns a newly initialized instance of RemoteReverseManager
 func NewReverseManager(ctx context.Context, sshPort int) *ReverseManager {
 	return &ReverseManager{
-		ctx:            ctx,
+		ctx:      ctx,
 		reverses: make(map[int]*reverse),
-		sshUser:        "root",
-		sshHost:        "localhost",
-		sshPort:        sshPort,
+		sshUser:  "root",
+		sshHost:  "localhost",
+		sshPort:  sshPort,
 	}
 }
 
@@ -95,7 +95,7 @@ func (r *reverse) start(ctx context.Context, c *ssh.ClientConfig, sshAddr string
 	}
 
 	// Listen on remote server port
-	listener, err := serverConn.Listen("tcp", fmt.Sprintf("localhost:%d", r.remotePort))
+	listener, err := serverConn.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", r.remotePort))
 	if err != nil {
 		return fmt.Errorf("failed open remote port %d: %s", r.remotePort, err)
 	}

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -37,7 +38,11 @@ func NewRemoteForwardManager(ctx context.Context, sshPort int) *RemoteForwardMan
 }
 
 // Add initializes a remote forward
-func (r *RemoteForwardManager) Add(localPort, remotePort int) error {
+func (r *RemoteForwardManager) Add(f *model.RemoteForward) error {
+
+	localPort := f.Local
+	remotePort := f.Remote
+
 	if _, ok := r.remoteForwards[localPort]; ok {
 		return fmt.Errorf("port %d is already taken, please check your remote forward configuration", localPort)
 	}

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -1,0 +1,113 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/okteto/okteto/pkg/log"
+	"golang.org/x/crypto/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// ReverseTunnel contains the information to connect and setup a reverse tunnel
+type ReverseTunnel struct {
+	SSHHost    string
+	SSHPort    int
+	LocalPort  int
+	RemotePort int
+}
+
+// NewReverseTunnel returns a configured reverse tunnel endpoint
+func NewReverseTunnel(sshPort, localPort, remotePort int) *ReverseTunnel {
+	return &ReverseTunnel{
+		SSHHost:    "localhost",
+		SSHPort:    sshPort,
+		LocalPort:  localPort,
+		RemotePort: remotePort,
+	}
+}
+
+// Start starts the reverse tunnel to the remote server. It will block until the connection sends an EOF
+func (r *ReverseTunnel) Start(ctx context.Context) error {
+	for {
+		err := r.start(ctx)
+		if err == nil {
+			log.Infof("connection closed cleanly")
+			return nil
+		}
+
+		log.Infof("reverse tunnel disconnected %d->%d, retrying: %s", r.RemotePort, r.LocalPort, err)
+		t := time.NewTicker(3 * time.Second)
+		<-t.C
+	}
+}
+
+func (r *ReverseTunnel) start(ctx context.Context) error {
+	log.Infof("starting reverse tunnel %d->%d", r.RemotePort, r.LocalPort)
+
+	// Connect to SSH remote server using serverEndpoint
+	config := &ssh.ClientConfig{
+		User:            "root",
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(),
+	}
+
+	serverConn, err := gossh.Dial("tcp", fmt.Sprintf("%s:%d", r.SSHHost, r.SSHPort), config)
+	if err != nil {
+		return err
+	}
+
+	// Listen on remote server port
+	listener, err := serverConn.Listen("tcp", fmt.Sprintf("localhost:%d", r.RemotePort))
+	if err != nil {
+		return fmt.Errorf("failed open remote port %d: %s", r.RemotePort, err)
+	}
+
+	defer listener.Close()
+
+	// handle incoming connections on reverse forwarded tunnel
+	for {
+		// listen on local port
+		local, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", r.LocalPort))
+		if err != nil {
+			return fmt.Errorf("failed to open local port %d: %s", r.RemotePort, err)
+		}
+
+		client, err := listener.Accept()
+		if err != nil {
+			return fmt.Errorf("failed to accept traffic from remote port %d: %s", r.RemotePort, err)
+		}
+
+		r.handleClient(client, local)
+	}
+}
+
+func (r *ReverseTunnel) handleClient(client net.Conn, local net.Conn) {
+	defer client.Close()
+	chDone := make(chan error, 1)
+	log.Debug("starting reverse tunnel transfer ")
+
+	// Start remote -> local data transfer
+	go func() {
+		_, err := io.Copy(client, local)
+		if err != nil {
+			log.Infof("error while copying %s:%d->localhost:%d: %s", r.SSHHost, r.RemotePort, r.LocalPort, err)
+		}
+
+		chDone <- nil
+	}()
+
+	// Start local -> remote data transfer
+	go func() {
+		_, err := io.Copy(local, client)
+		if err != nil {
+			log.Infof("error while copying localhost:%d->%s:%d: %s", r.LocalPort, r.SSHHost, r.RemotePort, err)
+		}
+		chDone <- nil
+	}()
+
+	log.Infof("started reverse tunnel %d->%d successfully", r.RemotePort, r.LocalPort)
+	<-chDone
+}

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -70,14 +70,14 @@ func (r *RemoteForwardManager) Start() error {
 	return nil
 }
 
-func (r *remoteForward) startWithRetry(ctx context.Context, c *ssh.ClientConfig, sshAddr string) error {
+func (r *remoteForward) startWithRetry(ctx context.Context, c *ssh.ClientConfig, sshAddr string) {
 	log.Infof("starting remote forward tunnel %d->%d", r.remotePort, r.localPort)
 
 	for {
 		err := r.start(ctx, c, sshAddr)
 		if err == nil {
 			log.Infof("remote forward tunnel %d->%d exited", r.remotePort, r.localPort)
-			return nil
+			return
 		}
 
 		log.Infof("remote forward tunnel %d->%d not connected, retrying: %s", r.remotePort, r.localPort, err)

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -80,7 +80,7 @@ func (r *remoteForward) startWithRetry(ctx context.Context, c *ssh.ClientConfig,
 			return nil
 		}
 
-		log.Infof("remote forward tunnel disconnected %d->%d, retrying: %s", r.remotePort, r.localPort, err)
+		log.Infof("remote forward tunnel %d->%d not connected, retrying: %s", r.remotePort, r.localPort, err)
 		t := time.NewTicker(3 * time.Second)
 		<-t.C
 	}

--- a/pkg/ssh/reverse_test.go
+++ b/pkg/ssh/reverse_test.go
@@ -7,41 +7,41 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 )
 
-func TestRemoteForwardManager_Add(t *testing.T) {
+func TestReverseManager_Add(t *testing.T) {
 	tests := []struct {
-		name           string
-		add            *model.RemoteForward
-		remoteForwards map[int]*remoteForward
-		wantErr        bool
+		name     string
+		add      *model.Reverse
+		reverses map[int]*reverse
+		wantErr  bool
 	}{
 		{
-			name:           "single",
-			add:            &model.RemoteForward{Local: 8080, Remote: 8081},
-			remoteForwards: map[int]*remoteForward{},
-			wantErr:        false,
+			name:     "single",
+			add:      &model.Reverse{Local: 8080, Remote: 8081},
+			reverses: map[int]*reverse{},
+			wantErr:  false,
 		},
 		{
-			name:           "existing",
-			add:            &model.RemoteForward{Local: 8080, Remote: 8081},
-			remoteForwards: map[int]*remoteForward{8080: &remoteForward{localPort: 8080, remotePort: 8081}},
-			wantErr:        true,
+			name:     "existing",
+			add:      &model.Reverse{Local: 8080, Remote: 8081},
+			reverses: map[int]*reverse{8080: &reverse{localPort: 8080, remotePort: 8081}},
+			wantErr:  true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := &RemoteForwardManager{
-				remoteForwards: tt.remoteForwards,
-				ctx:            context.TODO(),
-				sshUser:        "root",
-				sshHost:        "localhost",
-				sshPort:        22,
+			r := &ReverseManager{
+				reverses: tt.reverses,
+				ctx:      context.TODO(),
+				sshUser:  "root",
+				sshHost:  "localhost",
+				sshPort:  22,
 			}
 
 			if err := r.Add(tt.add); (err != nil) != tt.wantErr {
-				t.Errorf("RemoteForwardManager.Add() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ReverseManager.Add() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			f := r.remoteForwards[8080]
+			f := r.reverses[8080]
 			if f.localPort != 8080 {
 				t.Errorf("local port is not 8080, it is: %d", f.localPort)
 			}

--- a/pkg/ssh/reverse_test.go
+++ b/pkg/ssh/reverse_test.go
@@ -1,0 +1,54 @@
+package ssh
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+)
+
+func TestRemoteForwardManager_Add(t *testing.T) {
+	tests := []struct {
+		name           string
+		add            *model.RemoteForward
+		remoteForwards map[int]*remoteForward
+		wantErr        bool
+	}{
+		{
+			name:           "single",
+			add:            &model.RemoteForward{Local: 8080, Remote: 8081},
+			remoteForwards: map[int]*remoteForward{},
+			wantErr:        false,
+		},
+		{
+			name:           "existing",
+			add:            &model.RemoteForward{Local: 8080, Remote: 8081},
+			remoteForwards: map[int]*remoteForward{8080: &remoteForward{localPort: 8080, remotePort: 8081}},
+			wantErr:        true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RemoteForwardManager{
+				remoteForwards: tt.remoteForwards,
+				ctx:            context.TODO(),
+				sshUser:        "root",
+				sshHost:        "localhost",
+				sshPort:        22,
+			}
+
+			if err := r.Add(tt.add); (err != nil) != tt.wantErr {
+				t.Errorf("RemoteForwardManager.Add() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			f := r.remoteForwards[8080]
+			if f.localPort != 8080 {
+				t.Errorf("local port is not 8080, it is: %d", f.localPort)
+			}
+
+			if f.remotePort != 8081 {
+				t.Errorf("remote port is not 8081, it is: %d", f.remotePort)
+			}
+		})
+	}
+}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -193,7 +193,7 @@ func (s *Syncthing) initConfig() error {
 	return nil
 }
 
-// UpdateConfig updates the synchting config file
+// UpdateConfig updates the syncthing config file
 func (s *Syncthing) UpdateConfig() error {
 	buf := new(bytes.Buffer)
 	if err := configTemplate.Execute(buf, s); err != nil {
@@ -396,7 +396,7 @@ func (s *Syncthing) WaitForCompletion(ctx context.Context, dev *model.Dev, repor
 
 // Restart restarts the syncthing process
 func (s *Syncthing) Restart(ctx context.Context) error {
-	log.Infof("restarting synchting...")
+	log.Infof("restarting syncthing...")
 	_, err := s.APICall(ctx, "rest/system/restart", "POST", 200, nil, true, nil)
 	return err
 }


### PR DESCRIPTION
Contributes to #574 

## Proposed changes
- Add support for remote forward tunnels, so that debuggers and similar can connect back to localhost

SEE https://github.com/okteto/okteto/pull/594#issuecomment-566965320 for updated information

------ DEPRECATED
This is how the manifest would look like:
```
name: hello-world
image: okteto/golang:1
workdir: /okteto
command: ["go", "run", "main.go"]
volumes:
  - /go/pkg/
  - /root/.cache/go-build/
securityContext:
  capabilities:
    add:
    - SYS_PTRACE
forward:
  - 8080:8080
  - 2345:2345
remoteForward:
  - 9000:9000
  - 9001:9001
```
And this is how the UI looks like:
![image](https://user-images.githubusercontent.com/475313/71066479-81012b00-2127-11ea-9476-662c4aaa1255.png)

Design decisions:
- I'm using the term Remote Forward Tunnel to be consistent with the terminology used by OpenSSH
- We always open the listeners in localhost in both sides, to simplify the notation. If we want to allow forwarding traffics for servers not on `localhost` we could change the notation to something like: `127.0.0.1:8080:0.0.0:8080`. This is what OpenSSH does (but I find this extremely confusing)
- This feature requires SSH access, if remote is not enabled, it will automatically enable remote in a random port. If there is another remote running on 2222, the tunnel will fail.
- A tunnel failure doesn't interrupt the `up` sequence. It will pause for a second, and it will try to reconnect. All errors are logged to the log file,  and not to the UI.


I'll file a ticket to update our docs once this is fixed.