### PR TITLE
Switch to disable persistent volumes

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -393,7 +393,10 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 		message := "Attaching persistent volume"
 		up.updateStateFile(attaching)
 		for {
-			spinner.update(fmt.Sprintf("%s...", message))
+			if up.Dev.PersistentVolumeEnabled() {
+				spinner.update(fmt.Sprintf("%s...", message))
+			}
+
 			message = <-reporter
 			if message == "" {
 				return

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -320,8 +320,10 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 		return fmt.Errorf("`okteto up` is not allowed in this namespace")
 	}
 
-	if err := volumes.Create(up.Context, up.Dev, up.Client); err != nil {
-		return err
+	if up.Dev.PersistentVolumeEnabled() {
+		if err := volumes.Create(up.Context, up.Dev, up.Client); err != nil {
+			return err
+		}
 	}
 
 	devContainer := deployments.GetDevContainer(&d.Spec.Template.Spec, up.Dev.Container)

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -300,6 +300,7 @@ func TranslateOktetoVolumes(spec *apiv1.PodSpec, rule *model.TranslationRule) {
 	if spec.Volumes == nil {
 		spec.Volumes = []apiv1.Volume{}
 	}
+
 	for _, rV := range rule.Volumes {
 		found := false
 		for _, v := range spec.Volumes {
@@ -311,15 +312,21 @@ func TranslateOktetoVolumes(spec *apiv1.PodSpec, rule *model.TranslationRule) {
 		if found {
 			continue
 		}
+
 		v := apiv1.Volume{
-			Name: rV.Name,
-			VolumeSource: apiv1.VolumeSource{
-				PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
-					ClaimName: rV.Name,
-					ReadOnly:  false,
-				},
-			},
+			Name:         rV.Name,
+			VolumeSource: apiv1.VolumeSource{},
 		}
+
+		if rule.PersistentVolume {
+			v.VolumeSource.PersistentVolumeClaim = &apiv1.PersistentVolumeClaimVolumeSource{
+				ClaimName: rV.Name,
+				ReadOnly:  false,
+			}
+		} else {
+			v.VolumeSource.EmptyDir = &apiv1.EmptyDirVolumeSource{}
+		}
+
 		spec.Volumes = append(spec.Volumes, v)
 	}
 }

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -393,11 +393,12 @@ func (dev *Dev) syncthingSubPath() string {
 // ToTranslationRule translates a dev struct into a translation rule
 func (dev *Dev) ToTranslationRule(main *Dev) *TranslationRule {
 	rule := &TranslationRule{
-		Container:       dev.Container,
-		Image:           dev.Image,
-		ImagePullPolicy: dev.ImagePullPolicy,
-		Environment:     dev.Environment,
-		WorkDir:         dev.WorkDir,
+		Container:        dev.Container,
+		Image:            dev.Image,
+		ImagePullPolicy:  dev.ImagePullPolicy,
+		Environment:      dev.Environment,
+		WorkDir:          dev.WorkDir,
+		PersistentVolume: dev.PersistentVolumeEnabled(),
 		Volumes: []VolumeMount{
 			{
 				Name:      OktetoVolumeName,

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -274,10 +274,6 @@ func (dev *Dev) validate() error {
 		if len(dev.Services) > 0 {
 			return fmt.Errorf("'persistentVolume' must be set to true to work with services")
 		}
-
-		if len(dev.Volumes) > 0 {
-			return fmt.Errorf("'persistentVolume' must be set to true to work with volumes")
-		}
 	}
 
 	for _, s := range dev.Services {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -57,7 +57,6 @@ var (
 
 	devReplicas                      int32 = 1
 	devTerminationGracePeriodSeconds int64
-	persistentVolumeEnabled          bool = true
 )
 
 //Dev represents a cloud native development environment

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -18,19 +18,20 @@ type Translation struct {
 
 //TranslationRule represents how to apply a container translation in a deployment
 type TranslationRule struct {
-	Marker          string               `json:"marker"`
-	Node            string               `json:"node,omitempty"`
-	Container       string               `json:"container,omitempty"`
-	Image           string               `json:"image,omitempty"`
-	ImagePullPolicy apiv1.PullPolicy     `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
-	Environment     []EnvVar             `json:"environment,omitempty"`
-	Command         []string             `json:"command,omitempty"`
-	Args            []string             `json:"args,omitempty"`
-	WorkDir         string               `json:"workdir"`
-	Healthchecks    bool                 `json:"healthchecks" yaml:"healthchecks"`
-	Volumes         []VolumeMount        `json:"volumes,omitempty"`
-	SecurityContext *SecurityContext     `json:"securityContext,omitempty"`
-	Resources       ResourceRequirements `json:"resources,omitempty"`
+	Marker           string               `json:"marker"`
+	Node             string               `json:"node,omitempty"`
+	Container        string               `json:"container,omitempty"`
+	Image            string               `json:"image,omitempty"`
+	ImagePullPolicy  apiv1.PullPolicy     `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	Environment      []EnvVar             `json:"environment,omitempty"`
+	Command          []string             `json:"command,omitempty"`
+	Args             []string             `json:"args,omitempty"`
+	WorkDir          string               `json:"workdir"`
+	Healthchecks     bool                 `json:"healthchecks" yaml:"healthchecks"`
+	PersistentVolume bool                 `json:"persistentVolume" yaml:"persistentVolume"`
+	Volumes          []VolumeMount        `json:"volumes,omitempty"`
+	SecurityContext  *SecurityContext     `json:"securityContext,omitempty"`
+	Resources        ResourceRequirements `json:"resources,omitempty"`
 }
 
 //VolumeMount represents a volume mount

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -61,6 +61,7 @@ services:
 			},
 			Requests: ResourceList{},
 		},
+		PersistentVolume: true,
 		Volumes: []VolumeMount{
 			VolumeMount{
 				Name:      OktetoVolumeName,
@@ -100,6 +101,7 @@ services:
 			Limits:   ResourceList{},
 			Requests: ResourceList{},
 		},
+		PersistentVolume: true,
 		Volumes: []VolumeMount{
 			{
 				Name:      OktetoVolumeName,


### PR DESCRIPTION
Fixes #514 #517 

## Proposed changes
- Add a key to the manifest to control the usage of PVCs
- By default, it will be enabled. 

Manifest looks like this:
```
name: hello-world
image: okteto/golang:1
workdir: /okteto
command: ["go", "run", "main.go"]
persistentVolume: false
securityContext:
  capabilities:
    add:
    - SYS_PTRACE
```