### PR TITLE
Create private service for dev environments created from scratch

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -129,10 +129,8 @@ func runDown(dev *model.Dev) error {
 		if err := deployments.Destroy(dev, client); err != nil {
 			return err
 		}
-		if len(dev.Services) == 0 {
-			if err := services.Destroy(dev, client); err != nil {
-				return err
-			}
+		if err := services.Destroy(dev, client); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -376,7 +376,7 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 			}
 		}
 	}
-	if create && len(up.Dev.Services) == 0 {
+	if create {
 		if err := services.Create(up.Dev, up.Client); err != nil {
 			return err
 		}

--- a/pkg/k8s/services/translate.go
+++ b/pkg/k8s/services/translate.go
@@ -12,13 +12,15 @@ const (
 )
 
 func translate(dev *model.Dev) *apiv1.Service {
+	annotations := map[string]string{}
+	if len(dev.Services) > 0 {
+		annotations[oktetoAutoIngressAnnotation] = "true"
+	}
 	return &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dev.Name,
-			Namespace: dev.Namespace,
-			Annotations: map[string]string{
-				oktetoAutoIngressAnnotation: "true",
-			},
+			Name:        dev.Name,
+			Namespace:   dev.Namespace,
+			Annotations: annotations,
 		},
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{"app": dev.Name},


### PR DESCRIPTION
This makes it possible for other pods running in the cluster to have a reliable endpoint for the dev environment (to connect to a reverse debugger tunnel, for example)