### PR TITLE
Fix typo in manifest URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Okteto is compatible with any Kubernetes cluster, local or remote. If you can ru
 ## Learn More
 - [How does Okteto work?](docs/how-does-it-work.md)
 - Get started following our [installation guides](https://okteto.com/docs/getting-started/installation/index.html).
-- Check the Okteto [CLI reference](https://okteto.com/docs/reference/cli) and the [okteto.yml reference](https://okteto.com/docs/reference/manifest/index.htlm)
+- Check the Okteto [CLI reference](https://okteto.com/docs/reference/cli) and the [okteto.yml reference](https://okteto.com/docs/reference/manifest/index.html)
 - [Explore our samples](https://github.com/okteto/samples) to learn more about the power of Okteto
 - Frequently asked questions ([FAQs](https://okteto.com/docs/reference/faqs/index.html))
 


### PR DESCRIPTION
Typo in Okteto manifest documentation URL in README.md

