### PR TITLE
'okteto login showUrl' shows url, instead open browser

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,28 +20,22 @@ import (
 
 //Login starts the login handshake with github and okteto
 func Login() *cobra.Command {
-	showUrl := false
 	cmd := &cobra.Command{
 		Use:   "login [url]",
 		Short: "Login with Okteto",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoURL := okteto.CloudURL
 			if len(args) > 0 {
-				fmt.Printf("args0: " + args[0])
-				if (args[0] == "showUrl") {
-					showUrl = true
-				} else {
-					u, err := url.Parse(args[0])
-					if err != nil {
-						return fmt.Errorf("malformed login URL")
-					}
-	
-					if u.Scheme == "" {
-						u.Scheme = "https"
-					}
-	
-					oktetoURL = u.String()
+				u, err := url.Parse(args[0])
+				if err != nil {
+					return fmt.Errorf("malformed login URL")
 				}
+
+				if u.Scheme == "" {
+					u.Scheme = "https"
+				}
+
+				oktetoURL = u.String()
 			}
 
 			log.Debugf("authenticating with %s", oktetoURL)
@@ -67,11 +61,9 @@ func Login() *cobra.Command {
 
 			authorizationURL := buildAuthorizationURL(handler.baseURL, handler.state, port)
 			fmt.Println("Authentication will continue in your default browser")
-			if showUrl {
-				showAuthorizationURL(authorizationURL)
-			} else if err := open.Start(authorizationURL); err != nil {
-				showAuthorizationURL(authorizationURL)
-			}
+			open.Start(authorizationURL)
+			fmt.Printf("You can also open a browser and navigate to the following address: ")
+			fmt.Println(authorizationURL)
 
 			ticker := time.NewTicker(5 * time.Minute)
 			var code string
@@ -143,11 +135,6 @@ func randToken() string {
 	b := make([]byte, 32)
 	rand.Read(b)
 	return base64.StdEncoding.EncodeToString(b)
-}
-
-func showAuthorizationURL() {
-	fmt.Printf("Please open a browser and navigate to the following address:\n")
-	fmt.Println(authorizationURL)
 }
 
 func buildAuthorizationURL(baseURL, state string, port int) string {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -61,8 +61,10 @@ func Login() *cobra.Command {
 
 			authorizationURL := buildAuthorizationURL(handler.baseURL, handler.state, port)
 			fmt.Println("Authentication will continue in your default browser")
-			open.Start(authorizationURL)
-			fmt.Printf("You can also open a browser and navigate to the following address: ")
+			if err := open.Start(authorizationURL); err != nil {
+				log.Errorf("Something went wrong opening your browser: %s\n", err)
+			}
+			fmt.Printf("You can also open a browser and navigate to the following address:\n")
 			fmt.Println(authorizationURL)
 
 			ticker := time.NewTicker(5 * time.Minute)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,22 +20,28 @@ import (
 
 //Login starts the login handshake with github and okteto
 func Login() *cobra.Command {
+	showUrl := false
 	cmd := &cobra.Command{
 		Use:   "login [url]",
 		Short: "Login with Okteto",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoURL := okteto.CloudURL
 			if len(args) > 0 {
-				u, err := url.Parse(args[0])
-				if err != nil {
-					return fmt.Errorf("malformed login URL")
+				fmt.Printf("args0: " + args[0])
+				if (args[0] == "showUrl") {
+					showUrl = true
+				} else {
+					u, err := url.Parse(args[0])
+					if err != nil {
+						return fmt.Errorf("malformed login URL")
+					}
+	
+					if u.Scheme == "" {
+						u.Scheme = "https"
+					}
+	
+					oktetoURL = u.String()
 				}
-
-				if u.Scheme == "" {
-					u.Scheme = "https"
-				}
-
-				oktetoURL = u.String()
 			}
 
 			log.Debugf("authenticating with %s", oktetoURL)
@@ -61,9 +67,10 @@ func Login() *cobra.Command {
 
 			authorizationURL := buildAuthorizationURL(handler.baseURL, handler.state, port)
 			fmt.Println("Authentication will continue in your default browser")
-			if err := open.Start(authorizationURL); err != nil {
-				fmt.Printf("Please open a browser and navigate to the following address:\n")
-				fmt.Println(authorizationURL)
+			if showUrl {
+				showAuthorizationURL(authorizationURL)
+			} else if err := open.Start(authorizationURL); err != nil {
+				showAuthorizationURL(authorizationURL)
 			}
 
 			ticker := time.NewTicker(5 * time.Minute)
@@ -136,6 +143,11 @@ func randToken() string {
 	b := make([]byte, 32)
 	rand.Read(b)
 	return base64.StdEncoding.EncodeToString(b)
+}
+
+func showAuthorizationURL() {
+	fmt.Printf("Please open a browser and navigate to the following address:\n")
+	fmt.Println(authorizationURL)
 }
 
 func buildAuthorizationURL(baseURL, state string, port int) string {


### PR DESCRIPTION
Fixes #615
also outputs the login url on cli, because on wsl2 a browser did not open and login timed out..

## Proposed changes
- typing `okteto login [url]`
Results into:

> Authentication will continue in your default browser
> You can also open a browser and navigate to the following address: https://cloud.okteto.com/github/authorization-code?redirect=someEncodedRedirectUrl
>  ✓  Logged in as loginname
>     Run `okteto namespace` to switch your context and download your Kubernetes credentials.
> 
> 