### PR TITLE
upgrade to  latest golang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,11 @@ jobs:
           keys:
             - v4-pkg-cache-windows-{{ checksum "go.sum" }}
       - run: 
+          name: upgrade golang
+          command: choco upgrade golang
+      - run: 
           name: test
           command: |
-            choco upgrade golang
             go version
             go test ./...
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
       - run: 
           name: test
           command: |
+            choco upgrade golang
             go version
             go test ./...
       - save_cache:


### PR DESCRIPTION
Circle CI's Windows VM has go 1.12