### PR TITLE
"okteto status" command

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -32,8 +32,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-//Redeploy builds, pushes and redeploys the target deployment
-func Redeploy() *cobra.Command {
+//Push builds, pushes and redeploys the target deployment
+func Push() *cobra.Command {
 	var devPath string
 	var namespace string
 	var imageTag string
@@ -44,6 +44,11 @@ func Redeploy() *cobra.Command {
 		Short: "Builds, pushes and redeploys source code to the target deployment",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting push command")
+
+			if k8Client.InCluster() {
+				return errors.ErrNotInCluster
+			}
+
 			dev, err := loadDev(devPath)
 			if err != nil {
 				return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,69 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/cmd/status"
+	"github.com/okteto/okteto/pkg/errors"
+	k8Client "github.com/okteto/okteto/pkg/k8s/client"
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+//Status returns the status of the synchronization process
+func Status() *cobra.Command {
+	var devPath string
+	var namespace string
+	var showInfo bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: fmt.Sprintf("Status of the synchronization process"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Info("starting status command")
+			analytics.TrackStatus(true, showInfo)
+
+			if k8Client.InCluster() {
+				return errors.ErrNotInCluster
+			}
+
+			dev, err := loadDev(devPath)
+			if err != nil {
+				return err
+			}
+			if err := dev.UpdateNamespace(namespace); err != nil {
+				return err
+			}
+
+			_, _, namespace, err = k8Client.GetLocal()
+			if err != nil {
+				return err
+			}
+
+			if dev.Namespace == "" {
+				dev.Namespace = namespace
+			}
+
+			err = status.Run(dev, showInfo)
+			analytics.TrackStatus(err == nil, showInfo)
+			return err
+		},
+	}
+	cmd.Flags().StringVarP(&devPath, "file", "f", defaultManifest, "path to the manifest file")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the up command is executing")
+	cmd.Flags().BoolVarP(&showInfo, "info", "i", false, "show syncthing links for troubleshooting the synchronization service")
+	return cmd
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -381,7 +381,7 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 	}
 
 	log.Info("create deployment secrets")
-	if err := secrets.Create(up.Dev, up.Client, up.Sy.GUIPasswordHash); err != nil {
+	if err := secrets.Create(up.Dev, up.Client, up.Sy); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -74,7 +74,8 @@ func main() {
 	root.AddCommand(cmd.Init())
 	root.AddCommand(cmd.Up())
 	root.AddCommand(cmd.Down())
-	root.AddCommand(cmd.Redeploy())
+	root.AddCommand(cmd.Push())
+	root.AddCommand(cmd.Status())
 	root.AddCommand(cmd.Exec())
 	root.AddCommand(cmd.Restart())
 

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -40,6 +40,7 @@ const (
 	downEvent            = "Down"
 	downVolumesEvent     = "DownVolumes"
 	pushEvent            = "Push"
+	statusEvent          = "Status"
 	buildEvent           = "Build"
 	loginEvent           = "Login"
 	initEvent            = "Create Manifest"
@@ -144,6 +145,14 @@ func TrackPush(success bool, oktetoRegistryURL string) {
 		"oktetoRegistryURL": oktetoRegistryURL,
 	}
 	track(pushEvent, success, props)
+}
+
+// TrackStatus sends a tracking event to mixpanel when the user uses the status command
+func TrackStatus(success, showInfo bool) {
+	props := map[string]interface{}{
+		"showInfo": showInfo,
+	}
+	track(statusEvent, success, props)
 }
 
 func trackDisable(success bool) {

--- a/pkg/cmd/status/run.go
+++ b/pkg/cmd/status/run.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/syncthing"
+)
+
+//Run runs the "okteto status" sequence
+func Run(dev *model.Dev, showInfo bool) error {
+	sy, err := syncthing.Load(dev)
+	if err != nil {
+		return fmt.Errorf("error accessing to syncthing info file: %s", err)
+	}
+	if showInfo {
+		log.Information("Local syncthing url: http://%s", sy.GUIAddress)
+		log.Information("Remote syncthing url: http://%s", sy.RemoteGUIAddress)
+		log.Information("Syncthing username: okteto")
+		log.Information("Syncthing password: %s", sy.GUIPassword)
+	}
+	ctx := context.Background()
+	status, err := sy.GetCompletion(ctx, dev)
+	if err != nil {
+		return fmt.Errorf("error accessing syncthing status: %s", err)
+	}
+	status = 99
+	if status == 100 {
+		log.Success("Synchronization status: %.2f%%", status)
+	} else {
+		log.Yellow("Synchronization status: %.2f%%", status)
+	}
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,11 @@ func GetStateFile(namespace, name string) string {
 	return filepath.Join(GetDeploymentHome(namespace, name), "okteto.state")
 }
 
+// GetSyncthingInfoFile returns the path to the syncthing info file
+func GetSyncthingInfoFile(namespace, name string) string {
+	return filepath.Join(GetDeploymentHome(namespace, name), "syncthing.info")
+}
+
 // GetUserHomeDir returns the OS home dir
 func GetUserHomeDir() string {
 	if v, ok := os.LookupEnv("OKTETO_HOME"); ok {

--- a/pkg/k8s/secrets/configXML.go
+++ b/pkg/k8s/secrets/configXML.go
@@ -32,7 +32,7 @@ const configXML = `<configuration version="29">
     <hashers>0</hashers>
     <order>random</order>
     <ignoreDelete>false</ignoreDelete>
-    <scanProgressIntervalS>0</scanProgressIntervalS>
+    <scanProgressIntervalS>2</scanProgressIntervalS>
     <pullerPauseS>0</pullerPauseS>
     <maxConflicts>0</maxConflicts>
     <disableSparseFiles>false</disableSparseFiles>
@@ -92,7 +92,7 @@ const configXML = `<configuration version="29">
     <upgradeToPreReleases>false</upgradeToPreReleases>
     <keepTemporariesH>24</keepTemporariesH>
     <cacheIgnoredFiles>false</cacheIgnoredFiles>
-    <progressUpdateIntervalS>5</progressUpdateIntervalS>
+    <progressUpdateIntervalS>2</progressUpdateIntervalS>
     <limitBandwidthInLan>false</limitBandwidthInLan>
     <minHomeDiskFree unit="%">1</minHomeDiskFree>
     <releasesURL></releasesURL>

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/syncthing"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -39,7 +40,7 @@ func Get(name, namespace string, c *kubernetes.Clientset) (*v1.Secret, error) {
 }
 
 //Create creates the syncthing config secret
-func Create(dev *model.Dev, c *kubernetes.Clientset, guiPasswordHash string) error {
+func Create(dev *model.Dev, c *kubernetes.Clientset, s *syncthing.Syncthing) error {
 	secretName := GetSecretName(dev)
 	log.Debugf("creating configuration secret %s", secretName)
 
@@ -48,7 +49,7 @@ func Create(dev *model.Dev, c *kubernetes.Clientset, guiPasswordHash string) err
 		return fmt.Errorf("error getting kubernetes secret: %s", err)
 	}
 
-	config, err := getConfigXML(dev.Name, dev.MountPath, dev.DevPath, guiPasswordHash)
+	config, err := getConfigXML(s)
 	if err != nil {
 		return fmt.Errorf("error generating syncthing configuration: %s", err)
 	}

--- a/pkg/syncthing/configXML.go
+++ b/pkg/syncthing/configXML.go
@@ -25,7 +25,7 @@ const configXML = `<configuration version="29">
     <hashers>0</hashers>
     <order>random</order>
     <ignoreDelete>{{ .IgnoreDelete }}</ignoreDelete>
-    <scanProgressIntervalS>0</scanProgressIntervalS>
+    <scanProgressIntervalS>2</scanProgressIntervalS>
     <pullerPauseS>0</pullerPauseS>
     <maxConflicts>0</maxConflicts>
     <disableSparseFiles>false</disableSparseFiles>
@@ -82,7 +82,7 @@ const configXML = `<configuration version="29">
     <upgradeToPreReleases>false</upgradeToPreReleases>
     <keepTemporariesH>24</keepTemporariesH>
     <cacheIgnoredFiles>false</cacheIgnoredFiles>
-    <progressUpdateIntervalS>5</progressUpdateIntervalS>
+    <progressUpdateIntervalS>2</progressUpdateIntervalS>
     <limitBandwidthInLan>false</limitBandwidthInLan>
     <minHomeDiskFree unit="%">1</minHomeDiskFree>
     <releasesURL></releasesURL>

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -45,12 +45,11 @@ var (
 )
 
 const (
-	certFile          = "cert.pem"
-	keyFile           = "key.pem"
-	configFile        = "config.xml"
-	logFile           = "syncthing.log"
-	syncthingPidFile  = "syncthing.pid"
-	syncthingInfoFile = "syncthing.info"
+	certFile         = "cert.pem"
+	keyFile          = "key.pem"
+	configFile       = "config.xml"
+	logFile          = "syncthing.log"
+	syncthingPidFile = "syncthing.pid"
 
 	// DefaultRemoteDeviceID remote syncthing ID
 	DefaultRemoteDeviceID = "ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU"
@@ -436,11 +435,15 @@ func (s *Syncthing) WaitForCompletion(ctx context.Context, dev *model.Dev, repor
 }
 
 // GetCompletion returns the syncthing status
-func (s *Syncthing) GetCompletion(ctx context.Context, dev *model.Dev) (float64, error) {
+func (s *Syncthing) GetCompletion(ctx context.Context, dev *model.Dev, local bool) (float64, error) {
 	params := getFolderParameter(dev)
-	params["device"] = DefaultRemoteDeviceID
+	if local {
+		params["device"] = DefaultRemoteDeviceID
+	} else {
+		params["device"] = localDeviceID
+	}
 	completion := &Completion{}
-	body, err := s.APICall(ctx, "rest/db/completion", "GET", 200, params, true, nil)
+	body, err := s.APICall(ctx, "rest/db/completion", "GET", 200, params, local, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -34,6 +34,7 @@ import (
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"golang.org/x/crypto/bcrypt"
+	yaml "gopkg.in/yaml.v2"
 
 	ps "github.com/mitchellh/go-ps"
 	uuid "github.com/satori/go.uuid"
@@ -44,11 +45,12 @@ var (
 )
 
 const (
-	certFile         = "cert.pem"
-	keyFile          = "key.pem"
-	configFile       = "config.xml"
-	logFile          = "syncthing.log"
-	syncthingPidFile = "syncthing.pid"
+	certFile          = "cert.pem"
+	keyFile           = "key.pem"
+	configFile        = "config.xml"
+	logFile           = "syncthing.log"
+	syncthingPidFile  = "syncthing.pid"
+	syncthingInfoFile = "syncthing.info"
 
 	// DefaultRemoteDeviceID remote syncthing ID
 	DefaultRemoteDeviceID = "ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU"
@@ -66,29 +68,29 @@ const (
 
 // Syncthing represents the local syncthing process.
 type Syncthing struct {
-	APIKey           string
-	GUIPassword      string
-	GUIPasswordHash  string
-	binPath          string
-	Client           *http.Client
-	cmd              *exec.Cmd
-	Dev              *model.Dev
-	DevPath          string
-	FileWatcherDelay int
-	ForceSendOnly    bool
-	GUIAddress       string
-	Home             string
-	LogPath          string
-	ListenAddress    string
-	RemoteAddress    string
-	RemoteDeviceID   string
-	RemoteGUIAddress string
-	RemoteGUIPort    int
-	RemotePort       int
-	Source           string
-	Type             string
-	IgnoreDelete     bool
-	pid              int
+	APIKey           string       `yaml:"apikey"`
+	GUIPassword      string       `yaml:"password"`
+	GUIPasswordHash  string       `yaml:"-"`
+	binPath          string       `yaml:"-"`
+	Client           *http.Client `yaml:"-"`
+	cmd              *exec.Cmd    `yaml:"-"`
+	Dev              *model.Dev   `yaml:"-"`
+	DevPath          string       `yaml:"-"`
+	FileWatcherDelay int          `yaml:"-"`
+	ForceSendOnly    bool         `yaml:"-"`
+	GUIAddress       string       `yaml:"local"`
+	Home             string       `yaml:"-"`
+	LogPath          string       `yaml:"-"`
+	ListenAddress    string       `yaml:"-"`
+	RemoteAddress    string       `yaml:"-"`
+	RemoteDeviceID   string       `yaml:"-"`
+	RemoteGUIAddress string       `yaml:"remote"`
+	RemoteGUIPort    int          `yaml:"-"`
+	RemotePort       int          `yaml:"-"`
+	Source           string       `yaml:"-"`
+	Type             string       `yaml:"-"`
+	IgnoreDelete     bool         `yaml:"-"`
+	pid              int          `yaml:"-"`
 }
 
 //Ignores represents the .stignore file
@@ -160,6 +162,10 @@ func New(dev *model.Dev) (*Syncthing, error) {
 		Source:           dev.DevDir,
 		Type:             "sendonly",
 		IgnoreDelete:     true,
+	}
+
+	if err := s.Save(dev); err != nil {
+		log.Infof("error saving syncthing object: %s", err)
 	}
 
 	return s, nil
@@ -429,6 +435,28 @@ func (s *Syncthing) WaitForCompletion(ctx context.Context, dev *model.Dev, repor
 	}
 }
 
+// GetCompletion returns the syncthing status
+func (s *Syncthing) GetCompletion(ctx context.Context, dev *model.Dev) (float64, error) {
+	params := getFolderParameter(dev)
+	params["device"] = DefaultRemoteDeviceID
+	completion := &Completion{}
+	body, err := s.APICall(ctx, "rest/db/completion", "GET", 200, params, true, nil)
+	if err != nil {
+		return 0, err
+	}
+	err = json.Unmarshal(body, completion)
+	if err != nil {
+		return 0, err
+	}
+
+	if completion.GlobalBytes == 0 {
+		return 100, nil
+	}
+
+	progress := (float64(completion.GlobalBytes-completion.NeedBytes) / float64(completion.GlobalBytes)) * 100
+	return progress, nil
+}
+
 // Restart restarts the syncthing process
 func (s *Syncthing) Restart(ctx context.Context) error {
 	log.Infof("restarting syncthing...")
@@ -464,6 +492,39 @@ func (s *Syncthing) Stop(force bool) error {
 	}
 
 	return nil
+}
+
+// Save saves the syncthing object in the dev home folder
+func (s *Syncthing) Save(dev *model.Dev) error {
+	marshalled, err := yaml.Marshal(s)
+	if err != nil {
+		return err
+	}
+
+	syncthingInfoFile := config.GetSyncthingInfoFile(dev.Namespace, dev.Name)
+	if err := ioutil.WriteFile(syncthingInfoFile, marshalled, 0600); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Load loads the syncthing object from the dev home folder
+func Load(dev *model.Dev) (*Syncthing, error) {
+	syncthingInfoFile := config.GetSyncthingInfoFile(dev.Namespace, dev.Name)
+	b, err := ioutil.ReadFile(syncthingInfoFile)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Syncthing{
+		Client: NewAPIClient(),
+	}
+	if err := yaml.Unmarshal(b, s); err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
 
 // RemoveFolder deletes all the files created by the syncthing instance


### PR DESCRIPTION
Fixes #657

In order to access syncthing from a different command than `okteto up`, I need to store the syncthing object to deserialize it in the `okteto status` command.

The `--info` flag show access urls and credentials for the syncthing UI.
