### PR TITLE
fail if port is under 1024

### DIFF
--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -90,6 +90,10 @@ func NewPortForwardManager(ctx context.Context, restConfig *rest.Config, c kuber
 
 // Add initializes a port forward
 func (p *PortForwardManager) Add(f model.Forward) error {
+	if f.Local < 1024 {
+		return fmt.Errorf("port %d is reserved, please select a port above 1024", f.Local)
+	}
+
 	if _, ok := p.ports[f.Local]; ok {
 		return fmt.Errorf("port %d is already taken, please check your configuration", f.Local)
 	}

--- a/pkg/k8s/forward/manager_test.go
+++ b/pkg/k8s/forward/manager_test.go
@@ -26,20 +26,24 @@ import (
 func TestAdd(t *testing.T) {
 
 	pf := NewPortForwardManager(context.Background(), nil, nil)
-	if err := pf.Add(model.Forward{Local: 1010, Remote: 1010}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10100, Remote: 1010}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := pf.Add(model.Forward{Local: 1011, Remote: 1011}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10110, Remote: 1011}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := pf.Add(model.Forward{Local: 1010, Remote: 1011}); err == nil {
+	if err := pf.Add(model.Forward{Local: 10100, Remote: 1011}); err == nil {
 		t.Fatal("duplicated local port didn't return an error")
 	}
 
-	if err := pf.Add(model.Forward{Local: 1012, Remote: 0, Service: true, ServiceName: "svc"}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10120, Remote: 0, Service: true, ServiceName: "svc"}); err != nil {
 		t.Fatal(err)
+	}
+
+	if err := pf.Add(model.Forward{Local: 80, Remote: 1011}); err == nil {
+		t.Fatal("reserved local port didn't return an error")
 	}
 
 	if len(pf.ports) != 3 {


### PR DESCRIPTION
Fixes #630

The port-forward libraries are coded to not fail if at least one port is allocated, which in our case always succeeds due to syncthing. I'm adding this validation to automatically fail if the user selects a reserved port. 