### PR TITLE
use port forwards in the integration test

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -40,8 +40,9 @@ func Push() *cobra.Command {
 	var autoDeploy bool
 
 	cmd := &cobra.Command{
-		Use:   "push",
-		Short: "Builds, pushes and redeploys source code to the target deployment",
+		Use:    "push",
+		Hidden: true,
+		Short:  "Builds, pushes and redeploys source code to the target deployment",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting push command")
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -243,7 +243,7 @@ func TestAll(t *testing.T) {
 	}
 
 	log.Println("getting synchronized content")
-	c, err := getContent(name, namespace)
+	c, err := getContent()
 	if err != nil {
 		t.Fatalf("failed to get content: %s", err)
 	}
@@ -258,7 +258,7 @@ func TestAll(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	log.Println("getting updated content")
-	c, err = getContent(name, namespace)
+	c, err = getContent()
 	if err != nil {
 		t.Fatalf("failed to get updated content: %s", err)
 	}
@@ -316,8 +316,8 @@ func waitForDeployment(ctx context.Context, name string, revision, timeout int) 
 	return fmt.Errorf("%s didn't rollout after 30 seconds", name)
 }
 
-func getContent(name, namespace) (string, error) {
-	endpoint := fmt.Sprintf("http://localhost:8080", name, namespace)
+func getContent() (string, error) {
+	endpoint := "http://localhost:8080"
 	retries := 0
 	t := time.NewTicker(1 * time.Second)
 	for i := 0; i < 60; i++ {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -103,9 +103,9 @@ command:
   - "python"
   - "-m"
   - "http.server"
-	- "8080"
+  - "8080"
 forward:
-	- 8080
+  - 8080:8080
 workdir: /usr/src/app
 `
 )

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -103,7 +103,9 @@ command:
   - "python"
   - "-m"
   - "http.server"
-  - "8080"
+	- "8080"
+forward:
+	- 8080
 workdir: /usr/src/app
 `
 )
@@ -241,7 +243,7 @@ func TestAll(t *testing.T) {
 	}
 
 	log.Println("getting synchronized content")
-	c, err := getContent(name, namespace, url)
+	c, err := getContent(name, namespace)
 	if err != nil {
 		t.Fatalf("failed to get content: %s", err)
 	}
@@ -256,7 +258,7 @@ func TestAll(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	log.Println("getting updated content")
-	c, err = getContent(name, namespace, url)
+	c, err = getContent(name, namespace)
 	if err != nil {
 		t.Fatalf("failed to get updated content: %s", err)
 	}
@@ -314,8 +316,8 @@ func waitForDeployment(ctx context.Context, name string, revision, timeout int) 
 	return fmt.Errorf("%s didn't rollout after 30 seconds", name)
 }
 
-func getContent(name, namespace, url string) (string, error) {
-	endpoint := fmt.Sprintf("https://%s-%s.%s/", name, namespace, url)
+func getContent(name, namespace) (string, error) {
+	endpoint := fmt.Sprintf("http://localhost:8080", name, namespace)
 	retries := 0
 	t := time.NewTicker(1 * time.Second)
 	for i := 0; i < 60; i++ {


### PR DESCRIPTION
Don't use okteto cloud's ingress, since we want to test the CLI functionality.