### PR TITLE
use the current user for SSH

### DIFF
--- a/pkg/cmd/login/browser.go
+++ b/pkg/cmd/login/browser.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 )
@@ -63,8 +64,9 @@ func (h *Handler) AuthorizationURL() string {
 
 	authorizationURL, err := url.Parse(fmt.Sprintf("%s/auth/authorization-code", h.baseURL))
 	if err != nil {
-		panic(fmt.Sprintf("failed to build authorizationURL: %s", err))
+		log.Fatalf("failed to build authorizationURL: %s", err)
 	}
+
 	authorizationURL.RawQuery = params.Encode()
 	return authorizationURL.String()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -52,7 +53,7 @@ func GetHome() string {
 	home = filepath.Join(home, oktetoFolderName)
 
 	if err := os.MkdirAll(home, 0700); err != nil {
-		panic("failed to create the okteto directory")
+		log.Fatalf("failed to create the okteto directory: %s", err)
 	}
 
 	return home
@@ -64,7 +65,7 @@ func GetDeploymentHome(namespace, name string) string {
 	home = filepath.Join(home, oktetoFolderName, namespace, name)
 
 	if err := os.MkdirAll(home, 0700); err != nil {
-		panic("failed to create the okteto deployment directory")
+		log.Fatalf("failed to create the okteto deployment directory: %s", err)
 	}
 
 	return home

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,10 +50,10 @@ func GetBinaryFullPath() string {
 // GetHome returns the path of the folder
 func GetHome() string {
 	home := GetUserHomeDir()
-	home = filepath.Join(home, oktetoFolderName)
+	d := filepath.Join(home, oktetoFolderName)
 
-	if err := os.MkdirAll(home, 0700); err != nil {
-		log.Fatalf("failed to create the okteto directory: %s", err)
+	if err := os.MkdirAll(d, 0700); err != nil {
+		log.Fatalf("failed to create %s: %s", d, err)
 	}
 
 	return home
@@ -62,10 +62,10 @@ func GetHome() string {
 // GetDeploymentHome returns the path of the folder
 func GetDeploymentHome(namespace, name string) string {
 	home := GetUserHomeDir()
-	home = filepath.Join(home, oktetoFolderName, namespace, name)
+	d := filepath.Join(home, oktetoFolderName, namespace, name)
 
-	if err := os.MkdirAll(home, 0700); err != nil {
-		log.Fatalf("failed to create the okteto deployment directory: %s", err)
+	if err := os.MkdirAll(d, 0700); err != nil {
+		log.Fatalf("failed to create %s: %s", d, err)
 	}
 
 	return home

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -37,7 +37,7 @@ const (
 	oktetoBinName              = "okteto-bin"
 
 	//syncthing
-	oktetoBinImageTag      = "okteto/bin:1.1.5"
+	oktetoBinImageTag      = "okteto/bin:1.1.6"
 	oktetoSyncSecretVolume = "okteto-sync-secret"
 	oktetoDevSecretVolume  = "okteto-dev-secret"
 	oktetoSecretTemplate   = "okteto-%s"

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -37,7 +37,7 @@ const (
 	oktetoBinName              = "okteto-bin"
 
 	//syncthing
-	oktetoBinImageTag      = "okteto/bin:1.1.6"
+	oktetoBinImageTag      = "okteto/bin:1.1.7"
 	oktetoSyncSecretVolume = "okteto-sync-secret"
 	oktetoDevSecretVolume  = "okteto-dev-secret"
 	oktetoSecretTemplate   = "okteto-%s"

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -38,7 +38,7 @@ const (
 	oktetoSyncthingMountPath    = "/var/syncthing"
 	oktetoMarkerPathVariable    = "OKTETO_MARKER_PATH"
 	oktetoSSHServerPortVariable = "OKTETO_REMOTE_PORT"
-	oktetoDefaultSSHServerPort  = 22
+	oktetoDefaultSSHServerPort  = 2222
 
 	//DeprecatedOktetoVolumeName name of the (deprecated) okteto persistent volume
 	DeprecatedOktetoVolumeName = "okteto"

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -151,11 +151,11 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 		{
 			name: "custom port",
 			manifest: &Dev{
-				SSHServerPort: 2222,
+				SSHServerPort: 22220,
 			},
 			expected: []EnvVar{
 				{Name: oktetoMarkerPathVariable, Value: ""},
-				{Name: oktetoSSHServerPortVariable, Value: "2222"},
+				{Name: oktetoSSHServerPortVariable, Value: "22220"},
 			},
 		},
 	}

--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -17,9 +17,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func getSSHClientConfig(user string) *ssh.ClientConfig {
+func getSSHClientConfig() *ssh.ClientConfig {
 	sshConfig := &ssh.ClientConfig{
-		User: user,
 		// skipcq GSC-G106
 		// Ignoring this issue since the remote server doesn't have a set identity, and it's already secured by the
 		// port-forward tunnel to the kubernetes cluster.

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -28,7 +28,7 @@ import (
 // Exec executes the command over SSH
 func Exec(ctx context.Context, remotePort int, tty bool, inR io.Reader, outW, errW io.Writer, command []string) error {
 	log.Info("starting SSH connection")
-	sshConfig := getSSHClientConfig("root")
+	sshConfig := getSSHClientConfig()
 
 	var connection *ssh.Client
 	var err error

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -34,7 +34,6 @@ type reverse struct {
 type ReverseManager struct {
 	reverses map[int]*reverse
 	ctx      context.Context
-	sshUser  string
 	sshHost  string
 	sshPort  int
 }

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -44,7 +44,6 @@ func NewReverseManager(ctx context.Context, sshPort int) *ReverseManager {
 	return &ReverseManager{
 		ctx:      ctx,
 		reverses: make(map[int]*reverse),
-		sshUser:  "root",
 		sshHost:  "localhost",
 		sshPort:  sshPort,
 	}
@@ -69,7 +68,7 @@ func (r *ReverseManager) Start() error {
 	log.Info("starting remote forward manager")
 
 	// Connect to SSH remote server using serverEndpoint
-	c := getSSHClientConfig(r.sshUser)
+	c := getSSHClientConfig()
 	sshAddr := fmt.Sprintf("%s:%d", r.sshHost, r.sshPort)
 
 	for _, rt := range r.reverses {

--- a/pkg/ssh/reverse_test.go
+++ b/pkg/ssh/reverse_test.go
@@ -45,7 +45,6 @@ func TestReverseManager_Add(t *testing.T) {
 			r := &ReverseManager{
 				reverses: tt.reverses,
 				ctx:      context.TODO(),
-				sshUser:  "root",
 				sshHost:  "localhost",
 				sshPort:  22,
 			}


### PR DESCRIPTION
Fixes #688 

## Proposed changes
- Change `remote` default port to 2222 
- Fallback on the image's  user for SSH identity

This depends on https://github.com/okteto/devenv/pull/45 and  https://github.com/okteto/remote/pull/15
