### PR TITLE
Increase required watches for warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cli
 .syncthing*
 bin/*
 coverage.txt
+cmd/.stignore

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -99,5 +99,5 @@ func isWatchesConfigurationTooLow(value string) bool {
 		return false
 	}
 	log.Debugf("max_user_watches = %d", c)
-	return c <= 8192
+	return c <= 65536
 }

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -33,12 +33,12 @@ func Test_isWatchesConfigurationTooLow(t *testing.T) {
 		},
 		{
 			name:     "ok",
-			value:    "20000",
+			value:    "80000",
 			expected: false,
 		},
 		{
 			name:     "ok-trim",
-			value:    "20000\n",
+			value:    "80000\n",
 			expected: false,
 		},
 		{


### PR DESCRIPTION
Openshift comes with 65536by default