### PR TITLE
Support for in-cluster login execution

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/login"
-	"github.com/okteto/okteto/pkg/errors"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -49,8 +48,8 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if k8Client.InCluster() {
-				return errors.ErrNotInCluster
+			if len(token) == 0 && k8Client.InCluster() {
+				return fmt.Errorf("this command is not supported without the '--token' flag from inside a pod")
 			}
 
 			oktetoURL := okteto.CloudURL

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -53,7 +53,7 @@ var (
 	ErrUnknownSyncError = fmt.Errorf("Unknown syncthing error")
 
 	// ErrNotInCluster is returned when an unsupported command is invoked from a dev environment (e.g. okteto up)
-	ErrNotInCluster = fmt.Errorf("this command is not supported from inside a development environment")
+	ErrNotInCluster = fmt.Errorf("this command is not supported from inside a pod")
 
 	// ErrLostSyncthing is raised when we lose connectivity with syncthing
 	ErrLostSyncthing = fmt.Errorf("synchronization service unresponsive")


### PR DESCRIPTION
Now we have the `--token` flag, there is no need to restrict the inc-luster execution of the login command. It can also enable different scenarios, like building/pushing from the cluster.