### PR TITLE
Support for "--plain" option to show plain build container output

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -28,7 +28,7 @@ func Build() *cobra.Command {
 	var tag string
 	var target string
 	var noCache bool
-	var plain bool
+	var progress string
 	var buildArgs []string
 
 	cmd := &cobra.Command{
@@ -46,10 +46,11 @@ func Build() *cobra.Command {
 				log.Information("Your image won't be pushed. To push your image specify the flag '-t'.")
 			}
 
-			if _, err := build.Run(buildKitHost, isOktetoCluster, args[0], file, tag, target, noCache, buildArgs, plain); err != nil {
+			if _, err := build.Run(buildKitHost, isOktetoCluster, args[0], file, tag, target, noCache, buildArgs, progress); err != nil {
 				analytics.TrackBuild(false)
 				return err
 			}
+			log.Success("Build succeeded")
 			analytics.TrackBuild(true)
 			return nil
 		},
@@ -65,7 +66,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVarP(&tag, "tag", "t", "", "name and optionally a tag in the 'name:tag' format (it is automatically pushed)")
 	cmd.Flags().StringVarP(&target, "target", "", "", "set the target build stage to build")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "do not use cache when building the image")
-	cmd.Flags().BoolVarP(&plain, "plain", "", false, "show plain build container output")
+	cmd.Flags().StringVarP(&progress, "progress", "", "tty", "show plain/tty build output")
 	cmd.Flags().StringArrayVar(&buildArgs, "build-arg", nil, "set build-time variables")
 	return cmd
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -28,6 +28,7 @@ func Build() *cobra.Command {
 	var tag string
 	var target string
 	var noCache bool
+	var plain bool
 	var buildArgs []string
 
 	cmd := &cobra.Command{
@@ -45,7 +46,7 @@ func Build() *cobra.Command {
 				log.Information("Your image won't be pushed. To push your image specify the flag '-t'.")
 			}
 
-			if _, err := build.Run(buildKitHost, isOktetoCluster, args[0], file, tag, target, noCache, buildArgs); err != nil {
+			if _, err := build.Run(buildKitHost, isOktetoCluster, args[0], file, tag, target, noCache, buildArgs, plain); err != nil {
 				analytics.TrackBuild(false)
 				return err
 			}
@@ -64,6 +65,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVarP(&tag, "tag", "t", "", "name and optionally a tag in the 'name:tag' format (it is automatically pushed)")
 	cmd.Flags().StringVarP(&target, "target", "", "", "set the target build stage to build")
 	cmd.Flags().BoolVarP(&noCache, "no-cache", "", false, "do not use cache when building the image")
+	cmd.Flags().BoolVarP(&plain, "plain", "", false, "show plain build container output")
 	cmd.Flags().StringArrayVar(&buildArgs, "build-arg", nil, "set build-time variables")
 	return cmd
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -38,6 +38,7 @@ func Push() *cobra.Command {
 	var namespace string
 	var imageTag string
 	var autoDeploy bool
+	var plain bool
 	var deploymentName string
 
 	cmd := &cobra.Command{
@@ -80,7 +81,7 @@ func Push() *cobra.Command {
 				}
 			}
 
-			if err := runPush(dev, autoDeploy, imageTag, oktetoRegistryURL, c); err != nil {
+			if err := runPush(dev, autoDeploy, imageTag, oktetoRegistryURL, plain, c); err != nil {
 				analytics.TrackPush(false, oktetoRegistryURL)
 				return err
 			}
@@ -98,11 +99,12 @@ func Push() *cobra.Command {
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the push command is executed")
 	cmd.Flags().StringVarP(&imageTag, "tag", "t", "", "image tag to build, push and redeploy")
 	cmd.Flags().BoolVarP(&autoDeploy, "deploy", "d", false, "create deployment when it doesn't exist in a namespace")
+	cmd.Flags().BoolVarP(&plain, "plain", "", false, "show plain build container output")
 	cmd.Flags().StringVar(&deploymentName, "name", "", "name of the deployment to push to")
 	return cmd
 }
 
-func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL string, c *kubernetes.Clientset) error {
+func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL string, plain bool, c *kubernetes.Clientset) error {
 	create := false
 	d, err := deployments.Get(dev, dev.Namespace, c)
 	if err != nil {
@@ -132,7 +134,7 @@ func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL string
 	log.Infof("pushing with image tag %s", imageTag)
 
 	var imageDigest string
-	imageDigest, err = build.Run(buildKitHost, isOktetoCluster, ".", "Dockerfile", imageTag, "", false, nil)
+	imageDigest, err = build.Run(buildKitHost, isOktetoCluster, ".", "Dockerfile", imageTag, "", false, nil, plain)
 	if err != nil {
 		return fmt.Errorf("error building image '%s': %s", imageTag, err)
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -38,7 +38,7 @@ func Push() *cobra.Command {
 	var namespace string
 	var imageTag string
 	var autoDeploy bool
-	var plain bool
+	var progress string
 	var deploymentName string
 
 	cmd := &cobra.Command{
@@ -81,7 +81,7 @@ func Push() *cobra.Command {
 				}
 			}
 
-			if err := runPush(dev, autoDeploy, imageTag, oktetoRegistryURL, plain, c); err != nil {
+			if err := runPush(dev, autoDeploy, imageTag, oktetoRegistryURL, progress, c); err != nil {
 				analytics.TrackPush(false, oktetoRegistryURL)
 				return err
 			}
@@ -99,12 +99,12 @@ func Push() *cobra.Command {
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the push command is executed")
 	cmd.Flags().StringVarP(&imageTag, "tag", "t", "", "image tag to build, push and redeploy")
 	cmd.Flags().BoolVarP(&autoDeploy, "deploy", "d", false, "create deployment when it doesn't exist in a namespace")
-	cmd.Flags().BoolVarP(&plain, "plain", "", false, "show plain build container output")
+	cmd.Flags().StringVarP(&progress, "progress", "", "tty", "show plain/tty build output")
 	cmd.Flags().StringVar(&deploymentName, "name", "", "name of the deployment to push to")
 	return cmd
 }
 
-func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL string, plain bool, c *kubernetes.Clientset) error {
+func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL, progress string, c *kubernetes.Clientset) error {
 	create := false
 	d, err := deployments.Get(dev, dev.Namespace, c)
 	if err != nil {
@@ -134,7 +134,7 @@ func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL string
 	log.Infof("pushing with image tag %s", imageTag)
 
 	var imageDigest string
-	imageDigest, err = build.Run(buildKitHost, isOktetoCluster, ".", "Dockerfile", imageTag, "", false, nil, plain)
+	imageDigest, err = build.Run(buildKitHost, isOktetoCluster, ".", "Dockerfile", imageTag, "", false, nil, progress)
 	if err != nil {
 		return fmt.Errorf("error building image '%s': %s", imageTag, err)
 	}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Run runs the build sequence
-func Run(buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, target string, noCache bool, buildArgs []string) (string, error) {
+func Run(buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, target string, noCache bool, buildArgs []string, plain bool) (string, error) {
 	ctx := context.Background()
 
 	buildkitClient, err := getBuildkitClient(ctx, isOktetoCluster, buildKitHost)
@@ -43,5 +43,5 @@ func Run(buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, targe
 		return "", errors.Wrap(err, "failed to create build solver")
 	}
 
-	return solveBuild(ctx, buildkitClient, opt)
+	return solveBuild(ctx, buildkitClient, opt, plain)
 }

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Run runs the build sequence
-func Run(buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, target string, noCache bool, buildArgs []string, plain bool) (string, error) {
+func Run(buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, target string, noCache bool, buildArgs []string, progress string) (string, error) {
 	ctx := context.Background()
 
 	buildkitClient, err := getBuildkitClient(ctx, isOktetoCluster, buildKitHost)
@@ -43,5 +43,5 @@ func Run(buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, targe
 		return "", errors.Wrap(err, "failed to create build solver")
 	}
 
-	return solveBuild(ctx, buildkitClient, opt, plain)
+	return solveBuild(ctx, buildkitClient, opt, progress)
 }

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -197,7 +197,7 @@ func getClientForOktetoCluster(ctx context.Context, buildKitHost string) (*clien
 	return c, nil
 }
 
-func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, plain bool) (string, error) {
+func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, progress string) (string, error) {
 	var solveResp *client.SolveResponse
 	ch := make(chan *client.SolveStatus)
 	eg, ctx := errgroup.WithContext(ctx)
@@ -209,7 +209,7 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pla
 
 	eg.Go(func() error {
 		var c console.Console
-		if !plain {
+		if progress == "tty" {
 			if cn, err := console.ConsoleFromFile(os.Stderr); err == nil {
 				c = cn
 			}

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -197,7 +197,7 @@ func getClientForOktetoCluster(ctx context.Context, buildKitHost string) (*clien
 	return c, nil
 }
 
-func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt) (string, error) {
+func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, plain bool) (string, error) {
 	var solveResp *client.SolveResponse
 	ch := make(chan *client.SolveStatus)
 	eg, ctx := errgroup.WithContext(ctx)
@@ -209,8 +209,10 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt) (st
 
 	eg.Go(func() error {
 		var c console.Console
-		if cn, err := console.ConsoleFromFile(os.Stderr); err == nil {
-			c = cn
+		if !plain {
+			if cn, err := console.ConsoleFromFile(os.Stderr); err == nil {
+				c = cn
+			}
 		}
 		// not using shared context to not disrupt display but let it finish reporting errors
 		return progressui.DisplaySolveStatus(context.TODO(), "", c, os.Stdout, ch)


### PR DESCRIPTION
Support to show plain build container output.
Buildkit does not show the output of "RUN" instructions by default. "--plain" is useful for debugging Dockerfile scenarios.
Ideally, we should parse the buildkit output and show the info as we prefer, but that requires a lot of work.