### PR TITLE
remove OKTETO_TOKEN warning

### DIFF
--- a/pkg/okteto/auth.go
+++ b/pkg/okteto/auth.go
@@ -205,10 +205,6 @@ func authUserLegacy(ctx context.Context, client *graphql.Client, code string) (*
 //GetToken returns the token of the authenticated user
 func GetToken() (*Token, error) {
 	if currentToken == nil {
-		if len(os.Getenv("OKTETO_TOKEN")) > 0 {
-			return nil, fmt.Errorf("OKTETO_TOKEN is now deprecated, use the `okteto login --token` command instead")
-		}
-
 		p := getTokenPath()
 
 		b, err := ioutil.ReadFile(p)


### PR DESCRIPTION
Remove the OKTETO_TOKEN deprecation since it confused from other errors.