### PR TITLE
reduce log frequency

### DIFF
--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -382,7 +382,11 @@ func (s *Syncthing) WaitForScanning(ctx context.Context, dev *model.Dev, local b
 			continue
 		}
 
-		log.Infof("syncthing folder local=%t is '%s'", local, status.State)
+		if i%100 == 0 {
+			// one log every 10 seconds
+			log.Infof("syncthing folder local=%t is '%s'", local, status.State)
+		}
+
 		if status.State != "scanning" && status.State != "scan-waiting" {
 			return nil
 		}


### PR DESCRIPTION
When a sync goes wrong, this line gets logged once every 100 milliseconds, making the logs hard to parse. I think having one log every 10 seconds should be enough for diagnosis.