### PR TITLE
Improve the "okteto build" success message

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -42,15 +42,16 @@ func Build() *cobra.Command {
 				return err
 			}
 
-			if tag == "" {
-				log.Information("Your image won't be pushed. To push your image specify the flag '-t'.")
-			}
-
 			if _, err := build.Run(buildKitHost, isOktetoCluster, args[0], file, tag, target, noCache, buildArgs, progress); err != nil {
 				analytics.TrackBuild(false)
 				return err
 			}
-			log.Success("Build succeeded")
+			if tag == "" {
+				log.Success("Build succeeded")
+				log.Information("Your image won't be pushed. To push your image specify the flag '-t'.")
+			} else {
+				log.Success(fmt.Sprintf("Image '%s' successfully pushed", tag))
+			}
 			analytics.TrackBuild(true)
 			return nil
 		},


### PR DESCRIPTION
## Proposed changes
- Show a success "push" message when the "-t" flag is used

<img width="476" alt="Screenshot 2020-03-24 at 13 12 01" src="https://user-images.githubusercontent.com/7474696/77424245-12400780-6dd1-11ea-9814-b7500ee91821.png">
