### PR TITLE
Keep image content if persistentVolume.enabled is false

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -481,13 +481,13 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 	reporter := make(chan string)
 	defer close(reporter)
 	go func() {
-		message := "Attaching persistent volume"
-		up.updateStateFile(attaching)
+		message := "Activating your development environment"
+		if up.Dev.PersistentVolumeEnabled() {
+			message = "Attaching persistent volume"
+			up.updateStateFile(attaching)
+		}
 		for {
-			if up.Dev.PersistentVolumeEnabled() {
-				spinner.update(fmt.Sprintf("%s...", message))
-			}
-
+			spinner.update(fmt.Sprintf("%s...", message))
 			message = <-reporter
 			if message == "" {
 				return

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -329,6 +329,9 @@ func (dev *Dev) validate() error {
 		if len(dev.Services) > 0 {
 			return fmt.Errorf("'persistentVolume.enabled' must be set to true to work with services")
 		}
+		if len(dev.Volumes) > 0 {
+			return fmt.Errorf("'persistentVolume.enabled' must be set to true to use volumes")
+		}
 	}
 
 	if _, err := resource.ParseQuantity(dev.PersistentVolumeSize()); err != nil {
@@ -450,15 +453,20 @@ func (dev *Dev) ToTranslationRule(main *Dev) *TranslationRule {
 		Secrets:          dev.Secrets,
 		WorkDir:          dev.WorkDir,
 		PersistentVolume: dev.PersistentVolumeEnabled(),
-		Volumes: []VolumeMount{
-			{
+		Volumes:          []VolumeMount{},
+		SecurityContext:  dev.SecurityContext,
+		Resources:        dev.Resources,
+	}
+
+	if dev.PersistentVolumeEnabled() {
+		rule.Volumes = append(
+			rule.Volumes,
+			VolumeMount{
 				Name:      main.GetVolumeName(),
 				MountPath: dev.MountPath,
 				SubPath:   fullSubPath(0, dev.SubPath),
 			},
-		},
-		SecurityContext: dev.SecurityContext,
-		Resources:       dev.Resources,
+		)
 	}
 
 	if main == dev {


### PR DESCRIPTION
Related to #764

If `persistentVolume` is not enabled, this PR does not mount an emptyDir on the working dir, and the content of the image is not lost. In a later iteration this will be the default behavior