### PR TITLE
move version test to integration

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -43,9 +43,9 @@ func upgradeAvailable() string {
 		return ""
 	}
 
-	v, err := getVersion()
+	v, err := GetLatestVersionFromGithub()
 	if err != nil {
-		log.Infof("failed to get latest version: %s", err)
+		log.Errorf("failed to get latest version from github: %s", err)
 		return ""
 	}
 
@@ -67,7 +67,8 @@ func upgradeAvailable() string {
 	return ""
 }
 
-func getVersion() (string, error) {
+// GetLatestVersionFromGithub returns the latest okteto version from Github
+func GetLatestVersionFromGithub() (string, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
 	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 5})

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -47,15 +47,3 @@ func Test_shouldNotify(t *testing.T) {
 		})
 	}
 }
-
-func TestGetVersion(t *testing.T) {
-	v, err := getVersion()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = semver.NewVersion(v)
-	if err != nil {
-		t.Fatal(err)
-	}
-}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -32,7 +32,9 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/Masterminds/semver"
 	ps "github.com/mitchellh/go-ps"
+	okCmd "github.com/okteto/okteto/cmd"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/syncthing"
 	"go.undefinedlabs.com/scopeagent"
@@ -141,6 +143,18 @@ func TestMain(m *testing.M) {
 	os.Exit(scopeagent.Run(m, agent.WithMetadata(map[string]interface{}{
 		"mode": mode,
 	})))
+}
+
+func TestGetVersion(t *testing.T) {
+	v, err := okCmd.GetLatestVersionFromGithub()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = semver.NewVersion(v)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestDownloadSyncthing(t *testing.T) {


### PR DESCRIPTION
The github API sometimes times out in the unit test. I think it's better to validate this on integration.