### PR TITLE
don't log.error if github request fails

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -45,7 +45,7 @@ func upgradeAvailable() string {
 
 	v, err := GetLatestVersionFromGithub()
 	if err != nil {
-		log.Errorf("failed to get latest version from github: %s", err)
+		log.Infof("failed to get latest version from github: %s", err)
 		return ""
 	}
 


### PR DESCRIPTION
Github can throttle requests sometime. Let's log the error but not display it, since it's not related to the user's action.