### PR TITLE
enable spinner for windows

### DIFF
--- a/cmd/spinner.go
+++ b/cmd/spinner.go
@@ -15,7 +15,6 @@ package cmd
 
 import (
 	"fmt"
-	"runtime"
 	"time"
 
 	sp "github.com/briandowns/spinner"
@@ -35,19 +34,10 @@ func newSpinner(suffix string) *spinner {
 }
 
 func (p *spinner) start() {
-	if runtime.GOOS == "windows" {
-		fmt.Printf(" %s\n", p.sp.Suffix)
-		return
-	}
-
 	p.sp.Start()
 }
 
 func (p *spinner) stop() {
-	if runtime.GOOS == "windows" {
-		return
-	}
-
 	p.sp.Stop()
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 // indirect
 	github.com/beevik/ntp v0.3.0 // indirect
-	github.com/briandowns/spinner v1.7.0
+	github.com/briandowns/spinner v1.10.0
 	github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.1
 	github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/briandowns/spinner v1.7.0 h1:aan1hBBOoscry2TXAkgtxkJiq7Se0+9pt+TUWaPrB4g=
 github.com/briandowns/spinner v1.7.0/go.mod h1://Zf9tMcxfRUA36V23M6YGEAv+kECGfvpnLTnb8n4XQ=
+github.com/briandowns/spinner v1.10.0 h1:753NIJC2NHmPyVoPVWS+wh9eDx5umqe2U+JgX+KoTag=
+github.com/briandowns/spinner v1.10.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/chai2010/gettext-go v0.0.0-20170215093142-bf70f2a70fb1 h1:HD4PLRzjuCVW79mQ0/pdsalOLHJ+FaEoqJLxfltpb2U=


### PR DESCRIPTION
Signed-off-by: Vikas <vikas@posteo.de>

Fixes #535 

## Proposed changes
- spinner for windows was disabled, just enable and test
- update briandowns/spinner 
