### PR TITLE
Use a new cache key, old one seems broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - checkout
       - restore_cache: 
           keys:
-            - v2-pkg-cache-{{ checksum "go.sum" }}
+            - v3-pkg-cache-{{ checksum "go.sum" }}
       - run: 
           name: test
           environment:
@@ -25,7 +25,7 @@ jobs:
           paths:
             - bin
       - save_cache:
-          key: v2-pkg-cache-{{ checksum "go.sum" }}
+          key: v3-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
             - /go/pkg
@@ -44,7 +44,7 @@ jobs:
       - checkout
       - restore_cache: 
           keys:
-            - v2-pkg-cache-{{ checksum "go.sum" }}
+            - v3-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
       - run:
@@ -68,7 +68,7 @@ jobs:
             export OKTETO_CLIENTSIDE_TRANSLATION=true
             make integration
       - save_cache:
-          key: v2-pkg-cache-{{ checksum "go.sum" }}
+          key: v3-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
             - /go/pkg


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

CircleCI builds are broken with this error:
```
Failed to unarchive cache

Error untarring cache: Error extracting tarball /tmp/cache654176714 : tar: root/.cache/go-build: Cannot mkdir: Permission denied tar: root/.cache/go-build/00: Cannot mkdir: Permission denied tar: root/.cache/go-build/00/00015c315e11d1f90d358fe544c691ecf0b6f1cdb66bb43bd8867bcff3172ad0-d: Cannot open: Permission denied tar: root/.cache/go-build/00/000db332d5a45f0e73a5ec20b3c75f58e527bdd166b65874daadef10a3a39da9-a: Cannot open: Permission denied tar: root/.cache/go-build/00/00336485aa784cd6b99537ac9b57b78b0aa9fcf6f1e31ea3c056ec4e1f7c92c8-d: Cannot open: Permission denied tar: root/.cache/go-build/00/00649c58738016005feb1506cb8d5f223d573b1c46eef1e697eb18e1baa81452-a: Cannot open: Permission denied tar: root/.cache/go-build/00/006ea1e02faff9e74f75b6070e0102b655597bf472956838eecb7fa95de960fc-a: Cannot open: Permission denied tar: root/.cache/go-build/00/0070560b00133ccc41ba731d346828254705b7ed974e5654dee2f74683c58342-a: Cannot open: Permission denied tar: root/.cache/go-build/00/008c2cf220228baf93cdba1ddaeb62a1d9726b470981dbde1e96d538e1f7bbd9-a: Cannot open: Permission denied tar: ro: exit status 2
```