### PR TITLE
Validate relative volume paths and bind mounts are not supported

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -115,6 +115,14 @@ func (s *Stack) validate() error {
 		if svc.Image == "" {
 			return fmt.Errorf(fmt.Sprintf("Invalid service '%s': image cannot be empty", name))
 		}
+		for _, v := range svc.Volumes {
+			if !strings.HasPrefix(v, "/") {
+				return fmt.Errorf(fmt.Sprintf("Invalid volume '%s' in service '%s': must be an absolute path", v, name))
+			}
+			if !strings.Contains(v, ":") {
+				return fmt.Errorf(fmt.Sprintf("Invalid volume '%s' in service '%s': volume bind mounts are not supported", v, name))
+			}
+		}
 	}
 
 	return nil

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -146,7 +146,7 @@ func TestStack_validate(t *testing.T) {
 			stack: &Stack{
 				Name: "name",
 				Services: map[string]Service{
-					"": Service{},
+					"": {},
 				},
 			},
 		},
@@ -155,7 +155,7 @@ func TestStack_validate(t *testing.T) {
 			stack: &Stack{
 				Name: "name",
 				Services: map[string]Service{
-					"-bad-name": Service{},
+					"-bad-name": {},
 				},
 			},
 		},
@@ -164,7 +164,29 @@ func TestStack_validate(t *testing.T) {
 			stack: &Stack{
 				Name: "name",
 				Services: map[string]Service{
-					"name": Service{},
+					"name": {},
+				},
+			},
+		},
+		{
+			name: "relative-volume-path",
+			stack: &Stack{
+				Name: "name",
+				Services: map[string]Service{
+					"name": {
+						Volumes: []string{"relative"},
+					},
+				},
+			},
+		},
+		{
+			name: "volume-bind-mount",
+			stack: &Stack{
+				Name: "name",
+				Services: map[string]Service{
+					"name": {
+						Volumes: []string{"/source:/dest"},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Proposed changes
- Fast fail if relative volume paths or bind mounts are used
