### PR TITLE
fix python example link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We created a few guides to get you started with your favorite programming langua
 1. [Java Maven](https://github.com/okteto/java-maven-getting-started)
 1. [Node](https://github.com/okteto/node-getting-started)
 1. [PHP](https://github.com/okteto/php-getting-started)
-1. [Python](https://github.com/okteto/samples/tree/master/python)
+1. [Python](https://github.com/okteto/samples/tree/master/django)
 
 More samples on how to use Okteto [are available here](https://github.com/okteto/samples).
 


### PR DESCRIPTION
Fixes #
The old python example link was broken. I'm assuming the python example has been moved to / replaced with https://github.com/okteto/samples/tree/master/django
