### PR TITLE
Add okteto restart for a single service

### DIFF
--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -40,8 +40,11 @@ func Restart() *cobra.Command {
 			if err := dev.UpdateNamespace(namespace); err != nil {
 				return err
 			}
-
-			if err := executeRestart(dev); err != nil {
+			serviceName := ""
+			if len(args) > 0 {
+				serviceName = args[0]
+			}
+			if err := executeRestart(dev, serviceName); err != nil {
 				return err
 			}
 			log.Success("Development environment restarted")
@@ -56,7 +59,7 @@ func Restart() *cobra.Command {
 	return cmd
 }
 
-func executeRestart(dev *model.Dev) error {
+func executeRestart(dev *model.Dev, sn string) error {
 	log.Infof("restarting development environment")
 	client, _, namespace, err := k8Client.GetLocal()
 	if err != nil {
@@ -71,7 +74,7 @@ func executeRestart(dev *model.Dev) error {
 	spinner.Start()
 	defer spinner.Stop()
 
-	if err := pods.Restart(dev, client); err != nil {
+	if err := pods.Restart(dev, client, sn); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: adhaamehab <adhaamehab.me@gmail.com>

Fixes #510 

## Proposed changes
- Added a new argument to `okteto restart` which represents single service name to restart. 

- Command will fail with error message `Unable to find any service with the provided name` if the provided service name doesn't match any name in the services section in `okteto.yml`

- If no argument provided all pods will be restarted (normal behaviour) 
