### PR TITLE
Add pid file creation for okteto up command.

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -925,7 +925,7 @@ func createPIDFile(ns, dpName string) error {
 
 // cleanPIDFile deletes PID file after Up finishes
 func cleanPIDFile(ns, dpName string) {
-	filePath := filepath.Join(config.GetDeploymentHome(), "okteto.pid")
+	filePath := filepath.Join(config.GetDeploymentHome(ns, dpName), "okteto.pid")
 	if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
 		log.Infof("Unable to delete PID file at %s", filePath)
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -20,6 +20,8 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -27,6 +29,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	buildCMD "github.com/okteto/okteto/pkg/cmd/build"
+	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
@@ -162,6 +165,7 @@ func Up() *cobra.Command {
 
 //RunUp starts the up sequence
 func RunUp(dev *model.Dev, autoDeploy, build, forcePull, resetSyncthing bool) error {
+
 	up := &UpContext{
 		Dev:  dev,
 		Exit: make(chan error, 1),
@@ -228,6 +232,13 @@ func (up *UpContext) Activate(autoDeploy, build, resetSyncthing bool) {
 	if up.Dev.Namespace == "" {
 		up.Dev.Namespace = namespace
 	}
+
+	if err := createPIDFile(up.Dev.Namespace, up.Dev.Name); err != nil {
+		log.Infof("failed to create pid file for %s - %s", up.Dev.Namespace, up.Dev.Name)
+		up.Exit <- fmt.Errorf("couldn't create pid file for %s - %s", up.Dev.Namespace, up.Dev.Name)
+		return
+	}
+	defer cleanPIDFile(up.Dev.Namespace, up.Dev.Name)
 
 	up.Namespace, err = namespaces.Get(up.Dev.Namespace, up.Client)
 	if err != nil {
@@ -896,4 +907,26 @@ func printDisplayContext(dev *model.Dev) {
 		}
 	}
 	fmt.Println()
+}
+
+// createPIDFile creates a PID file to track Up state and existence
+func createPIDFile(ns, dpName string) error {
+	filePath := filepath.Join(config.GetDeploymentHome(ns, dpName), "okteto.pid")
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("Unable to create PID file at %s", filePath)
+	}
+	defer file.Close()
+	if _, err := file.WriteString(strconv.Itoa(os.Getpid())); err != nil {
+		return fmt.Errorf("Unable to write to PID file at %s", filePath)
+	}
+	return nil
+}
+
+// cleanPIDFile deletes PID file after Up finishes
+func cleanPIDFile(ns, dpName string) {
+	filePath := filepath.Join(config.GetOktetoHome(), "okteto.pid")
+	if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
+		log.Infof("Unable to delete PID file at %s", filePath)
+	}
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -925,7 +925,7 @@ func createPIDFile(ns, dpName string) error {
 
 // cleanPIDFile deletes PID file after Up finishes
 func cleanPIDFile(ns, dpName string) {
-	filePath := filepath.Join(config.GetOktetoHome(), "okteto.pid")
+	filePath := filepath.Join(config.GetDeploymentHome(), "okteto.pid")
 	if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) {
 		log.Infof("Unable to delete PID file at %s", filePath)
 	}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -15,8 +15,13 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 )
@@ -98,6 +103,33 @@ func Test_printDisplayContext(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			printDisplayContext(tt.dev)
 		})
+	}
+
+}
+
+func TestCreatePIDFile(t *testing.T) {
+	deploymentName := "deployment"
+	namespace := "namespace"
+	if err := createPIDFile(namespace, deploymentName); err != nil {
+		t.Fatal("unable to create pid file")
+	}
+
+	filePath := filepath.Join(config.GetDeploymentHome(namespace, deploymentName), "okteto.pid")
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		t.Fatal("didn't create pid file")
+	}
+
+	filePID, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Fatal("pid file is corrupted")
+	}
+	if string(filePID) != strconv.Itoa(os.Getpid()) {
+		t.Fatal("pid file content is invalid")
+	}
+
+	cleanPIDFile(namespace, deploymentName)
+	if _, err := os.Create(filePath); os.IsExist(err) {
+		t.Fatal("didn't delete pid file")
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: adhaamehab <adhaamehab.me@gmail.com>

Fixes #691 

## Proposed changes
- Okteto Up generates a `namespace-deployment.pid` file at `.okteto/` folder defined in the `$OKTETOHOME`
- The pid file gets deleted once `okteto up` finishes
- If the namespace isn't defined in `okteto.yml` file or `--namespace` flag. we use the namespace provided by the k8s client   
