### PR TITLE
only load body if required

### DIFF
--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 )
 
-func TestwaitUntilExitOrInterrupt(t *testing.T) {
+func Test_waitUntilExitOrInterrupt(t *testing.T) {
 	up := UpContext{}
 	up.Running = make(chan error, 1)
 	up.Running <- nil

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -26,17 +26,17 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 )
 
-func TestWaitUntilExitOrInterrupt(t *testing.T) {
+func TestwaitUntilExitOrInterrupt(t *testing.T) {
 	up := UpContext{}
 	up.Running = make(chan error, 1)
 	up.Running <- nil
-	err := up.WaitUntilExitOrInterrupt()
+	err := up.waitUntilExitOrInterrupt()
 	if err != nil {
 		t.Errorf("exited with error instead of nil: %s", err)
 	}
 
 	up.Running <- fmt.Errorf("custom-error")
-	err = up.WaitUntilExitOrInterrupt()
+	err = up.waitUntilExitOrInterrupt()
 	if err == nil {
 		t.Errorf("didn't report proper error")
 	}
@@ -47,7 +47,7 @@ func TestWaitUntilExitOrInterrupt(t *testing.T) {
 
 	up.Disconnect = make(chan error, 1)
 	up.Disconnect <- errors.ErrLostSyncthing
-	err = up.WaitUntilExitOrInterrupt()
+	err = up.waitUntilExitOrInterrupt()
 	if err != errors.ErrLostSyncthing {
 		t.Errorf("exited with error %s instead of %s", err, errors.ErrLostSyncthing)
 	}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -224,11 +224,11 @@ func (s *Syncthing) initConfig() error {
 	}
 
 	if err := ioutil.WriteFile(filepath.Join(s.Home, certFile), cert, 0700); err != nil {
-		return err
+		return fmt.Errorf("failed to write syncthing certificate: %w", err)
 	}
 
 	if err := ioutil.WriteFile(filepath.Join(s.Home, keyFile), key, 0700); err != nil {
-		return err
+		return fmt.Errorf("failed to write syncthing key: %w", err)
 	}
 
 	return nil
@@ -238,12 +238,13 @@ func (s *Syncthing) initConfig() error {
 func (s *Syncthing) UpdateConfig() error {
 	buf := new(bytes.Buffer)
 	if err := configTemplate.Execute(buf, s); err != nil {
-		return err
+		return fmt.Errorf("failed to write syncthing configuration template: %w", err)
 	}
 
 	if err := ioutil.WriteFile(filepath.Join(s.Home, configFile), buf.Bytes(), 0700); err != nil {
-		return err
+		return fmt.Errorf("failed to write syncthing configuration file: %w", err)
 	}
+
 	return nil
 }
 
@@ -267,18 +268,15 @@ func (s *Syncthing) Run(ctx context.Context) error {
 	s.cmd.Env = append(os.Environ(), "STNOUPGRADE=1")
 
 	if err := s.cmd.Start(); err != nil {
-		return err
+		return fmt.Errorf("failed to start syncthing: %w", err)
 	}
 
 	if s.cmd.Process == nil {
 		return nil
 	}
 
-	if err := ioutil.WriteFile(
-		pidPath,
-		[]byte(strconv.Itoa(s.cmd.Process.Pid)),
-		0600); err != nil {
-		return err
+	if err := ioutil.WriteFile(pidPath, []byte(strconv.Itoa(s.cmd.Process.Pid)), 0600); err != nil {
+		return fmt.Errorf("failed to write syncthing pid file: %w", err)
 	}
 
 	s.pid = s.cmd.Process.Pid
@@ -598,7 +596,7 @@ func (s *Syncthing) Save(dev *model.Dev) error {
 
 	syncthingInfoFile := config.GetSyncthingInfoFile(dev.Namespace, dev.Name)
 	if err := ioutil.WriteFile(syncthingInfoFile, marshalled, 0600); err != nil {
-		return err
+		return fmt.Errorf("failed to write syncthing info file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
When restarting syncthing, sometimes we get an EOF error because the process restarts before we consume the response. With this change, we only get the body of the response if when we care about it.

Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>
