### PR TITLE
block operations only if on dev env pod

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/errors"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
 
@@ -36,8 +37,8 @@ func Doctor() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting doctor command")
 
-			if k8Client.InCluster() {
-				return errors.ErrNotInCluster
+			if okteto.InDevEnv() {
+				return errors.ErrNotInDevEnv
 			}
 
 			dev, err := utils.LoadDev(devPath)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,6 +25,7 @@ import (
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/syncthing"
 	"github.com/spf13/cobra"
 )
@@ -41,8 +42,8 @@ func Status() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting status command")
 
-			if k8Client.InCluster() {
-				return errors.ErrNotInCluster
+			if okteto.InDevEnv() {
+				return errors.ErrNotInDevEnv
 			}
 
 			dev, err := utils.LoadDev(devPath)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -107,8 +107,8 @@ func Up() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Debug("starting up command")
 
-			if k8Client.InCluster() {
-				return errors.ErrNotInCluster
+			if okteto.InDevEnv() {
+				return errors.ErrNotInDevEnv
 			}
 
 			u := upgradeAvailable()

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -52,8 +52,8 @@ var (
 	// ErrUnknownSyncError is returned when syncthing reports an unknown sync error
 	ErrUnknownSyncError = fmt.Errorf("Unknown syncthing error")
 
-	// ErrNotInCluster is returned when an unsupported command is invoked from a dev environment (e.g. okteto up)
-	ErrNotInCluster = fmt.Errorf("this command is not supported from inside a pod")
+	// ErrNotInDevEnv is returned when an unsupported command is invoked from a dev environment (e.g. okteto up)
+	ErrNotInDevEnv = fmt.Errorf("this command is not supported from inside an okteto development environment")
 
 	// ErrLostSyncthing is raised when we lose connectivity with syncthing
 	ErrLostSyncthing = fmt.Errorf("synchronization service unresponsive")

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -147,3 +147,12 @@ func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, cluste
 
 	return clientcmd.WriteToFile(*cfg, kubeConfigPath)
 }
+
+// InDevEnv returns true if running in an Okteto dev pod
+func InDevEnv() bool {
+	if v, ok := os.LookupEnv("OKTETO_MARKER_PATH"); ok && v != "" {
+		return true
+	}
+
+	return false
+}

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -90,3 +90,28 @@ func TestSetKubeConfig(t *testing.T) {
 	}
 
 }
+
+func TestInDevEnv(t *testing.T) {
+	v := os.Getenv("OKTETO_MARKER_PATH")
+	os.Setenv("OKTETO_MARKER_PATH", "")
+	defer func() {
+		os.Setenv("OKTETO_MARKER_PATH", v)
+	}()
+
+	in := InDevEnv()
+	if in {
+		t.Errorf("in devenv when there was no marker env var")
+	}
+
+	os.Setenv("OKTETO_MARKER_PATH", "")
+	in = InDevEnv()
+	if in {
+		t.Errorf("in devenv when there was an empty marker env var")
+	}
+
+	os.Setenv("OKTETO_MARKER_PATH", "1")
+	in = InDevEnv()
+	if !in {
+		t.Errorf("not in devenv when there was a marker env var")
+	}
+}


### PR DESCRIPTION
## Proposed changes
- allow up, doctor and status on a kubernetes pod, and just block if within an okteto dev env
 
