### PR TITLE
Rename "development environment" to "development container"

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -37,8 +37,8 @@ func Doctor() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting doctor command")
 
-			if okteto.InDevEnv() {
-				return errors.ErrNotInDevEnv
+			if okteto.InDevContainer() {
+				return errors.ErrNotInDevContainer
 			}
 
 			dev, err := utils.LoadDev(devPath)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//Down deactivates the development environment
+//Down deactivates the development container
 func Down() *cobra.Command {
 	var devPath string
 	var namespace string
@@ -37,7 +37,7 @@ func Down() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "down",
-		Short: "Deactivates your development environment",
+		Short: "Deactivates your development container",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting down command")
 			ctx := context.Background()
@@ -55,7 +55,7 @@ func Down() *cobra.Command {
 				return err
 			}
 
-			log.Success("Development environment deactivated")
+			log.Success("Development container deactivated")
 			log.Information("Run 'okteto push' to deploy your code changes to the cluster")
 
 			if rm {
@@ -85,7 +85,7 @@ func Down() *cobra.Command {
 }
 
 func runDown(dev *model.Dev) error {
-	spinner := utils.NewSpinner("Deactivating your development environment...")
+	spinner := utils.NewSpinner("Deactivating your development container...")
 	spinner.Start()
 	defer spinner.Stop()
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -39,7 +39,7 @@ func Exec() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "exec <command>",
-		Short: "Execute a command in your development environment",
+		Short: "Execute a command in your development container",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -56,7 +56,7 @@ func Exec() *cobra.Command {
 
 			if errors.IsNotFound(err) {
 				return errors.UserError{
-					E:    fmt.Errorf("Development environment not found in namespace %s", dev.Namespace),
+					E:    fmt.Errorf("Development container not found in namespace %s", dev.Namespace),
 					Hint: "Run `okteto up` to launch it or use `okteto namespace` to select the correct namespace and try again",
 				}
 			}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -129,12 +129,12 @@ func executeInit(devPath string, overwrite bool, language string, workDir string
 func askForImage(language, defaultImage string) string {
 	var image string
 	fmt.Printf("Recommended image for development with %s: %s\n", language, log.BlueString(defaultImage))
-	fmt.Printf("Which docker image do you want to use for your development environment? [%s]: ", defaultImage)
+	fmt.Printf("Which docker image do you want to use for your development container? [%s]: ", defaultImage)
 	_, err := fmt.Scanln(&image)
 	fmt.Println()
 
 	if err != nil {
-		log.Debugf("Scanln failed to read dev environment image: %s", err)
+		log.Debugf("Scanln failed to read development container image: %s", err)
 		image = ""
 	}
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -92,7 +92,7 @@ func Push(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			log.Success("Source code pushed to the development environment '%s'", dev.Name)
+			log.Success("Source code pushed to '%s'", dev.Name)
 			log.Println()
 
 			analytics.TrackPush(true, oktetoRegistryURL)
@@ -162,7 +162,7 @@ func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL, progr
 			return err
 		}
 
-		log.Information("Development environment deactivated")
+		log.Information("Development container deactivated")
 	}
 
 	imageFromDeployment, err := getImageFromDeployment(trList)
@@ -175,7 +175,7 @@ func runPush(dev *model.Dev, autoDeploy bool, imageTag, oktetoRegistryURL, progr
 		return err
 	}
 
-	spinner := utils.NewSpinner(fmt.Sprintf("Pushing source code to the development environment '%s'...", dev.Name))
+	spinner := utils.NewSpinner(fmt.Sprintf("Pushing source code to '%s'...", dev.Name))
 	spinner.Start()
 	defer spinner.Stop()
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -31,7 +31,7 @@ func Restart() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "restart",
-		Short: "Restarts the pods of your development environment",
+		Short: "Restarts the deployment listed in the services field of the okteto manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dev, err := utils.LoadDev(devPath)
 			if err != nil {
@@ -47,20 +47,20 @@ func Restart() *cobra.Command {
 			if err := executeRestart(dev, serviceName); err != nil {
 				return err
 			}
-			log.Success("Development environment restarted")
+			log.Success("Deployments restarted")
 
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVarP(&devPath, "file", "f", defaultManifest, "path to the manifest file")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the exec command is executed")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the restart command is executed")
 
 	return cmd
 }
 
 func executeRestart(dev *model.Dev, sn string) error {
-	log.Infof("restarting development environment")
+	log.Infof("restarting services")
 	client, _, namespace, err := k8Client.GetLocal()
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func executeRestart(dev *model.Dev, sn string) error {
 		dev.Namespace = namespace
 	}
 
-	spinner := utils.NewSpinner("Restarting your development environment...")
+	spinner := utils.NewSpinner("Restarting deployments...")
 	spinner.Start()
 	defer spinner.Stop()
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -42,8 +42,8 @@ func Status() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting status command")
 
-			if okteto.InDevEnv() {
-				return errors.ErrNotInDevEnv
+			if okteto.InDevContainer() {
+				return errors.ErrNotInDevContainer
 			}
 
 			dev, err := utils.LoadDev(devPath)

--- a/docs/how-does-it-work.md
+++ b/docs/how-does-it-work.md
@@ -1,11 +1,11 @@
 ## How does Okteto work?
 
-Okteto swaps your applications pods by a development environment. Lets explain this process with a diagram:
+Okteto swaps your applications pods by a development container. Lets explain this process with a diagram:
 
 <img align="left" src="okteto-architecture.png">
 
-At a high level, Okteto works by swapping pods in your application with a development environment. In the diagram above, you can see how Okteto replaced the **api** pods by the development environment **api-dev**. 
+At a high level, Okteto works by swapping pods in your application with a development container. In the diagram above, you can see how Okteto replaced the **api** pods by the development container **api-dev**. 
 
-The development environment has a different container image (your development image, with all the tools you need pre-installed) but it keeps the rest of the configuration of the original pods (same identity, environment variables, start command, etc…). Although you can override pretty much every configuration of the pod via the Okteto yaml manifest.
+The development container has a different container image (your development image, with all the tools you need pre-installed) but it keeps the rest of the configuration of the original pods (same identity, environment variables, start command, sidecars, etc…). Although you can override pretty much every configuration of the pod via the Okteto manifest.
 
-Local code changes are automatically synchronized to the development environment via [syncthing](https://github.com/syncthing/syncthing). To accomplish this, Okteto launches syncthing both locally and in the development environment pod.  Both processes are securely connected via Kubernetes' port forwarding capabilities. 
+Local code changes are automatically synchronized to the development container via [syncthing](https://github.com/syncthing/syncthing). To accomplish this, Okteto launches syncthing both locally and in the development container. Both processes are securely connected via Kubernetes' port forwarding capabilities. 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -493,13 +493,13 @@ func waitForReady(namespace, name string) error {
 			log.Printf("okteto up is: %s", c)
 			return nil
 		} else if string(c) == "failed" {
-			return fmt.Errorf("dev environment failed")
+			return fmt.Errorf("development container failed")
 		}
 
 		<-t.C
 	}
 
-	return fmt.Errorf("dev environment was never ready")
+	return fmt.Errorf("development container was never ready")
 }
 
 func deploy(ctx context.Context, name, path string) error {

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	root := &cobra.Command{
 		Use:           fmt.Sprintf("%s COMMAND [ARG...]", config.GetBinaryName()),
-		Short:         "Manage cloud dev environments",
+		Short:         "Manage development containers",
 		SilenceErrors: true,
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			log.SetLevel(logLevel)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -93,7 +93,7 @@ func TrackDeleteNamespace(success bool) {
 	track(namespaceDeleteEvent, success, nil)
 }
 
-// TrackReconnect sends a tracking event to mixpanel when the dev environment reconnect
+// TrackReconnect sends a tracking event to mixpanel when the development container reconnect
 func TrackReconnect(success bool, clusterType string, swap bool) {
 	props := map[string]interface{}{
 		"clusterType": clusterType,
@@ -107,14 +107,14 @@ func TrackSyncError() {
 	track(syncErrorEvent, false, nil)
 }
 
-// TrackUp sends a tracking event to mixpanel when the user activates a development environment
+// TrackUp sends a tracking event to mixpanel when the user activates a development container
 func TrackUp(success bool, dev, clusterType string, single, swap, remote bool) {
 	props := map[string]interface{}{
-		"devEnvironmentName": dev,
-		"clusterType":        clusterType,
-		"singleService":      single,
-		"swap":               swap,
-		"remote":             remote,
+		"name":          dev,
+		"clusterType":   clusterType,
+		"singleService": single,
+		"swap":          swap,
+		"remote":        remote,
 	}
 	track(upEvent, success, props)
 }
@@ -132,17 +132,17 @@ func TrackExec(success bool) {
 	track(execEvent, success, nil)
 }
 
-// TrackDown sends a tracking event to mixpanel when the user deactivates a development environment
+// TrackDown sends a tracking event to mixpanel when the user deactivates a development container
 func TrackDown(success bool) {
 	track(downEvent, success, nil)
 }
 
-// TrackDownVolumes sends a tracking event to mixpanel when the user deactivates a development environment and its volumes
+// TrackDownVolumes sends a tracking event to mixpanel when the user deactivates a development container and its volumes
 func TrackDownVolumes(success bool) {
 	track(downVolumesEvent, success, nil)
 }
 
-// TrackPush sends a tracking event to mixpanel when the user pushes a development environment
+// TrackPush sends a tracking event to mixpanel when the user pushes a development container
 func TrackPush(success bool, oktetoRegistryURL string) {
 	props := map[string]interface{}{
 		"oktetoRegistryURL": oktetoRegistryURL,

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -52,8 +52,8 @@ var (
 	// ErrUnknownSyncError is returned when syncthing reports an unknown sync error
 	ErrUnknownSyncError = fmt.Errorf("Unknown syncthing error")
 
-	// ErrNotInDevEnv is returned when an unsupported command is invoked from a dev environment (e.g. okteto up)
-	ErrNotInDevEnv = fmt.Errorf("this command is not supported from inside an okteto development environment")
+	// ErrNotInDevContainer is returned when an unsupported command is invoked from a dev container (e.g. okteto up)
+	ErrNotInDevContainer = fmt.Errorf("this command is not supported from inside an development container")
 
 	// ErrLostSyncthing is raised when we lose connectivity with syncthing
 	ErrLostSyncthing = fmt.Errorf("synchronization service unresponsive")

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -93,7 +93,7 @@ func GetRevisionAnnotatedDeploymentOrFailed(dev *model.Dev, c *kubernetes.Client
 	return d, nil
 }
 
-//GetTranslations fills all the deployments pointed by a dev environment
+//GetTranslations fills all the deployments pointed by a development container
 func GetTranslations(dev *model.Dev, d *appsv1.Deployment, c *kubernetes.Clientset) (map[string]*model.Translation, error) {
 	result := map[string]*model.Translation{}
 	if d != nil {
@@ -214,7 +214,7 @@ func IsDevModeOn(d *appsv1.Deployment) bool {
 	return ok
 }
 
-//HasBeenChanged returns if a deployment has been updated since the development environment was activated
+//HasBeenChanged returns if a deployment has been updated since the development container was activated
 func HasBeenChanged(d *appsv1.Deployment) bool {
 	oktetoRevision := d.Annotations[okLabels.RevisionAnnotation]
 	if oktetoRevision == "" {
@@ -242,7 +242,7 @@ func TranslateDevModeOff(d *appsv1.Deployment) (*appsv1.Deployment, error) {
 	if trRulesJSON == "" {
 		dManifest := getAnnotation(d.GetObjectMeta(), oktetoDeploymentAnnotation)
 		if dManifest == "" {
-			log.Infof("%s/%s is not a development environment", d.Namespace, d.Name)
+			log.Infof("%s/%s is not a development container", d.Namespace, d.Name)
 			return d, nil
 		}
 		dOrig := &appsv1.Deployment{}

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -253,18 +253,18 @@ func TranslateResources(c *apiv1.Container, r model.ResourceRequirements) {
 
 //TranslateEnvVars translates the variables attached to a container
 func TranslateEnvVars(c *apiv1.Container, rule *model.TranslationRule) {
-	unusedDevEnv := map[string]string{}
+	unusedDevEnvVar := map[string]string{}
 	for _, val := range rule.Environment {
-		unusedDevEnv[val.Name] = val.Value
+		unusedDevEnvVar[val.Name] = val.Value
 	}
 	for i, envvar := range c.Env {
-		if value, ok := unusedDevEnv[envvar.Name]; ok {
+		if value, ok := unusedDevEnvVar[envvar.Name]; ok {
 			c.Env[i] = apiv1.EnvVar{Name: envvar.Name, Value: value}
-			delete(unusedDevEnv, envvar.Name)
+			delete(unusedDevEnvVar, envvar.Name)
 		}
 	}
 	for _, envvar := range rule.Environment {
-		if value, ok := unusedDevEnv[envvar.Name]; ok {
+		if value, ok := unusedDevEnvVar[envvar.Name]; ok {
 			c.Env = append(c.Env, apiv1.EnvVar{Name: envvar.Name, Value: value})
 		}
 	}

--- a/pkg/k8s/exec/exec.go
+++ b/pkg/k8s/exec/exec.go
@@ -28,7 +28,7 @@ import (
 	kexec "k8s.io/kubectl/pkg/cmd/exec"
 )
 
-// Exec executes the command in the dev environment container
+// Exec executes the command in the development container
 func Exec(ctx context.Context, c *kubernetes.Clientset, config *rest.Config, podNamespace, podName, container string, tty bool, stdin io.Reader, stdout, stderr io.Writer, command []string) error {
 
 	p := &kexec.ExecOptions{}

--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -107,12 +107,12 @@ func (p *PortForwardManager) AddReverse(_ model.Reverse) error {
 	return fmt.Errorf("not implemented")
 }
 
-// Start starts all the port forwarders to the dev environment
+// Start starts all the port forwarders to the development container
 func (p *PortForwardManager) Start(devPod, namespace string) error {
 	p.stopped = false
 	a, devPF, err := p.buildForwarderToDevPod(namespace, devPod)
 	if err != nil {
-		return fmt.Errorf("failed to forward ports to development environment: %w", err)
+		return fmt.Errorf("failed to forward ports to development container: %w", err)
 	}
 
 	p.activeDev = a

--- a/pkg/k8s/labels/labels.go
+++ b/pkg/k8s/labels/labels.go
@@ -26,10 +26,10 @@ const (
 	// DetachedDevLabel indicates the detached dev pods
 	DetachedDevLabel = "detached.dev.okteto.com"
 
-	// RevisionAnnotation indicates the revision when the development environment was activated
+	// RevisionAnnotation indicates the revision when the development container was activated
 	RevisionAnnotation = "dev.okteto.com/revision"
 
-	// DeploymentAnnotation indicates the original deployment manifest  when the development environment was activated
+	// DeploymentAnnotation indicates the original deployment manifest  when the development container was activated
 	DeploymentAnnotation = "dev.okteto.com/deployment"
 
 	// TranslationAnnotation sets the translation rules

--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -101,7 +101,7 @@ func GetDevPodInLoop(ctx context.Context, dev *model.Dev, c *kubernetes.Clientse
 		}
 
 		if time.Now().After(timeout) {
-			return nil, fmt.Errorf("kubernetes is taking too long to create the pod of your development environment. Please check for errors and try again")
+			return nil, fmt.Errorf("kubernetes is taking too long to create your development container. Please check for errors and try again")
 		}
 
 		select {
@@ -187,7 +187,7 @@ func MonitorDevPod(ctx context.Context, dev *model.Dev, pod *apiv1.Pod, c *kuber
 				return pod, nil
 			}
 			if pod.DeletionTimestamp != nil {
-				return nil, fmt.Errorf("development environment has been removed")
+				return nil, fmt.Errorf("development container has been removed")
 			}
 		case event := <-watchPodEvents.ResultChan():
 			e, ok := event.Object.(*v1.Event)
@@ -231,7 +231,7 @@ func Exists(podName, namespace string, c kubernetes.Interface) bool {
 func GetDevPodUserID(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset) int64 {
 	devPodLogs, err := GetDevPodLogs(ctx, dev, false, c)
 	if err != nil {
-		log.Errorf("failed to access development environment logs: %s", err)
+		log.Errorf("failed to access development container logs: %s", err)
 		return -1
 	}
 	return parseUserID(devPodLogs)
@@ -240,12 +240,12 @@ func GetDevPodUserID(ctx context.Context, dev *model.Dev, c *kubernetes.Clientse
 func parseUserID(output string) int64 {
 	lines := strings.Split(output, "\n")
 	if len(lines) == 0 {
-		log.Info("development environment logs not generated. USER cannot be inferred")
+		log.Info("development container logs not generated. USER cannot be inferred")
 		return -1
 	}
 
 	if !strings.HasPrefix(lines[0], "USER:") {
-		log.Infof("USER entry not not found in first development environment log line: %s", lines[0])
+		log.Infof("USER entry not not found in first development container log line: %s", lines[0])
 		return -1
 	}
 
@@ -310,7 +310,7 @@ func Restart(dev *model.Dev, c *kubernetes.Clientset, sn string) error {
 	)
 	if err != nil {
 		log.Infof("error listing pods to restart: %s", err)
-		return fmt.Errorf("failed to retrieve dev environment information")
+		return fmt.Errorf("failed to retrieve development container information")
 	}
 
 	found := false
@@ -353,7 +353,7 @@ func waitUntilRunning(namespace, selector string, c *kubernetes.Clientset) error
 
 		if err != nil {
 			log.Infof("error listing pods to check status after restart: %s", err)
-			return fmt.Errorf("failed to retrieve dev environment information")
+			return fmt.Errorf("failed to retrieve development container information")
 		}
 
 		allRunning := true

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -102,7 +102,7 @@ func Destroy(dev *model.Dev, c *kubernetes.Clientset) error {
 	return nil
 }
 
-//GetSecretName returns the okteto secret name for a given dev environment
+//GetSecretName returns the okteto secret name for a given development container
 func GetSecretName(dev *model.Dev) string {
 	return fmt.Sprintf(oktetoSecretTemplate, dev.Name)
 }

--- a/pkg/k8s/services/crud.go
+++ b/pkg/k8s/services/crud.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-//CreateDev deploys a default k8s service for a dev environment
+//CreateDev deploys a default k8s service for a development container
 func CreateDev(dev *model.Dev, c *kubernetes.Clientset) error {
 	old, err := Get(dev.Namespace, dev.Name, c)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
@@ -53,7 +53,7 @@ func CreateDev(dev *model.Dev, c *kubernetes.Clientset) error {
 	return nil
 }
 
-//DestroyDev destroys the default service for a dev environment
+//DestroyDev destroys the default service for a development container
 func DestroyDev(dev *model.Dev, c *kubernetes.Clientset) error {
 	log.Infof("deleting service '%s'", dev.Name)
 	sClient := c.CoreV1().Services(dev.Namespace)

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-//Create deploys the volume claim for a given dev environment
+//Create deploys the volume claim for a given development container
 func Create(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset) error {
 	vClient := c.CoreV1().PersistentVolumeClaims(dev.Namespace)
 	pvc := translate(dev)
@@ -81,7 +81,7 @@ func checkPVCValues(pvc *apiv1.PersistentVolumeClaim, dev *model.Dev) error {
 
 }
 
-//Destroy destroys the volume claim for a given dev environment
+//Destroy destroys the volume claim for a given development container
 func Destroy(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset) error {
 	vClient := c.CoreV1().PersistentVolumeClaims(dev.Namespace)
 	log.Infof("destroying volume claim '%s'", dev.GetVolumeName())

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -49,13 +49,13 @@ const (
 
 	//DeprecatedOktetoVolumeName name of the (deprecated) okteto persistent volume
 	DeprecatedOktetoVolumeName = "okteto"
-	//OktetoVolumeNameTemplate name template of the dev environment persistent volume
+	//OktetoVolumeNameTemplate name template of the development container persistent volume
 	OktetoVolumeNameTemplate = "okteto-%s"
-	//SourceCodeSubPath subpath in the dev environment persistent volume for the source code
+	//SourceCodeSubPath subpath in the development container persistent volume for the source code
 	SourceCodeSubPath = "src"
 	//OktetoSyncthingMountPath syncthing volume mount path
 	OktetoSyncthingMountPath = "/var/syncthing"
-	//SyncthingSubPath subpath in the dev environment persistent volume for the syncthing data
+	//SyncthingSubPath subpath in the development container persistent volume for the syncthing data
 	SyncthingSubPath = "syncthing"
 	//OktetoAutoCreateAnnotation indicates if the deployment was auto generatted by okteto up
 	OktetoAutoCreateAnnotation = "dev.okteto.com/auto-create"
@@ -93,7 +93,7 @@ var (
 	devTerminationGracePeriodSeconds int64
 )
 
-//Dev represents a cloud native development environment
+//Dev represents a development container
 type Dev struct {
 	Name                 string                `json:"name" yaml:"name"`
 	Labels               map[string]string     `json:"labels,omitempty" yaml:"labels,omitempty"`
@@ -139,13 +139,13 @@ type BuildInfoRaw struct {
 	Args       []EnvVar `yaml:"args,omitempty"`
 }
 
-// Volume represents a volume in the dev environment
+// Volume represents a volume in the development container
 type Volume struct {
 	SubPath   string
 	MountPath string
 }
 
-// ExternalVolume represents a external volume in the dev environment
+// ExternalVolume represents a external volume in the development container
 type ExternalVolume struct {
 	Name      string
 	SubPath   string
@@ -532,7 +532,7 @@ func (dev *Dev) LoadForcePull() {
 func (dev *Dev) Save(path string) error {
 	marshalled, err := yaml.Marshal(dev)
 	if err != nil {
-		log.Infof("failed to marshall dev environment: %s", err)
+		log.Infof("failed to marshall development container: %s", err)
 		return fmt.Errorf("Failed to generate your manifest")
 	}
 
@@ -556,7 +556,7 @@ func SerializeBuildArgs(buildArgs []EnvVar) []string {
 	return result
 }
 
-//GetVolumeName returns the okteto volume name for a given dev environment
+//GetVolumeName returns the okteto volume name for a given development container
 func (dev *Dev) GetVolumeName() string {
 	return fmt.Sprintf(OktetoVolumeNameTemplate, dev.Name)
 }

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -152,8 +152,8 @@ func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, cluste
 	return clientcmd.WriteToFile(*cfg, kubeConfigPath)
 }
 
-// InDevEnv returns true if running in an Okteto dev pod
-func InDevEnv() bool {
+// InDevContainer returns true if running in an Okteto dev pod
+func InDevContainer() bool {
 	if v, ok := os.LookupEnv(model.OktetoMarkerPathVariable); ok && v != "" {
 		return true
 	}

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -91,27 +91,27 @@ func TestSetKubeConfig(t *testing.T) {
 
 }
 
-func TestInDevEnv(t *testing.T) {
+func TestInDevContainer(t *testing.T) {
 	v := os.Getenv("OKTETO_MARKER_PATH")
 	os.Setenv("OKTETO_MARKER_PATH", "")
 	defer func() {
 		os.Setenv("OKTETO_MARKER_PATH", v)
 	}()
 
-	in := InDevEnv()
+	in := InDevContainer()
 	if in {
-		t.Errorf("in devenv when there was no marker env var")
+		t.Errorf("in dev container when there was no marker env var")
 	}
 
 	os.Setenv("OKTETO_MARKER_PATH", "")
-	in = InDevEnv()
+	in = InDevContainer()
 	if in {
-		t.Errorf("in devenv when there was an empty marker env var")
+		t.Errorf("in dev container when there was an empty marker env var")
 	}
 
 	os.Setenv("OKTETO_MARKER_PATH", "1")
-	in = InDevEnv()
+	in = InDevContainer()
 	if !in {
-		t.Errorf("not in devenv when there was a marker env var")
+		t.Errorf("not in dev container when there was a marker env var")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- Rename "development environment" to "development container".  The development environment is a wider concept.
