### PR TITLE
Accept single string as command in the okteto manifest

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -821,7 +821,7 @@ func (up *UpContext) runCommand() error {
 	up.updateStateFile(ready)
 
 	if up.Dev.ExecuteOverSSHEnabled() || up.Dev.RemoteModeEnabled() {
-		return ssh.Exec(up.Context, up.Dev.RemotePort, true, os.Stdin, os.Stdout, os.Stderr, up.Dev.Command)
+		return ssh.Exec(up.Context, up.Dev.RemotePort, true, os.Stdin, os.Stdout, os.Stderr, up.Dev.Command.Values)
 	}
 
 	return exec.Exec(
@@ -835,7 +835,7 @@ func (up *UpContext) runCommand() error {
 		os.Stdin,
 		os.Stdout,
 		os.Stderr,
-		up.Dev.Command,
+		up.Dev.Command.Values,
 	)
 }
 

--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -184,9 +184,11 @@ func GetDevConfig(language string) *model.Dev {
 	n := normalizeLanguage(language)
 	vals := languageDefaults[n]
 	dev := &model.Dev{
-		Image:           vals.image,
-		WorkDir:         vals.path,
-		Command:         vals.command,
+		Image:   vals.image,
+		WorkDir: vals.path,
+		Command: model.Command{
+			Values: vals.command,
+		},
 		Environment:     vals.environment,
 		Volumes:         vals.volumes,
 		Forward:         vals.forward,

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -107,7 +107,7 @@ type Dev struct {
 	ImagePullPolicy      apiv1.PullPolicy      `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 	Environment          []EnvVar              `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Secrets              []Secret              `json:"secrets,omitempty" yaml:"secrets,omitempty"`
-	Command              []string              `json:"command,omitempty" yaml:"command,omitempty"`
+	Command              Command               `json:"command,omitempty" yaml:"command,omitempty"`
 	Healthchecks         bool                  `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
 	WorkDir              string                `json:"workdir,omitempty" yaml:"workdir,omitempty"`
 	MountPath            string                `json:"mountpath,omitempty" yaml:"mountpath,omitempty"`
@@ -124,6 +124,11 @@ type Dev struct {
 	DevDir               string                `json:"-" yaml:"-"`
 	Services             []*Dev                `json:"services,omitempty" yaml:"services,omitempty"`
 	SSHServerPort        int                   `json:"sshServerPort,omitempty" yaml:"sshServerPort,omitempty"`
+}
+
+//Command represents the staart commaand of a development contaianer
+type Command struct {
+	Values []string
 }
 
 // BuildInfo represents the build info to generate an image
@@ -233,7 +238,6 @@ func Read(bytes []byte) (*Dev, error) {
 		Push:        &BuildInfo{},
 		Environment: make([]EnvVar, 0),
 		Secrets:     make([]Secret, 0),
-		Command:     make([]string, 0),
 		Forward:     make([]Forward, 0),
 		Volumes:     make([]Volume, 0),
 		Services:    make([]*Dev, 0),
@@ -299,8 +303,8 @@ func (dev *Dev) loadImage() {
 }
 
 func (dev *Dev) setDefaults() error {
-	if len(dev.Command) == 0 {
-		dev.Command = []string{"sh"}
+	if dev.Command.Values == nil {
+		dev.Command.Values = []string{"sh"}
 	}
 	setBuildDefaults(dev.Build)
 	setBuildDefaults(dev.Push)
@@ -665,8 +669,8 @@ func (dev *Dev) ToTranslationRule(main *Dev) *TranslationRule {
 		for _, s := range rule.Secrets {
 			rule.Args = append(rule.Args, "-s", fmt.Sprintf("%s:%s", s.GetFileName(), s.RemotePath))
 		}
-	} else if len(dev.Command) > 0 {
-		rule.Command = dev.Command
+	} else if len(dev.Command.Values) > 0 {
+		rule.Command = dev.Command.Values
 		rule.Args = []string{}
 	}
 

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -85,7 +85,7 @@ services:
 			t.Errorf("'name' was not parsed: %+v", main)
 		}
 
-		if len(dev.Command) != 1 || dev.Command[0] != "uwsgi" {
+		if len(dev.Command.Values) != 1 || dev.Command.Values[0] != "uwsgi" {
 			t.Errorf("command was not parsed: %+v", dev)
 		}
 
@@ -202,7 +202,7 @@ forward:
 				t.Fatal(err)
 			}
 
-			if len(d.Command) != 1 || d.Command[0] != "sh" {
+			if len(d.Command.Values) != 1 || d.Command.Values[0] != "sh" {
 				t.Errorf("command was parsed: %+v", d)
 			}
 
@@ -478,8 +478,8 @@ func Test_LoadRemote(t *testing.T) {
 
 	dev.LoadRemote("/tmp/key.pub")
 
-	if dev.Command[0] != "uwsgi" {
-		t.Errorf("command wasn't set: %s", dev.Command)
+	if dev.Command.Values[0] != "uwsgi" {
+		t.Errorf("command wasn't set: %s", dev.Command.Values)
 	}
 
 	if len(dev.Forward) != 1 {

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -48,6 +48,38 @@ func (e EnvVar) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (c *Command) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		err := unmarshal(&single)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(single, " ") {
+			c.Values = []string{"sh", "-c", single}
+		} else {
+			c.Values = []string{single}
+		}
+	} else {
+		c.Values = multi
+	}
+	return nil
+}
+
+// MarshalYAML Implements the marshaler interface of the yaml pkg.
+func (c Command) MarshalYAML() (interface{}, error) {
+	if len(c.Values) == 1 && !strings.Contains(c.Values[0], " ") {
+		return c.Values[0], nil
+	}
+	if len(c.Values) == 3 && c.Values[0] == "sh" && c.Values[1] == "-c" && !strings.Contains(c.Values[2], " ") {
+		return c.Values[2], nil
+	}
+	return c.Values, nil
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
 func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var rawString string
 	err := unmarshal(&rawString)

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -73,9 +73,6 @@ func (c Command) MarshalYAML() (interface{}, error) {
 	if len(c.Values) == 1 && !strings.Contains(c.Values[0], " ") {
 		return c.Values[0], nil
 	}
-	if len(c.Values) == 3 && c.Values[0] == "sh" && c.Values[1] == "-c" && !strings.Contains(c.Values[2], " ") {
-		return c.Values[2], nil
-	}
 	return c.Values, nil
 }
 

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -161,6 +161,44 @@ func TestEnvVarMashalling(t *testing.T) {
 	}
 }
 
+func TestCommandMashalling(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected Command
+	}{
+		{
+			"single-no-space",
+			[]byte("start.sh"),
+			Command{Values: []string{"start.sh"}},
+		},
+		{
+			"single-space",
+			[]byte("start.sh arg"),
+			Command{Values: []string{"sh", "-c", "start.sh arg"}},
+		},
+		{
+			"multiple",
+			[]byte("['yarn', 'install']"),
+			Command{Values: []string{"yarn", "install"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			var result Command
+			if err := yaml.Unmarshal(tt.data, &result); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("didn't unmarshal correctly. Actual %+v, Expected %+v", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestSecretMashalling(t *testing.T) {
 	file, err := ioutil.TempFile("/tmp", "okteto-secret-test")
 	if err != nil {

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -40,7 +40,7 @@ type Service struct {
 	Image           string       `yaml:"image"`
 	Build           *BuildInfo   `yaml:"build,omitempty"`
 	Replicas        int          `yaml:"replicas"`
-	Command         string       `yaml:"command,omitempty"`
+	Command         Command      `yaml:"command,omitempty"`
 	Environment     []EnvVar     `yaml:"environment,omitempty"`
 	Ports           []int        `yaml:"ports,omitempty"`
 	Volumes         []string     `yaml:"volumes,omitempty"`

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -67,7 +67,10 @@ services:
 	if s.Services["vote"].Build.Context != "vote" {
 		t.Errorf("'vote.build' was not parsed: %+v", s)
 	}
-	if s.Services["vote"].Command != "python app.py" {
+	if len(s.Services["vote"].Command.Values) != 3 {
+		t.Errorf("'vote.command' was not parsed: %+v", s)
+	}
+	if s.Services["vote"].Command.Values[0] != "sh" || s.Services["vote"].Command.Values[1] != "-c" || s.Services["vote"].Command.Values[2] != "python app.py" {
 		t.Errorf("'vote.command' was not parsed: %+v", s)
 	}
 	if s.Services["vote"].Replicas != 2 {


### PR DESCRIPTION
Single strings, when possible, improve readability and usability of okteto manifests