### PR TITLE
Add "(?d)" to absolute files too

### DIFF
--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -334,7 +334,7 @@ func (s *Syncthing) SendStignoreFile(ctx context.Context, dev *model.Dev) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "/") || strings.Contains(line, "(?d)") {
+		if strings.Contains(line, "(?d)") {
 			continue
 		}
 		ignores.Ignore[i] = fmt.Sprintf("(?d)%s", line)


### PR DESCRIPTION
This handles this syncthing error:
```
2020-06-14T11:09:25.471274015Z time="2020-06-14T11:09:25Z" level=info msg="[ATOPH] 11:09:25 VERBOSE: FolderErrors events.Event{SubscriptionID:981, GlobalID:982, Time:time.Time{wall:0xbfb19f395c104ed0, ext:638471692708, loc:(*time.Location)(0x16da660)}, Type:2097152, Data:map[string]interface {}{\"errors\":[]model.FileError{model.FileError{Path:\"bin\", Err:\"syncing: delete dir: directory contains ignored files (see ignore documentation for (?d) prefix)\\n\"}}, \"folder\":\"okteto-backend\"}}" process=syncthing
```
