### PR TITLE
Start the "login" sequence from "okteto namespace" if needed

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -25,7 +25,6 @@ import (
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
-	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 )
 
@@ -74,7 +73,7 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 				u, err = login.WithToken(ctx, oktetoURL, token)
 			} else {
 				log.Debugf("authenticating with the browser")
-				u, err = withBrowser(ctx, oktetoURL)
+				u, err = login.WithBrowser(ctx, oktetoURL)
 			}
 
 			if err != nil {
@@ -90,7 +89,7 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 				log.Success("Logged in as %s @ %s", u.GithubID, oktetoURL)
 			}
 
-			err = namespace.RunNamespace(ctx, "")
+			err = namespace.RunNamespace(ctx, "", "")
 			if err != nil {
 				log.Infof("error fetching your Kubernetes credentials: %s", err)
 				log.Hint("    Run `okteto namespace` to switch your context and download your Kubernetes credentials.")
@@ -107,25 +106,6 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 
 	cmd.Flags().StringVarP(&token, "token", "t", "", "API token for authentication.  (optional)")
 	return cmd
-}
-
-func withBrowser(ctx context.Context, oktetoURL string) (*okteto.User, error) {
-	h, err := login.StartWithBrowser(ctx, oktetoURL)
-	if err != nil {
-		log.Infof("couldn't start the login process: %s", err)
-		return nil, fmt.Errorf("couldn't start the login process, please try again")
-	}
-
-	authorizationURL := h.AuthorizationURL()
-	fmt.Println("Authentication will continue in your default browser")
-	if err := open.Start(authorizationURL); err != nil {
-		log.Errorf("Something went wrong opening your browser: %s\n", err)
-	}
-
-	fmt.Printf("You can also open a browser and navigate to the following address:\n")
-	fmt.Println(authorizationURL)
-
-	return login.EndWithBrowser(ctx, h)
 }
 
 func parseURL(u string) (string, error) {

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -68,7 +68,7 @@ func executeCreateNamespace(ctx context.Context, namespace string, members *[]st
 		}
 	}
 
-	if err := RunNamespace(ctx, namespace); err != nil {
+	if err := RunNamespace(ctx, namespace, ""); err != nil {
 		return fmt.Errorf("failed to activate your new namespace: %s", err)
 	}
 

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/skratchdot/open-golang/open"
 )
 
 // WithEnvVarIfAvailable authenticates the user with OKTETO_TOKEN value
@@ -49,6 +50,26 @@ func WithEnvVarIfAvailable(ctx context.Context) error {
 // WithToken authenticates the user with an API token
 func WithToken(ctx context.Context, url, token string) (*okteto.User, error) {
 	return okteto.AuthWithToken(ctx, url, token)
+}
+
+//WithBrowser authenticates the user with the brower
+func WithBrowser(ctx context.Context, oktetoURL string) (*okteto.User, error) {
+	h, err := StartWithBrowser(ctx, oktetoURL)
+	if err != nil {
+		log.Infof("couldn't start the login process: %s", err)
+		return nil, fmt.Errorf("couldn't start the login process, please try again")
+	}
+
+	authorizationURL := h.AuthorizationURL()
+	fmt.Println("Authentication will continue in your default browser")
+	if err := open.Start(authorizationURL); err != nil {
+		log.Errorf("Something went wrong opening your browser: %s\n", err)
+	}
+
+	fmt.Printf("You can also open a browser and navigate to the following address:\n")
+	fmt.Println(authorizationURL)
+
+	return EndWithBrowser(ctx, h)
 }
 
 // StartWithBrowser starts the authentication of the user with the IDP via a browser


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Eliminates one step from getting started guides
