### PR TITLE
Return clean on failure

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -822,7 +822,7 @@ func (up *UpContext) runCommand() error {
 	log.Infof("starting remote command")
 	up.updateStateFile(ready)
 
-	if up.Dev.ExecuteOverSSHEnabled() || up.Dev.RemoteModeEnabled() {
+	if up.Dev.RemoteModeEnabled() {
 		return ssh.Exec(up.Context, up.Dev.RemotePort, true, os.Stdin, os.Stdout, os.Stderr, up.Dev.Command.Values)
 	}
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -806,6 +806,8 @@ func (up *UpContext) cleanCommand() {
 
 	if err != nil {
 		log.Infof("failed to clean session: %s", err)
+		up.cleaned <- struct{}{}
+		return
 	}
 
 	if utils.IsWatchesConfigurationTooLow(out.String()) {

--- a/cmd/utils/watches.go
+++ b/cmd/utils/watches.go
@@ -47,9 +47,14 @@ func CheckLocalWatchesConfiguration() {
 //IsWatchesConfigurationTooLow returns if watches configuration is too low
 func IsWatchesConfigurationTooLow(value string) bool {
 	value = strings.TrimSuffix(string(value), "\n")
+	if value == "" {
+		log.Infof("max_user_watches is empty '%s'", value)
+		return false
+	}
+
 	c, err := strconv.Atoi(value)
 	if err != nil {
-		log.Infof("Fail to parse the value of max_user_watches: %s", err)
+		log.Infof("failed to parse the value of max_user_watches: %s", err)
 		return false
 	}
 	log.Debugf("max_user_watches = %d", c)

--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -182,7 +182,7 @@ func MonitorDevPod(ctx context.Context, dev *model.Dev, pod *apiv1.Pod, c *kuber
 				log.Errorf("type error getting pod: %s", event)
 				continue
 			}
-			log.Infof("pod %s updated", pod.Name)
+			log.Infof("dev pod %s updated to %s", pod.Name, pod.Status.Phase)
 			if pod.Status.Phase == apiv1.PodRunning {
 				return pod, nil
 			}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -295,6 +295,7 @@ func (s *Syncthing) WaitForPing(ctx context.Context, local bool) error {
 	for i := 0; ; i++ {
 		_, err := s.APICall(ctx, "rest/system/ping", "GET", 200, nil, local, nil, false)
 		if err == nil {
+			log.Debugf("syncthing local=%t responded to the ping", local)
 			return nil
 		}
 


### PR DESCRIPTION
If the "clean" command fails, we shouldn't try and get the watches configuration from the remote container.
