### PR TITLE
mount authorizedKeys as a volume to avoid permission issues

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -514,7 +514,13 @@ func (up *UpContext) devMode(d *appsv1.Deployment, create bool) error {
 	}
 
 	log.Info("create deployment secrets")
-	if err := secrets.Create(up.Dev, up.Client, up.Sy); err != nil {
+	pub := ""
+
+	if up.Dev.RemoteModeEnabled() {
+		pub = ssh.GetPublicKey()
+	}
+
+	if err := secrets.Create(up.Dev, up.Client, up.Sy, pub); err != nil {
 		return err
 	}
 

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -321,7 +321,7 @@ func TranslateVolumeMounts(c *apiv1.Container, rule *model.TranslationRule) {
 			c.VolumeMounts,
 			apiv1.VolumeMount{
 				Name:      oktetoAuthorizedKeysVolume,
-				MountPath: "/var/okteto/remote",
+				MountPath: "/var/okteto/remote/",
 			},
 		)
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -75,9 +75,6 @@ const (
 	ResourceAMDGPU apiv1.ResourceName = "amd.com/gpu"
 	//ResourceNVIDIAGPU nvidia.com/gpu resource
 	ResourceNVIDIAGPU apiv1.ResourceName = "nvidia.com/gpu"
-
-	// this path is expected by remote
-	authorizedKeysPath = "/var/okteto/secret/authorized_keys"
 )
 
 var (

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -498,8 +498,8 @@ func Test_LoadRemote(t *testing.T) {
 		t.Errorf("local key was not set correctly: %s", dev.Secrets[0].LocalPath)
 	}
 
-	if dev.Secrets[0].RemotePath != "/var/okteto/remote/authorized_keys" {
-		t.Errorf("remote key was not set at /var/okteto/remote/authorized_keys")
+	if dev.Secrets[0].RemotePath != "/var/okteto/secret/authorized_keys" {
+		t.Errorf("remote key was not set at /var/okteto/secret/authorized_keys")
 	}
 }
 

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -493,14 +493,6 @@ func Test_LoadRemote(t *testing.T) {
 	if dev.SSHServerPort != 2222 {
 		t.Errorf("server remote port wasn't 2222 it was %d", dev.SSHServerPort)
 	}
-
-	if dev.Secrets[0].LocalPath != "/tmp/key.pub" {
-		t.Errorf("local key was not set correctly: %s", dev.Secrets[0].LocalPath)
-	}
-
-	if dev.Secrets[0].RemotePath != "/var/okteto/secret/authorized_keys" {
-		t.Errorf("remote key was not set at /var/okteto/secret/authorized_keys")
-	}
 }
 
 func Test_Reverse(t *testing.T) {

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -47,6 +47,7 @@ type TranslationRule struct {
 	Volumes          []VolumeMount        `json:"volumes,omitempty"`
 	SecurityContext  *SecurityContext     `json:"securityContext,omitempty"`
 	Resources        ResourceRequirements `json:"resources,omitempty"`
+	RemoteEnabled    bool                 `json:"remoteEnabled,omitempty"`
 }
 
 //VolumeMount represents a volume mount


### PR DESCRIPTION
Fixes #920 

## Proposed changes
- Mount the "authorized_keys" using a volume instead of a secret to avoid permission issues

Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>

