### PR TITLE
print watches warning after the clean command finishes

### DIFF
--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -288,7 +288,7 @@ func parseUserID(output string) int64 {
 	}
 
 	if !strings.HasPrefix(lines[0], "USER:") {
-		log.Infof("USER entry not not found in first development container log line: %s", lines[0])
+		log.Infof("USER is not the first log line: %s", lines[0])
 		return -1
 	}
 


### PR DESCRIPTION
This is to avoid writing while the spinner is still printing out (it messes up the output)

![image](https://user-images.githubusercontent.com/475313/84963627-c2ff2f80-b0be-11ea-8a80-47d23dae0bcc.png)


Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>
