### PR TITLE
Remove "okteto namespace" sequence from "okteto login" command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,6 @@ jobs:
             - v3-pkg-cache-{{ checksum "go.sum" }}
       - run: 
           name: test
-          environment:
-            SCOPE_DSN: "https://fb562aaa137b41e69058a1b1774ae63e@app.scope.dev/"
           command: |
             make test
             bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 
 .PHONY: test
 test:
-	 go test -coverprofile=coverage.txt -covermode=atomic ./...
+	 go test -p 4 -coverprofile=coverage.txt -covermode=atomic ./...
 
 .PHONY: integration
 integration:

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/login"
@@ -87,14 +86,7 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 			} else {
 				log.Success("Logged in as %s @ %s", u.GithubID, oktetoURL)
 			}
-
-			err = namespace.RunNamespace(ctx, "")
-			if err != nil {
-				log.Infof("error fetching your Kubernetes credentials: %s", err)
-				log.Hint("    Run `okteto namespace` to switch your context and download your Kubernetes credentials.")
-			} else {
-				log.Hint("    Run 'okteto namespace' every time you need to activate your Okteto context again.")
-			}
+			log.Hint("    Run `okteto namespace` to switch your context and download your Kubernetes credentials.")
 			if u.New {
 				analytics.TrackSignup(true, u.ID)
 			}


### PR DESCRIPTION
## Proposed changes
- Don't run the `okteto namespace` sequence as part of `okteto login`
