### PR TITLE
Build with go 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - restore_cache: 
@@ -76,7 +76,7 @@ jobs:
           path: /root/.okteto        
   mock-publish-github-release:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - attach_workspace:
@@ -141,7 +141,7 @@ jobs:
           path: C:\Users\circleci\.okteto
   release:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - attach_workspace:
@@ -191,7 +191,7 @@ jobs:
             git push https://${GITHUB_TOKEN}@github.com/okteto/homebrew-okteto.git master
   release-master:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15
+      - image: okteto/golang-ci:1.15
     steps:
       - checkout
       - restore_cache: 
@@ -76,7 +76,7 @@ jobs:
           path: /root/.okteto        
   mock-publish-github-release:
     docker:
-      - image: circleci/golang:1.15
+      - image: okteto/golang-ci:1.15
     steps:
       - checkout
       - attach_workspace:
@@ -141,7 +141,7 @@ jobs:
           path: C:\Users\circleci\.okteto
   release:
     docker:
-      - image: circleci/golang:1.15
+      - image: okteto/golang-ci:1.15
     steps:
       - checkout
       - attach_workspace:
@@ -191,7 +191,7 @@ jobs:
             git push https://${GITHUB_TOKEN}@github.com/okteto/homebrew-okteto.git master
   release-master:
     docker:
-      - image: circleci/golang:1.15
+      - image: okteto/golang-ci:1.15
     steps:
       - checkout
       - setup_remote_docker:

--- a/go.mod
+++ b/go.mod
@@ -88,4 +88,4 @@ replace (
 	golang.org/x/crypto v0.0.0-20190129210102-0709b304e793 => golang.org/x/crypto v0.0.0-20180904163835-0709b304e793
 )
 
-go 1.14
+go 1.15


### PR DESCRIPTION
Use the newly released go 1.15 to build the binary