### PR TITLE
command to launch dev jobs

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,7 +15,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/okteto/okteto/cmd/job"
 	"github.com/okteto/okteto/cmd/namespace"
@@ -26,7 +25,7 @@ import (
 func Create(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: fmt.Sprintf("Creates resources"),
+		Short: "Creates resources",
 	}
 	cmd.AddCommand(namespace.Create(ctx))
 	cmd.AddCommand(job.Create(ctx))

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/okteto/okteto/cmd/job"
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/spf13/cobra"
 )
@@ -28,5 +29,6 @@ func Create(ctx context.Context) *cobra.Command {
 		Short: fmt.Sprintf("Creates resources"),
 	}
 	cmd.AddCommand(namespace.Create(ctx))
+	cmd.AddCommand(job.Create(ctx))
 	return cmd
 }

--- a/cmd/job/create.go
+++ b/cmd/job/create.go
@@ -15,7 +15,6 @@ package job
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/okteto/okteto/cmd/utils"
@@ -32,7 +31,7 @@ import (
 func Create(ctx context.Context) *cobra.Command {
 	var namespace string
 	var devPath string
-
+	var job string
 	cmd := &cobra.Command{
 		Use:   "job <name>",
 		Short: fmt.Sprintf("Creates a dev version of the job [beta]"),
@@ -50,13 +49,13 @@ func Create(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			err = executeCreateJob(ctx, dev, args[0])
+			err = executeCreateJob(ctx, dev, job)
 			analytics.TrackCreateJob(err == nil)
 			return err
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("create job requires one argument")
+			if len(args) != 0 {
+				job = args[0]
 			}
 			return nil
 		},

--- a/cmd/job/create.go
+++ b/cmd/job/create.go
@@ -1,0 +1,100 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/cmd/login"
+	k8Client "github.com/okteto/okteto/pkg/k8s/client"
+	"github.com/okteto/okteto/pkg/k8s/jobs"
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/spf13/cobra"
+)
+
+//Create creates a job
+func Create(ctx context.Context) *cobra.Command {
+	var namespace string
+	var devPath string
+
+	cmd := &cobra.Command{
+		Use:   "job <name>",
+		Short: fmt.Sprintf("Creates a dev version of the job [beta]"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
+				return err
+			}
+
+			dev, err := utils.LoadDev(devPath)
+			if err != nil {
+				return err
+			}
+
+			if err := dev.UpdateNamespace(namespace); err != nil {
+				return err
+			}
+
+			err = executeCreateJob(ctx, dev, args[0])
+			analytics.TrackCreateJob(err == nil)
+			return err
+		},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("create job requires one argument")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&devPath, "file", "f", utils.DefaultDevManifest, "path to the manifest file")
+	return cmd
+}
+
+func executeCreateJob(ctx context.Context, dev *model.Dev, job string) error {
+	if len(dev.Jobs) == 0 {
+		return fmt.Errorf("Unable to find any job with the provided name")
+	}
+
+	if job == "" {
+		job = dev.Jobs[0].Name
+	}
+
+	client, _, namespace, err := k8Client.GetLocal()
+	if err != nil {
+		return err
+	}
+
+	if dev.Namespace == "" {
+		dev.Namespace = namespace
+	}
+
+	for _, j := range dev.Jobs {
+		if j.Name == job {
+			n, err := jobs.CreateDevJob(j, dev, client)
+			if err != nil {
+				return fmt.Errorf("failed to create job: %s", err)
+			}
+
+			log.Success("started job: %s", n)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("Unable to find any job with the provided name")
+}

--- a/cmd/job/create.go
+++ b/cmd/job/create.go
@@ -37,7 +37,7 @@ func Create(ctx context.Context) *cobra.Command {
 	var job string
 	cmd := &cobra.Command{
 		Use:   "job <name>",
-		Short: fmt.Sprintf("Creates a dev version of the job [beta]"),
+		Short: "Creates a dev version of the job [beta]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
 				return err

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -50,6 +50,7 @@ const (
 	namespaceEvent       = "Namespace"
 	namespaceCreateEvent = "CreateNamespace"
 	namespaceDeleteEvent = "DeleteNamespace"
+	jobCreateEvent       = "CreateJob"
 	execEvent            = "Exec"
 	signupEvent          = "Signup"
 	disableEvent         = "Disable Analytics"
@@ -94,6 +95,11 @@ func TrackCreateNamespace(success bool) {
 // TrackDeleteNamespace sends a tracking event to mixpanel when the user deletes a namespace
 func TrackDeleteNamespace(success bool) {
 	track(namespaceDeleteEvent, success, nil)
+}
+
+// TrackCreateJob sends a tracking event to mixpanel when the user creates a job
+func TrackCreateJob(success bool) {
+	track(jobCreateEvent, success, nil)
 }
 
 // TrackReconnect sends a tracking event to mixpanel when the development container reconnect

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -238,6 +238,7 @@ func UpdateDeployments(trList map[string]*model.Translation, c *kubernetes.Clien
 		if tr.Deployment == nil {
 			continue
 		}
+
 		if err := update(tr.Deployment, c); err != nil {
 			return err
 		}

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -49,6 +49,10 @@ var (
 )
 
 func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
+	if t.Deployment == nil {
+		return nil
+	}
+
 	for _, rule := range t.Rules {
 		devContainer := GetDevContainer(&t.Deployment.Spec.Template.Spec, rule.Container)
 		if devContainer == nil {
@@ -65,6 +69,7 @@ func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientse
 		}
 		t.Deployment = dOrig
 	}
+	
 	annotations := t.Deployment.GetObjectMeta().GetAnnotations()
 	delete(annotations, revisionAnnotation)
 	t.Deployment.GetObjectMeta().SetAnnotations(annotations)

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -122,7 +122,7 @@ func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientse
 }
 
 // CommonTranslation are the translations applied to any podspec, both client or serverside
-func CommonTranslation(t *model.Translation, o metav1.Object, podSpec metav1.Object) {
+func CommonTranslation(t *model.Translation, o, podSpec metav1.Object) {
 	TranslateDevAnnotations(o, t.Annotations)
 	setAnnotation(o, oktetoVersionAnnotation, okLabels.Version)
 	setLabel(o, okLabels.DevLabel, "true")

--- a/pkg/k8s/jobs/crud.go
+++ b/pkg/k8s/jobs/crud.go
@@ -1,0 +1,124 @@
+package jobs
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/okteto/okteto/pkg/k8s/deployments"
+	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	revisionAnnotation      = "deployment.kubernetes.io/revision"
+	oktetoVersionAnnotation = "dev.okteto.com/version"
+)
+
+func get(dev *model.Dev, namespace string, c kubernetes.Interface) (*batchv1.Job, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("empty namespace")
+	}
+
+	var j *batchv1.Job
+	var err error
+
+	if len(dev.Labels) == 0 {
+		j, err = c.BatchV1().Jobs(namespace).Get(dev.Name, metav1.GetOptions{})
+		if err != nil {
+			log.Debugf("error while retrieving job %s/%s: %s", namespace, dev.Name, err)
+			return nil, err
+		}
+
+		return j, nil
+	}
+
+	jobs, err := c.BatchV1().Jobs(namespace).List(
+		metav1.ListOptions{
+			LabelSelector: dev.LabelsSelector(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(jobs.Items) == 0 {
+		return nil, fmt.Errorf("jobs for labels '%s' not found", dev.LabelsSelector())
+	}
+	if len(jobs.Items) > 1 {
+		return nil, fmt.Errorf("Found '%d' jobs for labels '%s' instead of 1", len(jobs.Items), dev.LabelsSelector())
+	}
+
+	return &jobs.Items[0], nil
+}
+
+//CreateDevJob applies the translations in your okteto manifest to the job
+func CreateDevJob(job *model.Dev, main *model.Dev, c kubernetes.Interface) (string, error) {
+	log.Info()
+	j, err := get(job, main.Namespace, c)
+	if err != nil {
+		return "", err
+	}
+
+	rule := job.ToTranslationRule(main)
+	t := &model.Translation{
+		Name:        main.Name,
+		Interactive: false,
+		Version:     model.TranslationVersion,
+		Job:         j,
+		Annotations: main.Annotations,
+		Tolerations: main.Tolerations,
+		Rules:       []*model.TranslationRule{rule},
+	}
+
+	newJob, err := translate(j, t)
+	created, err := c.BatchV1().Jobs(main.Namespace).Create(newJob)
+	return created.Name, err
+}
+
+func translate(old *batchv1.Job, t *model.Translation) (*batchv1.Job, error) {
+	job := old.DeepCopy()
+	job.Name = fmt.Sprintf("okteto-%s-%d", job.Name, time.Now().Unix())
+
+	// initialize unique values
+	job.Status = *&batchv1.JobStatus{}
+	job.ResourceVersion = ""
+	job.GetLabels()["job-name"] = job.Name
+	delete(job.GetLabels(), "controller-uid")
+	job.Spec.Selector = nil
+	job.Spec.Template.GetLabels()["job-name"] = job.Name
+	delete(job.Spec.Template.GetLabels(), "controller-uid")
+	delete(job.GetObjectMeta().GetAnnotations(), revisionAnnotation)
+
+	// apply okteto manifest overrides
+	deployments.TranslateDevAnnotations(job.Spec.Template.GetObjectMeta(), t.Annotations)
+	deployments.TranslateDevTolerations(&job.Spec.Template.Spec, t.Tolerations)
+	deployments.TranslatePodAffinity(&job.Spec.Template.Spec, t.Name)
+
+	job.Spec.Template.Spec.Tolerations = append(job.Spec.Template.Spec.Tolerations, t.Tolerations...)
+
+	job.GetObjectMeta().GetAnnotations()[oktetoVersionAnnotation] = okLabels.Version
+	job.GetObjectMeta().GetLabels()[okLabels.DevLabel] = "true"
+	job.Spec.Template.GetObjectMeta().GetLabels()[okLabels.DetachedDevLabel] = t.Name
+
+	for _, rule := range t.Rules {
+		devContainer := deployments.GetDevContainer(&job.Spec.Template.Spec, rule.Container)
+		if devContainer == nil {
+			return nil, fmt.Errorf("Container '%s' not found in job '%s'", rule.Container, job.Name)
+		}
+
+		deployments.TranslateDevContainer(devContainer, rule)
+		deployments.TranslateOktetoVolumes(&job.Spec.Template.Spec, rule)
+		deployments.TranslatePodSecurityContext(&job.Spec.Template.Spec, rule.SecurityContext)
+		deployments.TranslateOktetoDevSecret(&job.Spec.Template.Spec, t.Name, rule.Secrets)
+		if rule.Marker != "" {
+			deployments.TranslateOktetoBinVolumeMounts(devContainer)
+			deployments.TranslateOktetoInitBinContainer(&job.Spec.Template.Spec)
+			deployments.TranslateOktetoBinVolume(&job.Spec.Template.Spec)
+		}
+	}
+
+	return job, nil
+}

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -15,22 +15,24 @@ package model
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
 )
 
-//Translation represents the information for translating a deployment
+//Translation represents the information for translating a resource
 type Translation struct {
 	Interactive bool               `json:"interactive"`
 	Name        string             `json:"name"`
 	Version     string             `json:"version"`
 	Deployment  *appsv1.Deployment `json:"-"`
+	Job         *batchv1.Job       `json:"-"`
 	Annotations map[string]string  `json:"annotations,omitempty"`
 	Tolerations []apiv1.Toleration `json:"tolerations,omitempty"`
 	Replicas    int32              `json:"replicas"`
 	Rules       []*TranslationRule `json:"rules"`
 }
 
-//TranslationRule represents how to apply a container translation in a deployment
+//TranslationRule represents how to apply a container translation in a resource
 type TranslationRule struct {
 	Marker           string               `json:"marker"`
 	Node             string               `json:"node,omitempty"`


### PR DESCRIPTION
Fixes #998

## Proposed changes
Add  a "create job" command that copies an existing job and applies all the overrides, similarly to what we do for services. Since Jobs are ephemeral and can't be edited, we have to clone an existing one and launch it, instead of the approach we do with deployments.

I propose we release this on a separate command, as a 'beta', to see if this approach solves issues for the users who have requested this. 