### PR TITLE
Fix .stignore path

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -37,7 +38,7 @@ import (
 )
 
 const (
-	stignore          = ".stignore"
+	stignoreFile      = ".stignore"
 	secondaryManifest = "okteto.yaml"
 	defaultInitValues = "Use default values"
 )
@@ -148,6 +149,12 @@ func Run(namespace, devPath, language, workDir string, overwrite bool) error {
 	if err := dev.Save(devPath); err != nil {
 		return err
 	}
+
+	devDir, err := filepath.Abs(filepath.Dir(devPath))
+	if err != nil {
+		return err
+	}
+	stignore := filepath.Join(devDir, stignoreFile)
 
 	if !model.FileExists(stignore) {
 		log.Debugf("getting stignore for %s", language)

--- a/cmd/init/init_test.go
+++ b/cmd/init/init_test.go
@@ -37,6 +37,11 @@ func TestRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	stignorePath := filepath.Join(dir, ".stignore")
+	if _, err := os.Stat(stignorePath); os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+
 	dev, err := utils.LoadDev(p)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- `.stignore` must be the same as the okteto manifest. this was generating trash files when running tests
