### PR TITLE
Default to persistent volumes

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -129,14 +129,12 @@ func Run(namespace, devPath, language, workDir string, overwrite bool) error {
 			}
 		}
 
-		if supportsPersistentVolumes(namespace) {
-			dev.PersistentVolumeInfo = &model.PersistentVolumeInfo{
-				Enabled: true,
-			}
-		} else {
+		if !supportsPersistentVolumes(namespace) {
 			log.Yellow("Default storage class not found in your cluster. Persistent volumes not enabled in your okteto manifest")
 			dev.Volumes = nil
-			dev.PersistentVolumeInfo = nil
+			dev.PersistentVolumeInfo = &model.PersistentVolumeInfo{
+				Enabled: false,
+			}
 		}
 	} else {
 		linguist.SetForwardDefaults(dev, language)

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -61,8 +61,6 @@ volumes:
   - sub:/path
 secrets:
   - %s:/remote
-persistentVolume:
-  enabled: true
 resources:
   limits:
     cpu: 2
@@ -423,7 +421,9 @@ services:
 func Test_translateWithoutVolumes(t *testing.T) {
 	manifest := []byte(`name: web
 namespace: n
-image: web:latest`)
+image: web:latest
+persistentVolume:
+  enabled: false`)
 
 	dev, err := model.Read(manifest)
 	if err != nil {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -821,7 +821,7 @@ func (s *Secret) GetFileName() string {
 // PersistentVolumeEnabled returns true if persistent volumes are enabled for dev
 func (dev *Dev) PersistentVolumeEnabled() bool {
 	if dev.PersistentVolumeInfo == nil {
-		return false
+		return true
 	}
 	return dev.PersistentVolumeInfo.Enabled
 }

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -226,8 +226,8 @@ forward:
 				}
 			}
 
-			if d.PersistentVolumeEnabled() {
-				t.Errorf("persistent volume was enabled by default")
+			if !d.PersistentVolumeEnabled() {
+				t.Errorf("persistent volume was not enabled by default")
 			}
 		})
 	}
@@ -794,7 +794,7 @@ func TestPersistentVolumeEnabled(t *testing.T) {
       name: deployment
       container: core
       image: code/core:0.1.8`),
-			expected: false,
+			expected: true,
 		},
 		{
 			name: "set",


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- We defaulted this value to false in 1.8.5 and we have found several issues with this approach. We should default to true again and write more content about samples using persistent volumes

