### PR TITLE
Remove context from kubeconfig on `okteto namespace delete`

### DIFF
--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -53,8 +53,8 @@ func executeDeleteNamespace(ctx context.Context, namespace string) error {
 		return fmt.Errorf("failed to delete namespace: %s", err)
 	}
 
-	if err := CleanNamespace(ctx, namespace); err != nil {
-		return fmt.Errorf("failed to clean up namespace: %s", err)
+	if err := RemoveNamespace(ctx, namespace); err != nil {
+		return fmt.Errorf("failed to remove namespace: %s", err)
 	}
 
 	log.Success("Namespace '%s' deleted", namespace)

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -53,6 +53,10 @@ func executeDeleteNamespace(ctx context.Context, namespace string) error {
 		return fmt.Errorf("failed to delete namespace: %s", err)
 	}
 
+	if err := CleanNamespace(ctx, namespace); err != nil {
+		return fmt.Errorf("failed to clean up namespace: %s", err)
+	}
+
 	log.Success("Namespace '%s' deleted", namespace)
 	return nil
 }

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -85,35 +85,31 @@ func RunNamespace(ctx context.Context, namespace string) error {
 	}
 
 	kubeConfigFile := config.GetKubeConfigFile()
+	clusterHost := getClusterHost()
 
-	u, _ := url.Parse(okteto.GetURL())
-	parsedHost := strings.ReplaceAll(u.Host, ".", "_")
-
-	if err := okteto.SetKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), parsedHost); err != nil {
+	if err := okteto.SetKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), clusterHost); err != nil {
 		return err
 	}
 
-	log.Success("Updated context '%s' in '%s'", parsedHost, kubeConfigFile)
+	log.Success("Updated context '%s' in '%s'", clusterHost, kubeConfigFile)
 	return nil
 }
 
-//CleanNamespace cleans a namespace locally
-func CleanNamespace(ctx context.Context, namespace string) error {
+//RemoveNamespace removes an added namespace locally
+func RemoveNamespace(ctx context.Context, namespace string) error {
 	cred, err := okteto.GetCredentials(ctx, namespace)
 	if err != nil {
 		return err
 	}
 
 	kubeConfigFile := config.GetKubeConfigFile()
+	clusterHost := getClusterHost()
 
-	u, _ := url.Parse(okteto.GetURL())
-	parsedHost := strings.ReplaceAll(u.Host, ".", "_")
-
-	if err := okteto.RemoveKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), parsedHost); err != nil {
+	if err := okteto.RemoveKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), clusterHost); err != nil {
 		return err
 	}
 
-	log.Success("Cleaned context '%s' in '%s'", parsedHost, kubeConfigFile)
+	log.Success("Removed context '%s' in '%s'", clusterHost, kubeConfigFile)
 	return nil
 }
 
@@ -141,4 +137,9 @@ func askOktetoURL() (string, error) {
 	oktetoURL = u
 
 	return oktetoURL, nil
+}
+
+func getClusterHost() string {
+	u, _ := url.Parse(okteto.GetURL())
+	return strings.ReplaceAll(u.Host, ".", "_")
 }

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -97,6 +97,26 @@ func RunNamespace(ctx context.Context, namespace string) error {
 	return nil
 }
 
+//CleanNamespace cleans a namespace locally
+func CleanNamespace(ctx context.Context, namespace string) error {
+	cred, err := okteto.GetCredentials(ctx, namespace)
+	if err != nil {
+		return err
+	}
+
+	kubeConfigFile := config.GetKubeConfigFile()
+
+	u, _ := url.Parse(okteto.GetURL())
+	parsedHost := strings.ReplaceAll(u.Host, ".", "_")
+
+	if err := okteto.RemoveKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), parsedHost); err != nil {
+		return err
+	}
+
+	log.Success("Cleaned context '%s' in '%s'", parsedHost, kubeConfigFile)
+	return nil
+}
+
 func askIfLogin() bool {
 	result, err := utils.AskYesNo("Authentication required. Do you want to log into Okteto? [y/n]: ")
 	if err != nil {

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -148,7 +148,7 @@ func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, cluste
 	return clientcmd.WriteToFile(*cfg, kubeConfigPath)
 }
 
-//RemoveKubeConfig removes from a kubeconfig fle the okteto cluster credentials
+//RemoveKubeConfig removes okteto cluster context from a kubeconfig file
 func RemoveKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, clusterName string) error {
 	contextToRemoveName, _ := getContextName(cred, namespace, clusterName)
 	cfg, err := getOrCreateKubeConfig(kubeConfigPath)

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -26,8 +26,8 @@ func TestSetKubeConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-
 	defer os.Remove(file.Name())
+
 	c := &Credential{}
 	if err := SetKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com"); err != nil {
 		t.Fatal(err.Error())
@@ -86,9 +86,106 @@ func TestSetKubeConfig(t *testing.T) {
 	}
 
 	if len(cfg.Contexts) != 5 {
-		t.Errorf("the config file didn't have five contexts after adding the same twice: %+v", cfg.Contexts)
+		t.Fatalf("the config file didn't have five contexts after adding the same twice: %+v", cfg.Contexts)
+	}
+}
+
+func TestRemoveKubeConfig(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer os.Remove(file.Name())
+
+	c := &Credential{}
+
+	// empty config
+	if err := RemoveKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com"); err == nil {
+		t.Fatal("didn't return error for context not found")
 	}
 
+	if err := RemoveKubeConfig(c, file.Name(), "ns", "123-123-123", "cloud-okteto-com"); err == nil {
+		t.Fatal("didn't return error for context not found")
+	}
+
+	config := `apiVersion: v1
+clusters:
+- cluster:
+    server: ""
+  name: cloud-okteto-com
+- cluster:
+    server: ""
+  name: sf-okteto-com
+contexts:
+- context:
+    cluster: cloud-okteto-com
+    user: 123-123-123
+  name: cloud-okteto-com
+- context:
+    cluster: cloud-okteto-com
+    namespace: ns
+    user: 123-123-123
+  name: cloud-okteto-com-ns
+- context:
+    cluster: sf-okteto-com
+    user: 123-123-124
+  name: sf-okteto-com
+current-context: cloud-okteto-com-ns-2
+kind: Config
+preferences: {}
+users:
+- name: 123-123-123
+  user: {}
+- name: 123-123-124
+  user: {}`
+
+	if _, err := file.Write([]byte(config)); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// cluster and user still referenced
+	if err := RemoveKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	cfg, err := clientcmd.LoadFromFile(file.Name())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(cfg.Clusters) != 2 {
+		t.Errorf("the config file didn't have two clusters: %+v", cfg.Clusters)
+	}
+
+	if len(cfg.AuthInfos) != 2 {
+		t.Errorf("the config file didn't have two users: %+v", cfg.AuthInfos)
+	}
+
+	if len(cfg.Contexts) != 2 {
+		t.Errorf("the config file didn't have two contexts: %+v", cfg.Contexts)
+	}
+
+	// cluster and user no longer referenced
+	if err := RemoveKubeConfig(c, file.Name(), "ns", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	cfg, err = clientcmd.LoadFromFile(file.Name())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if len(cfg.Clusters) != 1 {
+		t.Errorf("the config file didn't have one cluster: %+v", cfg.Clusters)
+	}
+
+	if len(cfg.AuthInfos) != 1 {
+		t.Errorf("the config file didn't have one user: %+v", cfg.AuthInfos)
+	}
+
+	if len(cfg.Contexts) != 1 {
+		t.Errorf("the config file didn't have one contexts: %+v", cfg.Contexts)
+	}
 }
 
 func TestInDevContainer(t *testing.T) {

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -100,12 +100,12 @@ func TestRemoveKubeConfig(t *testing.T) {
 	c := &Credential{}
 
 	// empty config
-	if err := RemoveKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com"); err == nil {
-		t.Fatal("didn't return error for context not found")
+	if err := RemoveKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
 	}
 
-	if err := RemoveKubeConfig(c, file.Name(), "ns", "123-123-123", "cloud-okteto-com"); err == nil {
-		t.Fatal("didn't return error for context not found")
+	if err := RemoveKubeConfig(c, file.Name(), "ns", "123-123-123", "cloud-okteto-com"); err != nil {
+		t.Fatal(err.Error())
 	}
 
 	config := `apiVersion: v1


### PR DESCRIPTION
Fixes #493 

Will also remove cluster and user if no longer referenced by contexts.

