### PR TITLE
Set RunAsUser and RunAsGroup only at the container level

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -390,14 +390,6 @@ func TranslatePodSecurityContext(spec *apiv1.PodSpec, s *model.SecurityContext) 
 		spec.SecurityContext = &apiv1.PodSecurityContext{}
 	}
 
-	if s.RunAsUser != nil {
-		spec.SecurityContext.RunAsUser = s.RunAsUser
-	}
-
-	if s.RunAsGroup != nil {
-		spec.SecurityContext.RunAsGroup = s.RunAsGroup
-	}
-
 	if s.FSGroup != nil {
 		spec.SecurityContext.FSGroup = s.FSGroup
 	}
@@ -405,7 +397,7 @@ func TranslatePodSecurityContext(spec *apiv1.PodSpec, s *model.SecurityContext) 
 
 //TranslateContainerSecurityContext translates the security context attached to a container
 func TranslateContainerSecurityContext(c *apiv1.Container, s *model.SecurityContext) {
-	if s == nil || s.Capabilities == nil {
+	if s == nil {
 		return
 	}
 
@@ -413,6 +405,17 @@ func TranslateContainerSecurityContext(c *apiv1.Container, s *model.SecurityCont
 		c.SecurityContext = &apiv1.SecurityContext{}
 	}
 
+	if s.RunAsUser != nil {
+		c.SecurityContext.RunAsUser = s.RunAsUser
+	}
+
+	if s.RunAsGroup != nil {
+		c.SecurityContext.RunAsGroup = s.RunAsGroup
+	}
+
+	if s.Capabilities == nil {
+		return
+	}
 	if c.SecurityContext.Capabilities == nil {
 		c.SecurityContext.Capabilities = &apiv1.Capabilities{}
 	}

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -125,9 +125,7 @@ services:
 						},
 					},
 					SecurityContext: &apiv1.PodSecurityContext{
-						RunAsUser:  &runAsUser,
-						RunAsGroup: &runAsGroup,
-						FSGroup:    &fsGroup,
+						FSGroup: &fsGroup,
 					},
 					TerminationGracePeriodSeconds: &devTerminationGracePeriodSeconds,
 					Volumes: []apiv1.Volume{
@@ -218,6 +216,10 @@ services:
 									Name:  "OKTETO_NAME",
 									Value: "web",
 								},
+							},
+							SecurityContext: &apiv1.SecurityContext{
+								RunAsUser:  &runAsUser,
+								RunAsGroup: &runAsGroup,
 							},
 							Resources: apiv1.ResourceRequirements{
 								Limits: apiv1.ResourceList{
@@ -345,9 +347,7 @@ services:
 						},
 					},
 					SecurityContext: &apiv1.PodSecurityContext{
-						RunAsUser:  &rootUser,
-						RunAsGroup: &rootUser,
-						FSGroup:    &rootUser,
+						FSGroup: &rootUser,
 					},
 					TerminationGracePeriodSeconds: &devTerminationGracePeriodSeconds,
 					Volumes: []apiv1.Volume{
@@ -368,6 +368,10 @@ services:
 							ImagePullPolicy: apiv1.PullAlways,
 							Command:         []string{"./run_worker.sh"},
 							Args:            []string{},
+							SecurityContext: &apiv1.SecurityContext{
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
+							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
 									Name:      dev.GetVolumeName(),


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Fixes #1022

Container security context takes precedence over pod security context