### PR TITLE
Disable "RunAsNonRoot" if necessary

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -45,6 +45,7 @@ const (
 var (
 	devReplicas                      int32 = 1
 	devTerminationGracePeriodSeconds int64
+	falseBoolean                     = false
 )
 
 func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
@@ -407,10 +408,16 @@ func TranslateContainerSecurityContext(c *apiv1.Container, s *model.SecurityCont
 
 	if s.RunAsUser != nil {
 		c.SecurityContext.RunAsUser = s.RunAsUser
+		if *s.RunAsUser == 0 {
+			c.SecurityContext.RunAsNonRoot = &falseBoolean
+		}
 	}
 
 	if s.RunAsGroup != nil {
 		c.SecurityContext.RunAsGroup = s.RunAsGroup
+		if *s.RunAsGroup == 0 {
+			c.SecurityContext.RunAsNonRoot = &falseBoolean
+		}
 	}
 
 	if s.Capabilities == nil {

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -369,8 +369,9 @@ services:
 							Command:         []string{"./run_worker.sh"},
 							Args:            []string{},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:  &rootUser,
-								RunAsGroup: &rootUser,
+								RunAsUser:    &rootUser,
+								RunAsGroup:   &rootUser,
+								RunAsNonRoot: &falseBoolean,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{

--- a/pkg/k8s/services/crud.go
+++ b/pkg/k8s/services/crud.go
@@ -85,6 +85,9 @@ func GetPortsByPod(p *apiv1.Pod, c *kubernetes.Clientset) ([]int, error) {
 	for _, e := range eList.Items {
 		for _, s := range e.Subsets {
 			for _, a := range append(s.Addresses, s.NotReadyAddresses...) {
+				if a.TargetRef == nil {
+					continue
+				}
 				if a.TargetRef.UID == p.UID {
 					for _, p := range s.Ports {
 						result = append(result, int(p.Port))


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- If `RunAsNonRoot` is `true` and the dev image is root, `okteto up` fails.
