### PR TITLE
Support for variable expansion in labels

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -291,6 +291,11 @@ func Read(bytes []byte) (*Dev, error) {
 		s.loadName()
 	}
 
+	dev.loadLabels()
+	for _, s := range dev.Services {
+		s.loadLabels()
+	}
+
 	dev.loadImage()
 	for _, s := range dev.Services {
 		s.loadImage()
@@ -356,6 +361,12 @@ func loadAbsPath(folder, path string) string {
 func (dev *Dev) loadName() {
 	if len(dev.Name) > 0 {
 		dev.Name = os.ExpandEnv(dev.Name)
+	}
+}
+
+func (dev *Dev) loadLabels() {
+	for i := range dev.Labels {
+		dev.Labels[i] = os.ExpandEnv(dev.Labels[i])
 	}
 }
 

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -311,6 +311,46 @@ services:
 	}
 }
 
+func Test_loadLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		value  string
+		want   map[string]string
+	}{
+		{
+			name:   "no-var",
+			labels: map[string]string{"a": "1", "b": "2"},
+			value:  "3",
+			want:   map[string]string{"a": "1", "b": "2"},
+		},
+		{
+			name:   "var",
+			labels: map[string]string{"a": "1", "b": "${value}"},
+			value:  "3",
+			want:   map[string]string{"a": "1", "b": "3"},
+		},
+		{
+			name:   "mising",
+			labels: map[string]string{"a": "1", "b": "${valueX}"},
+			value:  "1",
+			want:   map[string]string{"a": "1", "b": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev := &Dev{Labels: tt.labels}
+			os.Setenv("value", tt.value)
+			dev.loadLabels()
+
+			if !reflect.DeepEqual(tt.want, dev.Labels) {
+				t.Errorf("got: '%v', expected: '%v'", dev.Labels, tt.want)
+			}
+		})
+	}
+}
+
 func Test_loadImage(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- This lets you run `NAME=api okteto up` when using labels, and reuse the same okteto manifest for different deployments.