### PR TITLE
Return a friendly error when running okteto exec on a non-dev pod

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -82,11 +82,6 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 	wrapped := []string{"sh", "-c"}
 	wrapped = append(wrapped, args...)
 
-	if dev.ExecuteOverSSHEnabled() || dev.RemoteModeEnabled() {
-		log.Infof("executing remote command over SSH")
-		return ssh.Exec(ctx, dev.RemotePort, true, os.Stdin, os.Stdout, os.Stderr, wrapped)
-	}
-
 	client, cfg, namespace, err := k8Client.GetLocal(dev.Context)
 	if err != nil {
 		return err
@@ -101,8 +96,21 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 		return err
 	}
 
+	if p == nil {
+		return errors.UserError{
+			E:    fmt.Errorf("development mode is not enabled on your deployment"),
+			Hint: "Run `okteto up` to enable it and try again",
+		}
+	}
+
 	if dev.Container == "" {
 		dev.Container = p.Spec.Containers[0].Name
+	}
+
+	if dev.ExecuteOverSSHEnabled() || dev.RemoteModeEnabled() {
+		log.Infof("executing remote command over SSH")
+		dev.LoadRemote(ssh.GetPublicKey())
+		return ssh.Exec(ctx, dev.RemotePort, true, os.Stdin, os.Stdout, os.Stderr, wrapped)
 	}
 
 	return exec.Exec(ctx, client, cfg, dev.Namespace, p.Name, dev.Container, true, os.Stdin, os.Stdout, os.Stderr, wrapped)


### PR DESCRIPTION
Fixes #1046

## Proposed changes
- Return a friendly error when running `okteto exec` on a non-dev container
- Check if the pod exists before running okteto exec in remote mode
