### PR TITLE
set -trimpath on the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 BINDIR    := $(CURDIR)/bin
 PLATFORMS := linux/amd64/okteto-Linux-x86_64 darwin/amd64/okteto-Darwin-x86_64 windows/amd64/okteto.exe linux/arm64/okteto-Linux-arm64
-BUILDCOMMAND := go build -ldflags "-s -w -X github.com/okteto/okteto/pkg/config.VersionString=${VERSION_STRING}" -tags "osusergo netgo static_build"
+BUILDCOMMAND := go build -trimpath -ldflags "-s -w -X github.com/okteto/okteto/pkg/config.VersionString=${VERSION_STRING}" -tags "osusergo netgo static_build"
 temp = $(subst /, ,$@)
 os = $(word 1, $(temp))
 arch = $(word 2, $(temp))


### PR DESCRIPTION
This removes the build path from the paths recorded in the binary

Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>
