### PR TITLE
Don't synchronize vendor by default

### DIFF
--- a/pkg/linguist/syncthing.go
+++ b/pkg/linguist/syncthing.go
@@ -88,6 +88,9 @@ jspm_packages
 *.so
 *.dylib
 
+# vendor folders
+vendor
+
 # Test binary, built with go test -c
 *.test
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- Ignore `vendor` for go apps by default
