### PR TITLE
Don't wait for remote init scan if using persistent volumes

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -779,8 +779,10 @@ func (up *upContext) startSyncthing() error {
 		return err
 	}
 
-	if err := up.Sy.WaitForScanning(up.Context, up.Dev, false); err != nil {
-		return err
+	if !up.Dev.PersistentVolumeEnabled() {
+		if err := up.Sy.WaitForScanning(up.Context, up.Dev, false); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/k8s/secrets/configXML.go
+++ b/pkg/k8s/secrets/configXML.go
@@ -22,7 +22,7 @@ import (
 
 const configXML = `<configuration version="32">
 {{ range .Folders }}
-<folder id="okteto-{{ .Name }}" label="{{ .Name }}" path="{{ .RemotePath }}" type="sendreceive" rescanIntervalS="300" fsWatcherEnabled="true" fsWatcherDelayS="1" ignorePerms="false" autoNormalize="true">
+<folder id="okteto-{{ .Name }}" label="{{ .Name }}" path="{{ .RemotePath }}" type="sendreceive" rescanIntervalS="{{ $.RescanInterval }}" fsWatcherEnabled="true" fsWatcherDelayS="1" ignorePerms="false" autoNormalize="true">
     <filesystemType>basic</filesystemType>
     <device id="ABKAVQF-RUO4CYO-FSC2VIP-VRX4QDA-TQQRN2J-MRDXJUC-FXNWP6N-S6ZSAAR" introducedBy=""></device>
     <device id="ATOPHFJ-VPVLDFY-QVZDCF2-OQQ7IOW-OG4DIXF-OA7RWU3-ZYA4S22-SI4XVAU" introducedBy=""></device>

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/okteto/okteto/pkg/log"
@@ -50,7 +51,7 @@ func (s *Syncthing) APICall(ctx context.Context, url, method string, code int, p
 		if err == nil {
 			return result, nil
 		}
-		if retries == 3 {
+		if retries == 3 || strings.Contains(url, "rest/db/ignores") {
 			return nil, err
 		}
 		log.Infof("retrying syncthing call[%s] local=%t: %s", url, local, err.Error())

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/okteto/okteto/pkg/log"
@@ -44,14 +43,14 @@ func NewAPIClient() *http.Client {
 }
 
 // APICall calls the syncthing API and returns the parsed json or an error
-func (s *Syncthing) APICall(ctx context.Context, url, method string, code int, params map[string]string, local bool, body []byte, readBody bool) ([]byte, error) {
+func (s *Syncthing) APICall(ctx context.Context, url, method string, code int, params map[string]string, local bool, body []byte, readBody bool, maxRetries int) ([]byte, error) {
 	retries := 0
 	for {
 		result, err := s.callWithRetry(ctx, url, method, code, params, local, body, readBody)
 		if err == nil {
 			return result, nil
 		}
-		if retries == 3 || strings.Contains(url, "rest/db/ignores") {
+		if retries == maxRetries {
 			return nil, err
 		}
 		log.Infof("retrying syncthing call[%s] local=%t: %s", url, local, err.Error())

--- a/pkg/syncthing/configXML.go
+++ b/pkg/syncthing/configXML.go
@@ -15,7 +15,7 @@ package syncthing
 
 const configXML = `<configuration version="32">
 {{ range .Folders }}
-<folder id="okteto-{{ .Name }}" label="{{ .Name }}" path="{{ .LocalPath }}" type="{{ $.Type }}" rescanIntervalS="300" fsWatcherEnabled="true" fsWatcherDelayS="1" ignorePerms="false" autoNormalize="true">
+<folder id="okteto-{{ .Name }}" label="{{ .Name }}" path="{{ .LocalPath }}" type="{{ $.Type }}" rescanIntervalS="{{ $.RescanInterval }}" fsWatcherEnabled="true" fsWatcherDelayS="1" ignorePerms="false" autoNormalize="true">
     <filesystemType>basic</filesystemType>
     <device id="ABKAVQF-RUO4CYO-FSC2VIP-VRX4QDA-TQQRN2J-MRDXJUC-FXNWP6N-S6ZSAAR" introducedBy=""></device>
     <device id="{{$.RemoteDeviceID}}" introducedBy=""></device>

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -319,7 +319,7 @@ func (s *Syncthing) WaitForPing(ctx context.Context, local bool) error {
 
 	log.Infof("waiting for syncthing local=%t to be ready", local)
 	for i := 0; ; i++ {
-		_, err := s.APICall(ctx, "rest/system/ping", "GET", 200, nil, local, nil, false)
+		_, err := s.APICall(ctx, "rest/system/ping", "GET", 200, nil, local, nil, false, 3)
 		if err == nil {
 			log.Infof("syncthing local=%t is ready", local)
 			return nil
@@ -350,7 +350,7 @@ func (s *Syncthing) SendStignoreFile(ctx context.Context, dev *model.Dev) error 
 		log.Infof("sending '.stignore' file %s to the remote syncthing", folder.Name)
 		params := getFolderParameter(&folder)
 		ignores := &Ignores{}
-		body, err := s.APICall(ctx, "rest/db/ignores", "GET", 200, params, true, nil, true)
+		body, err := s.APICall(ctx, "rest/db/ignores", "GET", 200, params, true, nil, true, 0)
 		if err != nil {
 			log.Infof("error getting ignore files: %s", err.Error())
 			continue
@@ -375,7 +375,7 @@ func (s *Syncthing) SendStignoreFile(ctx context.Context, dev *model.Dev) error 
 			log.Infof("error marshalling ignore files: %s", err.Error())
 			continue
 		}
-		_, err = s.APICall(ctx, "rest/db/ignores", "POST", 200, params, false, body, false)
+		_, err = s.APICall(ctx, "rest/db/ignores", "POST", 200, params, false, body, false, 0)
 		if err != nil {
 			log.Infof("error posting ignore files: %s", err.Error())
 			continue
@@ -389,7 +389,7 @@ func (s *Syncthing) ResetDatabase(ctx context.Context, dev *model.Dev, local boo
 	for _, folder := range s.Folders {
 		log.Infof("reseting syncthing database path=%s local=%t", folder.LocalPath, local)
 		params := getFolderParameter(&folder)
-		_, err := s.APICall(ctx, "rest/system/reset", "POST", 200, params, local, nil, false)
+		_, err := s.APICall(ctx, "rest/system/reset", "POST", 200, params, local, nil, false, 3)
 		if err != nil {
 			log.Infof("error posting 'rest/system/reset' local=%t syncthing API: %s", local, err)
 			if strings.Contains(err.Error(), "Client.Timeout") {
@@ -406,7 +406,7 @@ func (s *Syncthing) Overwrite(ctx context.Context, dev *model.Dev) error {
 	for _, folder := range s.Folders {
 		log.Infof("overriding local changes to the remote syncthing path=%s", folder.LocalPath)
 		params := getFolderParameter(&folder)
-		_, err := s.APICall(ctx, "rest/db/override", "POST", 200, params, true, nil, false)
+		_, err := s.APICall(ctx, "rest/db/override", "POST", 200, params, true, nil, false, 3)
 		if err != nil {
 			log.Infof("error posting 'rest/db/override' syncthing API: %s", err)
 			if strings.Contains(err.Error(), "Client.Timeout") {
@@ -438,7 +438,7 @@ func (s *Syncthing) waitForFolderScanning(ctx context.Context, folder *Folder, l
 	timeout := time.Now().Add(to)
 
 	for i := 0; ; i++ {
-		body, err := s.APICall(ctx, "rest/db/status", "GET", 200, params, local, nil, true)
+		body, err := s.APICall(ctx, "rest/db/status", "GET", 200, params, local, nil, true, 3)
 		if err != nil {
 			log.Infof("error calling 'rest/db/status' local=%t syncthing API: %s", local, err)
 			if strings.Contains(err.Error(), "Client.Timeout") {
@@ -553,7 +553,7 @@ func (s *Syncthing) WaitForCompletion(ctx context.Context, dev *model.Dev, repor
 func (s *Syncthing) GetStatus(ctx context.Context, folder *Folder, local bool) (*Status, error) {
 	params := getFolderParameter(folder)
 	status := &Status{}
-	body, err := s.APICall(ctx, "rest/db/status", "GET", 200, params, local, nil, true)
+	body, err := s.APICall(ctx, "rest/db/status", "GET", 200, params, local, nil, true, 3)
 	if err != nil {
 		log.Infof("error getting status: %s", err.Error())
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -581,7 +581,7 @@ func (s *Syncthing) GetCompletion(ctx context.Context, local bool) (*Completion,
 			params["device"] = localDeviceID
 		}
 		completion := &Completion{}
-		body, err := s.APICall(ctx, "rest/db/completion", "GET", 200, params, local, nil, true)
+		body, err := s.APICall(ctx, "rest/db/completion", "GET", 200, params, local, nil, true, 3)
 		if err != nil {
 			log.Infof("error calling 'rest/db/completion' local=%t syncthing API: %s", local, err)
 			if strings.Contains(err.Error(), "Client.Timeout") {
@@ -624,7 +624,7 @@ func (s *Syncthing) GetFolderErrors(ctx context.Context, folder *Folder, local b
 	params["timeout"] = "15"
 	params["events"] = "FolderErrors"
 	folderErrorsList := []FolderErrors{}
-	body, err := s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true)
+	body, err := s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true, 3)
 	if err != nil {
 		log.Infof("error getting events: %s", err.Error())
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -665,7 +665,7 @@ func (s *Syncthing) GetFolderErrors(ctx context.Context, folder *Folder, local b
 
 // Restart restarts the syncthing process
 func (s *Syncthing) Restart(ctx context.Context) error {
-	_, err := s.APICall(ctx, "rest/system/restart", "POST", 200, nil, true, nil, false)
+	_, err := s.APICall(ctx, "rest/system/restart", "POST", 200, nil, true, nil, false, 3)
 	return err
 }
 

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -92,6 +92,7 @@ type Syncthing struct {
 	Type             string       `yaml:"-"`
 	IgnoreDelete     bool         `yaml:"-"`
 	pid              int          `yaml:"-"`
+	RescanInterval   string       `yaml:"-"`
 }
 
 //Folder represents a sync folder
@@ -166,6 +167,10 @@ func New(dev *model.Dev) (*Syncthing, error) {
 		hash = []byte("")
 	}
 
+	rescanInterval := os.Getenv("OKTETO_RESCAN_INTERVAL")
+	if rescanInterval == "" {
+		rescanInterval = "3600"
+	}
 	s := &Syncthing{
 		APIKey:           "cnd",
 		GUIPassword:      pwd,
@@ -187,6 +192,7 @@ func New(dev *model.Dev) (*Syncthing, error) {
 		Type:             "sendonly",
 		IgnoreDelete:     true,
 		Folders:          []Folder{},
+		RescanInterval:   rescanInterval,
 	}
 	index := 1
 	for _, sync := range dev.Syncs {


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- Don't wait for remote init scan if using persistent volumes
- Configurable rescan interval
