### PR TITLE
If image is in okteto registry, we can always overwrite the tag

### DIFF
--- a/pkg/cmd/build/image.go
+++ b/pkg/cmd/build/image.go
@@ -53,7 +53,10 @@ func GetRepoNameWithoutTag(name string) string {
 //GetImageTag returns the image tag to build for a given services
 func GetImageTag(image, service, namespace, oktetoRegistryURL string) string {
 	if oktetoRegistryURL != "" {
-		return fmt.Sprintf("%s/%s/%s:okteto", oktetoRegistryURL, namespace, service)
+		if image == "" {
+			return fmt.Sprintf("%s/%s/%s:okteto", oktetoRegistryURL, namespace, service)
+		}
+		return image
 	}
 	imageWithoutTag := GetRepoNameWithoutTag(image)
 	return fmt.Sprintf("%s:okteto", imageWithoutTag)


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- If it is in a different registry, we rewrite the tag to `okteto` to avoid polluting the original image
