### PR TITLE
OKTETO_HOME to override .okteto folder not $HOME

### DIFF
--- a/cmd/up/state.go
+++ b/cmd/up/state.go
@@ -16,6 +16,7 @@ package up
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/log"
@@ -32,6 +33,7 @@ const (
 	synchronizing upState = "synchronizing"
 	ready         upState = "ready"
 	failed        upState = "failed"
+	stateFile             = "okteto.state"
 )
 
 func (up *upContext) updateStateFile(state upState) {
@@ -47,7 +49,7 @@ func (up *upContext) updateStateFileWithMessage(state upState, message string) {
 		log.Info("can't update state file, name is empty")
 	}
 
-	s := config.GetStateFile(up.Dev.Namespace, up.Dev.Name)
+	s := filepath.Join(config.GetDeploymentHome(up.Dev.Namespace, up.Dev.Name), stateFile)
 	log.Debugf("updating statefile %s: '%s'", s, state)
 
 	m := string(state)

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -54,7 +54,7 @@ func Test_getTrackID(t *testing.T) {
 			}
 			defer os.RemoveAll(dir)
 
-			os.Setenv("OKTETO_HOME", dir)
+			os.Setenv("OKTETO_USERHOME", dir)
 
 			if len(tt.machineID) > 0 {
 				if err := okteto.SaveMachineID(tt.machineID); err != nil {

--- a/pkg/cmd/doctor/run.go
+++ b/pkg/cmd/doctor/run.go
@@ -31,6 +31,7 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/pods"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/syncthing"
 	yaml "gopkg.in/yaml.v2"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -83,8 +84,8 @@ func Run(ctx context.Context, dev *model.Dev, devPath string, c *kubernetes.Clie
 	if model.FileExists(filepath.Join(config.GetOktetoHome(), "okteto.log")) {
 		files = append(files, filepath.Join(config.GetOktetoHome(), "okteto.log"))
 	}
-	if model.FileExists(config.GetSyncthingLogFile(dev.Namespace, dev.Name)) {
-		files = append(files, config.GetSyncthingLogFile(dev.Namespace, dev.Name))
+	if model.FileExists(syncthing.GetLogFile(dev.Namespace, dev.Name)) {
+		files = append(files, syncthing.GetLogFile(dev.Namespace, dev.Name))
 	}
 	if podPath != "" {
 		files = append(files, podPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,21 +78,6 @@ func GetDeploymentHome(namespace, name string) string {
 	return d
 }
 
-// GetStateFile returns the path to the state file
-func GetStateFile(namespace, name string) string {
-	return filepath.Join(GetDeploymentHome(namespace, name), "okteto.state")
-}
-
-// GetSyncthingInfoFile returns the path to the syncthing info file
-func GetSyncthingInfoFile(namespace, name string) string {
-	return filepath.Join(GetDeploymentHome(namespace, name), "syncthing.info")
-}
-
-// GetSyncthingLogFile returns the path to the syncthing log file
-func GetSyncthingLogFile(namespace, name string) string {
-	return filepath.Join(GetDeploymentHome(namespace, name), "syncthing.log")
-}
-
 // GetUserHomeDir returns the OS home dir
 func GetUserHomeDir() string {
 	if v, ok := os.LookupEnv("OKTETO_USERHOME"); ok {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,7 +129,7 @@ func homedirWindows() (string, error) {
 	path := os.Getenv("HOMEPATH")
 	home := drive + path
 	if drive == "" || path == "" {
-		return "", fmt.Errorf("HOME, HOMEDRIVE, HOMEPATH, or USERPROFILE are empty. Use $OKTETO_HOME to set your home directory")
+		return "", fmt.Errorf("HOME, HOMEDRIVE, HOMEPATH, or USERPROFILE are empty. Use $OKTETO_USERHOME to set your home directory")
 	}
 
 	return home, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -97,7 +97,7 @@ func GetSyncthingLogFile(namespace, name string) string {
 func GetUserHomeDir() string {
 	if v, ok := os.LookupEnv("OKTETO_USERHOME"); ok {
 		if !model.FileExists(v) {
-			log.Fatalf("OKTETO_USERHOME points to a non-existing file: %s", v)
+			log.Fatalf("OKTETO_USERHOME points to a non-existing directory: %s", v)
 		}
 
 		return v

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 )
 
 const (
@@ -47,6 +48,14 @@ func GetBinaryFullPath() string {
 
 // GetOktetoHome returns the path of the okteto folder
 func GetOktetoHome() string {
+	if v, ok := os.LookupEnv("OKTETO_HOME"); ok {
+		if !model.FileExists(v) {
+			log.Fatalf("OKTETO_HOME points to a non-existing directory: %s", v)
+		}
+
+		return v
+	}
+
 	home := GetUserHomeDir()
 	d := filepath.Join(home, oktetoFolderName)
 
@@ -86,7 +95,11 @@ func GetSyncthingLogFile(namespace, name string) string {
 
 // GetUserHomeDir returns the OS home dir
 func GetUserHomeDir() string {
-	if v, ok := os.LookupEnv("OKTETO_HOME"); ok {
+	if v, ok := os.LookupEnv("OKTETO_USERHOME"); ok {
+		if !model.FileExists(v) {
+			log.Fatalf("OKTETO_USERHOME points to a non-existing file: %s", v)
+		}
+
 		return v
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,7 +32,7 @@ func TestGetUserHomeDir(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	os.Setenv("OKTETO_HOME", dir)
+	os.Setenv("OKTETO_USERHOME", dir)
 	home = GetUserHomeDir()
 	if home != dir {
 		t.Fatalf("OKTETO_HOME override failed, got %s instead of %s", home, dir)
@@ -115,9 +115,8 @@ func TestGetOktetoHome(t *testing.T) {
 	os.Setenv("OKTETO_HOME", dir)
 
 	got := GetOktetoHome()
-	expected := filepath.Join(dir, ".okteto")
-	if got != expected {
-		t.Errorf("expected %s, got %s", expected, got)
+	if got != dir {
+		t.Errorf("expected %s, got %s", dir, got)
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -35,7 +35,7 @@ func TestGetUserHomeDir(t *testing.T) {
 	os.Setenv("OKTETO_USERHOME", dir)
 	home = GetUserHomeDir()
 	if home != dir {
-		t.Fatalf("OKTETO_HOME override failed, got %s instead of %s", home, dir)
+		t.Fatalf("OKTETO_USERHOME override failed, got %s instead of %s", home, dir)
 	}
 
 }
@@ -130,7 +130,7 @@ func TestGetDeploymentHome(t *testing.T) {
 	os.Setenv("OKTETO_HOME", dir)
 
 	got := GetDeploymentHome("ns", "dp")
-	expected := filepath.Join(dir, ".okteto", "ns", "dp")
+	expected := filepath.Join(dir, "ns", "dp")
 	if got != expected {
 		t.Errorf("expected %s, got %s", expected, got)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,6 +16,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 )
@@ -30,7 +31,10 @@ func TestGetUserHomeDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv("OKTETO_USERHOME")
+	}()
 
 	os.Setenv("OKTETO_USERHOME", dir)
 	home = GetUserHomeDir()
@@ -38,6 +42,11 @@ func TestGetUserHomeDir(t *testing.T) {
 		t.Fatalf("OKTETO_USERHOME override failed, got %s instead of %s", home, dir)
 	}
 
+	oktetoHome := GetOktetoHome()
+	expected := path.Join(dir, ".okteto")
+	if oktetoHome != expected {
+		t.Errorf("got %s, expected %s", oktetoHome, expected)
+	}
 }
 
 func Test_homedirWindows(t *testing.T) {
@@ -106,11 +115,14 @@ func Test_homedirWindows(t *testing.T) {
 }
 
 func TestGetOktetoHome(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv("OKTETO_HOME")
+	}()
 
 	os.Setenv("OKTETO_HOME", dir)
 

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -22,19 +22,23 @@ import (
 
 func TestKeyExists(t *testing.T) {
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	defer os.RemoveAll(dir)
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv("OKTETO_HOME")
+	}()
 
-	os.Setenv("OKTETO_USERHOME", dir)
+	os.Setenv("OKTETO_HOME", dir)
+
 	if KeyExists() {
 		t.Error("keys shouldn't exist in an empty directory")
 	}
 
-	if _, err := os.Create(filepath.Join(dir, ".okteto", publicKeyFile)); err != nil {
+	if _, err := os.Create(filepath.Join(dir, publicKeyFile)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -42,7 +46,7 @@ func TestKeyExists(t *testing.T) {
 		t.Error("keys shouldn't exist when private key is missing")
 	}
 
-	if _, err := os.Create(filepath.Join(dir, ".okteto", privateKeyFile)); err != nil {
+	if _, err := os.Create(filepath.Join(dir, privateKeyFile)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -53,14 +57,17 @@ func TestKeyExists(t *testing.T) {
 }
 
 func TestGenerateKeys(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	defer os.RemoveAll(dir)
-	os.Setenv("OKTETO_HOME", dir)
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv("OKTETO_HOME")
+	}()
 
+	os.Setenv("OKTETO_HOME", dir)
 	public, private := getKeyPaths()
 	if err := generateKeys(public, private, 128); err != nil {
 		t.Error(err)

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -29,7 +29,7 @@ func TestKeyExists(t *testing.T) {
 
 	defer os.RemoveAll(dir)
 
-	os.Setenv("OKTETO_HOME", dir)
+	os.Setenv("OKTETO_USERHOME", dir)
 	if KeyExists() {
 		t.Error("keys shouldn't exist in an empty directory")
 	}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -180,7 +180,7 @@ func New(dev *model.Dev) (*Syncthing, error) {
 		FileWatcherDelay: DefaultFileWatcherDelay,
 		GUIAddress:       fmt.Sprintf("localhost:%d", guiPort),
 		Home:             config.GetDeploymentHome(dev.Namespace, dev.Name),
-		LogPath:          config.GetSyncthingLogFile(dev.Namespace, dev.Name),
+		LogPath:          GetLogFile(dev.Namespace, dev.Name),
 		ListenAddress:    fmt.Sprintf("localhost:%d", listenPort),
 		RemoteAddress:    fmt.Sprintf("tcp://localhost:%d", remotePort),
 		RemoteDeviceID:   DefaultRemoteDeviceID,
@@ -706,7 +706,7 @@ func (s *Syncthing) SaveConfig(dev *model.Dev) error {
 		return err
 	}
 
-	syncthingInfoFile := config.GetSyncthingInfoFile(dev.Namespace, dev.Name)
+	syncthingInfoFile := getInfoFile(dev.Namespace, dev.Name)
 	if err := ioutil.WriteFile(syncthingInfoFile, marshalled, 0600); err != nil {
 		return fmt.Errorf("failed to write syncthing info file: %w", err)
 	}
@@ -716,7 +716,7 @@ func (s *Syncthing) SaveConfig(dev *model.Dev) error {
 
 // Load loads the syncthing object from the dev home folder
 func Load(dev *model.Dev) (*Syncthing, error) {
-	syncthingInfoFile := config.GetSyncthingInfoFile(dev.Namespace, dev.Name)
+	syncthingInfoFile := getInfoFile(dev.Namespace, dev.Name)
 	b, err := ioutil.ReadFile(syncthingInfoFile)
 	if err != nil {
 		return nil, err
@@ -816,4 +816,13 @@ func getBinaryName() string {
 func getFolderParameter(folder *Folder) map[string]string {
 	folderName := fmt.Sprintf("okteto-%s", folder.Name)
 	return map[string]string{"folder": folderName, "device": DefaultRemoteDeviceID}
+}
+
+func getInfoFile(namespace, name string) string {
+	return filepath.Join(config.GetDeploymentHome(namespace, name), "syncthing.info")
+}
+
+// GetLogFile returns the path to the syncthing log file
+func GetLogFile(namespace, name string) string {
+	return filepath.Join(config.GetDeploymentHome(namespace, name), "syncthing.log")
 }

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncthing
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestGetFiles(t *testing.T) {
+
+	dir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv("OKTETO_HOME")
+	}()
+
+	os.Setenv("OKTETO_HOME", dir)
+	log := GetLogFile("test", "application")
+	expected := path.Join(dir, "test", "application", "syncthing.log")
+
+	if log != expected {
+		t.Errorf("got %s, expected %s", log, expected)
+	}
+
+	info := getInfoFile("test", "application")
+	expected = path.Join(dir, "test", "application", "syncthing.info")
+	if info != expected {
+		t.Errorf("got %s, expected %s", info, expected)
+	}
+}


### PR DESCRIPTION
Fixes #1104

## Proposed changes
- OKTETO_HOME now points to the replacement for the .okteto folder
- Added an OKTETO_USERHOME for those who want to replace the $HOME directory (we've run into this in the past with minimalistic setups)

This is a breaking change, so we need to document it in the release notes.
