### PR TITLE
fail okteto up if port is already taken locally

### DIFF
--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -91,7 +91,11 @@ func NewPortForwardManager(ctx context.Context, restConfig *rest.Config, c kuber
 // Add initializes a port forward
 func (p *PortForwardManager) Add(f model.Forward) error {
 	if _, ok := p.ports[f.Local]; ok {
-		return fmt.Errorf("port %d is already taken, please check your configuration", f.Local)
+		return fmt.Errorf("port %d is listed multiple times, please check your configuration", f.Local)
+	}
+
+	if !model.IsPortAvailable(f.Local) {
+		return fmt.Errorf("port %d is already in use in your local machine, please check your configuration", f.Local)
 	}
 
 	p.ports[f.Local] = f

--- a/pkg/k8s/forward/manager_test.go
+++ b/pkg/k8s/forward/manager_test.go
@@ -26,19 +26,19 @@ import (
 func TestAdd(t *testing.T) {
 
 	pf := NewPortForwardManager(context.Background(), nil, nil)
-	if err := pf.Add(model.Forward{Local: 1010, Remote: 1010}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10100, Remote: 1010}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := pf.Add(model.Forward{Local: 1011, Remote: 1011}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10110, Remote: 1011}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := pf.Add(model.Forward{Local: 1010, Remote: 1011}); err == nil {
+	if err := pf.Add(model.Forward{Local: 10100, Remote: 1011}); err == nil {
 		t.Fatal("duplicated local port didn't return an error")
 	}
 
-	if err := pf.Add(model.Forward{Local: 1012, Remote: 0, Service: true, ServiceName: "svc"}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10120, Remote: 0, Service: true, ServiceName: "svc"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/model/port.go
+++ b/pkg/model/port.go
@@ -13,7 +13,12 @@
 
 package model
 
-import "net"
+import (
+	"fmt"
+	"net"
+
+	"github.com/okteto/okteto/pkg/log"
+)
 
 // GetAvailablePort returns a random port that's available
 func GetAvailablePort() (int, error) {
@@ -30,4 +35,17 @@ func GetAvailablePort() (int, error) {
 	defer listener.Close()
 	return listener.Addr().(*net.TCPAddr).Port, nil
 
+}
+
+// IsPortAvailable returns true if the port is already taken
+func IsPortAvailable(port int) bool {
+	address := fmt.Sprintf(":%d", port)
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		log.Infof("port %s is taken: %s", address, err)
+		return false
+	}
+
+	defer listener.Close()
+	return true
 }

--- a/pkg/model/port_test.go
+++ b/pkg/model/port_test.go
@@ -1,0 +1,53 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestGetAvailablePort(t *testing.T) {
+	p, err := GetAvailablePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if p == 0 {
+		t.Fatal("got an empty port")
+	}
+}
+
+func TestIsPortAvailable(t *testing.T) {
+	p, err := GetAvailablePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsPortAvailable(p) {
+		t.Fatalf("port %d wasn't available", p)
+	}
+
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer l.Close()
+
+	if IsPortAvailable(p) {
+		t.Fatalf("port %d was available", p)
+	}
+}

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -48,11 +48,15 @@ func NewForwardManager(ctx context.Context, sshAddr, localInterface, remoteInter
 
 func (fm *ForwardManager) canAdd(localPort int) error {
 	if _, ok := fm.reverses[localPort]; ok {
-		return fmt.Errorf("port %d is already taken, please check your reverse forwards configuration", localPort)
+		return fmt.Errorf("port %d is listed multiple times, please check your reverse forwards configuration", localPort)
 	}
 
 	if _, ok := fm.forwards[localPort]; ok {
-		return fmt.Errorf("port %d is already taken, please check your forwards configuration", localPort)
+		return fmt.Errorf("port %d is listed multiple times, please check your forwards configuration", localPort)
+	}
+
+	if !model.IsPortAvailable(localPort) {
+		return fmt.Errorf("port %d is already in use in your local machine, please check your configuration", localPort)
 	}
 
 	return nil

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -273,23 +273,23 @@ func (fm *ForwardManager) waitForwardsConnected() error {
 func TestAdd(t *testing.T) {
 
 	pf := NewForwardManager(context.Background(), "0.0.0.0:22000", "0.0.0.0", "0.0.0.0", nil)
-	if err := pf.Add(model.Forward{Local: 1010, Remote: 1010}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10010, Remote: 1010}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := pf.Add(model.Forward{Local: 1011, Remote: 1011}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10011, Remote: 1011}); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := pf.Add(model.Forward{Local: 1010, Remote: 1011}); err == nil {
+	if err := pf.Add(model.Forward{Local: 10010, Remote: 1011}); err == nil {
 		t.Fatal("duplicated local port didn't return an error")
 	}
 
-	if err := pf.Add(model.Forward{Local: 1012, Remote: 15123, Service: true, ServiceName: "svc"}); err != nil {
+	if err := pf.Add(model.Forward{Local: 10012, Remote: 15123, Service: true, ServiceName: "svc"}); err != nil {
 		t.Fatal(err)
 	}
 
-	if pf.forwards[1012].remoteAddress != "svc:15123" {
+	if pf.forwards[10012].remoteAddress != "svc:15123" {
 		t.Fatalf("expected 'svc:15123', got '%s'", pf.forwards[1012].remoteAddress)
 	}
 }

--- a/pkg/ssh/reverse_test.go
+++ b/pkg/ssh/reverse_test.go
@@ -49,16 +49,16 @@ func TestReverseManager_Add(t *testing.T) {
 			}
 
 			if err := r.AddReverse(tt.add); (err != nil) != tt.wantErr {
-				t.Errorf("ReverseManager.Add() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("ReverseManager.Add() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			f := r.reverses[8080]
 			if f.localAddress != ":8080" {
-				t.Errorf("local address is not :8080, it is: %s", f.localAddress)
+				t.Fatalf("local address is not :8080, it is: %s", f.localAddress)
 			}
 
 			if f.remoteAddress != ":8081" {
-				t.Errorf("remote address is not :8081, it is: %s", f.remoteAddress)
+				t.Fatalf("remote address is not :8081, it is: %s", f.remoteAddress)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>

Fixes #1100

## Proposed changes
- okteto up will fail if the ports listed in the forward and reverse configuration are already in use in the local machine
