### PR TITLE
recreate context on every up iteration

### DIFF
--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -14,8 +14,6 @@
 package up
 
 import (
-	"context"
-
 	"github.com/docker/docker/pkg/term"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/syncthing"
@@ -26,8 +24,6 @@ import (
 
 // upContext is the common context of all operations performed during the up command
 type upContext struct {
-	Context        context.Context
-	Cancel         context.CancelFunc
 	Dev            *model.Dev
 	Namespace      *apiv1.Namespace
 	isSwap         bool

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -40,6 +40,7 @@ type upContext struct {
 	inFd              uintptr
 	isTerm            bool
 	stateTerm         *term.State
+	isRunning         bool
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -24,7 +24,7 @@ import (
 // upContext is the common context of all operations performed during the up command
 type upContext struct {
 	Dev               *model.Dev
-	IsOktetoNamespace bool
+	isOktetoNamespace bool
 	isSwap            bool
 	Client            *kubernetes.Clientset
 	RestConfig        *rest.Config

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -17,30 +17,29 @@ import (
 	"github.com/docker/docker/pkg/term"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/syncthing"
-	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 // upContext is the common context of all operations performed during the up command
 type upContext struct {
-	Dev            *model.Dev
-	Namespace      *apiv1.Namespace
-	isSwap         bool
-	Client         *kubernetes.Clientset
-	RestConfig     *rest.Config
-	Pod            string
-	Forwarder      forwarder
-	Disconnect     chan error
-	CommandResult  chan error
-	Exit           chan error
-	Sy             *syncthing.Syncthing
-	cleaned        chan string
-	success        bool
-	resetSyncthing bool
-	inFd           uintptr
-	isTerm         bool
-	stateTerm      *term.State
+	Dev               *model.Dev
+	IsOktetoNamespace bool
+	isSwap            bool
+	Client            *kubernetes.Clientset
+	RestConfig        *rest.Config
+	Pod               string
+	Forwarder         forwarder
+	Disconnect        chan error
+	CommandResult     chan error
+	Exit              chan error
+	Sy                *syncthing.Syncthing
+	cleaned           chan string
+	success           bool
+	resetSyncthing    bool
+	inFd              uintptr
+	isTerm            bool
+	stateTerm         *term.State
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -210,7 +210,7 @@ func (up *upContext) start(autoDeploy, build bool) error {
 		return fmt.Errorf("'okteto up' is not allowed in the current namespace")
 	}
 
-	up.IsOktetoNamespace = namespaces.IsOktetoNamespace(ns)
+	up.isOktetoNamespace = namespaces.IsOktetoNamespace(ns)
 
 	if err := createPIDFile(up.Dev.Namespace, up.Dev.Name); err != nil {
 		log.Infof("failed to create pid file for %s - %s: %s", up.Dev.Namespace, up.Dev.Name, err)
@@ -448,7 +448,7 @@ func (up *upContext) waitUntilExitOrInterrupt() error {
 
 func (up *upContext) buildDevImage(ctx context.Context, d *appsv1.Deployment, create bool) error {
 	oktetoRegistryURL := ""
-	if up.IsOktetoNamespace {
+	if up.isOktetoNamespace {
 		var err error
 		oktetoRegistryURL, err = okteto.GetRegistry()
 		if err != nil {
@@ -530,7 +530,7 @@ func (up *upContext) devMode(ctx context.Context, d *appsv1.Deployment, create b
 		return err
 	}
 
-	if err := deployments.TranslateDevMode(trList, up.Client, up.IsOktetoNamespace); err != nil {
+	if err := deployments.TranslateDevMode(trList, up.Client, up.isOktetoNamespace); err != nil {
 		return err
 	}
 
@@ -873,7 +873,7 @@ func (up *upContext) runCommand(ctx context.Context) error {
 }
 
 func (up *upContext) getClusterType() string {
-	if up.IsOktetoNamespace {
+	if up.isOktetoNamespace {
 		return "okteto"
 	}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -258,6 +258,8 @@ func (up *upContext) activate(autoDeploy, build bool) {
 	isRetry := false
 
 	for {
+		// create a new context on every iteration
+		up.Context, up.Cancel = context.WithCancel(context.Background())
 		up.Disconnect = make(chan error, 1)
 		up.CommandResult = make(chan error, 1)
 		up.cleaned = make(chan string, 1)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -263,6 +263,7 @@ func (up *upContext) activate(autoDeploy, build bool) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer up.shutdown(cancel)
 
+		up.isRunning = true
 		up.Disconnect = make(chan error, 1)
 		up.CommandResult = make(chan error, 1)
 		up.cleaned = make(chan string, 1)
@@ -893,6 +894,10 @@ func (up *upContext) getClusterType() string {
 
 // Shutdown runs the cancellation sequence. It will wait for all tasks to finish for up to 500 milliseconds
 func (up *upContext) shutdown(cancel context.CancelFunc) {
+	if !up.isRunning {
+		return
+	}
+
 	log.Infof("starting shutdown sequence")
 	if !up.success {
 		analytics.TrackUpError(true, up.isSwap)
@@ -921,6 +926,7 @@ func (up *upContext) shutdown(cancel context.CancelFunc) {
 		}
 	}
 
+	up.isRunning = false
 	log.Info("completed shutdown sequence")
 }
 

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -205,9 +205,9 @@ func UpdateOktetoRevision(ctx context.Context, d *appsv1.Deployment, client *kub
 }
 
 //TranslateDevMode translates the deployment manifests to put them in dev mode
-func TranslateDevMode(tr map[string]*model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
+func TranslateDevMode(tr map[string]*model.Translation, c *kubernetes.Clientset, isOktetoNamespace bool) error {
 	for _, t := range tr {
-		err := translate(t, ns, c)
+		err := translate(t, c, isOktetoNamespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -19,7 +19,6 @@ import (
 	"os"
 
 	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
-	"github.com/okteto/okteto/pkg/k8s/namespaces"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 
@@ -48,7 +47,7 @@ var (
 	falseBoolean                     = false
 )
 
-func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientset) error {
+func translate(t *model.Translation, c *kubernetes.Clientset, isOktetoNamespace bool) error {
 	for _, rule := range t.Rules {
 		devContainer := GetDevContainer(&t.Deployment.Spec.Template.Spec, rule.Container)
 		if devContainer == nil {
@@ -69,7 +68,7 @@ func translate(t *model.Translation, ns *apiv1.Namespace, c *kubernetes.Clientse
 	delete(annotations, revisionAnnotation)
 	t.Deployment.GetObjectMeta().SetAnnotations(annotations)
 
-	if c != nil && namespaces.IsOktetoNamespace(ns) {
+	if c != nil && isOktetoNamespace {
 		c := os.Getenv("OKTETO_CLIENTSIDE_TRANSLATION")
 		if c == "" {
 			commonTranslation(t)

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -96,7 +96,7 @@ services:
 			},
 		},
 	}
-	err = translate(tr1, nil, nil)
+	err = translate(tr1, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ services:
 			},
 		},
 	}
-	err = translate(tr2, nil, nil)
+	err = translate(tr2, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +441,7 @@ persistentVolume:
 		Deployment:  d1,
 		Rules:       []*model.TranslationRule{rule1},
 	}
-	err = translate(tr1, nil, nil)
+	err = translate(tr1, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -15,6 +15,7 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -116,7 +117,9 @@ func Exec(ctx context.Context, remotePort int, tty bool, inR io.Reader, outW, er
 	}
 	go func() {
 		if _, err = io.Copy(stdin, inR); err != nil {
-			log.Infof("error while reading from stdIn: %s", err)
+			if !errors.Is(err, io.EOF) {
+				log.Infof("error while reading from stdIn: %s", err)
+			}
 		}
 	}()
 

--- a/pkg/ssh/pool.go
+++ b/pkg/ssh/pool.go
@@ -63,7 +63,10 @@ func (p *pool) keepAlive() {
 	for {
 		select {
 		case <-p.ctx.Done():
-			log.Infof("ssh pool keep alive completed")
+			if p.ctx.Err() != nil {
+				log.Infof("ssh pool keep alive completed with error: %s", p.ctx.Err())
+			}
+
 			return
 		case <-t.C:
 			if _, _, err := p.client.SendRequest("dev.okteto.com/keepalive", true, nil); err != nil {


### PR DESCRIPTION
Since the kubernetes calls now require a context, we should recreate the context after every `cancel` signal. I think it's better to remove ctx and cancel from the `upContext` struct, so the scope of each is clearer
