### PR TITLE
Reduce default scan period

### DIFF
--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -169,7 +169,7 @@ func New(dev *model.Dev) (*Syncthing, error) {
 
 	rescanInterval := os.Getenv("OKTETO_RESCAN_INTERVAL")
 	if rescanInterval == "" {
-		rescanInterval = "3600"
+		rescanInterval = "300"
 	}
 	s := &Syncthing{
 		APIKey:           "cnd",


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- Periodic scan is useful if, for any reason, the filewatcher misses an event
