### PR TITLE
Monitor syncthing using ping

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -804,6 +804,7 @@ Then, try to run 'okteto down -v' + 'okteto up'  again`,
 	}
 
 	go up.Sy.Monitor(ctx, up.Disconnect)
+	go up.Sy.MonitorStatus(ctx, up.Disconnect)
 	log.Infof("restarting syncthing to update sync mode to sendreceive")
 	return up.Sy.Restart(ctx)
 }

--- a/pkg/syncthing/monitor.go
+++ b/pkg/syncthing/monitor.go
@@ -17,8 +17,61 @@ import (
 	"context"
 	"time"
 
+	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
 )
+
+// Monitor will send a message to disconnected if remote syncthing is disconnected for more than 10 seconds.
+func (s *Syncthing) Monitor(ctx context.Context, disconnect chan error) {
+	ticker := time.NewTicker(10 * time.Second)
+	retries := 0
+	for {
+		select {
+		case <-ticker.C:
+			if s.checkLocalAndRemotePing(ctx) {
+				retries = 0
+				continue
+			}
+			log.Infof("syncthing ping error %d", retries)
+			if retries >= 3 {
+				log.Infof("syncthing ping error, sending disconnect signal")
+				disconnect <- errors.ErrLostSyncthing
+				return
+			}
+			retries++
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// MonitorStatus will send a message to disconnected if there is a synchronization error
+func (s *Syncthing) MonitorStatus(ctx context.Context, disconnect chan error) {
+	ticker := time.NewTicker(300 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			err := s.checkLocalAndRemoteStatus(ctx)
+			switch err {
+			case nil, errors.ErrBusySyncthing, errors.ErrLostSyncthing:
+				continue
+			default:
+				log.Infof("syncthing monitor error, sending disconnect signal: %s", err)
+				disconnect <- err
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Syncthing) checkLocalAndRemotePing(ctx context.Context) bool {
+	if !s.Ping(ctx, true) {
+		return false
+	}
+	return s.Ping(ctx, false)
+}
 
 func (s *Syncthing) checkLocalAndRemoteStatus(ctx context.Context) error {
 	if err := s.checkStatus(ctx, true); err != nil {
@@ -43,29 +96,4 @@ func (s *Syncthing) checkStatus(ctx context.Context, local bool) error {
 		}
 	}
 	return nil
-}
-
-// Monitor will send a message to disconnected if remote syncthing is disconnected for more than 10 seconds.
-func (s *Syncthing) Monitor(ctx context.Context, disconnect chan error) {
-	ticker := time.NewTicker(20 * time.Second)
-	retries := 0
-	for {
-		select {
-		case <-ticker.C:
-			err := s.checkLocalAndRemoteStatus(ctx)
-			if err == nil {
-				retries = 0
-				continue
-			}
-			log.Infof("syncthing monitor error %d: %s", retries, err)
-			if retries >= 3 {
-				log.Infof("syncthing monitor error, sending disconnect signal: %s", err)
-				disconnect <- err
-				return
-			}
-			retries++
-		case <-ctx.Done():
-			return
-		}
-	}
 }


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

"rest/db/status" is cpu intensve operation and it usually returns timeouts.

## Proposed changes
- Use ping to monitor syncthing every 10s. Fail with connection errors if 3 ping errors in a row.
- Monitor "rest/db/status" every 5 minutes. Ignore connections errors in ""rest/db/status", they would be cautch by ping anyway.
