### PR TITLE
Free ports on shutdown

### DIFF
--- a/pkg/ssh/forward.go
+++ b/pkg/ssh/forward.go
@@ -59,14 +59,18 @@ func (f *forward) start() {
 	f.setConnected()
 
 	for {
-		localConn, err := localListener.Accept()
-		if err != nil {
-			log.Infof("%s -> failed to accept connection: %v", f.String(), err)
-			continue
+		select {
+		case <-f.ctx.Done():
+			return
+		default:
+			localConn, err := localListener.Accept()
+			if err != nil {
+				log.Infof("%s -> failed to accept connection: %v", f.String(), err)
+				continue
+			}
+
+			go f.handle(localConn)
 		}
-
-		go f.handle(localConn)
-
 	}
 }
 

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -117,6 +117,7 @@ func (fm *ForwardManager) Start(devPod, namespace string) error {
 	for _, ff := range fm.forwards {
 		ff.pool = pool
 		go ff.start()
+
 	}
 
 	for _, rt := range fm.reverses {
@@ -129,7 +130,6 @@ func (fm *ForwardManager) Start(devPod, namespace string) error {
 
 // Stop sends a stop signal to all the connections
 func (fm *ForwardManager) Stop() {
-	// TODO stop forwards and reverses
 
 	if fm.pf != nil {
 		fm.pf.Stop()

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -54,17 +54,19 @@ func (r *reverse) start() {
 	defer remoteListener.Close()
 
 	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		default:
+			r.setConnected()
+			remoteConn, err := remoteListener.Accept()
+			if err != nil {
+				log.Infof("%s -> failed to accept connection: %v", r.String(), err)
+				continue
+			}
 
-		r.setConnected()
-
-		remoteConn, err := remoteListener.Accept()
-		if err != nil {
-			log.Infof("%s -> failed to accept connection: %v", r.String(), err)
-			continue
+			go r.handle(remoteConn)
 		}
-
-		go r.handle(remoteConn)
-
 	}
 }
 

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -74,7 +74,7 @@ func (r *reverse) handle(remote net.Conn) {
 	defer remote.Close()
 
 	quit := make(chan struct{}, 1)
-	local, err := getConn(r.localAddress, 3)
+	local, err := getConn(r.ctx, r.localAddress, 3)
 	if err != nil {
 		log.Infof("%s -> failed to listen on local address: %v", r.String(), err)
 		return


### PR DESCRIPTION
Fixes #1139

## Proposed changes
- Make the SSH connection context-aware, so the shutdown routine frees the ports quicker

I tested this by doing:
- okteto up to the same dev container on a second terminal
- killing the pod to make it reconnect