### PR TITLE
set default loglevel to warn during init

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,8 @@ import (
 )
 
 func init() {
+	log.SetLevel("warn")
+
 	// override client-go error handlers to downgrade the "logging before flag.Parse" error
 	errorHandlers := []func(error){
 		func(e error) {


### PR DESCRIPTION
This sets the default value so that logs before the main command not show up in the ui