### PR TITLE
retrieve port from SSH config if the port is not defined.

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -109,7 +109,21 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 
 	if dev.RemoteModeEnabled() {
 		log.Infof("executing remote command over SSH")
+		if dev.RemotePort == 0 {
+			p, err := ssh.GetPort(dev.Name)
+			if err != nil {
+				log.Infof("failed to get the SSH port for %s: %s", dev.Name, err)
+				return errors.UserError{
+					E:    fmt.Errorf("development mode is not enabled on your deployment"),
+					Hint: "Run `okteto up` to enable it and try again",
+				}
+			}
+
+			dev.RemotePort = p
+		}
+
 		dev.LoadRemote(ssh.GetPublicKey())
+
 		return ssh.Exec(ctx, dev.Interface, dev.RemotePort, true, os.Stdin, os.Stdout, os.Stderr, wrapped)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,7 +50,7 @@ func GetBinaryFullPath() string {
 func GetOktetoHome() string {
 	if v, ok := os.LookupEnv("OKTETO_FOLDER"); ok {
 		if !model.FileExists(v) {
-			log.Fatalf("OKTETO_FOLDER points to a non-existing directory: %s", v)
+			log.Fatalf("OKTETO_FOLDER doesn't exist: %s", v)
 		}
 
 		return v

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -60,6 +60,32 @@ func RemoveEntry(name string) error {
 	return remove(getSSHConfigPath(), buildHostname(name))
 }
 
+// GetPort returns the corresponding SSH port for the dev env
+func GetPort(name string) (int, error) {
+	cfg, err := getConfig(getSSHConfigPath())
+	if err != nil {
+		return 0, err
+	}
+
+	hostname := buildHostname(name)
+	i, found := findHost(cfg, hostname)
+	if !found {
+		return 0, fmt.Errorf("development container not found")
+	}
+
+	param := cfg.hosts[i].getParam(portKeyword)
+	if param == nil {
+		return 0, fmt.Errorf("port not found")
+	}
+
+	port, err := strconv.Atoi(param.value())
+	if err != nil {
+		return 0, fmt.Errorf("invalid port: %s", param.value())
+	}
+
+	return port, nil
+}
+
 func remove(path, name string) error {
 	cfg, err := getConfig(path)
 	if err != nil {

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -225,6 +225,39 @@ func Test_removeHost(t *testing.T) {
 	}
 }
 
+func TestGetPort(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(dir)
+
+	if err := os.Setenv("OKTETO_HOME", dir); err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Unsetenv("OKTETO_HOME")
+
+	if _, err := GetPort(t.Name()); err == nil {
+		t.Fatal("expected error on non existing host")
+	}
+
+	if err := AddEntry(t.Name(), "localhost", 123456); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := GetPort(t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if p != 123456 {
+		t.Errorf("got %d, expected %d", p, 123456)
+	}
+
+}
+
 func Test_getSSHConfigPath(t *testing.T) {
 	ssh := getSSHConfigPath()
 	parts := strings.Split(ssh, string(os.PathSeparator))


### PR DESCRIPTION
Signed-off-by: Ramiro Berrelleza <rberrelleza@gmail.com>

improves #1145

## Proposed changes
-  If the port is not defined in the manifest, and remote mode is enabled, we retrieve the port from the ssh config entry.

