### PR TITLE
Note that context is not present in local Kubeconfig

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -28,6 +28,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	buildCMD "github.com/okteto/okteto/pkg/cmd/build"
+	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
@@ -201,7 +202,9 @@ func (up *upContext) start(autoDeploy, build bool) error {
 	var err error
 	up.Client, up.RestConfig, namespace, err = k8Client.GetLocal(up.Dev.Context)
 	if err != nil {
-		return fmt.Errorf("failed to load your local Kubeconfig: %s", err)
+		kubecfg := config.GetKubeConfigFile()
+		log.Infof("failed to load local Kubeconfig: %s", err)
+		return fmt.Errorf("failed to load your local Kubeconfig: %q context not found in %q", up.Dev.Context, kubecfg)
 	}
 
 	if up.Dev.Namespace == "" {


### PR DESCRIPTION
Signed-off-by: Daniel Snitkovskiy <thelastdan1@gmail.com>

Fixes #1017 

## Proposed changes
- Log the original error message (with the full error attached)
- Note to the client that $CONTEXT not found in $KUBECONFIG

![image](https://user-images.githubusercontent.com/15274429/97954789-5331ce80-1d59-11eb-8d77-2bbb0a1aad17.png)

cc @rberrelleza 
