### PR TITLE
don't check if reverse is taken in the local machine

### DIFF
--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -57,6 +57,10 @@ func (fm *ForwardManager) canAdd(localPort int, checkAvailable bool) error {
 		return fmt.Errorf("port %d is listed multiple times, please check your forwards configuration", localPort)
 	}
 
+	if !checkAvailable {
+		return nil
+	}
+
 	if !model.IsPortAvailable(fm.localInterface, localPort) {
 		if localPort <= 1024 {
 			os := runtime.GOOS

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -48,7 +48,7 @@ func NewForwardManager(ctx context.Context, sshAddr, localInterface, remoteInter
 	}
 }
 
-func (fm *ForwardManager) canAdd(localPort int) error {
+func (fm *ForwardManager) canAdd(localPort int, checkAvailable bool) error {
 	if _, ok := fm.reverses[localPort]; ok {
 		return fmt.Errorf("port %d is listed multiple times, please check your reverse forwards configuration", localPort)
 	}
@@ -76,7 +76,7 @@ func (fm *ForwardManager) canAdd(localPort int) error {
 // Add initializes a remote forward
 func (fm *ForwardManager) Add(f model.Forward) error {
 
-	if err := fm.canAdd(f.Local); err != nil {
+	if err := fm.canAdd(f.Local, true); err != nil {
 		return err
 	}
 

--- a/pkg/ssh/reverse.go
+++ b/pkg/ssh/reverse.go
@@ -30,7 +30,7 @@ type reverse struct {
 // AddReverse adds a reverse forward
 func (fm *ForwardManager) AddReverse(f model.Reverse) error {
 
-	if err := fm.canAdd(f.Local); err != nil {
+	if err := fm.canAdd(f.Local, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes #1170

## Proposed changes
- don't check if port is taken for the case of reverse forwards, since it's a valid scenario. 
