### PR TITLE
Handle connection refused error when retrying

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -102,6 +102,7 @@ func IsTransient(err error) bool {
 		strings.Contains(err.Error(), "operation timed out"),
 		strings.Contains(err.Error(), "can't assign requested address"),
 		strings.Contains(err.Error(), "command exited without exit status or exit signal"),
+		strings.Contains(err.Error(), "connection refused"),
 		strings.Contains(err.Error(), "network is unreachable"):
 		return true
 	default:


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

@rberrelleza I have received several doctor files where the reconnection logic fails with this error:
```
time="2020-11-22T20:36:51+02:00" level=info msg="activate failed with: Delete \"https://i.i.i.i:443/api/v1/namespaces/xxx/pods/yyy\": dial tcp i.i.i.i:443: connect: connection refused" action=afc75856-b7ee-4cdf-8c04-d850db10e2ff version=1.9.6
```