### PR TITLE
vstest debugging environment variables in okteto.yml to debug and  at…

### DIFF
--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -209,6 +209,14 @@ func init() {
 				Name:  "ASPNETCORE_ENVIRONMENT",
 				Value: "Development",
 			},
+			{
+				Name:  "VSTEST_HOST_DEBUG",
+				Value: "0",
+			},
+			{
+				Name:  "VSTEST_RUNNER_DEBUG",
+				Value: "0",
+			},
 		},
 		forward: []model.Forward{},
 		remote:  22000,


### PR DESCRIPTION
…tach to process via ssh

Signed-off-by: alan@alanmbarr.com <alan@alanmbarr.com>

Fixes #

## Proposed changes
-  add env vars to the okteto yml for .net core to populate debug variables for users to use the ssh debug for tests
