### PR TITLE
Troubleshoot windows test failures

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -234,12 +234,12 @@ func TestAll(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		deployment, err := getDeployment(ctx, namespace, name)
+		originalDeployment, err := getDeployment(ctx, namespace, name)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		log.Printf("deployment: %s, revision: %s", deployment.Name, deployment.Annotations[" deployment.kubernetes.io/revision"])
+		log.Printf("deployment: %s, revision: %s", originalDeployment.Name, originalDeployment.Annotations[" deployment.kubernetes.io/revision"])
 
 		var wg sync.WaitGroup
 		p, err := up(ctx, &wg, namespace, name, manifestPath, oktetoPath)
@@ -282,6 +282,13 @@ func TestAll(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		d, err := getDeployment(ctx, namespace, name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("deployment: %s, revision: %s", d.Name, d.Annotations[" deployment.kubernetes.io/revision"])
+
 		if err := down(ctx, namespace, name, manifestPath, oktetoPath); err != nil {
 			t.Fatal(err)
 		}
@@ -290,7 +297,7 @@ func TestAll(t *testing.T) {
 			t.Error(err)
 		}
 
-		if err := compareDeployment(ctx, deployment); err != nil {
+		if err := compareDeployment(ctx, originalDeployment); err != nil {
 			t.Error(err)
 		}
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -27,6 +27,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -126,9 +127,17 @@ func TestMain(m *testing.M) {
 	}
 
 	mode = "server"
-	if _, ok := os.LookupEnv("OKTETO_CLIENTSIDE_TRANSLATION"); ok {
-		log.Println("running in CLIENTSIDE mode")
-		mode = "client"
+	if v, ok := os.LookupEnv("OKTETO_CLIENTSIDE_TRANSLATION"); ok {
+		clientside, err := strconv.ParseBool(v)
+		if err != nil {
+			log.Printf("'%s' is not a valid value for environment variable %s", v, k)
+			os.Exit(1)
+		}
+
+		if clientside {
+			mode = "client"
+			log.Println("running in CLIENTSIDE mode")
+		}
 	}
 
 	if runtime.GOOS == "windows" {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -239,7 +239,7 @@ func TestAll(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		log.Printf("deployment: %s, revision: %s", originalDeployment.Name, originalDeployment.Annotations[" deployment.kubernetes.io/revision"])
+		log.Printf("deployment: %s, revision: %s", originalDeployment.Name, originalDeployment.Annotations["deployment.kubernetes.io/revision"])
 
 		var wg sync.WaitGroup
 		p, err := up(ctx, &wg, namespace, name, manifestPath, oktetoPath)
@@ -287,7 +287,7 @@ func TestAll(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		log.Printf("deployment: %s, revision: %s", d.Name, d.Annotations[" deployment.kubernetes.io/revision"])
+		log.Printf("deployment: %s, revision: %s", d.Name, d.Annotations["deployment.kubernetes.io/revision"])
 
 		if err := down(ctx, namespace, name, manifestPath, oktetoPath); err != nil {
 			t.Fatal(err)
@@ -319,6 +319,7 @@ func waitForDeployment(ctx context.Context, namespace, name string, revision, ti
 		log.Printf("waitForDeployment output: %s", output)
 
 		if strings.Contains(output, "is different from the running revision") {
+
 			time.Sleep(1 * time.Second)
 			continue
 		}


### PR DESCRIPTION
## Proposed changes
- Specify the namespace on each process call to prevent getting deployments from other tests 
-  Log the revision to track changes
