### PR TITLE
Only inject mount key on Okteto Cloud

### DIFF
--- a/pkg/registry/file.go
+++ b/pkg/registry/file.go
@@ -28,15 +28,7 @@ import (
 )
 
 //GetDockerfile returns the dockerfile with the cache translations
-func GetDockerfile(path, dockerFile string, isOktetoCluster bool) (string, error) {
-	if dockerFile == "" {
-		dockerFile = filepath.Join(path, "Dockerfile")
-	}
-
-	if !isOktetoCluster {
-		return dockerFile, nil
-	}
-
+func GetDockerfile(path, dockerFile string) (string, error) {
 	fileWithCacheHandler, err := getDockerfileWithCacheHandler(dockerFile)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temporary build folder")


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- Injecting a mount cache key degrades the cache performance on OE installations and hard multitenancy is not an issue in dedicated cluster environments. 
