### PR TITLE
Fix image name generation when deployment does not exists and it is an okteto cluster

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -131,8 +131,11 @@ func runPush(ctx context.Context, dev *model.Dev, autoDeploy bool, imageTag, okt
 			d.Annotations[model.OktetoAutoCreateAnnotation] = model.OktetoPushCmd
 			exists = false
 
-			if imageTag == "" && oktetoRegistryURL == "" {
-				return fmt.Errorf("you need to specify the image tag to build with the '-t' argument")
+			if imageTag == "" {
+				if oktetoRegistryURL == "" {
+					return fmt.Errorf("you need to specify the image tag to build with the '-t' argument")
+				}
+				imageTag = registry.GetImageTag("", dev.Name, dev.Namespace, oktetoRegistryURL)
 			}
 		}
 	}

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -1,0 +1,114 @@
+// +build integration
+
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	k8Client "github.com/okteto/okteto/pkg/k8s/client"
+)
+
+const (
+	pushGitRepo   = "git@github.com:okteto/react-getting-started.git"
+	pushGitFolder = "react-getting-started"
+	pushManifest  = "okteto.yml"
+)
+
+func TestPush(t *testing.T) {
+	if mode == "client" {
+		t.Skip("this test is not required for client-side translation")
+		return
+	}
+
+	ctx := context.Background()
+	oktetoPath, err := getOktetoPath(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tName := fmt.Sprintf("TestPush-%s", runtime.GOOS)
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	namespace := fmt.Sprintf("%s-%s", name, user)
+
+	t.Run(tName, func(t *testing.T) {
+		log.Printf("running %s \n", tName)
+		k8Client.Reset()
+		if err := createNamespace(ctx, oktetoPath, namespace); err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("created namespace %s \n", namespace)
+
+		if err := cloneGitRepo(ctx, pushGitRepo); err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("cloned repo %s \n", pushGitRepo)
+
+		defer deleteGitRepo(ctx, pushGitFolder)
+
+		if err := oktetoPush(ctx, oktetoPath, pushManifest); err != nil {
+			t.Fatal(err)
+		}
+
+		log.Printf("pushed using %s \n", pushManifest)
+
+		endpoint := fmt.Sprintf("https://react-getting-started-%s.cloud.okteto.net", namespace)
+		content, err := getContent(endpoint, 150)
+		if err != nil {
+			t.Fatalf("failed to get app content: %s", err)
+		}
+
+		if !strings.Contains(content, "Web site created using create-react-app") {
+			t.Fatalf("wrong app content: %s", content)
+		}
+
+		d, err := getDeployment(ctx, namespace, "react-getting-started")
+		if err != nil {
+			t.Fatalf("error getting 'react-getting-started' deployment: %s", err.Error())
+		}
+
+		imageName := fmt.Sprintf("registry.cloud.okteto.net/%s/react-getting-started:okteto", namespace)
+		if d.Spec.Template.Spec.Containers[0].Image != imageName {
+			t.Fatalf("wrong image built for okteto push: expected '%s', got '%s'", imageName, d.Spec.Template.Spec.Containers[0].Image)
+		}
+
+		if err := deleteNamespace(ctx, oktetoPath, namespace); err != nil {
+			log.Printf("failed to delete namespace %s: %s\n", namespace, err)
+		}
+	})
+}
+
+func oktetoPush(ctx context.Context, oktetoPath, oktetoManifestPath string) error {
+	log.Printf("okteto push %s", oktetoManifestPath)
+	cmd := exec.Command(oktetoPath, "push", "-d", "-f", oktetoManifestPath)
+	cmd.Env = os.Environ()
+	cmd.Dir = pushGitFolder
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("okteto push failed: %s - %s", string(o), err)
+	}
+	log.Printf("okteto push %s success", oktetoManifestPath)
+	return nil
+}

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -46,7 +46,7 @@ func GetRepoNameAndTag(name string) (string, string) {
 //GetImageTag returns the image tag to build for a given services
 func GetImageTag(image, service, namespace, oktetoRegistryURL string) string {
 	if oktetoRegistryURL != "" {
-		if image == "" || image == model.DefaultImage {
+		if image == "" {
 			return fmt.Sprintf("%s/%s/%s:okteto", oktetoRegistryURL, namespace, service)
 		}
 		return image

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -129,14 +129,6 @@ func Test_GetDevImageTag(t *testing.T) {
 			expected:            "registry.cloud.okteto.net/ns/dev:okteto",
 		},
 		{
-			name:                "default-image-from-deployment",
-			dev:                 &model.Dev{Name: "dev", Namespace: "ns"},
-			imageTag:            "",
-			imageFromDeployment: model.DefaultImage,
-			oktetoRegistryURL:   okteto.CloudRegistryURL,
-			expected:            "registry.cloud.okteto.net/ns/dev:okteto",
-		},
-		{
 			name:                "okteto",
 			dev:                 &model.Dev{Name: "dev", Namespace: "ns"},
 			imageTag:            "",


### PR DESCRIPTION
## Proposed changes
- Also, add an e2e test for `okteto push`
