### PR TITLE
Recreate podWatcher if there is an issue accessing to pod events

### DIFF
--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -267,6 +267,10 @@ func WaitUntilRunning(ctx context.Context, dev *model.Dev, podName string, c *ku
 			pod, ok := event.Object.(*v1.Pod)
 			if !ok {
 				log.Errorf("type error getting pod: %s", event)
+				watchPod, err = c.CoreV1().Pods(dev.Namespace).Watch(ctx, opts)
+				if err != nil {
+					return err
+				}
 				continue
 			}
 			log.Infof("dev pod %s is now %s", pod.Name, pod.Status.Phase)


### PR DESCRIPTION
## Proposed changes
- If the pod watcher connection break, `okteto up` gets into an infinite loop trying the fetch pod events.
