### PR TITLE
build images without activating the namespace if they are not in the okteto registry

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -22,7 +22,6 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/cmd/login"
-	"github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/spf13/cobra"
 )
@@ -69,13 +68,8 @@ func Build(ctx context.Context) *cobra.Command {
 			}
 			log.Information("Running your build in %s...", buildKitHost)
 
-			_, _, namespace, err := client.GetLocal("")
-			if err != nil {
-				return fmt.Errorf("failed to load your local Kubeconfig: %s", err)
-			}
-
 			ctx := context.Background()
-			if err := build.Run(ctx, namespace, buildKitHost, isOktetoCluster, path, file, tag, target, noCache, cacheFrom, buildArgs, progress); err != nil {
+			if err := build.Run(ctx, "", buildKitHost, isOktetoCluster, path, file, tag, target, noCache, cacheFrom, buildArgs, progress); err != nil {
 				analytics.TrackBuild(false)
 				return err
 			}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -85,10 +85,15 @@ func ExpandOktetoDevRegistry(ctx context.Context, namespace, tag string) (string
 		return tag, nil
 	}
 
-	c, _, _, err := client.GetLocal("")
+	c, _, ns, err := client.GetLocal("")
 	if err != nil {
 		return "", fmt.Errorf("failed to load your local Kubeconfig: %s", err)
 	}
+
+	if namespace == "" {
+		namespace = ns
+	}
+
 	n, err := namespaces.Get(ctx, namespace, c)
 	if err != nil {
 		return "", fmt.Errorf("failed to get your current namespace '%s': %s", namespace, err.Error())


### PR DESCRIPTION

## Proposed changes
- Users should be able to build an image not hosted in okteto without activating a namespace

