### PR TITLE
Add pod affinities only to dev pods created for "services"

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -99,11 +99,12 @@ func translate(t *model.Translation, c *kubernetes.Clientset, isOktetoNamespace 
 	setLabel(t.Deployment.Spec.Template.GetObjectMeta(), okLabels.DevLabel, "true")
 	TranslateDevAnnotations(t.Deployment.Spec.Template.GetObjectMeta(), t.Annotations)
 	TranslateDevTolerations(&t.Deployment.Spec.Template.Spec, t.Tolerations)
-	TranslatePodAffinity(&t.Deployment.Spec.Template.Spec, t.Name)
 	t.Deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &devTerminationGracePeriodSeconds
 
 	if t.Interactive {
 		TranslateOktetoSyncSecret(&t.Deployment.Spec.Template.Spec, t.Name)
+	} else {
+		TranslatePodAffinity(&t.Deployment.Spec.Template.Spec, t.Name)
 	}
 	for _, rule := range t.Rules {
 		devContainer := GetDevContainer(&t.Deployment.Spec.Template.Spec, rule.Container)
@@ -115,7 +116,7 @@ func translate(t *model.Translation, c *kubernetes.Clientset, isOktetoNamespace 
 		TranslateOktetoVolumes(&t.Deployment.Spec.Template.Spec, rule)
 		TranslatePodSecurityContext(&t.Deployment.Spec.Template.Spec, rule.SecurityContext)
 		TranslateOktetoDevSecret(&t.Deployment.Spec.Template.Spec, t.Name, rule.Secrets)
-		if rule.OktetoBinImageTag != "" {
+		if rule.IsMainDevContainer() {
 			TranslateOktetoBinVolumeMounts(devContainer)
 			TranslateOktetoInitBinContainer(rule.OktetoBinImageTag, &t.Deployment.Spec.Template.Spec)
 			TranslateOktetoBinVolume(&t.Deployment.Spec.Template.Spec)

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -104,20 +104,6 @@ services:
 		Spec: appsv1.DeploymentSpec{
 			Template: apiv1.PodTemplateSpec{
 				Spec: apiv1.PodSpec{
-					Affinity: &apiv1.Affinity{
-						PodAffinity: &apiv1.PodAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											okLabels.InteractiveDevLabel: "web",
-										},
-									},
-									TopologyKey: "kubernetes.io/hostname",
-								},
-							},
-						},
-					},
 					Tolerations: []apiv1.Toleration{
 						{
 							Key:      "nvidia/cpu",
@@ -465,20 +451,6 @@ persistentVolume:
 		Spec: appsv1.DeploymentSpec{
 			Template: apiv1.PodTemplateSpec{
 				Spec: apiv1.PodSpec{
-					Affinity: &apiv1.Affinity{
-						PodAffinity: &apiv1.PodAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
-								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchLabels: map[string]string{
-											okLabels.InteractiveDevLabel: "web",
-										},
-									},
-									TopologyKey: "kubernetes.io/hostname",
-								},
-							},
-						},
-					},
 					TerminationGracePeriodSeconds: &devTerminationGracePeriodSeconds,
 					Volumes: []apiv1.Volume{
 						{

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -50,6 +50,11 @@ type TranslationRule struct {
 	Resources         ResourceRequirements `json:"resources,omitempty"`
 }
 
+//IsMainDevContainer returns true if the translation rule applies to the main dev container of the okteto manifest
+func (r *TranslationRule) IsMainDevContainer() bool {
+	return r.OktetoBinImageTag != ""
+}
+
 //VolumeMount represents a volume mount
 type VolumeMount struct {
 	Name      string `json:"name,omitempty"`


### PR DESCRIPTION
## Proposed changes
`okteto up` uses affinities to enforce all dev pods run on the same node, to make it possible to share a volume between the main dev pod, and the ones defined by "services".
Afinnities are only needed by pods defined by "services". Adding the affinities to the main dev container gives scheduling issues if other affinities are defined in the deployment under development.
