### PR TITLE
Unify how sync status is computed between "okteto status" and "okteto…

### DIFF
--- a/pkg/cmd/status/run.go
+++ b/pkg/cmd/status/run.go
@@ -37,17 +37,22 @@ func Run(ctx context.Context, dev *model.Dev, sy *syncthing.Syncthing) (float64,
 		log.Infof("error accessing remote syncthing status: %s", err)
 		return 0, fmt.Errorf("error accessing remote syncthing status")
 	}
-	if progressLocal == 100 && progressRemote == 100 {
-		return 100, nil
+
+	return computeProgress(progressLocal, progressRemote), nil
+}
+
+func computeProgress(local, remote float64) float64 {
+	if local == 100 && remote == 100 {
+		return 100
 	}
-	if progressLocal == 100 {
-		return progressRemote, nil
+
+	if local == 100 {
+		return remote
 	}
-	if progressRemote == 100 {
-		return progressLocal, nil
+	if remote == 100 {
+		return local
 	}
-	progress := (progressLocal + progressRemote) / 2
-	return progress, nil
+	return (local + remote) / 2
 }
 
 //Wait waits for the okteto up sequence to finish

--- a/pkg/cmd/status/run.go
+++ b/pkg/cmd/status/run.go
@@ -37,6 +37,15 @@ func Run(ctx context.Context, dev *model.Dev, sy *syncthing.Syncthing) (float64,
 		log.Infof("error accessing remote syncthing status: %s", err)
 		return 0, fmt.Errorf("error accessing remote syncthing status")
 	}
+	if progressLocal == 100 && progressRemote == 100 {
+		return 100, nil
+	}
+	if progressLocal == 100 {
+		return progressRemote, nil
+	}
+	if progressRemote == 100 {
+		return progressLocal, nil
+	}
 	progress := (progressLocal + progressRemote) / 2
 	return progress, nil
 }

--- a/pkg/cmd/status/run_test.go
+++ b/pkg/cmd/status/run_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"testing"
+)
+
+func Test_computeProgress(t *testing.T) {
+	var tests = []struct {
+		name     string
+		local    float64
+		remote   float64
+		expected float64
+	}{
+		{
+			name:     "both-100",
+			local:    100,
+			remote:   100,
+			expected: 100,
+		},
+		{
+			name:     "local-100",
+			local:    100,
+			remote:   30,
+			expected: 30,
+		},
+		{
+			name:     "remote-100",
+			local:    30,
+			remote:   100,
+			expected: 30,
+		},
+		{
+			name:     "none-100",
+			local:    30,
+			remote:   50,
+			expected: 40,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeProgress(tt.local, tt.remote)
+			if result != tt.expected {
+				t.Fatalf("Test '%s' failed: expected %.f got %.f", tt.name, tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
… up"

Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

People get confused by showing two sync statuses that don't match.

## Proposed changes
- The idea is to compute the status based on one-way sync if dual-sync is not happening
