### PR TITLE
Backward compatibility if none of "workdir" and "sync" is defined

### DIFF
--- a/pkg/model/volumes.go
+++ b/pkg/model/volumes.go
@@ -23,6 +23,9 @@ import (
 )
 
 func (dev *Dev) translateDeprecatedVolumeFields() error {
+	if dev.WorkDir == "" && dev.MountPath == "" && len(dev.Sync.Folders) == 0 {
+		dev.WorkDir = "/okteto"
+	}
 	if err := dev.translateDeprecatedMountPath(nil); err != nil {
 		return err
 	}

--- a/pkg/model/volumes_test.go
+++ b/pkg/model/volumes_test.go
@@ -27,6 +27,29 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "none",
+			dev: &Dev{
+				WorkDir: "",
+				Volumes: []Volume{},
+				Sync: Sync{
+					Folders: []SyncFolder{},
+				},
+			},
+			result: &Dev{
+				Volumes: []Volume{},
+				WorkDir: "/okteto",
+				Sync: Sync{
+					Folders: []SyncFolder{
+						{
+							LocalPath:  ".",
+							RemotePath: "/okteto",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "workdir",
 			dev: &Dev{
 				WorkDir: "/workdir",


### PR DESCRIPTION
## Proposed changes
Currently, manifests of this kind are broken:
```
name: guestbook
image: okteto/python:3
command: bash
```
