### PR TITLE
Refresh k8s credentials for okteto managed namespaces

### DIFF
--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -16,8 +16,6 @@ package namespace
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -78,7 +76,7 @@ func RunNamespace(ctx context.Context, namespace string) error {
 		}
 	}
 
-	cred, err := okteto.GetCredentials(ctx, namespace)
+	cred, err := okteto.GetCredentials(ctx)
 	if err != nil {
 		return err
 	}
@@ -87,13 +85,13 @@ func RunNamespace(ctx context.Context, namespace string) error {
 	}
 
 	kubeConfigFile := config.GetKubeConfigFile()
-	clusterHost := getClusterHost()
+	clusterContext := okteto.GetClusterContext()
 
-	if err := okteto.SetKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), clusterHost); err != nil {
+	if err := okteto.SetKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), clusterContext, true); err != nil {
 		return err
 	}
 
-	log.Success("Updated context '%s' in '%s'", clusterHost, kubeConfigFile)
+	log.Success("Updated context '%s' in '%s'", clusterContext, kubeConfigFile)
 	return nil
 }
 
@@ -121,9 +119,4 @@ func askOktetoURL() (string, error) {
 	oktetoURL = u
 
 	return oktetoURL, nil
-}
-
-func getClusterHost() string {
-	u, _ := url.Parse(okteto.GetURL())
-	return strings.ReplaceAll(u.Host, ".", "_")
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -39,6 +39,7 @@ import (
 	upCmd "github.com/okteto/okteto/cmd/up"
 	"github.com/okteto/okteto/pkg/config"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/syncthing"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -256,6 +257,17 @@ func TestAll(t *testing.T) {
 		}
 
 		log.Printf("deployment: %s, revision: %s", originalDeployment.Name, originalDeployment.Annotations["deployment.kubernetes.io/revision"])
+
+		//set bad server to test k8s credential refresh
+		kubeConfigFile := config.GetKubeConfigFile()
+		cred, err := okteto.GetCredentials(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cred.Server = "https://31.192.137.200:443"
+		if err := okteto.SetKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), okteto.GetClusterContext(), false); err != nil {
+			t.Fatal(err)
+		}
 
 		var wg sync.WaitGroup
 		p, err := up(ctx, &wg, namespace, name, manifestPath, oktetoPath)

--- a/pkg/k8s/client/retry.go
+++ b/pkg/k8s/client/retry.go
@@ -1,0 +1,94 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/okteto"
+)
+
+var (
+	roundTripHost  string
+	roundTripToken string
+)
+
+type refreshCredentials struct {
+	rt http.RoundTripper
+}
+
+func refreshCredentialsFn(rt http.RoundTripper) http.RoundTripper {
+	return &refreshCredentials{
+		rt: rt,
+	}
+}
+
+func (rc *refreshCredentials) RoundTrip(req *http.Request) (*http.Response, error) {
+	if roundTripHost != "" {
+		req.Host = roundTripHost
+		req.URL.Host = roundTripHost
+		req.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", roundTripToken)}
+	}
+	resp, errOrig := rc.rt.RoundTrip(req)
+	if okteto.GetClusterContext() != currentContext {
+		return resp, errOrig
+	}
+	if req.Method != http.MethodGet {
+		return resp, errOrig
+	}
+	if !isCredentialError(resp, errOrig) {
+		return resp, errOrig
+	}
+
+	log.Infof("refreshing kubernetes credentials...")
+	var err error
+	var host string
+	ctx := context.Background()
+	host, roundTripToken, err = okteto.RefreshOktetoKubeconfig(ctx, namespace)
+	if err != nil {
+		log.Infof("failed to refresh your kubernetes credentials: %s", err.Error())
+		return resp, errOrig
+	}
+
+	r, _ := url.Parse(host)
+	roundTripHost = r.Host
+	req.Host = roundTripHost
+	req.URL.Host = roundTripHost
+	req.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", roundTripToken)}
+	return rc.rt.RoundTrip(req)
+}
+
+func isCredentialError(resp *http.Response, err error) bool {
+	if resp != nil && resp.StatusCode == 401 {
+		return true
+	}
+	if err != nil && strings.Contains(err.Error(), "i/o timeout") {
+		return true
+	}
+	if err != nil && strings.Contains(err.Error(), "context deadline exceeded") {
+		return true
+	}
+	if err != nil && strings.Contains(err.Error(), "x509") {
+		return true
+	}
+	if err != nil && strings.Contains(err.Error(), "no such host") {
+		return true
+	}
+	return false
+}

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -106,7 +106,7 @@ func translateAPIErr(err error) error {
 }
 
 //SetKubeConfig updates a kubeconfig file with okteto cluster credentials
-func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, clusterName string) error {
+func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, clusterName string, setCurrent bool) error {
 	cfg, err := getOrCreateKubeConfig(kubeConfigPath)
 	if err != nil {
 		return err
@@ -141,7 +141,9 @@ func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, cluste
 	context.Namespace = namespace
 	cfg.Contexts[clusterName] = context
 
-	cfg.CurrentContext = clusterName
+	if setCurrent {
+		cfg.CurrentContext = clusterName
+	}
 
 	return clientcmd.WriteToFile(*cfg, kubeConfigPath)
 }

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -29,23 +29,23 @@ func TestSetKubeConfig(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	c := &Credential{}
-	if err := SetKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com"); err != nil {
+	if err := SetKubeConfig(c, file.Name(), "", "123-123-123", "cloud-okteto-com", true); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	if err := SetKubeConfig(c, file.Name(), "ns", "123-123-123", "cloud-okteto-com"); err != nil {
+	if err := SetKubeConfig(c, file.Name(), "ns", "123-123-123", "cloud-okteto-com", true); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-123", "cloud-okteto-com"); err != nil {
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-123", "cloud-okteto-com", true); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	if err := SetKubeConfig(c, file.Name(), "", "123-123-124", "sf-okteto-com"); err != nil {
+	if err := SetKubeConfig(c, file.Name(), "", "123-123-124", "sf-okteto-com", true); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-124", "sf-okteto-com"); err != nil {
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-124", "sf-okteto-com", true); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -72,11 +72,11 @@ func TestSetKubeConfig(t *testing.T) {
 
 	// add duplicated
 
-	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-124", "sf-okteto-com"); err != nil {
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-124", "sf-okteto-com", true); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-123", "cloud-okteto-com"); err != nil {
+	if err := SetKubeConfig(c, file.Name(), "ns-2", "123-123-123", "cloud-okteto-com", true); err != nil {
 		t.Fatal(err.Error())
 	}
 

--- a/pkg/okteto/credential.go
+++ b/pkg/okteto/credential.go
@@ -15,7 +15,6 @@ package okteto
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -37,11 +36,11 @@ type Credential struct {
 
 // GetCredentials returns the space config credentials
 func GetCredentials(ctx context.Context) (*Credential, error) {
-	q := fmt.Sprintf(`query{
+	q := `query{
 		credentials(space: ""){
 			server, certificate, token, namespace
 		},
-	}`)
+	}`
 
 	var cred Credentials
 	if err := query(ctx, q, &cred); err != nil {


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
This PR implements a k8s credentials refresh when getting a k8s client to a namespace managed by okteto.
It opens the door to implement a rotation of k8s credentials.

The implementation uses a k8s transport that intercept connection errors to the API server and refresh the k8s credentials if the namespace is manged by okteto