### PR TITLE
Add persistent volume enable default value to true

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -284,7 +284,8 @@ func Read(bytes []byte) (*Dev, error) {
 		Sync: Sync{
 			Folders: make([]SyncFolder, 0),
 		},
-		Services: make([]*Dev, 0),
+		Services:             make([]*Dev, 0),
+		PersistentVolumeInfo: &PersistentVolumeInfo{Enabled: true},
 	}
 
 	if bytes != nil {


### PR DESCRIPTION
Fixes #1254 

## Proposed changes
- Set persistent volume enabled to true as a default value. This will always create a persistent volume even when no persistent volume field specified
