### PR TITLE
Add autocreate field to manifest

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -114,6 +114,7 @@ func Run(namespace, k8sContext, devPath, language, workDir string, overwrite boo
 			return err
 		}
 		if d == nil {
+			dev.Autocreate = true
 			linguist.SetForwardDefaults(dev, language)
 		} else {
 			dev.Container = container

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -475,9 +475,9 @@ func (up *upContext) getCurrentDeployment(ctx context.Context, autoDeploy bool) 
 		err = errors.UserError{
 			E: fmt.Errorf("Deployment %s not found in namespace '%s'", up.Dev.Name, up.Dev.Namespace),
 			Hint: `Please:
-	- Make sure your application is deployed and ready.
-	- Make sure your context is pointing to the right namespace.
-	- Set the 'autocreate' property in your okteto.yml manifest if you want to automatically create a new development container.
+      - Make sure your application is deployed.
+      - Make sure your context is pointing to the right namespace.
+      - To automatically create a new deployment, set 'autocreate' in your okteto manifest.
     More information is available here: https://okteto.com/docs/reference/cli#up`,
 		}
 		return nil, false, err

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -467,10 +467,11 @@ func (up *upContext) getCurrentDeployment(ctx context.Context, autoDeploy bool) 
 		return nil, false, err
 	}
 
-	if !autoDeploy {
-		if err := utils.AskIfDeploy(up.Dev.Name, up.Dev.Namespace); err != nil {
-			return nil, false, err
-		}
+	if !autoDeploy && !up.Dev.Autocreate {
+		err = errors.UserError{
+			E:    fmt.Errorf("Can't autocreate deployment"),
+			Hint: "Deploy your app first on okteto cloud or enable it using --deploy arg or setting autocreate variable to true in your manifest"}
+		return nil, false, err
 	}
 
 	return up.Dev.GevSandbox(), true, nil

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -105,8 +105,8 @@ func Up() *cobra.Command {
 			checkLocalWatchesConfiguration()
 
 			if autoDeploy {
-				log.Yellow(`The use of 'deploy' flag will be deprecated in a future release. 
-Please set 'autocreate' in your okteto manifest to get the same behavior. 
+				log.Yellow(`The 'deploy' flag is deprecated and will be removed in a future release.
+Set the 'autocreate' field in your okteto manifest to get the same behavior.
 More information is available here: https://okteto.com/docs/reference/cli#up`)
 			}
 
@@ -480,11 +480,9 @@ func (up *upContext) getCurrentDeployment(ctx context.Context, autoDeploy bool) 
 
 	if !up.Dev.Autocreate {
 		err = errors.UserError{
-			E: fmt.Errorf("Deployment %s not found in namespace '%s'", up.Dev.Name, up.Dev.Namespace),
-			Hint: `Please:
-      - Make sure your application is deployed.
-      - Make sure your context is pointing to the right namespace.
-      - To automatically create a new deployment, set 'autocreate' in your okteto manifest.
+			E: fmt.Errorf("Deployment '%s' not found in namespace '%s'", up.Dev.Name, up.Dev.Namespace),
+			Hint: `Verify that your application has been deployed and your Kubernetes context is pointing to the right namespace
+    Or set the 'autocreate' field in your okteto manifest if you want to create a standalone development container
     More information is available here: https://okteto.com/docs/reference/cli#up`,
 		}
 		return nil, false, err

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -105,9 +105,9 @@ func Up() *cobra.Command {
 			checkLocalWatchesConfiguration()
 
 			if autoDeploy {
-				log.Yellow(`Warning: The use of 'deploy' flag will be deprecated in a future release. 
-    	 Please set 'autocreate' in your okteto manifest to get the same behaviour. 
-    	 More information is available here: https://okteto.com/docs/reference/cli#up`)
+				log.Yellow(`The use of 'deploy' flag will be deprecated in a future release. 
+Please set 'autocreate' in your okteto manifest to get the same behavior. 
+More information is available here: https://okteto.com/docs/reference/cli#up`)
 			}
 
 			dev, err := loadDevOrInit(namespace, k8sContext, devPath)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -104,6 +104,12 @@ func Up() *cobra.Command {
 
 			checkLocalWatchesConfiguration()
 
+			if autoDeploy {
+				log.Yellow(`Warning: The use of 'deploy' flag will be deprecated in a future release. 
+    	 Please set 'autocreate' in your okteto manifest to get the same behaviour. 
+    	 More information is available here: https://okteto.com/docs/reference/cli#up`)
+			}
+
 			dev, err := loadDevOrInit(namespace, k8sContext, devPath)
 			if err != nil {
 				return err
@@ -146,6 +152,7 @@ func Up() *cobra.Command {
 	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the up command is executed")
 	cmd.Flags().IntVarP(&remote, "remote", "r", 0, "configures remote execution on the specified port")
 	cmd.Flags().BoolVarP(&autoDeploy, "deploy", "d", false, "create deployment when it doesn't exist in a namespace")
+	cmd.Flags().MarkHidden("deploy")
 	cmd.Flags().BoolVarP(&build, "build", "", false, "build on-the-fly the dev image using the info provided by the 'build' okteto manifest field")
 	cmd.Flags().BoolVarP(&forcePull, "pull", "", false, "force dev image pull")
 	cmd.Flags().BoolVarP(&resetSyncthing, "reset", "", false, "reset the file synchronization database")

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -473,8 +473,13 @@ func (up *upContext) getCurrentDeployment(ctx context.Context, autoDeploy bool) 
 
 	if !up.Dev.Autocreate {
 		err = errors.UserError{
-			E:    fmt.Errorf("Deployment %s not found in namespace '%s'", up.Dev.Name, up.Dev.Namespace),
-			Hint: "- Make sure your application is deployed and ready.\n-Make sure your context is pointing to the right namespace.\n- Set the `autocreate` property in your okteto.yml manifest if you want to automatically create a new development container."}
+			E: fmt.Errorf("Deployment %s not found in namespace '%s'", up.Dev.Name, up.Dev.Namespace),
+			Hint: `Please:
+	- Make sure your application is deployed and ready.
+	- Make sure your context is pointing to the right namespace.
+	- Set the 'autocreate' property in your okteto.yml manifest if you want to automatically create a new development container.
+    More information is available here: https://okteto.com/docs/reference/cli#up`,
+		}
 		return nil, false, err
 	}
 

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -144,6 +144,7 @@ type Dev struct {
 	Resources            ResourceRequirements  `json:"resources,omitempty" yaml:"resources,omitempty"`
 	Services             []*Dev                `json:"services,omitempty" yaml:"services,omitempty"`
 	PersistentVolumeInfo *PersistentVolumeInfo `json:"persistentVolume,omitempty" yaml:"persistentVolume,omitempty"`
+	Autocreate           bool                  `json:"autocreate,omitempty" yaml:"autocreate,omitempty"`
 }
 
 //Command represents the start command of a development contaianer

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -114,6 +114,7 @@ var (
 //Dev represents a development container
 type Dev struct {
 	Name                 string                `json:"name" yaml:"name"`
+	Autocreate           bool                  `json:"autocreate,omitempty" yaml:"autocreate,omitempty"`
 	Labels               map[string]string     `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations          map[string]string     `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Tolerations          []apiv1.Toleration    `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
@@ -144,7 +145,6 @@ type Dev struct {
 	Resources            ResourceRequirements  `json:"resources,omitempty" yaml:"resources,omitempty"`
 	Services             []*Dev                `json:"services,omitempty" yaml:"services,omitempty"`
 	PersistentVolumeInfo *PersistentVolumeInfo `json:"persistentVolume,omitempty" yaml:"persistentVolume,omitempty"`
-	Autocreate           bool                  `json:"autocreate,omitempty" yaml:"autocreate,omitempty"`
 }
 
 //Command represents the start command of a development contaianer


### PR DESCRIPTION
Signed-off-by: jLopezbarb <javier@okteto.com>

Fixes #1285 

## Proposed changes
- Creates a autocrate field in manifest to deploy even when there is no application deployed on Okteto Cloud.
- Returns an error if someone tries to create a deployment without adding this field on manifest or adding the --deploy arg
