### PR TITLE
Restore previous sleeping state on "okteto down"

### DIFF
--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -109,6 +109,7 @@ func GetTranslations(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, 
 	result := map[string]*model.Translation{}
 	if d != nil {
 		rule := dev.ToTranslationRule(dev)
+		replicas := getPreviousDeploymentReplicas(d)
 		result[d.Name] = &model.Translation{
 			Interactive: true,
 			Name:        dev.Name,
@@ -116,7 +117,7 @@ func GetTranslations(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, 
 			Deployment:  d,
 			Annotations: dev.Annotations,
 			Tolerations: dev.Tolerations,
-			Replicas:    *d.Spec.Replicas,
+			Replicas:    replicas,
 			Rules:       []*model.TranslationRule{rule},
 		}
 	}

--- a/pkg/k8s/deployments/utils.go
+++ b/pkg/k8s/deployments/utils.go
@@ -71,7 +71,6 @@ func getTranslationFromAnnotation(annotations map[string]string) (model.Translat
 	return tr, nil
 }
 
-//GetTranslations fills all the deployments pointed by a development container
 func getPreviousDeploymentReplicas(d *appsv1.Deployment) int32 {
 	replicas := *d.Spec.Replicas
 	previousState, ok := d.Annotations[okLabels.StateBeforeSleepingAnnontation]

--- a/pkg/k8s/deployments/utils.go
+++ b/pkg/k8s/deployments/utils.go
@@ -17,9 +17,15 @@ import (
 	"encoding/json"
 
 	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
+	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type stateBeforeSleeping struct {
+	Replicas int
+}
 
 func setLabel(o metav1.Object, key, value string) {
 	labels := o.GetLabels()
@@ -63,4 +69,19 @@ func getTranslationFromAnnotation(annotations map[string]string) (model.Translat
 		return model.Translation{}, err
 	}
 	return tr, nil
+}
+
+//GetTranslations fills all the deployments pointed by a development container
+func getPreviousDeploymentReplicas(d *appsv1.Deployment) int32 {
+	replicas := *d.Spec.Replicas
+	previousState, ok := d.Annotations[okLabels.StateBeforeSleepingAnnontation]
+	if !ok {
+		return replicas
+	}
+	var state stateBeforeSleeping
+	if err := json.Unmarshal([]byte(previousState), &state); err != nil {
+		log.Infof("error getting previous state of deployment '%s': %s", d.Name, err.Error())
+		return 1
+	}
+	return int32(state.Replicas)
 }

--- a/pkg/k8s/labels/labels.go
+++ b/pkg/k8s/labels/labels.go
@@ -55,4 +55,7 @@ const (
 
 	//DefaultStorageClassAnnotation indicates the defaault storage class
 	DefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+
+	//StateBeforeSleepingAnnontation indicates the state of the resource prior to scale it to zero
+	StateBeforeSleepingAnnontation = "dev.okteto.com/state-before-sleeping"
 )


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- `okteto up` checks the replicas before a sleeping operation and annotatess that value to be used by `okteto down`
