### PR TITLE
Jlopezbarb/logs just for up

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -190,6 +190,10 @@ func loadDevOverrides(dev *model.Dev, namespace, k8sContext string, forcePull bo
 
 	dev.LoadContext(namespace, k8sContext)
 
+	if dev.Namespace == "" {
+		dev.Namespace, _ = k8Client.GetNamespace(k8sContext)
+	}
+
 	if remote > 0 {
 		dev.RemotePort = remote
 	}
@@ -208,10 +212,6 @@ func loadDevOverrides(dev *model.Dev, namespace, k8sContext string, forcePull bo
 
 	if forcePull {
 		dev.LoadForcePull()
-	}
-
-	if dev.Namespace == "" {
-		dev.Namespace, _ = k8Client.GetNamespace(k8sContext)
 	}
 
 	return nil

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -119,7 +119,7 @@ More information is available here: https://okteto.com/docs/reference/cli#up`)
 				return err
 			}
 
-			log.CreateLogFile(config.GetDeploymentHome(dev.Namespace, dev.Name), config.VersionString)
+			log.ConfigureFileLogger(config.GetDeploymentHome(dev.Namespace, dev.Name), config.VersionString)
 
 			if err := checkStignoreConfiguration(dev); err != nil {
 				log.Infof("failed to check '.stignore' configuration: %s", err.Error())

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -44,7 +44,6 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/ssh"
-	"github.com/sirupsen/logrus"
 
 	"github.com/okteto/okteto/pkg/k8s/forward"
 	"github.com/okteto/okteto/pkg/syncthing"
@@ -120,7 +119,7 @@ More information is available here: https://okteto.com/docs/reference/cli#up`)
 				return err
 			}
 
-			log.Init(logrus.WarnLevel, config.GetDeploymentHome(dev.Namespace, dev.Name), config.VersionString)
+			log.CreateLogFile(config.GetDeploymentHome(dev.Namespace, dev.Name), config.VersionString)
 
 			if err := checkStignoreConfiguration(dev); err != nil {
 				log.Infof("failed to check '.stignore' configuration: %s", err.Error())

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -44,6 +44,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/ssh"
+	"github.com/sirupsen/logrus"
 
 	"github.com/okteto/okteto/pkg/k8s/forward"
 	"github.com/okteto/okteto/pkg/syncthing"
@@ -229,6 +230,8 @@ func (up *upContext) start(autoDeploy, build bool) error {
 	if up.Dev.Namespace == "" {
 		up.Dev.Namespace = namespace
 	}
+
+	log.Init(logrus.WarnLevel, config.GetDeploymentHome(up.Dev.Namespace, up.Dev.Name), config.VersionString)
 
 	ctx := context.Background()
 	ns, err := namespaces.Get(ctx, up.Dev.Namespace, up.Client)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func init() {
 
 func main() {
 	ctx := context.Background()
-	log.Init(logrus.WarnLevel, config.GetOktetoHome(), config.VersionString)
+	log.Init(logrus.WarnLevel)
 	var logLevel string
 
 	root := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ import (
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
@@ -61,7 +60,6 @@ func init() {
 
 func main() {
 	ctx := context.Background()
-	log.Init(logrus.WarnLevel, config.GetOktetoHome(), config.VersionString)
 	var logLevel string
 
 	root := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
@@ -60,6 +61,7 @@ func init() {
 
 func main() {
 	ctx := context.Background()
+	log.Init(logrus.WarnLevel, config.GetOktetoHome(), config.VersionString)
 	var logLevel string
 
 	root := &cobra.Command{

--- a/pkg/cmd/doctor/run.go
+++ b/pkg/cmd/doctor/run.go
@@ -88,9 +88,9 @@ func Run(ctx context.Context, dev *model.Dev, devPath string, c *kubernetes.Clie
 	files := []string{summaryFilename}
 	files = append(files, stignoreFilenames...)
 
-	deploymentLogs := filepath.Join(config.GetDeploymentHome(dev.Namespace, dev.Name), "okteto.log")
-	if model.FileExists(deploymentLogs) {
-		files = append(files, deploymentLogs)
+	deploymentLogsPath := filepath.Join(config.GetDeploymentHome(dev.Namespace, dev.Name), "okteto.log")
+	if model.FileExists(deploymentLogsPath) {
+		files = append(files, deploymentLogsPath)
 	}
 
 	if model.FileExists(syncthing.GetLogFile(dev.Namespace, dev.Name)) {

--- a/pkg/cmd/doctor/run.go
+++ b/pkg/cmd/doctor/run.go
@@ -87,9 +87,12 @@ func Run(ctx context.Context, dev *model.Dev, devPath string, c *kubernetes.Clie
 	archiveName := fmt.Sprintf("okteto-doctor-%s.zip", now.Format("20060102150405"))
 	files := []string{summaryFilename}
 	files = append(files, stignoreFilenames...)
-	if model.FileExists(filepath.Join(config.GetOktetoHome(), "okteto.log")) {
-		files = append(files, filepath.Join(config.GetOktetoHome(), "okteto.log"))
+
+	deploymentLogs := filepath.Join(config.GetDeploymentHome(dev.Namespace, dev.Name), "okteto.log")
+	if model.FileExists(deploymentLogs) {
+		files = append(files, deploymentLogs)
 	}
+
 	if model.FileExists(syncthing.GetLogFile(dev.Namespace, dev.Name)) {
 		files = append(files, syncthing.GetLogFile(dev.Namespace, dev.Name))
 	}

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -80,6 +80,7 @@ func GetLocal(k8sContext string) (*kubernetes.Clientset, *rest.Config, string, e
 		}
 
 		setAnalytics(currentContext, config.Host)
+		return client, config, namespace, nil
 	}
 
 	return client, config, namespace, nil

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -35,6 +35,7 @@ const (
 )
 
 var (
+	clientConfig   clientcmd.ClientConfig
 	client         *kubernetes.Clientset
 	config         *rest.Config
 	namespace      string
@@ -45,17 +46,8 @@ var (
 //GetLocal returns a kubernetes client with the local configuration. It will detect if KUBECONFIG is defined.
 func GetLocal(k8sContext string) (*kubernetes.Clientset, *rest.Config, string, error) {
 	if client == nil {
-		var err error
-
-		clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-			clientcmd.NewDefaultClientConfigLoadingRules(),
-			&clientcmd.ConfigOverrides{
-				CurrentContext: k8sContext,
-				ClusterInfo:    clientcmdapi.Cluster{Server: ""},
-			},
-		)
-
-		namespace, _, err = clientConfig.Namespace()
+		clientConfig = GetClientConfig(k8sContext)
+		namespace, err := GetNamespace(k8sContext)
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -91,6 +83,30 @@ func GetLocal(k8sContext string) (*kubernetes.Clientset, *rest.Config, string, e
 	}
 
 	return client, config, namespace, nil
+}
+
+//GetNamespace returns the name of the namespace in use
+func GetNamespace(k8sContext string) (string, error) {
+	clientConfig = GetClientConfig(k8sContext)
+	namespace, _, err := clientConfig.Namespace()
+	if err != nil {
+		return "", err
+	}
+	return namespace, nil
+}
+
+//GetClientConfig sets the client config for the context in use
+func GetClientConfig(k8sContext string) clientcmd.ClientConfig {
+	if clientConfig == nil {
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			clientcmd.NewDefaultClientConfigLoadingRules(),
+			&clientcmd.ConfigOverrides{
+				CurrentContext: k8sContext,
+				ClusterInfo:    clientcmdapi.Cluster{Server: ""},
+			},
+		)
+	}
+	return clientConfig
 }
 
 //Reset cleans the cached client

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -46,8 +46,9 @@ var (
 //GetLocal returns a kubernetes client with the local configuration. It will detect if KUBECONFIG is defined.
 func GetLocal(k8sContext string) (*kubernetes.Clientset, *rest.Config, string, error) {
 	if client == nil {
+		var err error
 		clientConfig = GetClientConfig(k8sContext)
-		namespace, err := GetNamespace(k8sContext)
+		namespace, err = GetNamespace(k8sContext)
 		if err != nil {
 			return nil, nil, "", err
 		}
@@ -80,7 +81,6 @@ func GetLocal(k8sContext string) (*kubernetes.Clientset, *rest.Config, string, e
 		}
 
 		setAnalytics(currentContext, config.Host)
-		return client, config, namespace, nil
 	}
 
 	return client, config, namespace, nil

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -62,6 +62,10 @@ func Init(level logrus.Level, dir, version string) {
 	log.out.SetOutput(os.Stdout)
 	log.out.SetLevel(level)
 
+	CreateLogFile(dir, version)
+}
+
+func CreateLogFile(dir, version string) {
 	fileLogger := logrus.New()
 	fileLogger.SetFormatter(&logrus.TextFormatter{
 		DisableColors: true,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -58,11 +58,9 @@ func init() {
 }
 
 // Init configures the logger for the package to use.
-func Init(level logrus.Level, dir, version string) {
+func Init(level logrus.Level) {
 	log.out.SetOutput(os.Stdout)
 	log.out.SetLevel(level)
-
-	CreateLogFile(dir, version)
 }
 
 func CreateLogFile(dir, version string) {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -63,7 +63,7 @@ func Init(level logrus.Level) {
 	log.out.SetLevel(level)
 }
 
-func CreateLogFile(dir, version string) {
+func ConfigureFileLogger(dir, version string) {
 	fileLogger := logrus.New()
 	fileLogger.SetFormatter(&logrus.TextFormatter{
 		DisableColors: true,


### PR DESCRIPTION
Fixes #977 

## Proposed changes
- Get the logs just for the up command, creating a log file for every dev container 
- Creates a folder with the namespace and name of the dev container for storing the logs of that container.
- When doing Okteto doctor retrieves the logs of the Okteto manifest from the current working directory