### PR TITLE
Jlopezbarb/fix integration tests

### DIFF
--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -35,8 +35,7 @@ func Test_waitUntilExitOrInterrupt(t *testing.T) {
 	if err == nil {
 		t.Errorf("didn't report proper error")
 	}
-
-	if err != errors.ErrCommandFailed {
+	if _, ok := err.(errors.CommandError); !ok {
 		t.Errorf("didn't translate the error: %s", err)
 	}
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -423,7 +423,7 @@ func createNamespace(ctx context.Context, oktetoPath, namespace string) error {
 
 	log.Printf("create namespace output: \n%s\n", string(o))
 
-	_, _, n, err := k8Client.GetLocal("")
+	n, err := k8Client.GetNamespace("")
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -35,7 +35,6 @@ const (
 )
 
 var (
-	clientConfig   clientcmd.ClientConfig
 	client         *kubernetes.Clientset
 	config         *rest.Config
 	namespace      string


### PR DESCRIPTION
Fixes Integration tests

## Proposed changes
-  Removes clientConfig as global variable to allow resetting the client, namespace and the configuration
- Integration tests now calls getNamespace instead of GetLocal and discarding the client and configuration variable to get the namespace.
 
