### PR TITLE
Refactor dev.Namespace and dev.Context initialization in a single place

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -41,19 +41,14 @@ func Doctor() *cobra.Command {
 				return errors.ErrNotInDevContainer
 			}
 
-			dev, err := utils.LoadDev(devPath)
-			if err != nil {
-				return err
-			}
-			dev.LoadContext(namespace, k8sContext)
-
-			c, _, namespace, err := k8Client.GetLocal(dev.Context)
+			dev, err := utils.LoadDev(devPath, namespace, k8sContext)
 			if err != nil {
 				return err
 			}
 
-			if dev.Namespace == "" {
-				dev.Namespace = namespace
+			c, _, err := k8Client.GetLocal(dev.Context)
+			if err != nil {
+				return err
 			}
 
 			ctx := context.Background()

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -46,7 +46,7 @@ func Doctor() *cobra.Command {
 				return err
 			}
 
-			c, _, err := k8Client.GetLocal(dev.Context)
+			c, _, err := k8Client.GetLocalWithContext(dev.Context)
 			if err != nil {
 				return err
 			}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -42,12 +42,10 @@ func Down() *cobra.Command {
 		Short: "Deactivates your development container",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			dev, err := utils.LoadDev(devPath)
+			dev, err := utils.LoadDev(devPath, namespace, k8sContext)
 			if err != nil {
 				return err
 			}
-
-			dev.LoadContext(namespace, k8sContext)
 
 			if err := runDown(ctx, dev); err != nil {
 				analytics.TrackDown(false)
@@ -92,12 +90,9 @@ func runDown(ctx context.Context, dev *model.Dev) error {
 	spinner.Start()
 	defer spinner.Stop()
 
-	client, _, namespace, err := k8Client.GetLocal(dev.Context)
+	client, _, err := k8Client.GetLocal(dev.Context)
 	if err != nil {
 		return err
-	}
-	if dev.Namespace == "" {
-		dev.Namespace = namespace
 	}
 
 	d, err := deployments.Get(ctx, dev, dev.Namespace, client)
@@ -123,12 +118,9 @@ func removeVolume(ctx context.Context, dev *model.Dev) error {
 	spinner.Start()
 	defer spinner.Stop()
 
-	client, _, namespace, err := k8Client.GetLocal(dev.Context)
+	client, _, err := k8Client.GetLocal(dev.Context)
 	if err != nil {
 		return err
-	}
-	if dev.Namespace == "" {
-		dev.Namespace = namespace
 	}
 
 	return volumes.Destroy(ctx, dev, client)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -90,7 +90,7 @@ func runDown(ctx context.Context, dev *model.Dev) error {
 	spinner.Start()
 	defer spinner.Stop()
 
-	client, _, err := k8Client.GetLocal(dev.Context)
+	client, _, err := k8Client.GetLocalWithContext(dev.Context)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func removeVolume(ctx context.Context, dev *model.Dev) error {
 	spinner.Start()
 	defer spinner.Stop()
 
-	client, _, err := k8Client.GetLocal(dev.Context)
+	client, _, err := k8Client.GetLocalWithContext(dev.Context)
 	if err != nil {
 		return err
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -46,11 +46,10 @@ func Exec() *cobra.Command {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			dev, err := utils.LoadDev(devPath)
+			dev, err := utils.LoadDev(devPath, namespace, k8sContext)
 			if err != nil {
 				return err
 			}
-			dev.LoadContext(namespace, k8sContext)
 			err = executeExec(ctx, dev, args)
 			analytics.TrackExec(err == nil)
 
@@ -83,13 +82,9 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 	wrapped := []string{"sh", "-c"}
 	wrapped = append(wrapped, args...)
 
-	client, cfg, namespace, err := k8Client.GetLocal(dev.Context)
+	client, cfg, err := k8Client.GetLocal(dev.Context)
 	if err != nil {
 		return err
-	}
-
-	if dev.Namespace == "" {
-		dev.Namespace = namespace
 	}
 
 	if err := status.Wait(ctx, dev); err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -82,7 +82,7 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 	wrapped := []string{"sh", "-c"}
 	wrapped = append(wrapped, args...)
 
-	client, cfg, err := k8Client.GetLocal(dev.Context)
+	client, cfg, err := k8Client.GetLocalWithContext(dev.Context)
 	if err != nil {
 		return err
 	}

--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -172,7 +172,7 @@ func Run(namespace, k8sContext, devPath, language, workDir string, overwrite boo
 }
 
 func getDeployment(ctx context.Context, namespace, k8sContext string) (*appsv1.Deployment, string, error) {
-	c, _, err := k8Client.GetLocal(k8sContext)
+	c, _, err := k8Client.GetLocalWithContext(k8sContext)
 	if err != nil {
 		log.Yellow("Failed to load your local Kubeconfig: %s", err)
 		return nil, "", nil
@@ -205,7 +205,7 @@ func getDeployment(ctx context.Context, namespace, k8sContext string) (*appsv1.D
 }
 
 func supportsPersistentVolumes(ctx context.Context, namespace, k8sContext string) bool {
-	c, _, err := k8Client.GetLocal(k8sContext)
+	c, _, err := k8Client.GetLocalWithContext(k8sContext)
 	if err != nil {
 		log.Infof("couldn't get kubernetes local client: %s", err.Error())
 		return false

--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	initCMD "github.com/okteto/okteto/pkg/cmd/init"
+	"github.com/okteto/okteto/pkg/k8s/client"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
 	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
@@ -171,13 +172,13 @@ func Run(namespace, k8sContext, devPath, language, workDir string, overwrite boo
 }
 
 func getDeployment(ctx context.Context, namespace, k8sContext string) (*appsv1.Deployment, string, error) {
-	c, _, currentNamespace, err := k8Client.GetLocal(k8sContext)
+	c, _, err := k8Client.GetLocal(k8sContext)
 	if err != nil {
 		log.Yellow("Failed to load your local Kubeconfig: %s", err)
 		return nil, "", nil
 	}
 	if namespace == "" {
-		namespace = currentNamespace
+		namespace = client.GetCurrentNamespace(k8sContext)
 	}
 
 	d, err := askForDeployment(ctx, namespace, c)
@@ -204,13 +205,13 @@ func getDeployment(ctx context.Context, namespace, k8sContext string) (*appsv1.D
 }
 
 func supportsPersistentVolumes(ctx context.Context, namespace, k8sContext string) bool {
-	c, _, currentNamespace, err := k8Client.GetLocal(k8sContext)
+	c, _, err := k8Client.GetLocal(k8sContext)
 	if err != nil {
 		log.Infof("couldn't get kubernetes local client: %s", err.Error())
 		return false
 	}
 	if namespace == "" {
-		namespace = currentNamespace
+		namespace = client.GetCurrentNamespace(k8sContext)
 	}
 
 	ns, err := namespaces.Get(ctx, namespace, c)

--- a/cmd/init/init_test.go
+++ b/cmd/init/init_test.go
@@ -42,7 +42,7 @@ func TestRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dev, err := utils.LoadDev(p)
+	dev, err := utils.LoadDev(p, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestRun(t *testing.T) {
 		t.Fatalf("manifest wasn't overwritten: %s", err)
 	}
 
-	dev, err = utils.LoadDev(p)
+	dev, err = utils.LoadDev(p, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/init/init_test.go
+++ b/cmd/init/init_test.go
@@ -42,7 +42,7 @@ func TestRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dev, err := utils.LoadDev(p, "", "")
+	dev, err := utils.LoadDev(p, "namespace", "context")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestRun(t *testing.T) {
 		t.Fatalf("manifest wasn't overwritten: %s", err)
 	}
 
-	dev, err = utils.LoadDev(p, "", "")
+	dev, err = utils.LoadDev(p, "namespace", "context")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/client"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/namespaces"
 	"github.com/okteto/okteto/pkg/log"
@@ -175,7 +176,7 @@ func waitUntilRunning(ctx context.Context, name, namespace string, timeout time.
 }
 
 func getCurrentNamespace(ctx context.Context) (string, error) {
-	c, _, namespace, err := k8Client.GetLocal("")
+	c, _, err := k8Client.GetLocal("")
 	if err != nil {
 		log.Infof("couldn't get the current namespace: %s", err)
 		return "", errors.UserError{
@@ -183,6 +184,7 @@ func getCurrentNamespace(ctx context.Context) (string, error) {
 			Hint: "Run 'okteto namespace', or use the '--namespace' parameter",
 		}
 	}
+	namespace := client.GetCurrentNamespace("")
 
 	ns, err := namespaces.Get(ctx, namespace, c)
 	if err != nil {

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -50,10 +50,7 @@ func destroy(ctx context.Context) *cobra.Command {
 			}
 
 			if namespace == "" {
-				namespace, err = getCurrentNamespace(ctx)
-				if err != nil {
-					return err
-				}
+				namespace = getCurrentNamespace(ctx)
 			}
 
 			if err := deletePipeline(ctx, name, namespace, wait, destroyVolumes, timeout); err != nil {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -52,7 +52,7 @@ func Push(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
-			dev, err := utils.LoadDevOrDefault(devPath, deploymentName)
+			dev, err := utils.LoadDevOrDefault(devPath, deploymentName, namespace, k8sContext)
 			if err != nil {
 				return err
 			}
@@ -61,15 +61,9 @@ func Push(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("deployment name provided does not match the name field in your okteto manifest")
 			}
 
-			dev.LoadContext(namespace, k8sContext)
-
-			c, _, configNamespace, err := k8Client.GetLocal(dev.Context)
+			c, _, err := k8Client.GetLocal(dev.Context)
 			if err != nil {
 				return err
-			}
-
-			if dev.Namespace == "" {
-				dev.Namespace = configNamespace
 			}
 
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -61,7 +61,7 @@ func Push(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("deployment name provided does not match the name field in your okteto manifest")
 			}
 
-			c, _, err := k8Client.GetLocal(dev.Context)
+			c, _, err := k8Client.GetLocalWithContext(dev.Context)
 			if err != nil {
 				return err
 			}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -65,7 +65,7 @@ func Restart() *cobra.Command {
 
 func executeRestart(ctx context.Context, dev *model.Dev, sn string) error {
 	log.Infof("restarting services")
-	client, _, err := k8Client.GetLocal(dev.Context)
+	client, _, err := k8Client.GetLocalWithContext(dev.Context)
 	if err != nil {
 		return err
 	}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -38,11 +38,10 @@ func Restart() *cobra.Command {
 		Short: "Restarts the deployments listed in the services field of the okteto manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			dev, err := utils.LoadDev(devPath)
+			dev, err := utils.LoadDev(devPath, namespace, k8sContext)
 			if err != nil {
 				return err
 			}
-			dev.LoadContext(namespace, k8sContext)
 			serviceName := ""
 			if len(args) > 0 {
 				serviceName = args[0]
@@ -66,13 +65,9 @@ func Restart() *cobra.Command {
 
 func executeRestart(ctx context.Context, dev *model.Dev, sn string) error {
 	log.Infof("restarting services")
-	client, _, namespace, err := k8Client.GetLocal(dev.Context)
+	client, _, err := k8Client.GetLocal(dev.Context)
 	if err != nil {
 		return err
-	}
-
-	if dev.Namespace == "" {
-		dev.Namespace = namespace
 	}
 
 	spinner := utils.NewSpinner("Restarting deployments...")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,7 +21,6 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/status"
 	"github.com/okteto/okteto/pkg/errors"
-	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -45,19 +44,9 @@ func Status() *cobra.Command {
 				return errors.ErrNotInDevContainer
 			}
 
-			dev, err := utils.LoadDev(devPath)
+			dev, err := utils.LoadDev(devPath, namespace, k8sContext)
 			if err != nil {
 				return err
-			}
-			dev.LoadContext(namespace, k8sContext)
-
-			_, _, namespace, err = k8Client.GetLocal(dev.Context)
-			if err != nil {
-				return err
-			}
-
-			if dev.Namespace == "" {
-				dev.Namespace = namespace
 			}
 
 			sy, err := syncthing.Load(dev)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -162,7 +162,7 @@ More information is available here: https://okteto.com/docs/reference/cli#up`)
 }
 
 func loadDevOrInit(namespace, k8sContext, devPath string) (*model.Dev, error) {
-	dev, err := utils.LoadDev(devPath)
+	dev, err := utils.LoadDev(devPath, namespace, k8sContext)
 
 	if err == nil {
 		return dev, nil
@@ -183,17 +183,10 @@ func loadDevOrInit(namespace, k8sContext, devPath string) (*model.Dev, error) {
 	}
 
 	log.Success(fmt.Sprintf("okteto manifest (%s) created", devPath))
-	return utils.LoadDev(devPath)
+	return utils.LoadDev(devPath, namespace, k8sContext)
 }
 
 func loadDevOverrides(dev *model.Dev, namespace, k8sContext string, forcePull bool, remote int, autoDeploy bool) error {
-
-	dev.LoadContext(namespace, k8sContext)
-
-	if dev.Namespace == "" {
-		dev.Namespace, _ = k8Client.GetNamespace(k8sContext)
-	}
-
 	if remote > 0 {
 		dev.RemotePort = remote
 	}
@@ -221,7 +214,7 @@ func (up *upContext) start(autoDeploy, build bool) error {
 
 	var err error
 
-	up.Client, up.RestConfig, _, err = k8Client.GetLocal(up.Dev.Context)
+	up.Client, up.RestConfig, err = k8Client.GetLocal(up.Dev.Context)
 	if err != nil {
 		kubecfg := config.GetKubeConfigFile()
 		log.Infof("failed to load local Kubeconfig: %s", err)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -214,7 +214,7 @@ func (up *upContext) start(autoDeploy, build bool) error {
 
 	var err error
 
-	up.Client, up.RestConfig, err = k8Client.GetLocal(up.Dev.Context)
+	up.Client, up.RestConfig, err = k8Client.GetLocalWithContext(up.Dev.Context)
 	if err != nil {
 		kubecfg := config.GetKubeConfigFile()
 		log.Infof("failed to load local Kubeconfig: %s", err)

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -63,7 +63,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			def, err := LoadDevOrDefault("/tmp/a-path", tt.deployment, "", "")
+			def, err := LoadDevOrDefault("/tmp/a-path", tt.deployment, "namespace", "context")
 			if tt.expectErr {
 				if err == nil {
 					t.Fatal("expected error when loading")
@@ -99,7 +99,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			loaded, err := LoadDevOrDefault(f.Name(), "foo", "", "")
+			loaded, err := LoadDevOrDefault(f.Name(), "foo", "namespace", "context")
 			if err != nil {
 				t.Fatalf("unexpected error when loading existing manifest: %s", err.Error())
 			}
@@ -115,7 +115,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 		})
 	}
 	name := "demo-deployment"
-	def, err := LoadDevOrDefault("/tmp/bad-path", name, "", "")
+	def, err := LoadDevOrDefault("/tmp/bad-path", name, "namespace", "context")
 	if err != nil {
 		t.Fatal("default dev was not returned")
 	}
@@ -124,7 +124,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 		t.Errorf("expected %s, got %s", name, def.Name)
 	}
 
-	_, err = LoadDevOrDefault("/tmp/bad-path", "", "", "")
+	_, err = LoadDevOrDefault("/tmp/bad-path", "", "namespace", "context")
 	if err == nil {
 		t.Error("expected error with empty deployment name")
 	}

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -63,7 +63,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			def, err := LoadDevOrDefault("/tmp/a-path", tt.deployment)
+			def, err := LoadDevOrDefault("/tmp/a-path", tt.deployment, "", "")
 			if tt.expectErr {
 				if err == nil {
 					t.Fatal("expected error when loading")
@@ -99,7 +99,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			loaded, err := LoadDevOrDefault(f.Name(), "foo")
+			loaded, err := LoadDevOrDefault(f.Name(), "foo", "", "")
 			if err != nil {
 				t.Fatalf("unexpected error when loading existing manifest: %s", err.Error())
 			}
@@ -115,7 +115,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 		})
 	}
 	name := "demo-deployment"
-	def, err := LoadDevOrDefault("/tmp/bad-path", name)
+	def, err := LoadDevOrDefault("/tmp/bad-path", name, "", "")
 	if err != nil {
 		t.Fatal("default dev was not returned")
 	}
@@ -124,7 +124,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 		t.Errorf("expected %s, got %s", name, def.Name)
 	}
 
-	_, err = LoadDevOrDefault("/tmp/bad-path", "")
+	_, err = LoadDevOrDefault("/tmp/bad-path", "", "", "")
 	if err == nil {
 		t.Error("expected error with empty deployment name")
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -505,7 +505,7 @@ func killLocalSyncthing() error {
 
 func destroyPod(ctx context.Context, name, namespace string) error {
 	log.Printf("destroying pods of %s", name)
-	c, _, _, err := k8Client.GetLocal("")
+	c, _, err := k8Client.GetLocal("")
 	if err != nil {
 		return err
 	}
@@ -680,7 +680,7 @@ func getOktetoPath(ctx context.Context) (string, error) {
 }
 
 func getDeployment(ctx context.Context, ns, name string) (*appsv1.Deployment, error) {
-	client, _, _, err := k8Client.GetLocal("")
+	client, _, err := k8Client.GetLocal("")
 	if err != nil {
 		return nil, err
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -505,7 +505,7 @@ func killLocalSyncthing() error {
 
 func destroyPod(ctx context.Context, name, namespace string) error {
 	log.Printf("destroying pods of %s", name)
-	c, _, err := k8Client.GetLocal("")
+	c, _, err := k8Client.GetLocal()
 	if err != nil {
 		return err
 	}
@@ -680,7 +680,7 @@ func getOktetoPath(ctx context.Context) (string, error) {
 }
 
 func getDeployment(ctx context.Context, ns, name string) (*appsv1.Deployment, error) {
-	client, _, err := k8Client.GetLocal("")
+	client, _, err := k8Client.GetLocal()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/init/run.go
+++ b/pkg/cmd/init/run.go
@@ -35,7 +35,7 @@ var (
 
 //SetDevDefaultsFromDeployment sets dev defaults from a running deployment
 func SetDevDefaultsFromDeployment(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, container string) error {
-	c, _, err := k8Client.GetLocal(dev.Context)
+	c, _, err := k8Client.GetLocalWithContext(dev.Context)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/init/run.go
+++ b/pkg/cmd/init/run.go
@@ -35,7 +35,7 @@ var (
 
 //SetDevDefaultsFromDeployment sets dev defaults from a running deployment
 func SetDevDefaultsFromDeployment(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, container string) error {
-	c, _, _, err := k8Client.GetLocal(dev.Context)
+	c, _, err := k8Client.GetLocal(dev.Context)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/client"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/namespaces"
 	"github.com/okteto/okteto/pkg/log"
@@ -100,12 +101,12 @@ func translateEnvFile(svc *model.Service, filename string) error {
 }
 
 func translateBuildImages(ctx context.Context, s *model.Stack, forceBuild, noCache bool) error {
-	c, _, configNamespace, err := k8Client.GetLocal("")
+	c, _, err := k8Client.GetLocal("")
 	if err != nil {
 		return err
 	}
 	if s.Namespace == "" {
-		s.Namespace = configNamespace
+		s.Namespace = client.GetCurrentNamespace("")
 	}
 
 	oktetoRegistryURL := ""

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -101,7 +101,7 @@ func translateEnvFile(svc *model.Service, filename string) error {
 }
 
 func translateBuildImages(ctx context.Context, s *model.Stack, forceBuild, noCache bool) error {
-	c, _, err := k8Client.GetLocal("")
+	c, _, err := k8Client.GetLocal()
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -15,6 +15,7 @@ package client
 
 import (
 	"context"
+	"log"
 	"net/url"
 	"strings"
 
@@ -35,69 +36,50 @@ const (
 )
 
 var (
-	client         *kubernetes.Clientset
-	config         *rest.Config
-	namespace      string
-	currentContext string
-	localClusters  = []string{"127.", "172.", "192.", "169.", model.Localhost, "::1", "fe80::", "fc00::"}
+	client           *kubernetes.Clientset
+	config           *rest.Config
+	clientConfig     clientcmd.ClientConfig
+	currentNamespace string
+	currentContext   string
+	localClusters    = []string{"127.", "172.", "192.", "169.", model.Localhost, "::1", "fe80::", "fc00::"}
 )
 
 //GetLocal returns a kubernetes client with the local configuration. It will detect if KUBECONFIG is defined.
-func GetLocal(k8sContext string) (*kubernetes.Clientset, *rest.Config, string, error) {
+func GetLocal(currentContext string) (*kubernetes.Clientset, *rest.Config, error) {
 	if client == nil {
 		var err error
-		clientConfig := GetClientConfig(k8sContext)
-		namespace, err = GetNamespace(k8sContext)
-		if err != nil {
-			return nil, nil, "", err
-		}
-
-		rawConfig, err := clientConfig.RawConfig()
-		if err != nil {
-			return nil, nil, "", err
-		}
-
-		if k8sContext != "" {
-			currentContext = k8sContext
-		} else {
-			currentContext = rawConfig.CurrentContext
-		}
+		clientConfig = getClientConfig(currentContext)
 		if okteto.GetClusterContext() == currentContext {
 			ctx := context.Background()
+			namespace := GetCurrentNamespace(currentContext)
+			if err != nil {
+				return nil, nil, err
+			}
 			go okteto.RefreshOktetoKubeconfig(ctx, namespace)
 		}
 
 		config, err = clientConfig.ClientConfig()
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, err
 		}
 
 		config.Wrap(refreshCredentialsFn)
 
 		client, err = kubernetes.NewForConfig(config)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, err
 		}
 
 		setAnalytics(currentContext, config.Host)
 	}
 
-	return client, config, namespace, nil
+	return client, config, nil
 }
 
-//GetNamespace returns the name of the namespace in use
-func GetNamespace(k8sContext string) (string, error) {
-	var err error
-	clientConfig := GetClientConfig(k8sContext)
-	namespace, _, err = clientConfig.Namespace()
-	if err != nil {
-		return "", err
+func getClientConfig(k8sContext string) clientcmd.ClientConfig {
+	if clientConfig != nil {
+		return clientConfig
 	}
-	return namespace, nil
-}
-
-//GetClientConfig sets the client config for the context in use
-func GetClientConfig(k8sContext string) clientcmd.ClientConfig {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		clientcmd.NewDefaultClientConfigLoadingRules(),
 		&clientcmd.ConfigOverrides{
@@ -107,11 +89,40 @@ func GetClientConfig(k8sContext string) clientcmd.ClientConfig {
 	)
 }
 
+//GetCurrentContext sets the client config for the context in use
+func GetCurrentContext() string {
+	if currentContext != "" {
+		return currentContext
+	}
+	cc := getClientConfig("")
+	rawConfig, err := cc.RawConfig()
+	if err != nil {
+		log.Fatalf("error accessing you kubeconfig file: %s", err.Error())
+	}
+	currentContext = rawConfig.CurrentContext
+	return currentContext
+}
+
+//GetCurrentNamespace returns the name of the namespace in use by a given context
+func GetCurrentNamespace(k8sContext string) string {
+	if currentNamespace != "" {
+		return currentNamespace
+	}
+	namespace, _, err := getClientConfig(k8sContext).Namespace()
+	if err != nil {
+		log.Fatalf("error accessing you kubeconfig file: %s", err.Error())
+	}
+	currentNamespace = namespace
+	return currentNamespace
+}
+
 //Reset cleans the cached client
 func Reset() {
 	client = nil
 	config = nil
-	namespace = ""
+	clientConfig = nil
+	currentNamespace = ""
+	currentContext = ""
 }
 
 // InCluster returns true if Okteto is running on a Kubernetes cluster

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -45,7 +45,12 @@ var (
 )
 
 //GetLocal returns a kubernetes client with the local configuration. It will detect if KUBECONFIG is defined.
-func GetLocal(currentContext string) (*kubernetes.Clientset, *rest.Config, error) {
+func GetLocal() (*kubernetes.Clientset, *rest.Config, error) {
+	return GetLocalWithContext("")
+}
+
+//GetLocalWithContext returns a kubernetes client for a given context. It will detect if KUBECONFIG is defined.
+func GetLocalWithContext(currentContext string) (*kubernetes.Clientset, *rest.Config, error) {
 	if client == nil {
 		var err error
 		clientConfig = getClientConfig(currentContext)

--- a/pkg/k8s/client/retry.go
+++ b/pkg/k8s/client/retry.go
@@ -60,7 +60,7 @@ func (rc *refreshCredentials) RoundTrip(req *http.Request) (*http.Response, erro
 	var err error
 	var host string
 	ctx := context.Background()
-	host, roundTripToken, err = okteto.RefreshOktetoKubeconfig(ctx, namespace)
+	host, roundTripToken, err = okteto.RefreshOktetoKubeconfig(ctx, currentNamespace)
 	if err != nil {
 		log.Infof("failed to refresh your kubernetes credentials: %s", err.Error())
 		return resp, errOrig

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -827,16 +827,6 @@ func (dev *Dev) ToTranslationRule(main *Dev) *TranslationRule {
 	return rule
 }
 
-//LoadContext loads the dev namespace and context
-func (dev *Dev) LoadContext(namespace, k8sContext string) {
-	if namespace != "" {
-		dev.Namespace = namespace
-	}
-	if k8sContext != "" {
-		dev.Context = k8sContext
-	}
-}
-
 //GevSandbox returns a deployment sandbox
 func (dev *Dev) GevSandbox() *appsv1.Deployment {
 	image := dev.Image.Name

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -85,7 +85,7 @@ func ExpandOktetoDevRegistry(ctx context.Context, namespace, tag string) (string
 		return tag, nil
 	}
 
-	c, _, err := client.GetLocal("")
+	c, _, err := client.GetLocal()
 	if err != nil {
 		return "", fmt.Errorf("failed to load your local Kubeconfig: %s", err)
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -85,13 +85,13 @@ func ExpandOktetoDevRegistry(ctx context.Context, namespace, tag string) (string
 		return tag, nil
 	}
 
-	c, _, ns, err := client.GetLocal("")
+	c, _, err := client.GetLocal("")
 	if err != nil {
 		return "", fmt.Errorf("failed to load your local Kubeconfig: %s", err)
 	}
 
 	if namespace == "" {
-		namespace = ns
+		namespace = client.GetCurrentNamespace("")
 	}
 
 	n, err := namespaces.Get(ctx, namespace, c)


### PR DESCRIPTION
## Proposed changes

- The logic to initialize `dev.Namespace` and `dev.Context`is different places. This PR unifies their initialization in a single place
