### PR TITLE
Fix return in exec when no error exists

### DIFF
--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -167,6 +167,9 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 	cmd := shellescape.QuoteCommand(command)
 	log.Infof("executing command over ssh: '%s'", cmd)
 	err = session.Run(cmd)
+	if err == nil {
+		return nil
+	}
 
 	log.Infof("command failed: %s", err)
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
- A segmentation fault error happens if a `CommandError` error is generated with `Reason` to nil
