### PR TITLE
Regenerate k8s client using the same config to make retries logic mor…

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -38,7 +38,7 @@ type CommandError struct {
 
 // Error returns the error message
 func (u CommandError) Error() string {
-	return fmt.Sprintf("%s: %s", u.E.Error(), u.Reason.Error())
+	return fmt.Sprintf("%s: %s", u.E.Error(), strings.ToLower(u.Reason.Error()))
 }
 
 var (

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -173,14 +173,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 
 	log.Infof("command failed: %s", err)
 
-	if okErrors.IsTransient(err) {
-		return err
-	}
-
-	return okErrors.CommandError{
-		E:      okErrors.ErrCommandFailed,
-		Reason: err,
-	}
+	return err
 }
 
 func isTerminal(r io.Reader) (int, bool) {


### PR DESCRIPTION
…e stable

Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Output looks like this when the command fails:
```
ls: cannot access 'asdsas': No such file or directory
 x  Command execution failed: process exited with status 2
 ```