### PR TITLE
Return error if the Okteto API returns an empty response when fetchin…

### DIFF
--- a/pkg/okteto/credential.go
+++ b/pkg/okteto/credential.go
@@ -15,6 +15,7 @@ package okteto
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -45,6 +46,10 @@ func GetCredentials(ctx context.Context) (*Credential, error) {
 	var cred Credentials
 	if err := query(ctx, q, &cred); err != nil {
 		return nil, err
+	}
+
+	if cred.Credentials.Server == "" {
+		return nil, fmt.Errorf("%s is not available. Please, retry again in a few minutes", GetURL())
 	}
 
 	return &cred.Credentials, nil


### PR DESCRIPTION
…g credentials

## Proposed changes
- This fixes an issue where `okteto namespace` initializes the kubeconfig file with empty credentials instead of returning an error
