### PR TITLE
fix null ref due to process not found

### DIFF
--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -700,6 +700,11 @@ func (s *Syncthing) HardTerminate() error {
 				continue
 			}
 
+			if pr == nil {
+				log.Infof("process  %d not found", p.Pid)
+				continue
+			}
+
 			name = pr.Executable()
 		}
 


### PR DESCRIPTION
`FindProcess` returns a nil process struct if the PID doesn't map to a current process.

Signed-off-by: Ramiro <rberrelleza@gmail.com>
