### PR TITLE
Move overflow warning just for exec

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,12 +108,6 @@ func main() {
 				log.Hint("    %s", uErr.Hint)
 			}
 		}
-		if cErr, ok := err.(errors.CommandError); ok {
-			if strings.Contains(cErr.Reason.Error(), "exit code 137") || strings.Contains(cErr.Reason.Error(), "4294967295") || strings.Contains(cErr.Reason.Error(), "status 137") {
-				log.Yellow(`Insufficient memory. Please update your resources on your okteto manifest.
-More information is available here: https://okteto.com/docs/reference/manifest#resources-object-optional`)
-			}
-		}
 		os.Exit(1)
 	}
 }

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -174,6 +174,13 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 	if strings.Contains(err.Error(), "exit status 130") {
 		return nil
 	}
+	if strings.Contains(err.Error(), "exit status 130") {
+		return nil
+	}
+	if strings.Contains(err.Error(), "exit code 137") || strings.Contains(err.Error(), "exit status 137") {
+		log.Yellow(`Insufficient memory. Please update your resources on your okteto manifest.
+More information is available here: https://okteto.com/docs/reference/manifest#resources-object-optional`)
+	}
 
 	log.Infof("command failed: %s", err)
 


### PR DESCRIPTION
Signed-off-by: jLopezbarb <javier@okteto.com>

## Proposed changes
- Move warning showing memory errors to the exec file instead of running the verification of the fail command in all commands
- Remove exit status 4294967295 from the memory error because it may be of another type
