### PR TITLE
Update memory limit error

### DIFF
--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -118,19 +118,19 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 	var errorToReturn string
 	if strings.Contains(errorMessage, "maximum cpu usage") {
 		cpuMaximumRegex, _ := regexp.Compile(`cpu usage per Pod is (\d*\w*)`)
-		maximumCpu := cpuMaximumRegex.FindStringSubmatch(errorMessage)[1]
-		var limitCpuString string
-		if limitCpu, ok := dev.Resources.Limits["cpu"]; ok {
-			limitCpuString = limitCpu.String()
+		maximumCpuPerPod := cpuMaximumRegex.FindStringSubmatch(errorMessage)[1]
+		var manifestCpu string
+		if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
+			manifestCpu = limitCpu.String()
 		}
 		errorToReturn += fmt.Sprintf("Maximum CPU limit per pod is %s, the current value is %s. ", maximumCpu, limitCpuString)
 	}
 	if strings.Contains(errorMessage, "maximum memory usage") {
 		memoryMaximumRegex, _ := regexp.Compile(`memory usage per Pod is (\d*\w*)`)
-		maximumMemory := memoryMaximumRegex.FindStringSubmatch(errorMessage)[1]
-		var limitMemoryString string
-		if limitMemory, ok := dev.Resources.Limits["memory"]; ok {
-			limitMemoryString = limitMemory.String()
+		maximumMemoryPerPod := memoryMaximumRegex.FindStringSubmatch(errorMessage)[1]
+		var manifestMemory string
+		if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
+			manifestMemory = limitMemory.String()
 		}
 		errorToReturn += fmt.Sprintf("Maximum memory limit per pod is %s, the current value is %s.", maximumMemory, limitMemoryString)
 	}

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -88,16 +88,8 @@ func GetRevisionAnnotatedDeploymentOrFailed(ctx context.Context, dev *model.Dev,
 		return nil, err
 	}
 
-	for _, c := range d.Status.Conditions {
-		if c.Type == appsv1.DeploymentReplicaFailure && c.Reason == "FailedCreate" && c.Status == apiv1.ConditionTrue {
-			if strings.Contains(c.Message, "exceeded quota") {
-				log.Infof("%s: %s", errors.ErrQuota, c.Message)
-				return nil, errors.ErrQuota
-			} else if isResourcesRelatedError(c.Message) {
-				return nil, getResourceLimitError(c.Message, dev)
-			}
-			return nil, fmt.Errorf(c.Message)
-		}
+	if err = checkConditionErrors(d, dev); err != nil {
+		return nil, err
 	}
 
 	if d.Generation != d.Status.ObservedGeneration {
@@ -105,6 +97,21 @@ func GetRevisionAnnotatedDeploymentOrFailed(ctx context.Context, dev *model.Dev,
 	}
 
 	return d, nil
+}
+
+func checkConditionErrors(deployment *appsv1.Deployment, dev *model.Dev) error {
+	for _, c := range deployment.Status.Conditions {
+		if c.Type == appsv1.DeploymentReplicaFailure && c.Reason == "FailedCreate" && c.Status == apiv1.ConditionTrue {
+			if strings.Contains(c.Message, "exceeded quota") {
+				log.Infof("%s: %s", errors.ErrQuota, c.Message)
+				return errors.ErrQuota
+			} else if isResourcesRelatedError(c.Message) {
+				return getResourceLimitError(c.Message, dev)
+			}
+			return fmt.Errorf(c.Message)
+		}
+	}
+	return nil
 }
 
 func isResourcesRelatedError(errorMessage string) bool {
@@ -123,7 +130,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 		if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
 			manifestCpu = limitCpu.String()
 		}
-		errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s)", manifestCpu, maximumCpuPerPod)
+		errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCpu, maximumCpuPerPod)
 	}
 	if strings.Contains(errorMessage, "maximum memory usage") {
 		memoryMaximumRegex, _ := regexp.Compile(`memory usage per Pod is (\d*\w*)`)
@@ -132,9 +139,9 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 		if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
 			manifestMemory = limitMemory.String()
 		}
-		errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s)", manifestMemory, maximumMemoryPerPod)
+		errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
 	}
-	return fmt.Errorf(errorToReturn)
+	return fmt.Errorf(strings.TrimSpace(errorToReturn))
 }
 
 //GetTranslations fills all the deployments pointed by a development container

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -123,7 +123,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 		if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
 			manifestCpu = limitCpu.String()
 		}
-		errorToReturn += fmt.Sprintf("Maximum CPU limit per pod is %s, the current value is %s. ", maximumCpu, limitCpuString)
+		errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s)", manifestCpu, maximumCpuPerPod)
 	}
 	if strings.Contains(errorMessage, "maximum memory usage") {
 		memoryMaximumRegex, _ := regexp.Compile(`memory usage per Pod is (\d*\w*)`)
@@ -132,7 +132,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 		if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
 			manifestMemory = limitMemory.String()
 		}
-		errorToReturn += fmt.Sprintf("Maximum memory limit per pod is %s, the current value is %s.", maximumMemory, limitMemoryString)
+		errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s)", manifestMemory, maximumMemoryPerPod)
 	}
 	return fmt.Errorf(errorToReturn)
 }

--- a/pkg/k8s/deployments/crud_test.go
+++ b/pkg/k8s/deployments/crud_test.go
@@ -1,0 +1,192 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGet(t *testing.T) {
+	ctx := context.Background()
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "test",
+		},
+	}
+
+	dev := &model.Dev{Name: "fake"}
+
+	clientset := fake.NewSimpleClientset(deployment)
+	s, err := Get(ctx, dev, deployment.GetNamespace(), clientset)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s == nil {
+		t.Fatal("empty service")
+	}
+
+	if s.Name != deployment.GetName() {
+		t.Fatalf("wrong service. Got %s, expected %s", s.Name, deployment.GetName())
+	}
+}
+
+func TestCheckConditionErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		deployment  *appsv1.Deployment
+		dev         *model.Dev
+		expectedErr error
+	}{
+		{
+			"Wrong quota",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "exceeded quota",
+						},
+					},
+				},
+			},
+			&model.Dev{
+				Resources: model.ResourceRequirements{
+					Limits: model.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("2"),
+						apiv1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			errors.ErrQuota,
+		},
+		{
+			"Memory per pod exceeded",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "maximum memory usage per Pod is 3Gi, but limit is 4294967296",
+						},
+					},
+				},
+			},
+			&model.Dev{
+				Resources: model.ResourceRequirements{
+					Limits: model.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("2"),
+						apiv1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			fmt.Errorf("The value of resources.limits.memory in your okteto manifest (5Gi) exceeds the maximum memory limit per pod (3Gi)."),
+		},
+		{
+			"Cpu per pod exceeded",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "maximum cpu usage per Pod is 1, but limit is 2,",
+						},
+					},
+				},
+			},
+			&model.Dev{
+				Resources: model.ResourceRequirements{
+					Limits: model.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("2"),
+						apiv1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			fmt.Errorf("The value of resources.limits.cpu in your okteto manifest (2) exceeds the maximum CPU limit per pod (1)."),
+		},
+		{
+			"Cpu and memory per pod exceeded",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "maximum cpu usage per Pod is 1, but limit is 2, maximum memory usage per Pod is 3Gi, but limit is 4294967296",
+						},
+					},
+				},
+			},
+			&model.Dev{
+				Resources: model.ResourceRequirements{
+					Limits: model.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("2"),
+						apiv1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			fmt.Errorf("The value of resources.limits.cpu in your okteto manifest (2) exceeds the maximum CPU limit per pod (1). The value of resources.limits.memory in your okteto manifest (5Gi) exceeds the maximum memory limit per pod (3Gi)."),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := checkConditionErrors(tt.deployment, tt.dev)
+
+			if err == nil {
+				t.Fatalf("Didn't receive any error. Expected %s", tt.expectedErr)
+			}
+
+			if err.Error() != tt.expectedErr.Error() {
+				t.Fatalf("wrong error. Got %s, expected %s", err, tt.expectedErr)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: jLopezbarb <javier@okteto.com>

Fixes [maximum cpu usage per Pod is 1, but limit is 2, maximum memory usage per Pod is 3Gi, but limit is 4294967296]

## Proposed changes
- Parser kubernetes error and treat it reformat it to: "Maximum[resource] limit per pod is [cluster limit], the current value is [manifest value]." 

