### PR TITLE
consider "deployed" when waiting for the pipeline

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -156,7 +156,7 @@ func waitUntilRunning(ctx context.Context, name, namespace string, timeout time.
 			}
 
 			switch p.Status {
-			case "running":
+			case "deployed", "running":
 				return nil
 			case "error":
 				attempts++


### PR DESCRIPTION
on Okteto Cloud, the pipeline also returns "deployed" as a valid final state. This is breaking the `--wait` command.