### PR TITLE
Compute sync completion based on remote device

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -22,6 +22,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/status"
+	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/exec"
 	"github.com/okteto/okteto/pkg/k8s/pods"
@@ -112,7 +113,8 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 		}
 	}
 
-	if err := status.Wait(ctx, dev); err != nil {
+	waitForStates := []config.UpState{config.Ready}
+	if err := status.Wait(ctx, dev, waitForStates); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Users report that `okteto up` gets stuck when syncthing large folders. I have been investigating several doctor files and it looks like querying the local syncthing API for the remote synchronization state is less reliable.

## Proposed changes
- As soon as the remote syncthing API initializes what it needs to be synched, query the remote synchthing API for completion state instead of the local syncthing API. In the meantime, query the local syncthing API.
- Reduce the frequency of synthing status API calls, it is documented to be very expensive.
- Fix `okteto status` for the case syncthing is not yet ready.
