### PR TITLE
Support for okteto build --secret

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -35,6 +35,7 @@ func Build(ctx context.Context) *cobra.Command {
 	var cacheFrom []string
 	var progress string
 	var buildArgs []string
+	var secrets []string
 
 	cmd := &cobra.Command{
 		Use:   "build [PATH]",
@@ -69,7 +70,7 @@ func Build(ctx context.Context) *cobra.Command {
 			log.Information("Running your build in %s...", buildKitHost)
 
 			ctx := context.Background()
-			if err := build.Run(ctx, "", buildKitHost, isOktetoCluster, path, file, tag, target, noCache, cacheFrom, buildArgs, progress); err != nil {
+			if err := build.Run(ctx, "", buildKitHost, isOktetoCluster, path, file, tag, target, noCache, cacheFrom, buildArgs, secrets, progress); err != nil {
 				analytics.TrackBuild(buildKitHost, false)
 				return err
 			}
@@ -93,5 +94,6 @@ func Build(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringArrayVar(&cacheFrom, "cache-from", nil, "cache source images")
 	cmd.Flags().StringVarP(&progress, "progress", "", "tty", "show plain/tty build output")
 	cmd.Flags().StringArrayVar(&buildArgs, "build-arg", nil, "set build-time variables")
+	cmd.Flags().StringArrayVar(&secrets, "secret", nil, "secret files exposed to the build. Format: id=mysecret,src=/local/secret")
 	return cmd
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -225,7 +225,7 @@ func buildImage(ctx context.Context, dev *model.Dev, imageTag, imageFromDeployme
 	log.Infof("pushing with image tag %s", buildTag)
 
 	buildArgs := model.SerializeBuildArgs(dev.Push.Args)
-	if err := build.Run(ctx, dev.Namespace, buildKitHost, isOktetoCluster, dev.Push.Context, dev.Push.Dockerfile, buildTag, dev.Push.Target, noCache, dev.Push.CacheFrom, buildArgs, progress); err != nil {
+	if err := build.Run(ctx, dev.Namespace, buildKitHost, isOktetoCluster, dev.Push.Context, dev.Push.Dockerfile, buildTag, dev.Push.Target, noCache, dev.Push.CacheFrom, buildArgs, nil, progress); err != nil {
 		return "", fmt.Errorf("error building image '%s': %s", buildTag, err)
 	}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -397,7 +397,7 @@ func (up *upContext) buildDevImage(ctx context.Context, d *appsv1.Deployment, cr
 	log.Infof("building dev image tag %s", imageTag)
 
 	buildArgs := model.SerializeBuildArgs(up.Dev.Image.Args)
-	if err := buildCMD.Run(ctx, up.Dev.Namespace, buildKitHost, isOktetoCluster, up.Dev.Image.Context, up.Dev.Image.Dockerfile, imageTag, up.Dev.Image.Target, false, up.Dev.Image.CacheFrom, buildArgs, "tty"); err != nil {
+	if err := buildCMD.Run(ctx, up.Dev.Namespace, buildKitHost, isOktetoCluster, up.Dev.Image.Context, up.Dev.Image.Dockerfile, imageTag, up.Dev.Image.Target, false, up.Dev.Image.CacheFrom, buildArgs, nil, "tty"); err != nil {
 		return fmt.Errorf("error building dev image '%s': %s", imageTag, err)
 	}
 	for _, s := range up.Dev.Services {

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Run runs the build sequence
-func Run(ctx context.Context, namespace, buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, target string, noCache bool, cacheFrom, buildArgs []string, progress string) error {
+func Run(ctx context.Context, namespace, buildKitHost string, isOktetoCluster bool, path, dockerFile, tag, target string, noCache bool, cacheFrom, buildArgs, secrets []string, progress string) error {
 	log.Infof("building your image on %s", buildKitHost)
 	buildkitClient, err := getBuildkitClient(ctx, isOktetoCluster, buildKitHost)
 	if err != nil {
@@ -55,7 +55,7 @@ func Run(ctx context.Context, namespace, buildKitHost string, isOktetoCluster bo
 			return err
 		}
 	}
-	opt, err := getSolveOpt(path, dockerFile, tag, target, noCache, cacheFrom, buildArgs)
+	opt, err := getSolveOpt(path, dockerFile, tag, target, noCache, cacheFrom, buildArgs, secrets)
 	if err != nil {
 		return errors.Wrap(err, "failed to create build solver")
 	}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -160,7 +160,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, forceBuild, noCac
 		imageTag := registry.GetImageTag(svc.Image, name, s.Namespace, oktetoRegistryURL)
 		log.Information("Building image for service '%s'...", name)
 		buildArgs := model.SerializeBuildArgs(svc.Build.Args)
-		if err := build.Run(ctx, s.Namespace, buildKitHost, isOktetoCluster, svc.Build.Context, svc.Build.Dockerfile, imageTag, svc.Build.Target, noCache, svc.Build.CacheFrom, buildArgs, "tty"); err != nil {
+		if err := build.Run(ctx, s.Namespace, buildKitHost, isOktetoCluster, svc.Build.Context, svc.Build.Dockerfile, imageTag, svc.Build.Target, noCache, svc.Build.CacheFrom, buildArgs, nil, "tty"); err != nil {
 			return fmt.Errorf("error building image for '%s': %s", name, err)
 		}
 		svc.Image = imageTag


### PR DESCRIPTION
Fixes #1330

## Proposed changes

Support for `okteto build --secret id=mysecret,src=/local/secret`.
`secrets` are not supported for neither `okteto up --build`, `okteto push` nor `okteto stack deploy --build`.
I prefer to wait for docker-compose to have an official format to support secrets:
https://github.com/docker/compose/issues/6358