### PR TITLE
remove mock-release from PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,11 +91,6 @@ jobs:
             sha=$(cat ./artifacts/bin/okteto-Darwin-x86_64.sha256 | awk '{print $1}')
             sha_arm=$(cat ./artifacts/bin/okteto-Darwin-arm64.sha256 | awk '{print $1}')
             ./update_homebrew_formula.sh 0.0.1 $sha $sha_arm
-      - run: *init-gcloud
-      - run:
-          name: mock upload binaries
-          command: |
-            gsutil -m rsync -n -r ./artifacts/bin gs://downloads.okteto.com/cli/${CIRCLE_SHA1}  
       - setup_remote_docker:
           version: "19.03.8"
       - run:


### PR DESCRIPTION
Don't use gcloud in the PRs, since most people won't have access to it.