### PR TITLE
Show an info message if a pipeline is deployed/destroyed in a context…

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -47,6 +47,10 @@ func deploy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
+			if !okteto.IsAuthenticated() {
+				return errors.ErrNotLogged
+			}
+
 			var err error
 			if name == "" {
 				name, err = getPipelineName()
@@ -83,6 +87,11 @@ func deploy(ctx context.Context) *cobra.Command {
 
 			if namespace == "" {
 				namespace = getCurrentNamespace(ctx)
+			}
+
+			currentContext := client.GetSessionContext("")
+			if okteto.GetClusterContext() != currentContext {
+				log.Information("Pipeline context: %s/%s", okteto.GetURL(), namespace)
 			}
 
 			if err := deployPipeline(ctx, name, namespace, repository, branch, wait, timeout); err != nil {
@@ -175,7 +184,7 @@ func getCurrentNamespace(ctx context.Context) string {
 	if okteto.GetClusterContext() == currentContext {
 		return client.GetContextNamespace("")
 	}
-	return ""
+	return okteto.GetUsername()
 }
 
 func getRepositoryURL(ctx context.Context, path string) (string, error) {

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
@@ -41,6 +42,10 @@ func destroy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
+			if !okteto.IsAuthenticated() {
+				return errors.ErrNotLogged
+			}
+
 			var err error
 			if name == "" {
 				name, err = getPipelineName()
@@ -51,6 +56,11 @@ func destroy(ctx context.Context) *cobra.Command {
 
 			if namespace == "" {
 				namespace = getCurrentNamespace(ctx)
+			}
+
+			currentContext := client.GetSessionContext("")
+			if okteto.GetClusterContext() != currentContext {
+				log.Information("Pipeline context: %s/%s", okteto.GetURL(), namespace)
 			}
 
 			if err := deletePipeline(ctx, name, namespace, wait, destroyVolumes, timeout); err != nil {


### PR DESCRIPTION
… different than your current kubernetes context

Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

It is confusing when your k8s context is pointing to a cluster but the pipeline is running in another cluster