### PR TITLE
Support "autocreate" for "okteto push"

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -81,6 +81,16 @@ func Push(ctx context.Context) *cobra.Command {
 				}
 			}
 
+			if autoDeploy {
+				log.Warning(`The 'deploy' flag is deprecated and will be removed in a future release.
+    Set the 'autocreate' field in your okteto manifest to get the same behavior.
+    More information is available here: https://okteto.com/docs/reference/cli#up`)
+			}
+
+			if !dev.Autocreate {
+				dev.Autocreate = autoDeploy
+			}
+
 			if err := runPush(ctx, dev, autoDeploy, imageTag, oktetoRegistryURL, progress, noCache, c); err != nil {
 				analytics.TrackPush(false, oktetoRegistryURL)
 				return err
@@ -114,23 +124,28 @@ func runPush(ctx context.Context, dev *model.Dev, autoDeploy bool, imageTag, okt
 			return err
 		}
 
-		if len(dev.Services) == 0 {
-			if !autoDeploy {
-				if err := utils.AskIfDeploy(dev.Name, dev.Namespace); err != nil {
-					return err
-				}
+		if !dev.Autocreate {
+			return errors.UserError{
+				E: fmt.Errorf("Deployment '%s' not found in namespace '%s'", dev.Name, dev.Namespace),
+				Hint: `Verify that your application has been deployed and your Kubernetes context is pointing to the right namespace
+    Or set the 'autocreate' field in your okteto manifest if you want to create a standalone deployment
+    More information is available here: https://okteto.com/docs/reference/cli#up`,
 			}
+		}
 
-			d = dev.GevSandbox()
-			d.Annotations[model.OktetoAutoCreateAnnotation] = model.OktetoPushCmd
-			exists = false
+		if len(dev.Services) > 0 {
+			return fmt.Errorf("'autocreate' cannot be used in combination with 'services'")
+		}
 
-			if imageTag == "" {
-				if oktetoRegistryURL == "" {
-					return fmt.Errorf("you need to specify the image tag to build with the '-t' argument")
-				}
-				imageTag = registry.GetImageTag("", dev.Name, dev.Namespace, oktetoRegistryURL)
+		d = dev.GevSandbox()
+		d.Annotations[model.OktetoAutoCreateAnnotation] = model.OktetoPushCmd
+		exists = false
+
+		if imageTag == "" {
+			if oktetoRegistryURL == "" {
+				return fmt.Errorf("you need to specify the image tag to build with the '-t' argument")
 			}
+			imageTag = registry.GetImageTag("", dev.Name, dev.Namespace, oktetoRegistryURL)
 		}
 	}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -97,9 +97,9 @@ func Up() *cobra.Command {
 			checkLocalWatchesConfiguration()
 
 			if autoDeploy {
-				log.Yellow(`The 'deploy' flag is deprecated and will be removed in a future release.
-Set the 'autocreate' field in your okteto manifest to get the same behavior.
-More information is available here: https://okteto.com/docs/reference/cli#up`)
+				log.Warning(`The 'deploy' flag is deprecated and will be removed in a future release.
+    Set the 'autocreate' field in your okteto manifest to get the same behavior.
+    More information is available here: https://okteto.com/docs/reference/cli#up`)
 			}
 
 			dev, err := loadDevOrInit(namespace, k8sContext, devPath)


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

We implemented it for `okteto up`, but we didn't update the behavior for `okteto push` accordingly 