### PR TITLE
Build stack images in the Okteto Registry when possible

### DIFF
--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -53,7 +53,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			err = stack.Deploy(ctx, s, forceBuild, wait, noCache)
 			analytics.TrackDeployStack(err == nil)
 			if err == nil {
-				log.Success("Successfully deployed stack '%s'", s.Name)
+				log.Success("Stack '%s' successfully deployed", s.Name)
 			}
 			return err
 		},

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -44,7 +44,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 			err = stack.Destroy(ctx, s, rm)
 			analytics.TrackDestroyStack(err == nil)
 			if err == nil {
-				log.Success("Successfully destroyed stack '%s'", s.Name)
+				log.Success("Stack '%s' successfully destroyed", s.Name)
 			}
 			return err
 		},

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -74,13 +74,14 @@ func Deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool)
 }
 
 func deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool, c *kubernetes.Clientset) error {
-	spinner := utils.NewSpinner(fmt.Sprintf("Deploying stack '%s'...", s.Name))
-	spinner.Start()
-	defer spinner.Stop()
 
 	if err := translate(ctx, s, forceBuild, noCache); err != nil {
 		return err
 	}
+
+	spinner := utils.NewSpinner(fmt.Sprintf("Deploying stack '%s'...", s.Name))
+	spinner.Start()
+	defer spinner.Stop()
 
 	for name := range s.Services {
 		if len(s.Services[name].Volumes) == 0 {

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -171,7 +171,7 @@ func (s *Stack) validate() error {
 		if err := validateStackName(name); err != nil {
 			return fmt.Errorf("Invalid service name '%s': %s", name, err)
 		}
-		if svc.Image == "" {
+		if svc.Image == "" && svc.Build == nil {
 			return fmt.Errorf(fmt.Sprintf("Invalid service '%s': image cannot be empty", name))
 		}
 		for _, v := range svc.Volumes {
@@ -222,8 +222,8 @@ func (s *Stack) GetConfigMapName() string {
 	return fmt.Sprintf("okteto-%s", s.Name)
 }
 
-//SetLastBuiltAnnotationtamp sets the dev timestamp
-func (svc *Service) SetLastBuiltAnnotationtamp() {
+//SetLastBuiltAnnotation sets the dev timestamp
+func (svc *Service) SetLastBuiltAnnotation() {
 	if svc.Annotations == nil {
 		svc.Annotations = map[string]string{}
 	}


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

This makes it possible to build/deploy the stack if you don't have write access to the service image. It also does the `image` field optional if you define a `build` primitive