### PR TITLE
Support for stack entrypoints

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -150,6 +150,11 @@ type Dev struct {
 	InitContainer        InitContainer         `json:"initContainer,omitempty" yaml:"initContainer,omitempty"`
 }
 
+//Entrypoint represents the start command of a development contaianer
+type Entrypoint struct {
+	Values []string
+}
+
 //Command represents the start command of a development contaianer
 type Command struct {
 	Values []string

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -82,6 +82,35 @@ func (e EnvVar) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (e *Entrypoint) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		err := unmarshal(&single)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(single, " ") {
+			e.Values = []string{"sh", "-c", single}
+		} else {
+			e.Values = []string{single}
+		}
+	} else {
+		e.Values = multi
+	}
+	return nil
+}
+
+// MarshalYAML Implements the marshaler interface of the yaml pkg.
+func (e Entrypoint) MarshalYAML() (interface{}, error) {
+	if len(e.Values) == 1 && !strings.Contains(e.Values[0], " ") {
+		return e.Values[0], nil
+	}
+	return e.Values, nil
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
 func (c *Command) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var multi []string
 	err := unmarshal(&multi)

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -46,6 +46,7 @@ type Service struct {
 	Image           string             `yaml:"image"`
 	Build           *BuildInfo         `yaml:"build,omitempty"`
 	Replicas        int32              `yaml:"replicas"`
+	Entrypoint      Entrypoint         `yaml:"entrypoint,omitempty"`
 	Command         Command            `yaml:"command,omitempty"`
 	Args            Args               `yaml:"args,omitempty"`
 	Environment     []EnvVar           `yaml:"environment,omitempty"`
@@ -153,6 +154,11 @@ func ReadStack(bytes []byte) (*Stack, error) {
 		}
 		if svc.Resources.Storage.Size.Value.Cmp(resource.MustParse("0")) == 0 {
 			svc.Resources.Storage.Size.Value = resource.MustParse("1Gi")
+		}
+		if len(svc.Entrypoint.Values) > 0 {
+			svc.Args.Values = nil
+			svc.Args.Values = svc.Command.Values
+			svc.Command.Values = svc.Entrypoint.Values
 		}
 		s.Services[i] = svc
 	}

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -44,6 +44,8 @@ services:
       storage:
         size: 1Gi
         class: standard
+    entrypoint: e
+    command: c
     volumes:
       - /var/lib/postgresql/data`)
 	s, err := ReadStack(manifest)
@@ -117,6 +119,19 @@ services:
 	if s.Services["db"].Replicas != 1 {
 		t.Errorf("'db.replicas' was not parsed: %+v", s)
 	}
+	if len(s.Services["db"].Command.Values) != 1 {
+		t.Errorf("'db.command' was not parsed: %+v", s.Services["db"].Command.Values)
+	}
+	if s.Services["db"].Command.Values[0] != "e" {
+		t.Errorf("'db.command' was not parsed: %+v", s.Services["db"].Command.Values)
+	}
+	if len(s.Services["db"].Args.Values) != 1 {
+		t.Errorf("'db.args' was not parsed: %+v", s.Services["db"].Args.Values)
+	}
+	if s.Services["db"].Args.Values[0] != "c" {
+		t.Errorf("'db.args' was not parsed: %+v", s.Services["db"].Args.Values)
+	}
+
 	if len(s.Services["db"].Volumes) != 1 {
 		t.Errorf("'db.volumes' was not parsed: %+v", s)
 	}


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Fixes #

## Proposed changes
This makes it possible for people using `command` as an entrypoint to migrate to the compose syntax 