### PR TITLE
Return no error when the command is interrupted

### DIFF
--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -171,7 +171,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(err.Error(), "status 130") {
+	if strings.Contains(err.Error(), "status 130") || strings.Contains(err.Error(), "4294967295") {
 		return nil
 	}
 	if strings.Contains(err.Error(), "exit code 137") || strings.Contains(err.Error(), "exit status 137") {


### PR DESCRIPTION
Signed-off-by: javi <javi.fuenla.caro@gmail.com>

## Proposed changes
- Return no errors when the command in up is killed by unexpected error (signals)
