### PR TITLE
Refactor wait for completion logic

### DIFF
--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -105,7 +105,6 @@ func (up *upContext) startSyncthing(ctx context.Context) error {
 		if err := up.Sy.ResetDatabase(ctx, up.Dev); err != nil {
 			return err
 		}
-
 		up.resetSyncthing = false
 	}
 
@@ -152,15 +151,11 @@ func (up *upContext) synchronizeFiles(ctx context.Context) error {
 
 	reporter := make(chan float64)
 	go func() {
-		var previous float64
 		for c := range reporter {
-			if c > previous {
-				value := int64(c)
-				if value > 0 && value < 100 {
-					spinner.Stop()
-					progressBar.SetCurrent(value)
-					previous = c
-				}
+			value := int64(c)
+			if value > 0 && value < 100 {
+				spinner.Stop()
+				progressBar.SetCurrent(value)
 			}
 		}
 		quit <- true

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -38,7 +38,7 @@ func (akt *addAPIKeyTransport) RoundTrip(req *http.Request) (*http.Response, err
 //NewAPIClient returns a new syncthing api client configured to call the syncthing api
 func NewAPIClient() *http.Client {
 	return &http.Client{
-		Timeout:   30 * time.Second,
+		Timeout:   10 * time.Second,
 		Transport: &addAPIKeyTransport{http.DefaultTransport},
 	}
 }
@@ -46,23 +46,29 @@ func NewAPIClient() *http.Client {
 // APICall calls the syncthing API and returns the parsed json or an error
 func (s *Syncthing) APICall(ctx context.Context, url, method string, code int, params map[string]string, local bool, body []byte, readBody bool, maxRetries int) ([]byte, error) {
 	retries := 0
+	ticker := time.NewTicker(200 * time.Millisecond)
 	for {
-		result, err := s.callWithRetry(ctx, url, method, code, params, local, body, readBody)
-		if err == nil {
-			return result, nil
-		}
-		if retries == maxRetries {
-			return nil, err
-		}
+		select {
+		case <-ticker.C:
+			result, err := s.callWithRetry(ctx, url, method, code, params, local, body, readBody)
+			if err == nil {
+				return result, nil
+			}
 
-		if strings.Contains(err.Error(), "connection refused") {
-			log.Infof("syncthing is not ready, retrying local=%t", local)
-		} else {
-			log.Infof("retrying syncthing call[%s] local=%t: %s", url, local, err.Error())
-		}
+			if retries >= maxRetries {
+				return nil, err
+			}
+			retries++
 
-		time.Sleep(200 * time.Millisecond)
-		retries++
+			if strings.Contains(err.Error(), "connection refused") {
+				log.Infof("syncthing is not ready, retrying local=%t", local)
+			} else {
+				log.Infof("retrying syncthing call[%s] local=%t: %s", url, local, err.Error())
+			}
+		case <-ctx.Done():
+			log.Infof("call to syncthing.APICall %s canceled", url)
+			return nil, ctx.Err()
+		}
 	}
 }
 
@@ -73,7 +79,6 @@ func (s *Syncthing) callWithRetry(ctx context.Context, url, method string, code 
 		s.Client.Timeout = 3 * time.Second
 	} else {
 		urlPath = path.Join(s.RemoteGUIAddress, url)
-		s.Client.Timeout = 25 * time.Second
 		if url == "rest/db/ignores" || url == "rest/system/ping" {
 			s.Client.Timeout = 5 * time.Second
 		}

--- a/pkg/syncthing/completion.go
+++ b/pkg/syncthing/completion.go
@@ -1,0 +1,189 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncthing
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+)
+
+// Completion represents the completion of a syncthing folder.
+type Completion struct {
+	Completion  float64 `json:"completion"`
+	GlobalBytes int64   `json:"globalBytes"`
+	NeedBytes   int64   `json:"needBytes"`
+	GlobalItems int64   `json:"globalItems"`
+	NeedItems   int64   `json:"needItems"`
+	NeedDeletes int64   `json:"needDeletes"`
+}
+
+//waitForCompletion represents a wait for completion iteration
+type waitForCompletion struct {
+	localCompletion           *Completion
+	remoteCompletion          *Completion
+	previousLocalGlobalBytes  int64
+	previousRemoteGlobalBytes int64
+	globalBytesRetries        int64
+	needDeletesRetries        int64
+	retries                   int64
+	progress                  float64
+	sy                        *Syncthing
+	hasBeenReset              bool
+}
+
+// WaitForCompletion waits for the remote to be totally synched
+func (s *Syncthing) WaitForCompletion(ctx context.Context, dev *model.Dev, reporter chan float64) error {
+	defer close(reporter)
+	ticker := time.NewTicker(250 * time.Millisecond)
+	wfc := &waitForCompletion{sy: s}
+	for {
+		select {
+		case <-ticker.C:
+			wfc.retries++
+			if wfc.retries%50 == 0 {
+				log.Info("checking syncthing for error....")
+				if err := s.IsHealthy(ctx, false, 3); err != nil {
+					return err
+				}
+			}
+
+			if err := s.Overwrite(ctx, dev); err != nil {
+				if err != errors.ErrBusySyncthing {
+					return err
+				}
+			}
+			if err := wfc.computeProgress(ctx); err != nil {
+				if err != errors.ErrBusySyncthing {
+					return err
+				}
+				continue
+			}
+
+			reporter <- wfc.progress
+
+			if wfc.needsDatabaseReset() {
+				err := wfc.resetDatabase(ctx, dev)
+				analytics.TrackResetDatabase(err == nil)
+				continue
+			}
+
+			if wfc.isCompleted() {
+				return nil
+			}
+
+		case <-ctx.Done():
+			log.Info("call to syncthing.WaitForCompletion canceled")
+			return ctx.Err()
+		}
+	}
+}
+
+func (wfc *waitForCompletion) computeProgress(ctx context.Context) error {
+	localCompletion, err := wfc.sy.GetCompletion(ctx, true, DefaultRemoteDeviceID)
+	if err != nil {
+		return err
+	}
+	wfc.localCompletion = localCompletion
+	log.Infof("syncthing status in local: globalBytes %d, needBytes %d, globalItems %d, needItems %d, needDeletes %d", localCompletion.GlobalBytes, localCompletion.NeedBytes, localCompletion.GlobalItems, localCompletion.NeedItems, localCompletion.NeedDeletes)
+
+	remoteCompletion, err := wfc.sy.GetCompletion(ctx, false, DefaultRemoteDeviceID)
+	if err != nil {
+		return err
+	}
+	wfc.remoteCompletion = remoteCompletion
+	log.Infof("syncthing status in remote: globalBytes %d, needBytes %d, globalItems %d, needItems %d, needDeletes %d",
+		remoteCompletion.GlobalBytes,
+		remoteCompletion.NeedBytes,
+		remoteCompletion.GlobalItems,
+		remoteCompletion.NeedItems,
+		remoteCompletion.NeedDeletes,
+	)
+	if localCompletion.GlobalBytes == 0 {
+		wfc.progress = 100
+	} else {
+		wfc.progress = (float64(localCompletion.GlobalBytes-localCompletion.NeedBytes) / float64(localCompletion.GlobalBytes)) * 100
+	}
+	return nil
+}
+
+func (wfc *waitForCompletion) needsDatabaseReset() bool {
+	if wfc.localCompletion.GlobalBytes == wfc.remoteCompletion.GlobalBytes {
+		wfc.globalBytesRetries = 0
+		wfc.previousLocalGlobalBytes = wfc.localCompletion.GlobalBytes
+		wfc.previousRemoteGlobalBytes = wfc.remoteCompletion.GlobalBytes
+		return false
+	}
+	log.Infof("local globalBytes %d, remote global bytes %d", wfc.localCompletion.GlobalBytes, wfc.remoteCompletion.GlobalBytes)
+	if wfc.localCompletion.GlobalBytes != wfc.previousLocalGlobalBytes {
+		log.Infof("local globalBytes has changed %d vs %d", wfc.localCompletion.GlobalBytes, wfc.previousLocalGlobalBytes)
+		wfc.previousLocalGlobalBytes = wfc.localCompletion.GlobalBytes
+		wfc.previousRemoteGlobalBytes = wfc.remoteCompletion.GlobalBytes
+		wfc.globalBytesRetries = 0
+		return false
+	}
+	if wfc.remoteCompletion.GlobalBytes != wfc.previousRemoteGlobalBytes {
+		log.Infof("remote globalBytes has changed %d vs %d", wfc.remoteCompletion.GlobalBytes, wfc.previousRemoteGlobalBytes)
+		wfc.previousLocalGlobalBytes = wfc.localCompletion.GlobalBytes
+		wfc.previousRemoteGlobalBytes = wfc.remoteCompletion.GlobalBytes
+		wfc.globalBytesRetries = 0
+		return false
+	}
+	wfc.globalBytesRetries++
+	log.Infof("globalBytesRetries %d", wfc.globalBytesRetries)
+	return wfc.globalBytesRetries > 360 // 90 seconds
+}
+
+func (wfc *waitForCompletion) resetDatabase(ctx context.Context, dev *model.Dev) error {
+	if wfc.hasBeenReset {
+		return fmt.Errorf("inconsistent syncthing state")
+	}
+	log.Info("resetting syncthing database in wait for completion loop...")
+	if err := wfc.sy.ResetDatabase(ctx, dev); err != nil {
+		return err
+	}
+	wfc.hasBeenReset = true
+	wfc.globalBytesRetries = 0
+	if err := wfc.sy.WaitForScanning(ctx, dev, true); err != nil {
+		return err
+	}
+	return wfc.sy.WaitForScanning(ctx, dev, false)
+}
+
+func (wfc *waitForCompletion) isCompleted() bool {
+	if wfc.localCompletion.NeedBytes > 0 {
+		return false
+	}
+	if wfc.localCompletion.GlobalBytes != wfc.remoteCompletion.GlobalBytes {
+		return false
+	}
+
+	if wfc.localCompletion.NeedDeletes > 0 {
+		wfc.needDeletesRetries++
+		if wfc.needDeletesRetries < 50 {
+			log.Info("synced completed, but need deletes, retrying...")
+			return false
+		}
+	}
+	if !wfc.sy.IsAllOverwritten() {
+		log.Info("synced completed, but overwrites not sent, retrying...")
+		return false
+	}
+	return true
+}

--- a/pkg/syncthing/completion_test.go
+++ b/pkg/syncthing/completion_test.go
@@ -1,0 +1,260 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syncthing
+
+import (
+	"testing"
+)
+
+func Test_needsDatabaseReset(t *testing.T) {
+	tests := []struct {
+		name                      string
+		wfc                       *waitForCompletion
+		previousLocalGlobalBytes  int64
+		previousRemoteGlobalBytes int64
+		globalBytesRetries        int64
+		want                      bool
+	}{
+		{
+			name: "global-bytes-ok",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				previousLocalGlobalBytes:  0,
+				previousRemoteGlobalBytes: 0,
+				globalBytesRetries:        10,
+			},
+			previousLocalGlobalBytes:  10,
+			previousRemoteGlobalBytes: 10,
+			globalBytesRetries:        0,
+			want:                      false,
+		},
+		{
+			name: "local-global-bytes-changed",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 20,
+				},
+				previousLocalGlobalBytes:  1,
+				previousRemoteGlobalBytes: 20,
+				globalBytesRetries:        10,
+			},
+			previousLocalGlobalBytes:  10,
+			previousRemoteGlobalBytes: 20,
+			globalBytesRetries:        0,
+			want:                      false,
+		},
+		{
+			name: "remote-global-bytes-changed",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 20,
+				},
+				previousLocalGlobalBytes:  10,
+				previousRemoteGlobalBytes: 2,
+				globalBytesRetries:        10,
+			},
+			previousLocalGlobalBytes:  10,
+			previousRemoteGlobalBytes: 20,
+			globalBytesRetries:        0,
+			want:                      false,
+		},
+		{
+			name: "increment-global-bytes-retries",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 20,
+				},
+				previousLocalGlobalBytes:  10,
+				previousRemoteGlobalBytes: 20,
+				globalBytesRetries:        10,
+			},
+			previousLocalGlobalBytes:  10,
+			previousRemoteGlobalBytes: 20,
+			globalBytesRetries:        11,
+			want:                      false,
+		},
+		{
+			name: "reset",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 20,
+				},
+				previousLocalGlobalBytes:  10,
+				previousRemoteGlobalBytes: 20,
+				globalBytesRetries:        360,
+			},
+			previousLocalGlobalBytes:  10,
+			previousRemoteGlobalBytes: 20,
+			globalBytesRetries:        361,
+			want:                      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.wfc.needsDatabaseReset()
+			if result != tt.want {
+				t.Errorf("test '%s' wrong completed: %t vs %t", tt.name, result, tt.want)
+			}
+			if tt.wfc.previousLocalGlobalBytes != tt.previousLocalGlobalBytes {
+				t.Errorf("test '%s' wrong previousLocalGlobalBytes: %d vs %d", tt.name, tt.wfc.previousLocalGlobalBytes, tt.previousLocalGlobalBytes)
+			}
+			if tt.wfc.previousRemoteGlobalBytes != tt.previousRemoteGlobalBytes {
+				t.Errorf("test '%s' wrong previousRemoteGlobalBytes: %d vs %d", tt.name, tt.wfc.previousRemoteGlobalBytes, tt.previousRemoteGlobalBytes)
+			}
+			if tt.wfc.globalBytesRetries != tt.globalBytesRetries {
+				t.Errorf("test '%s' wrong globalBytesRetries: %d vs %d", tt.name, tt.wfc.globalBytesRetries, tt.globalBytesRetries)
+			}
+		})
+	}
+}
+
+func Test_isCompleted(t *testing.T) {
+	tests := []struct {
+		name               string
+		wfc                *waitForCompletion
+		needDeletesRetries int64
+		want               bool
+	}{
+		{
+			name: "need-bytes",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					NeedBytes: 10,
+				},
+			},
+			needDeletesRetries: 0,
+			want:               false,
+		},
+		{
+			name: "not-matching-global-bytes",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					NeedBytes:   0,
+					GlobalBytes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 20,
+				},
+			},
+			needDeletesRetries: 0,
+			want:               false,
+		},
+		{
+			name: "need-deletes",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					NeedBytes:   0,
+					GlobalBytes: 10,
+					NeedDeletes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+			},
+			needDeletesRetries: 1,
+			want:               false,
+		},
+		{
+			name: "completed-retried-need-deletes",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					NeedBytes:   0,
+					GlobalBytes: 10,
+					NeedDeletes: 10,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				needDeletesRetries: 50,
+				sy: &Syncthing{
+					Folders: []*Folder{},
+				},
+			},
+			needDeletesRetries: 51,
+			want:               true,
+		},
+		{
+			name: "not-overwritten",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					NeedBytes:   0,
+					GlobalBytes: 10,
+					NeedDeletes: 0,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				sy: &Syncthing{
+					Folders: []*Folder{
+						{
+							Overwritten: false,
+						},
+					},
+				},
+			},
+			needDeletesRetries: 0,
+			want:               false,
+		},
+		{
+			name: "completed",
+			wfc: &waitForCompletion{
+				localCompletion: &Completion{
+					NeedBytes:   0,
+					GlobalBytes: 10,
+					NeedDeletes: 0,
+				},
+				remoteCompletion: &Completion{
+					GlobalBytes: 10,
+				},
+				sy: &Syncthing{
+					Folders: []*Folder{
+						{
+							Overwritten: true,
+						},
+					},
+				},
+			},
+			needDeletesRetries: 0,
+			want:               true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			completed := tt.wfc.isCompleted()
+			if completed != tt.want {
+				t.Errorf("test '%s' wrong completed: %t vs %t", tt.name, completed, tt.want)
+			}
+			if tt.wfc.needDeletesRetries != tt.needDeletesRetries {
+				t.Errorf("test '%s' wrong needDeletesRetries: %d vs %d", tt.name, tt.wfc.needDeletesRetries, tt.needDeletesRetries)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactor wait for completion method in several functions to make it possible to unit test it.
Fixes a regression in the loop that is now covered by tests:
https://github.com/okteto/okteto/blob/master/pkg/syncthing/syncthing.go#L541