### PR TITLE
Inject remote stignore as a secret instead of using the syncthing API

### DIFF
--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -108,7 +108,6 @@ func (up *upContext) startSyncthing(ctx context.Context) error {
 		up.resetSyncthing = false
 	}
 
-	up.Sy.SendStignoreFile(ctx)
 	spinner.Update("Scanning file system...")
 	if err := up.Sy.WaitForScanning(ctx, up.Dev, true); err != nil {
 		return err

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -117,6 +117,10 @@ func Up() *cobra.Command {
 				log.Infof("failed to check '.stignore' configuration: %s", err.Error())
 			}
 
+			if err := addStignoreSecrets(dev); err != nil {
+				return err
+			}
+
 			if _, ok := os.LookupEnv("OKTETO_AUTODEPLOY"); ok {
 				autoDeploy = true
 			}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -71,6 +71,8 @@ const (
 	OktetoAutoCreateAnnotation = "dev.okteto.com/auto-create"
 	//OktetoRestartAnnotation indicates the dev pod must be recreated to pull the latest version of its image
 	OktetoRestartAnnotation = "dev.okteto.com/restart"
+	//OktetoStignoreAnnotation indicates the hash of the stignore files to force redeployment
+	OktetoStignoreAnnotation = "dev.okteto.com/stignore"
 
 	//OktetoInitContainer name of the okteto init container
 	OktetoInitContainer = "okteto-init"

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -38,7 +38,7 @@ func (akt *addAPIKeyTransport) RoundTrip(req *http.Request) (*http.Response, err
 //NewAPIClient returns a new syncthing api client configured to call the syncthing api
 func NewAPIClient() *http.Client {
 	return &http.Client{
-		Timeout:   10 * time.Second,
+		Timeout:   60 * time.Second,
 		Transport: &addAPIKeyTransport{http.DefaultTransport},
 	}
 }
@@ -76,10 +76,10 @@ func (s *Syncthing) callWithRetry(ctx context.Context, url, method string, code 
 	var urlPath string
 	if local {
 		urlPath = path.Join(s.GUIAddress, url)
-		s.Client.Timeout = 3 * time.Second
+		s.Client.Timeout = 5 * time.Second
 	} else {
 		urlPath = path.Join(s.RemoteGUIAddress, url)
-		if url == "rest/db/ignores" || url == "rest/system/ping" {
+		if url == "rest/system/ping" {
 			s.Client.Timeout = 5 * time.Second
 		}
 	}

--- a/pkg/syncthing/monitor.go
+++ b/pkg/syncthing/monitor.go
@@ -28,7 +28,6 @@ func (s *Syncthing) Monitor(ctx context.Context, disconnect chan error) {
 	for {
 		select {
 		case <-ticker.C:
-			s.SendStignoreFile(ctx)
 			if s.checkLocalAndRemotePing(ctx) {
 				retries = 0
 				continue


### PR DESCRIPTION
The send stignore syncthing API timeouts almost every time because it blocks if synchthing is synchronizing files.
Having stignore in the remote syncthing is important to optimize the syncthing of files, reduce scans, ...
This PR injects the stignore file as a secret to make sure the file is available before syncthing starts
