### PR TITLE
Defines OKTETO_CONTEXT var to define a default context for okteto comm…

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -85,6 +85,10 @@ func Init() *cobra.Command {
 
 // Run runs the sequence to generate okteto.yml
 func Run(namespace, k8sContext, devPath, language, workDir string, overwrite bool) error {
+	if k8sContext == "" {
+		k8sContext = os.Getenv(client.OktetoContextVariableName)
+	}
+
 	fmt.Println("This command walks you through creating an okteto manifest.")
 	fmt.Println("It only covers the most common items, and tries to guess sensible defaults.")
 	fmt.Println("See https://okteto.com/docs/reference/manifest for the official documentation about the okteto manifest.")
@@ -108,6 +112,8 @@ func Run(namespace, k8sContext, devPath, language, workDir string, overwrite boo
 	if err != nil {
 		return err
 	}
+
+	dev.Context = k8sContext
 
 	if checkForDeployment {
 		d, container, err := getDeployment(ctx, namespace, k8sContext)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -107,7 +107,7 @@ func Up() *cobra.Command {
 				return err
 			}
 
-			if err := loadDevOverrides(dev, namespace, k8sContext, forcePull, remote, autoDeploy); err != nil {
+			if err := loadDevOverrides(dev, forcePull, remote, autoDeploy); err != nil {
 				return err
 			}
 
@@ -182,7 +182,7 @@ func loadDevOrInit(namespace, k8sContext, devPath string) (*model.Dev, error) {
 	return utils.LoadDev(devPath, namespace, k8sContext)
 }
 
-func loadDevOverrides(dev *model.Dev, namespace, k8sContext string, forcePull bool, remote int, autoDeploy bool) error {
+func loadDevOverrides(dev *model.Dev, forcePull bool, remote int, autoDeploy bool) error {
 	if remote > 0 {
 		dev.RemotePort = remote
 	}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -55,11 +55,16 @@ func LoadDev(devPath, namespace, k8sContext string) (*model.Dev, error) {
 func loadContext(dev *model.Dev, k8sContext string) {
 	if k8sContext != "" {
 		dev.Context = k8sContext
+		return
 	}
-	if dev.Context == "" {
-		dev.Context = client.GetSessionContext("")
+	if dev.Context != "" {
+		return
 	}
-
+	if os.Getenv(client.OktetoContextVariableName) != "" {
+		dev.Context = os.Getenv(client.OktetoContextVariableName)
+		return
+	}
+	dev.Context = client.GetSessionContext("")
 }
 
 func loadNamespace(dev *model.Dev, namespace string) {

--- a/pkg/cmd/stack/destroy.go
+++ b/pkg/cmd/stack/destroy.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -111,6 +112,7 @@ func helmReleaseExist(c *action.List, name string) (bool, error) {
 
 func destroyHelmRelease(ctx context.Context, spinner *utils.Spinner, s *model.Stack) error {
 	settings := cli.New()
+	settings.KubeContext = os.Getenv(client.OktetoContextVariableName)
 
 	actionConfig := new(action.Configuration)
 

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -16,6 +16,7 @@ package client
 import (
 	"log"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/okteto/okteto/pkg/analytics"
@@ -32,6 +33,8 @@ const (
 	oktetoClusterType = "okteto"
 	localClusterType  = "local"
 	remoteClusterType = "remote"
+	//OktetoContextVariableName defines the kubeconfig context of okteto commands
+	OktetoContextVariableName = "OKTETO_CONTEXT"
 )
 
 var (
@@ -41,7 +44,7 @@ var (
 
 //GetLocal returns a kubernetes client with the local configuration. It will detect if KUBECONFIG is defined.
 func GetLocal() (*kubernetes.Clientset, *rest.Config, error) {
-	return GetLocalWithContext("")
+	return GetLocalWithContext(os.Getenv(OktetoContextVariableName))
 }
 
 //GetLocalWithContext returns a kubernetes client for a given context. It will detect if KUBECONFIG is defined.
@@ -94,6 +97,9 @@ func GetSessionContext(k8sContext string) string {
 
 //GetContextNamespace returns the name of the namespace in use by a given context
 func GetContextNamespace(k8sContext string) string {
+	if k8sContext == "" {
+		k8sContext = os.Getenv(OktetoContextVariableName)
+	}
 	namespace, _, err := getClientConfig(k8sContext).Namespace()
 	if err != nil {
 		log.Fatalf("error accessing you kubeconfig file: %s", err.Error())


### PR DESCRIPTION
…ands

Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

For example, if a user defines `export OKTETO_CONTEXT=cloud_okteto_com`, by default, every okteto command will run on Okteto Cloud.