### PR TITLE
Store the stack manifest without adding default values

### DIFF
--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -15,6 +15,7 @@ package stack
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -105,7 +106,8 @@ func Test_translateEnvVars(t *testing.T) {
 
 func Test_translateConfigMap(t *testing.T) {
 	s := &model.Stack{
-		Name: "stackName",
+		Manifest: []byte("manifest"),
+		Name:     "stackName",
 		Services: map[string]model.Service{
 			"svcName": {
 				Image: "image",
@@ -122,7 +124,7 @@ func Test_translateConfigMap(t *testing.T) {
 	if result.Data[nameField] != "stackName" {
 		t.Errorf("Wrong data.name: '%s'", result.Data[nameField])
 	}
-	if result.Data[yamlField] != "bmFtZTogc3RhY2tOYW1lCnNlcnZpY2VzOgogIHN2Y05hbWU6CiAgICBpbWFnZTogaW1hZ2UKICAgIHJlcGxpY2FzOiAwCg==" {
+	if result.Data[yamlField] != base64.StdEncoding.EncodeToString(s.Manifest) {
 		t.Errorf("Wrong data.yaml: '%s'", result.Data[yamlField])
 	}
 }

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -36,6 +36,7 @@ type Stack struct {
 	Name      string             `yaml:"name"`
 	Namespace string             `yaml:"namespace,omitempty"`
 	Services  map[string]Service `yaml:"services,omitempty"`
+	Manifest  []byte             `yaml:"-"`
 }
 
 //Service represents an okteto stack service
@@ -121,7 +122,9 @@ func GetStack(name, stackPath string) (*Stack, error) {
 
 //ReadStack reads an okteto stack
 func ReadStack(bytes []byte) (*Stack, error) {
-	s := &Stack{}
+	s := &Stack{
+		Manifest: bytes,
+	}
 	if err := yaml.UnmarshalStrict(bytes, s); err != nil {
 		if strings.HasPrefix(err.Error(), "yaml: unmarshal errors:") {
 			var sb strings.Builder


### PR DESCRIPTION
Store the original stack manifest. If not, we are adding default values like the namespace or the build context