### PR TITLE
Remove reference to "okteto push" on "okteto down"

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -53,7 +53,6 @@ func Down() *cobra.Command {
 			}
 
 			log.Success("Development container deactivated")
-			log.Information("Run 'okteto push' to deploy your code changes to the cluster")
 
 			if rm {
 				if err := removeVolume(ctx, dev); err != nil {


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Eliminate `okteto push` hint after `okteto down` as `okteto pipeline deploy` is becoming the preferred workflow