### PR TITLE
Set env var if exists on local

### DIFF
--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -73,7 +73,11 @@ func (e *EnvVar) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	e.Name, err = ExpandEnv(parts[0])
-	return err
+	if err != nil {
+		return err
+	}
+	e.Value = os.Getenv(e.Name)
+	return nil
 }
 
 // MarshalYAML Implements the marshaler interface of the yaml pkg.

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -135,6 +135,11 @@ func TestEnvVarMashalling(t *testing.T) {
 			[]byte(`$UNDEFINED`),
 			EnvVar{Name: "", Value: ""},
 		},
+		{
+			"local_env_expanded",
+			[]byte(`OKTETO_TEST_ENV_MARSHALLING`),
+			EnvVar{Name: "OKTETO_TEST_ENV_MARSHALLING", Value: "true"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -142,6 +147,10 @@ func TestEnvVarMashalling(t *testing.T) {
 
 			var result EnvVar
 			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1399 

## Proposed changes
- If there is no = on an environment variable declaration, set its value if it is declared locally.
- It was affecting `Okteto up` and `Okteto stack` commands
