### PR TITLE
Take the namespace from the OKTETO_NAMESPACE envvar when running in a…

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -184,7 +184,7 @@ func getCurrentNamespace(ctx context.Context) string {
 	if okteto.GetClusterContext() == currentContext {
 		return client.GetContextNamespace("")
 	}
-	return ""
+	return os.Getenv("OKTETO_NAMESPACE")
 }
 
 func getRepositoryURL(ctx context.Context, path string) (string, error) {


### PR DESCRIPTION
… pipeline

Otherwise, the pipeline is always executed in the personal namespace