### PR TITLE
Add annotations and labels to endpoints

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -332,14 +332,14 @@ func translateIngress(ingressName string, s *model.Stack) *extensions.Ingress {
 	}
 }
 
-func translateEndpoints(endpoints []model.Endpoint) []extensions.HTTPIngressPath {
+func translateEndpoints(endpoints model.Endpoint) []extensions.HTTPIngressPath {
 	paths := make([]extensions.HTTPIngressPath, 0)
-	for _, endpoint := range endpoints {
+	for _, rule := range endpoints.Rules {
 		path := extensions.HTTPIngressPath{
-			Path: endpoint.Path,
+			Path: rule.Path,
 			Backend: extensions.IngressBackend{
-				ServiceName: endpoint.Service,
-				ServicePort: intstr.IntOrString{IntVal: endpoint.Port},
+				ServiceName: rule.Service,
+				ServicePort: intstr.IntOrString{IntVal: rule.Port},
 			},
 		}
 		paths = append(paths, path)
@@ -360,9 +360,13 @@ func translateLabels(svcName string, s *model.Stack) map[string]string {
 }
 
 func translateIngressLabels(endpointName string, s *model.Stack) map[string]string {
+	endpoint := s.Endpoints[endpointName]
 	labels := map[string]string{
 		okLabels.StackNameLabel:         s.Name,
 		okLabels.StackEndpointNameLabel: endpointName,
+	}
+	for k := range endpoint.Labels {
+		labels[k] = endpoint.Labels[k]
 	}
 	return labels
 }

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -502,9 +502,13 @@ func Test_translateService(t *testing.T) {
 func Test_translateEndpoints(t *testing.T) {
 	s := &model.Stack{
 		Name: "stackName",
-		Endpoints: map[string][]model.Endpoint{
-			"svcName": {
-				{Path: "/", Port: 80, Service: "svcName"},
+		Endpoints: map[string]model.Endpoint{
+			"endpoint1": {
+				Rules: []model.EndpointRule{
+					{Path: "/",
+						Service: "svcName",
+						Port:    80},
+				},
 			},
 		},
 		Services: map[string]*model.Service{
@@ -513,8 +517,8 @@ func Test_translateEndpoints(t *testing.T) {
 			},
 		},
 	}
-	result := translateIngress("svcName", s)
-	if result.Name != "svcName" {
+	result := translateIngress("endpoint1", s)
+	if result.Name != "endpoint1" {
 		t.Errorf("Wrong service name: '%s'", result.Name)
 	}
 
@@ -536,12 +540,12 @@ func Test_translateEndpoints(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(result.Spec.Rules[0].HTTP.Paths, paths) {
-		t.Errorf("Wrong service ports: '%v'", result.Spec.Rules[0].HTTP.Paths)
+		t.Errorf("Wrong ingress: '%v'", result.Spec.Rules[0].HTTP.Paths)
 	}
 
 	labels := map[string]string{
 		okLabels.StackNameLabel:         "stackName",
-		okLabels.StackEndpointNameLabel: "svcName",
+		okLabels.StackEndpointNameLabel: "endpoint1",
 	}
 	if !reflect.DeepEqual(result.Labels, labels) {
 		t.Errorf("Wrong labels: '%s'", result.Labels)

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -545,3 +545,23 @@ func isDefaultProbes(d *Dev) bool {
 	}
 	return true
 }
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (endpoint *Endpoint) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var rules []EndpointRule
+	err := unmarshal(&rules)
+	if err == nil {
+		endpoint.Rules = rules
+		return nil
+	}
+	type endpointType Endpoint // prevent recursion
+	var endpointRaw endpointType
+	err = unmarshal(&endpointRaw)
+	if err != nil {
+		return err
+	}
+	endpoint.Annotations = endpointRaw.Annotations
+	endpoint.Rules = endpointRaw.Rules
+	endpoint.Labels = endpointRaw.Labels
+	return nil
+}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -484,3 +484,59 @@ func TestDevMarshalling(t *testing.T) {
 		})
 	}
 }
+
+func TestEndpointUnmarshalling(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected Endpoint
+	}{
+		{
+			name: "rule",
+			data: []byte("- path: /\n  service: test\n  port: 8080"),
+			expected: Endpoint{
+				Rules: []EndpointRule{{
+					Path:    "/",
+					Service: "test",
+					Port:    8080,
+				}},
+			},
+		},
+		{
+			name: "full-endpoint",
+			data: []byte("labels:\n  key1: value1\nannotations:\n  key2: value2\nrules:\n- path: /\n  service: test\n  port: 8080"),
+			expected: Endpoint{
+				Labels:      map[string]string{"key1": "value1"},
+				Annotations: map[string]string{"key2": "value2"},
+				Rules: []EndpointRule{{
+					Path:    "/",
+					Service: "test",
+					Port:    8080,
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			var endpoint Endpoint
+			if err := yaml.UnmarshalStrict(tt.data, &endpoint); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(endpoint.Annotations, tt.expected.Annotations) {
+				t.Errorf("didn't unmarshal correctly annotations. Actual %v, Expected %v", endpoint.Annotations, tt.expected.Annotations)
+			}
+
+			if !reflect.DeepEqual(endpoint.Labels, tt.expected.Labels) {
+				t.Errorf("didn't unmarshal correctly labels. Actual %v, Expected %v", endpoint.Labels, tt.expected.Labels)
+			}
+
+			if !reflect.DeepEqual(endpoint.Rules, tt.expected.Rules) {
+				t.Errorf("didn't unmarshal correctly rules. Actual %v, Expected %v", endpoint.Rules, tt.expected.Rules)
+			}
+
+		})
+	}
+}

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -28,7 +28,7 @@ type StackRaw struct {
 	Name      string                 `yaml:"name"`
 	Namespace string                 `yaml:"namespace,omitempty"`
 	Services  map[string]*ServiceRaw `yaml:"services,omitempty"`
-	Endpoints map[string][]Endpoint  `yaml:"endpoints,omitempty"`
+	Endpoints map[string]Endpoint    `yaml:"endpoints,omitempty"`
 
 	// Docker-compose not implemented
 	Networks *WarningType `yaml:"networks,omitempty"`

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -367,9 +367,11 @@ func TestStack_validate(t *testing.T) {
 			name: "endpoint-of-undefined-service",
 			stack: &Stack{
 				Name: "name",
-				Endpoints: map[string][]Endpoint{
+				Endpoints: map[string]Endpoint{
 					"endpoint1": {
-						{Service: "app"},
+						Rules: []EndpointRule{
+							{Service: "app"},
+						},
 					},
 				},
 				Services: map[string]*Service{
@@ -381,10 +383,12 @@ func TestStack_validate(t *testing.T) {
 			name: "endpoint-of-unexported-port",
 			stack: &Stack{
 				Name: "name",
-				Endpoints: map[string][]Endpoint{
+				Endpoints: map[string]Endpoint{
 					"endpoint1": {
-						{Service: "name",
-							Port: 80},
+						Rules: []EndpointRule{
+							{Service: "app",
+								Port: 80},
+						},
 					},
 				},
 				Services: map[string]*Service{


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1407 

## Proposed changes
- The user can specify annotations and labels for an ingress service
- The user can use set directly the rules if there is no need to add labels/annotations
