### PR TITLE
Add error if user has not the permissions for ns

### DIFF
--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -22,6 +22,8 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
+	k8Client "github.com/okteto/okteto/pkg/k8s/client"
+	"github.com/okteto/okteto/pkg/k8s/namespaces"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
@@ -87,6 +89,10 @@ func RunNamespace(ctx context.Context, namespace string) error {
 	kubeConfigFile := config.GetKubeConfigFile()
 	clusterContext := okteto.GetClusterContext()
 
+	if err = isNamespaceAvailable(ctx, namespace); err != nil {
+		return err
+	}
+
 	if err := okteto.SetKubeConfig(cred, kubeConfigFile, namespace, okteto.GetUserID(), clusterContext, true); err != nil {
 		return err
 	}
@@ -119,4 +125,17 @@ func askOktetoURL() (string, error) {
 	oktetoURL = u
 
 	return oktetoURL, nil
+}
+
+func isNamespaceAvailable(ctx context.Context, namespace string) error {
+	client, _, err := k8Client.GetLocal()
+	if err != nil {
+		return err
+	}
+
+	_, err = namespaces.Get(ctx, namespace, client)
+	if err != nil {
+		return fmt.Errorf("Cannot get '%s' namespace. Please make sure it's created and you have the right permissions.", namespace)
+	}
+	return nil
 }

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -135,7 +135,7 @@ func isNamespaceAvailable(ctx context.Context, namespace string) error {
 
 	_, err = namespaces.Get(ctx, namespace, client)
 	if err != nil {
-		return fmt.Errorf("Cannot get '%s' namespace. Please make sure it's created and you have the right permissions.", namespace)
+		return fmt.Errorf("Namespace '%s' not found. Please verify that the namespace exists and that you have access to it.", namespace)
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1417 

## Proposed changes
-  Checks if user can get the namespace before updating context. If the user has not access to the namespace it throws an error
-  