### PR TITLE
Remove warning message if restart is always

### DIFF
--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -112,7 +112,7 @@ type ServiceRaw struct {
 	Profiles          *WarningType `yaml:"profiles,omitempty"`
 	PullPolicy        *WarningType `yaml:"pull_policy,omitempty"`
 	ReadOnly          *WarningType `yaml:"read_only,omitempty"`
-	Restart           *WarningType `yaml:"restart,omitempty"`
+	Restart           *string      `yaml:"restart,omitempty"`
 	Runtime           *WarningType `yaml:"runtime,omitempty"`
 	Secrets           *WarningType `yaml:"secrets,omitempty"`
 	SecurityOpt       *WarningType `yaml:"security_opt,omitempty"`
@@ -732,7 +732,9 @@ func getServiceNotSupportedFields(svcName string, svcInfo *ServiceRaw) []string 
 		notSupported = append(notSupported, fmt.Sprintf("services[%s].read_only", svcName))
 	}
 	if svcInfo.Restart != nil {
-		notSupported = append(notSupported, fmt.Sprintf("services[%s].restart", svcName))
+		if *svcInfo.Restart != "always" {
+			notSupported = append(notSupported, fmt.Sprintf("services[%s].restart", svcName))
+		}
 	}
 	if svcInfo.Runtime != nil {
 		notSupported = append(notSupported, fmt.Sprintf("services[%s].runtime", svcName))

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -539,3 +539,38 @@ func Test_validateIngressCreationPorts(t *testing.T) {
 		})
 	}
 }
+
+func Test_restartFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest []byte
+		isInList bool
+	}{
+		{
+			name:     "no-restart-field",
+			manifest: []byte("services:\n  app:\n    ports:\n    - 9213\n    public: true\n    image: okteto/vote:1"),
+			isInList: false,
+		},
+		{
+			name:     "restart-field-always",
+			manifest: []byte("services:\n  app:\n    ports:\n    - 9213\n    image: okteto/vote:1\n    restart: always"),
+			isInList: false,
+		},
+		{
+			name:     "restart-field-not-always",
+			manifest: []byte("services:\n  app:\n    ports:\n    - 9213:9213\n    image: okteto/vote:1\n    restart: never"),
+			isInList: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := ReadStack(tt.manifest, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(s.Warnings) == 0 && tt.isInList {
+				t.Fatalf("Expected to see a warning but there is no warning")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1425

## Proposed changes
-  If restart field is set to 'always' not show the warning at the end
-  