### PR TITLE
Don't create the stack metadata until image builds are done

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -48,6 +48,10 @@ func Deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool)
 		return err
 	}
 
+	if err := translate(ctx, s, forceBuild, noCache); err != nil {
+		return err
+	}
+
 	cfg := translateConfigMap(s)
 	output := fmt.Sprintf("Deploying stack '%s'...", s.Name)
 	cfg.Data[statusField] = progressingStatus
@@ -56,7 +60,7 @@ func Deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool)
 		return err
 	}
 
-	err = deploy(ctx, s, forceBuild, wait, noCache, c)
+	err = deploy(ctx, s, wait, c)
 	if err != nil {
 		output = fmt.Sprintf("%s\nStack '%s' deployment failed: %s", output, s.Name, err.Error())
 		cfg.Data[statusField] = errorStatus
@@ -74,12 +78,7 @@ func Deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool)
 	return err
 }
 
-func deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool, c *kubernetes.Clientset) error {
-
-	if err := translate(ctx, s, forceBuild, noCache); err != nil {
-		return err
-	}
-
+func deploy(ctx context.Context, s *model.Stack, wait bool, c *kubernetes.Clientset) error {
 	spinner := utils.NewSpinner(fmt.Sprintf("Deploying stack '%s'...", s.Name))
 	spinner.Start()
 	defer spinner.Stop()


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Otherwise, if the build fails, the stack is created in Cloud with no content.