### PR TITLE
Refactor for envs vars, labels and annotations

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -348,7 +348,7 @@ func translateEndpoints(endpoints model.Endpoint) []extensions.HTTPIngressPath {
 
 func translateIngressAnnotations(endpointName string, s *model.Stack) map[string]string {
 	endpoint := s.Endpoints[endpointName]
-	annotations := map[string]string{okLabels.OktetoIngressAutoGenerateHost: "true"}
+	annotations := model.Annotations{okLabels.OktetoIngressAutoGenerateHost: "true"}
 	for k := range endpoint.Annotations {
 		annotations[k] = endpoint.Annotations[k]
 	}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -137,11 +137,11 @@ func Test_translateDeployment(t *testing.T) {
 		Name: "stackName",
 		Services: map[string]*model.Service{
 			"svcName": {
-				Labels: map[string]string{
+				Labels: model.Labels{
 					"label1": "value1",
 					"label2": "value2",
 				},
-				Annotations: map[string]string{
+				Annotations: model.Annotations{
 					"annotation1": "value1",
 					"annotation2": "value2",
 				},
@@ -237,11 +237,11 @@ func Test_translateStatefulSet(t *testing.T) {
 		Name: "stackName",
 		Services: map[string]*model.Service{
 			"svcName": {
-				Labels: map[string]string{
+				Labels: model.Labels{
 					"label1": "value1",
 					"label2": "value2",
 				},
-				Annotations: map[string]string{
+				Annotations: model.Annotations{
 					"annotation1": "value1",
 					"annotation2": "value2",
 				},
@@ -419,11 +419,11 @@ func Test_translateService(t *testing.T) {
 		Name: "stackName",
 		Services: map[string]*model.Service{
 			"svcName": {
-				Labels: map[string]string{
+				Labels: model.Labels{
 					"label1": "value1",
 					"label2": "value2",
 				},
-				Annotations: map[string]string{
+				Annotations: model.Annotations{
 					"annotation1": "value1",
 					"annotation2": "value2",
 				},
@@ -504,8 +504,8 @@ func Test_translateEndpoints(t *testing.T) {
 		Name: "stackName",
 		Endpoints: map[string]model.Endpoint{
 			"endpoint1": {
-				Labels:      map[string]string{"label1": "value1"},
-				Annotations: map[string]string{"annotation1": "value1"},
+				Labels:      model.Labels{"label1": "value1"},
+				Annotations: model.Annotations{"annotation1": "value1"},
 				Rules: []model.EndpointRule{
 					{Path: "/",
 						Service: "svcName",

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -257,7 +257,7 @@ func UpdateOktetoRevision(ctx context.Context, d *appsv1.Deployment, client *kub
 //SetLastBuiltAnnotation sets the deployment timestacmp
 func SetLastBuiltAnnotation(d *appsv1.Deployment) {
 	if d.Spec.Template.Annotations == nil {
-		d.Spec.Template.Annotations = map[string]string{}
+		d.Spec.Template.Annotations = model.Annotations{}
 	}
 	d.Spec.Template.Annotations[labels.LastBuiltAnnotation] = time.Now().UTC().Format(labels.TimeFormat)
 }

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -90,7 +90,7 @@ services:
 		Version:     model.TranslationVersion,
 		Deployment:  d1,
 		Rules:       []*model.TranslationRule{rule1},
-		Annotations: map[string]string{"key": "value"},
+		Annotations: model.Annotations{"key": "value"},
 		Tolerations: []apiv1.Toleration{
 			{
 				Key:      "nvidia/cpu",
@@ -315,7 +315,7 @@ services:
 		Version:     model.TranslationVersion,
 		Deployment:  d2,
 		Rules:       []*model.TranslationRule{rule2},
-		Annotations: map[string]string{"key": "value"},
+		Annotations: model.Annotations{"key": "value"},
 		Tolerations: []apiv1.Toleration{
 			{
 				Key:      "nvidia/cpu",

--- a/pkg/k8s/deployments/utils_test.go
+++ b/pkg/k8s/deployments/utils_test.go
@@ -91,7 +91,7 @@ func Test_getPreviousDeploymentReplicas(t *testing.T) {
 			name: "sleeping-state-ok",
 			d: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
+					Annotations: model.Annotations{
 						okLabels.StateBeforeSleepingAnnontation: "{\"Replicas\":3}",
 					},
 				},
@@ -105,7 +105,7 @@ func Test_getPreviousDeploymentReplicas(t *testing.T) {
 			name: "sleeping-state-ko",
 			d: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
+					Annotations: model.Annotations{
 						okLabels.StateBeforeSleepingAnnontation: "wrong",
 					},
 				},

--- a/pkg/k8s/services/translate.go
+++ b/pkg/k8s/services/translate.go
@@ -26,7 +26,7 @@ const (
 )
 
 func translate(dev *model.Dev) *apiv1.Service {
-	annotations := map[string]string{}
+	annotations := model.Annotations{}
 	if len(dev.Services) == 0 {
 		annotations[oktetoAutoIngressAnnotation] = "true"
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -127,7 +127,7 @@ type Dev struct {
 	Image                *BuildInfo            `json:"image,omitempty" yaml:"image,omitempty"`
 	Push                 *BuildInfo            `json:"-" yaml:"push,omitempty"`
 	ImagePullPolicy      apiv1.PullPolicy      `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
-	Environment          Environments          `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Environment          Environment           `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Secrets              []Secret              `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 	Command              Command               `json:"command,omitempty" yaml:"command,omitempty"`
 	Healthchecks         bool                  `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
@@ -170,12 +170,12 @@ type Args struct {
 
 // BuildInfo represents the build info to generate an image
 type BuildInfo struct {
-	Name       string       `yaml:"name,omitempty"`
-	Context    string       `yaml:"context,omitempty"`
-	Dockerfile string       `yaml:"dockerfile,omitempty"`
-	CacheFrom  []string     `yaml:"cache_from,omitempty"`
-	Target     string       `yaml:"target,omitempty"`
-	Args       Environments `yaml:"args,omitempty"`
+	Name       string      `yaml:"name,omitempty"`
+	Context    string      `yaml:"context,omitempty"`
+	Dockerfile string      `yaml:"dockerfile,omitempty"`
+	CacheFrom  []string    `yaml:"cache_from,omitempty"`
+	Target     string      `yaml:"target,omitempty"`
+	Args       Environment `yaml:"args,omitempty"`
 }
 
 // Volume represents a volume in the development container
@@ -275,7 +275,7 @@ type Labels map[string]string
 type Annotations map[string]string
 
 // Environment is a list of environment variables (key, value pairs).
-type Environments []EnvVar
+type Environment []EnvVar
 
 //Get returns a Dev object from a given file
 func Get(devPath string) (*Dev, error) {
@@ -311,7 +311,7 @@ func Read(bytes []byte) (*Dev, error) {
 	dev := &Dev{
 		Image:       &BuildInfo{},
 		Push:        &BuildInfo{},
-		Environment: make(Environments, 0),
+		Environment: make(Environment, 0),
 		Secrets:     make([]Secret, 0),
 		Forward:     make([]Forward, 0),
 		Volumes:     make([]Volume, 0),
@@ -741,7 +741,7 @@ func (dev *Dev) Save(path string) error {
 }
 
 //SerializeBuildArgs returns build  aaargs as a llist of strings
-func SerializeBuildArgs(buildArgs Environments) []string {
+func SerializeBuildArgs(buildArgs Environment) []string {
 	result := []string{}
 	for _, e := range buildArgs {
 		result = append(

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -127,7 +127,7 @@ type Dev struct {
 	Image                *BuildInfo            `json:"image,omitempty" yaml:"image,omitempty"`
 	Push                 *BuildInfo            `json:"-" yaml:"push,omitempty"`
 	ImagePullPolicy      apiv1.PullPolicy      `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
-	Environment          []EnvVar              `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Environment          Environments          `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Secrets              []Secret              `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 	Command              Command               `json:"command,omitempty" yaml:"command,omitempty"`
 	Healthchecks         bool                  `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
@@ -170,12 +170,12 @@ type Args struct {
 
 // BuildInfo represents the build info to generate an image
 type BuildInfo struct {
-	Name       string   `yaml:"name,omitempty"`
-	Context    string   `yaml:"context,omitempty"`
-	Dockerfile string   `yaml:"dockerfile,omitempty"`
-	CacheFrom  []string `yaml:"cache_from,omitempty"`
-	Target     string   `yaml:"target,omitempty"`
-	Args       []EnvVar `yaml:"args,omitempty"`
+	Name       string       `yaml:"name,omitempty"`
+	Context    string       `yaml:"context,omitempty"`
+	Dockerfile string       `yaml:"dockerfile,omitempty"`
+	CacheFrom  []string     `yaml:"cache_from,omitempty"`
+	Target     string       `yaml:"target,omitempty"`
+	Args       Environments `yaml:"args,omitempty"`
 }
 
 // Volume represents a volume in the development container
@@ -271,8 +271,11 @@ type ResourceList map[apiv1.ResourceName]resource.Quantity
 // Labels is a set of (key, value) pairs.
 type Labels map[string]string
 
-// Labels is a set of (key, value) pairs.
+// Annotations is a set of (key, value) pairs.
 type Annotations map[string]string
+
+// Environment is a list of environment variables (key, value pairs).
+type Environments []EnvVar
 
 //Get returns a Dev object from a given file
 func Get(devPath string) (*Dev, error) {
@@ -308,7 +311,7 @@ func Read(bytes []byte) (*Dev, error) {
 	dev := &Dev{
 		Image:       &BuildInfo{},
 		Push:        &BuildInfo{},
-		Environment: make([]EnvVar, 0),
+		Environment: make(Environments, 0),
 		Secrets:     make([]Secret, 0),
 		Forward:     make([]Forward, 0),
 		Volumes:     make([]Volume, 0),
@@ -738,7 +741,7 @@ func (dev *Dev) Save(path string) error {
 }
 
 //SerializeBuildArgs returns build  aaargs as a llist of strings
-func SerializeBuildArgs(buildArgs []EnvVar) []string {
+func SerializeBuildArgs(buildArgs Environments) []string {
 	result := []string{}
 	for _, e := range buildArgs {
 		result = append(

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -117,7 +117,7 @@ var (
 type Dev struct {
 	Name                 string                `json:"name" yaml:"name"`
 	Autocreate           bool                  `json:"autocreate,omitempty" yaml:"autocreate,omitempty"`
-	Labels               map[string]string     `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Labels               Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations          map[string]string     `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Tolerations          []apiv1.Toleration    `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
 	Context              string                `json:"context,omitempty" yaml:"context,omitempty"`
@@ -267,6 +267,9 @@ type Probes struct {
 
 // ResourceList is a set of (resource name, quantity) pairs.
 type ResourceList map[apiv1.ResourceName]resource.Quantity
+
+// Labels is a set of (key, value) pairs.
+type Labels map[string]string
 
 //Get returns a Dev object from a given file
 func Get(devPath string) (*Dev, error) {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -118,7 +118,7 @@ type Dev struct {
 	Name                 string                `json:"name" yaml:"name"`
 	Autocreate           bool                  `json:"autocreate,omitempty" yaml:"autocreate,omitempty"`
 	Labels               Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations          map[string]string     `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Annotations          Annotations           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Tolerations          []apiv1.Toleration    `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
 	Context              string                `json:"context,omitempty" yaml:"context,omitempty"`
 	Namespace            string                `json:"namespace,omitempty" yaml:"namespace,omitempty"`
@@ -270,6 +270,9 @@ type ResourceList map[apiv1.ResourceName]resource.Quantity
 
 // Labels is a set of (key, value) pairs.
 type Labels map[string]string
+
+// Labels is a set of (key, value) pairs.
+type Annotations map[string]string
 
 //Get returns a Dev object from a given file
 func Get(devPath string) (*Dev, error) {
@@ -494,7 +497,7 @@ func (dev *Dev) setDefaults() error {
 		dev.Labels = map[string]string{}
 	}
 	if dev.Annotations == nil {
-		dev.Annotations = map[string]string{}
+		dev.Annotations = Annotations{}
 	}
 	if dev.Healthchecks {
 		log.Yellow("The use of 'healthchecks' field is deprecated and will be removed in a future release. Please use the field 'probes' instead.")
@@ -534,7 +537,7 @@ func (dev *Dev) setDefaults() error {
 			s.Labels = map[string]string{}
 		}
 		if s.Annotations == nil {
-			s.Annotations = map[string]string{}
+			s.Annotations = Annotations{}
 		}
 		if s.Name != "" && len(s.Labels) > 0 {
 			return fmt.Errorf("'name' and 'labels' cannot be defined at the same time for service '%s'", s.Name)
@@ -749,7 +752,7 @@ func SerializeBuildArgs(buildArgs []EnvVar) []string {
 //SetLastBuiltAnnotation sets the dev timestacmp
 func (dev *Dev) SetLastBuiltAnnotation() {
 	if dev.Annotations == nil {
-		dev.Annotations = map[string]string{}
+		dev.Annotations = Annotations{}
 	}
 	dev.Annotations[labels.LastBuiltAnnotation] = time.Now().UTC().Format(labels.TimeFormat)
 }
@@ -923,7 +926,7 @@ func (dev *Dev) GevSandbox() *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dev.Name,
 			Namespace: dev.Namespace,
-			Annotations: map[string]string{
+			Annotations: Annotations{
 				OktetoAutoCreateAnnotation: OktetoUpCmd,
 			},
 		},

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -357,9 +357,10 @@ func Test_loadLabels(t *testing.T) {
 			dev := &Dev{Labels: tt.labels}
 			os.Setenv("value", tt.value)
 			dev.loadLabels()
-
-			if !reflect.DeepEqual(tt.want, dev.Labels) {
-				t.Errorf("got: '%v', expected: '%v'", dev.Labels, tt.want)
+			for key, value := range dev.Labels {
+				if tt.want[key] != value {
+					t.Errorf("got: '%v', expected: '%v'", dev.Labels, tt.want)
+				}
 			}
 		})
 	}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -33,6 +33,8 @@ command: ["uwsgi"]
 annotations:
   key1: value1
   key2: value2
+labels:
+  key3: value3
 resources:
   requests:
     memory: "64Mi"
@@ -326,27 +328,27 @@ services:
 func Test_loadLabels(t *testing.T) {
 	tests := []struct {
 		name   string
-		labels map[string]string
+		labels Labels
 		value  string
-		want   map[string]string
+		want   Labels
 	}{
 		{
 			name:   "no-var",
-			labels: map[string]string{"a": "1", "b": "2"},
+			labels: Labels{"a": "1", "b": "2"},
 			value:  "3",
-			want:   map[string]string{"a": "1", "b": "2"},
+			want:   Labels{"a": "1", "b": "2"},
 		},
 		{
 			name:   "var",
-			labels: map[string]string{"a": "1", "b": "${value}"},
+			labels: Labels{"a": "1", "b": "${value}"},
 			value:  "3",
-			want:   map[string]string{"a": "1", "b": "3"},
+			want:   Labels{"a": "1", "b": "3"},
 		},
 		{
 			name:   "missing",
-			labels: map[string]string{"a": "1", "b": "${valueX}"},
+			labels: Labels{"a": "1", "b": "${valueX}"},
 			value:  "1",
-			want:   map[string]string{"a": "1", "b": ""},
+			want:   Labels{"a": "1", "b": ""},
 		},
 	}
 

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -154,7 +154,7 @@ func Test_LoadDevDefaults(t *testing.T) {
 	var tests = []struct {
 		name                string
 		manifest            []byte
-		expectedEnvironment Environments
+		expectedEnvironment Environment
 		expectedForward     []Forward
 	}{
 		{
@@ -162,7 +162,7 @@ func Test_LoadDevDefaults(t *testing.T) {
 			[]byte(`name: service
 container: core
 workdir: /app`),
-			Environments{},
+			Environment{},
 			[]Forward{},
 		},
 		{
@@ -170,7 +170,7 @@ workdir: /app`),
 			[]byte(`name: service
 container: core
 workdir: /app`),
-			Environments{},
+			Environment{},
 			[]Forward{},
 		},
 		{
@@ -181,7 +181,7 @@ workdir: /app
 environment:
   - ENV=production
   - name=test-node`),
-			Environments{
+			Environment{
 				{Name: "ENV", Value: "production"},
 				{Name: "name", Value: "test-node"},
 			},
@@ -195,7 +195,7 @@ workdir: /app
 forward:
   - 9000:8000
   - 9001:8001`),
-			Environments{},
+			Environment{},
 			[]Forward{
 				{Local: 9000, Remote: 8000, Service: false, ServiceName: ""},
 				{Local: 9001, Remote: 8001, Service: false, ServiceName: ""},

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -154,7 +154,7 @@ func Test_LoadDevDefaults(t *testing.T) {
 	var tests = []struct {
 		name                string
 		manifest            []byte
-		expectedEnvironment []EnvVar
+		expectedEnvironment Environments
 		expectedForward     []Forward
 	}{
 		{
@@ -162,7 +162,7 @@ func Test_LoadDevDefaults(t *testing.T) {
 			[]byte(`name: service
 container: core
 workdir: /app`),
-			[]EnvVar{},
+			Environments{},
 			[]Forward{},
 		},
 		{
@@ -170,7 +170,7 @@ workdir: /app`),
 			[]byte(`name: service
 container: core
 workdir: /app`),
-			[]EnvVar{},
+			Environments{},
 			[]Forward{},
 		},
 		{
@@ -181,7 +181,7 @@ workdir: /app
 environment:
   - ENV=production
   - name=test-node`),
-			[]EnvVar{
+			Environments{
 				{Name: "ENV", Value: "production"},
 				{Name: "name", Value: "test-node"},
 			},
@@ -195,7 +195,7 @@ workdir: /app
 forward:
   - 9000:8000
   - 9001:8001`),
-			[]EnvVar{},
+			Environments{},
 			[]Forward{
 				{Local: 9000, Remote: 8000, Service: false, ServiceName: ""},
 				{Local: 9001, Remote: 8001, Service: false, ServiceName: ""},

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -26,12 +26,12 @@ import (
 
 // BuildInfoRaw represents the build info for serialization
 type buildInfoRaw struct {
-	Name       string   `yaml:"name,omitempty"`
-	Context    string   `yaml:"context,omitempty"`
-	Dockerfile string   `yaml:"dockerfile,omitempty"`
-	CacheFrom  []string `yaml:"cache_from,omitempty"`
-	Target     string   `yaml:"target,omitempty"`
-	Args       []EnvVar `yaml:"args,omitempty"`
+	Name       string       `yaml:"name,omitempty"`
+	Context    string       `yaml:"context,omitempty"`
+	Dockerfile string       `yaml:"dockerfile,omitempty"`
+	CacheFrom  []string     `yaml:"cache_from,omitempty"`
+	Target     string       `yaml:"target,omitempty"`
+	Args       Environments `yaml:"args,omitempty"`
 }
 
 type syncRaw struct {
@@ -591,6 +591,19 @@ func (a *Annotations) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		annotations[key] = value
 	}
 	*a = annotations
+	return nil
+}
+
+func (e *Environments) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	envs := make(Environments, 0)
+	result, err := getKeyValue(unmarshal)
+	if err != nil {
+		return err
+	}
+	for key, value := range result {
+		envs = append(envs, EnvVar{Name: key, Value: value})
+	}
+	*e = envs
 	return nil
 }
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -581,6 +581,19 @@ func (l *Labels) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+func (a *Annotations) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	annotations := make(Annotations)
+	result, err := getKeyValue(unmarshal)
+	if err != nil {
+		return err
+	}
+	for key, value := range result {
+		annotations[key] = value
+	}
+	*a = annotations
+	return nil
+}
+
 func getKeyValue(unmarshal func(interface{}) error) (map[string]string, error) {
 	result := make(map[string]string)
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -26,12 +26,12 @@ import (
 
 // BuildInfoRaw represents the build info for serialization
 type buildInfoRaw struct {
-	Name       string       `yaml:"name,omitempty"`
-	Context    string       `yaml:"context,omitempty"`
-	Dockerfile string       `yaml:"dockerfile,omitempty"`
-	CacheFrom  []string     `yaml:"cache_from,omitempty"`
-	Target     string       `yaml:"target,omitempty"`
-	Args       Environments `yaml:"args,omitempty"`
+	Name       string      `yaml:"name,omitempty"`
+	Context    string      `yaml:"context,omitempty"`
+	Dockerfile string      `yaml:"dockerfile,omitempty"`
+	CacheFrom  []string    `yaml:"cache_from,omitempty"`
+	Target     string      `yaml:"target,omitempty"`
+	Args       Environment `yaml:"args,omitempty"`
 }
 
 type syncRaw struct {
@@ -594,8 +594,8 @@ func (a *Annotations) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (e *Environments) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	envs := make(Environments, 0)
+func (e *Environment) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	envs := make(Environment, 0)
 	result, err := getKeyValue(unmarshal)
 	if err != nil {
 		return err

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -52,15 +52,15 @@ type Service struct {
 	Command    Command            `yaml:"command,omitempty"`
 	EnvFiles   []string           `yaml:"env_file,omitempty"`
 
-	Environment     []EnvVar          `yaml:"environment,omitempty"`
-	Expose          []int32           `yaml:"expose,omitempty"`
-	Image           string            `yaml:"image,omitempty"`
-	Labels          Labels            `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Ports           []Port            `yaml:"ports,omitempty"`
-	StopGracePeriod int64             `yaml:"stop_grace_period,omitempty"`
-	Volumes         []StackVolume     `yaml:"volumes,omitempty"`
-	WorkingDir      string            `yaml:"working_dir,omitempty"`
+	Environment     []EnvVar      `yaml:"environment,omitempty"`
+	Expose          []int32       `yaml:"expose,omitempty"`
+	Image           string        `yaml:"image,omitempty"`
+	Labels          Labels        `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations     Annotations   `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Ports           []Port        `yaml:"ports,omitempty"`
+	StopGracePeriod int64         `yaml:"stop_grace_period,omitempty"`
+	Volumes         []StackVolume `yaml:"volumes,omitempty"`
+	WorkingDir      string        `yaml:"working_dir,omitempty"`
 
 	Public    bool            `yaml:"public,omitempty"`
 	Replicas  int32           `yaml:"replicas,omitempty"`
@@ -107,9 +107,9 @@ type Port struct {
 
 //Endpoints represents an okteto stack ingress
 type Endpoint struct {
-	Labels      Labels            `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Rules       []EndpointRule    `yaml:"rules,omitempty"`
+	Labels      Labels         `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations Annotations    `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Rules       []EndpointRule `yaml:"rules,omitempty"`
 }
 
 // EndpointRule represents an okteto ingress rule
@@ -319,7 +319,7 @@ func (s *Stack) GetConfigMapName() string {
 //SetLastBuiltAnnotation sets the dev timestamp
 func (svc *Service) SetLastBuiltAnnotation() {
 	if svc.Annotations == nil {
-		svc.Annotations = map[string]string{}
+		svc.Annotations = Annotations{}
 	}
 	svc.Annotations[labels.LastBuiltAnnotation] = time.Now().UTC().Format(labels.TimeFormat)
 }

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -52,7 +52,7 @@ type Service struct {
 	Command    Command            `yaml:"command,omitempty"`
 	EnvFiles   []string           `yaml:"env_file,omitempty"`
 
-	Environment     []EnvVar      `yaml:"environment,omitempty"`
+	Environment     Environments  `yaml:"environment,omitempty"`
 	Expose          []int32       `yaml:"expose,omitempty"`
 	Image           string        `yaml:"image,omitempty"`
 	Labels          Labels        `json:"labels,omitempty" yaml:"labels,omitempty"`
@@ -73,7 +73,7 @@ type StackVolume struct {
 }
 
 type Envs struct {
-	List []EnvVar
+	List Environments
 }
 
 //StackResources represents an okteto stack resources

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -55,7 +55,7 @@ type Service struct {
 	Environment     []EnvVar          `yaml:"environment,omitempty"`
 	Expose          []int32           `yaml:"expose,omitempty"`
 	Image           string            `yaml:"image,omitempty"`
-	Labels          map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Labels          Labels            `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations     map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Ports           []Port            `yaml:"ports,omitempty"`
 	StopGracePeriod int64             `yaml:"stop_grace_period,omitempty"`
@@ -107,7 +107,7 @@ type Port struct {
 
 //Endpoints represents an okteto stack ingress
 type Endpoint struct {
-	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Labels      Labels            `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Rules       []EndpointRule    `yaml:"rules,omitempty"`
 }

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -52,7 +52,7 @@ type Service struct {
 	Command    Command            `yaml:"command,omitempty"`
 	EnvFiles   []string           `yaml:"env_file,omitempty"`
 
-	Environment     Environments  `yaml:"environment,omitempty"`
+	Environment     Environment   `yaml:"environment,omitempty"`
 	Expose          []int32       `yaml:"expose,omitempty"`
 	Image           string        `yaml:"image,omitempty"`
 	Labels          Labels        `json:"labels,omitempty" yaml:"labels,omitempty"`
@@ -73,7 +73,7 @@ type StackVolume struct {
 }
 
 type Envs struct {
-	List Environments
+	List Environment
 }
 
 //StackResources represents an okteto stack resources

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -56,7 +56,7 @@ type ServiceRaw struct {
 	Expose                   *RawMessage        `yaml:"expose,omitempty"`
 	Image                    string             `yaml:"image,omitempty"`
 	Labels                   Labels             `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations              map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Annotations              Annotations        `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Ports                    []PortRaw          `yaml:"ports,omitempty"`
 	Scale                    int32              `yaml:"scale"`
 	StopGracePeriodSneakCase *RawMessage        `yaml:"stop_grace_period,omitempty"`
@@ -269,11 +269,6 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, isCompose bool) (*Servic
 	s.Labels = serviceRaw.Labels
 
 	s.Annotations = serviceRaw.Annotations
-	for key, annotation := range serviceRaw.Annotations {
-		if _, ok := s.Annotations[key]; !ok {
-			s.Annotations[key] = annotation
-		}
-	}
 
 	s.StopGracePeriod, err = unmarshalDuration(serviceRaw.StopGracePeriod)
 	if err != nil {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -55,7 +55,7 @@ type ServiceRaw struct {
 	Environment              *RawMessage        `yaml:"environment,omitempty"`
 	Expose                   *RawMessage        `yaml:"expose,omitempty"`
 	Image                    string             `yaml:"image,omitempty"`
-	Labels                   *RawMessage        `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Labels                   Labels             `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations              map[string]string  `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	Ports                    []PortRaw          `yaml:"ports,omitempty"`
 	Scale                    int32              `yaml:"scale"`
@@ -266,10 +266,7 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, isCompose bool) (*Servic
 		return nil, err
 	}
 
-	s.Labels, err = unmarshalLabels(serviceRaw.Labels)
-	if err != nil {
-		return nil, err
-	}
+	s.Labels = serviceRaw.Labels
 
 	s.Annotations = serviceRaw.Annotations
 	for key, annotation := range serviceRaw.Annotations {
@@ -485,36 +482,6 @@ func unmarshalEnvs(raw *RawMessage) ([]EnvVar, error) {
 	}
 
 	return envList, err
-}
-
-func unmarshalLabels(raw *RawMessage) (map[string]string, error) {
-	envMap := make(map[string]string)
-	if raw == nil {
-		return envMap, nil
-	}
-	err := raw.unmarshal(&envMap)
-	if err == nil {
-		return envMap, nil
-	}
-	var envList []string
-	err = raw.unmarshal(&envList)
-	if err == nil {
-		for _, env := range envList {
-			if strings.Contains(env, "=") {
-				splittedEnv := strings.Split(env, "=")
-				if len(splittedEnv) == 2 {
-					envMap[splittedEnv[0]] = splittedEnv[1]
-				} else {
-					return envMap, fmt.Errorf("Environment variable malformed: %s.", env)
-				}
-			} else {
-				envMap[env] = ""
-			}
-		}
-		return envMap, nil
-	}
-
-	return envMap, err
 }
 
 func unmarshalDuration(raw *RawMessage) (int64, error) {

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -38,7 +38,7 @@ type TranslationRule struct {
 	Container         string               `json:"container,omitempty"`
 	Image             string               `json:"image,omitempty"`
 	ImagePullPolicy   apiv1.PullPolicy     `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
-	Environment       []EnvVar             `json:"environment,omitempty"`
+	Environment       Environments         `json:"environment,omitempty"`
 	Secrets           []Secret             `json:"secrets,omitempty"`
 	Command           []string             `json:"command,omitempty"`
 	Args              []string             `json:"args,omitempty"`

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -38,7 +38,7 @@ type TranslationRule struct {
 	Container         string               `json:"container,omitempty"`
 	Image             string               `json:"image,omitempty"`
 	ImagePullPolicy   apiv1.PullPolicy     `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
-	Environment       Environments         `json:"environment,omitempty"`
+	Environment       Environment          `json:"environment,omitempty"`
 	Secrets           []Secret             `json:"secrets,omitempty"`
 	Command           []string             `json:"command,omitempty"`
 	Args              []string             `json:"args,omitempty"`

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -24,7 +24,7 @@ type Translation struct {
 	Name        string             `json:"name"`
 	Version     string             `json:"version"`
 	Deployment  *appsv1.Deployment `json:"-"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
+	Annotations Annotations        `json:"annotations,omitempty"`
 	Tolerations []apiv1.Toleration `json:"tolerations,omitempty"`
 	Replicas    int32              `json:"replicas"`
 	Rules       []*TranslationRule `json:"rules"`

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -63,7 +63,7 @@ services:
 		Command:           []string{"/var/okteto/bin/start.sh"},
 		Args:              []string{"-r"},
 		Probes:            &Probes{},
-		Environment: Environments{
+		Environment: Environment{
 			{
 				Name:  "OKTETO_NAMESPACE",
 				Value: "n",
@@ -131,7 +131,7 @@ services:
 		Args:            nil,
 		Healthchecks:    true,
 		Probes:          &Probes{Readiness: true, Liveness: true, Startup: true},
-		Environment:     make(Environments, 0),
+		Environment:     make(Environment, 0),
 		SecurityContext: &SecurityContext{
 			RunAsUser:  &rootUser,
 			RunAsGroup: &rootUser,
@@ -162,7 +162,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 	tests := []struct {
 		name     string
 		manifest *Dev
-		expected Environments
+		expected Environment
 	}{
 		{
 			name: "default",
@@ -170,7 +170,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				Image:         &BuildInfo{},
 				SSHServerPort: oktetoDefaultSSHServerPort,
 			},
-			expected: Environments{
+			expected: Environment{
 				{Name: "OKTETO_NAMESPACE", Value: ""},
 				{Name: "OKTETO_NAME", Value: ""},
 			},
@@ -181,7 +181,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				Image:         &BuildInfo{},
 				SSHServerPort: 22220,
 			},
-			expected: Environments{
+			expected: Environment{
 				{Name: "OKTETO_NAMESPACE", Value: ""},
 				{Name: "OKTETO_NAME", Value: ""},
 				{Name: oktetoSSHServerPortVariable, Value: "22220"},

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -63,7 +63,7 @@ services:
 		Command:           []string{"/var/okteto/bin/start.sh"},
 		Args:              []string{"-r"},
 		Probes:            &Probes{},
-		Environment: []EnvVar{
+		Environment: Environments{
 			{
 				Name:  "OKTETO_NAMESPACE",
 				Value: "n",
@@ -131,7 +131,7 @@ services:
 		Args:            nil,
 		Healthchecks:    true,
 		Probes:          &Probes{Readiness: true, Liveness: true, Startup: true},
-		Environment:     make([]EnvVar, 0),
+		Environment:     make(Environments, 0),
 		SecurityContext: &SecurityContext{
 			RunAsUser:  &rootUser,
 			RunAsGroup: &rootUser,
@@ -162,7 +162,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 	tests := []struct {
 		name     string
 		manifest *Dev
-		expected []EnvVar
+		expected Environments
 	}{
 		{
 			name: "default",
@@ -170,7 +170,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				Image:         &BuildInfo{},
 				SSHServerPort: oktetoDefaultSSHServerPort,
 			},
-			expected: []EnvVar{
+			expected: Environments{
 				{Name: "OKTETO_NAMESPACE", Value: ""},
 				{Name: "OKTETO_NAME", Value: ""},
 			},
@@ -181,7 +181,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				Image:         &BuildInfo{},
 				SSHServerPort: 22220,
 			},
-			expected: []EnvVar{
+			expected: Environments{
 				{Name: "OKTETO_NAMESPACE", Value: ""},
 				{Name: "OKTETO_NAME", Value: ""},
 				{Name: oktetoSSHServerPortVariable, Value: "22220"},


### PR DESCRIPTION
Fixes #1415

## Proposed changes
-  Now these three fields works in the same way when unmarshalling them.
-  They can accept map and list syntax.
-  When unmarshalling you can use env vars as key or value
