### PR TITLE
Split command and entrypoint without "sh -c"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-getter v1.5.0
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/machinebox/graphql v0.2.2
 	github.com/manifoldco/promptui v0.3.2
 	github.com/matryer/is v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -795,6 +795,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kballard/go-shellquote"
 	"github.com/okteto/okteto/pkg/log"
 	apiv1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
@@ -95,10 +96,9 @@ func (e *Entrypoint) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(single, " ") {
-			e.Values = []string{"sh", "-c", single}
-		} else {
-			e.Values = []string{single}
+		e.Values, err = shellquote.Split(single)
+		if err != nil {
+			return err
 		}
 	} else {
 		e.Values = multi
@@ -124,10 +124,9 @@ func (c *Command) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(single, " ") {
-			c.Values = []string{"sh", "-c", single}
-		} else {
-			c.Values = []string{single}
+		c.Values, err = shellquote.Split(single)
+		if err != nil {
+			return err
 		}
 	} else {
 		c.Values = multi
@@ -153,7 +152,10 @@ func (a *Args) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		a.Values = []string{single}
+		a.Values, err = shellquote.Split(single)
+		if err != nil {
+			return err
+		}
 	} else {
 		a.Values = multi
 	}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -96,9 +96,13 @@ func (e *Entrypoint) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		e.Values, err = shellquote.Split(single)
-		if err != nil {
-			return err
+		if strings.Contains(single, " && ") {
+			e.Values = []string{"sh", "-c", single}
+		} else {
+			e.Values, err = shellquote.Split(single)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		e.Values = multi
@@ -124,9 +128,13 @@ func (c *Command) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		c.Values, err = shellquote.Split(single)
-		if err != nil {
-			return err
+		if strings.Contains(single, " && ") {
+			c.Values = []string{"sh", "-c", single}
+		} else {
+			c.Values, err = shellquote.Split(single)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		c.Values = multi
@@ -152,9 +160,13 @@ func (a *Args) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		a.Values, err = shellquote.Split(single)
-		if err != nil {
-			return err
+		if strings.Contains(single, " && ") {
+			a.Values = []string{"sh", "-c", single}
+		} else {
+			a.Values, err = shellquote.Split(single)
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		a.Values = multi

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -184,7 +184,7 @@ func TestCommandUnmashalling(t *testing.T) {
 		{
 			"single-space",
 			[]byte("start.sh arg"),
-			Command{Values: []string{"sh", "-c", "start.sh arg"}},
+			Command{Values: []string{"start.sh", "arg"}},
 		},
 		{
 			"multiple",

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -187,6 +187,11 @@ func TestCommandUnmashalling(t *testing.T) {
 			Command{Values: []string{"start.sh", "arg"}},
 		},
 		{
+			"double-command",
+			[]byte("mkdir myproject && cd myproject"),
+			Command{Values: []string{"sh", "-c", "mkdir myproject && cd myproject"}},
+		},
+		{
 			"multiple",
 			[]byte("['yarn', 'install']"),
 			Command{Values: []string{"yarn", "install"}},

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -112,6 +112,11 @@ type Endpoint struct {
 	Rules       []EndpointRule `yaml:"rules,omitempty"`
 }
 
+//Endpoints represents an okteto stack command
+type CommandStack struct {
+	Values []string
+}
+
 // EndpointRule represents an okteto ingress rule
 type EndpointRule struct {
 	Path    string `yaml:"path,omitempty"`

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kballard/go-shellquote"
 	apiv1 "k8s.io/api/core/v1"
 )
 
@@ -48,7 +49,7 @@ type ServiceRaw struct {
 	CapDropSneakCase         []apiv1.Capability `yaml:"cap_drop,omitempty"`
 	CapDrop                  []apiv1.Capability `yaml:"capDrop,omitempty"`
 	Command                  Args               `yaml:"command,omitempty"`
-	Entrypoint               Command            `yaml:"entrypoint,omitempty"`
+	Entrypoint               CommandStack       `yaml:"entrypoint,omitempty"`
 	Args                     Args               `yaml:"args,omitempty"`
 	EnvFilesSneakCase        []string           `yaml:"env_file,omitempty"`
 	EnvFiles                 []string           `yaml:"envFile,omitempty"`
@@ -820,4 +821,28 @@ func getDeployNotSupportedFields(svcName string, deploy *DeployInfoRaw) []string
 	}
 
 	return notSupported
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (c *CommandStack) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err != nil {
+		var single string
+		err := unmarshal(&single)
+		if err != nil {
+			return err
+		}
+		if strings.Contains(single, " && ") {
+			c.Values = []string{"sh", "-c", single}
+		} else {
+			c.Values, err = shellquote.Split(single)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		c.Values = multi
+	}
+	return nil
 }

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -74,11 +74,11 @@ services:
 	if s.Services["vote"].Build.Context != "vote" {
 		t.Errorf("'vote.build' was not parsed: %+v", s.Services["vote"].Build)
 	}
-	if len(s.Services["vote"].Entrypoint.Values) != 3 {
-		t.Errorf("'vote.entrypoint' was not parsed: %+v", s)
+	if len(s.Services["vote"].Entrypoint.Values) != 2 {
+		t.Errorf("'vote.entrypoint' was not parsed: %+v", s.Services["vote"].Entrypoint.Values)
 	}
-	if s.Services["vote"].Entrypoint.Values[0] != "sh" || s.Services["vote"].Entrypoint.Values[1] != "-c" || s.Services["vote"].Entrypoint.Values[2] != "python app.py" {
-		t.Errorf("'vote.entrypoint' was not parsed: %+v", s)
+	if s.Services["vote"].Entrypoint.Values[0] != "python" && s.Services["vote"].Entrypoint.Values[0] != "app.py" {
+		t.Errorf("'vote.entrypoint' was not parsed: %+v", s.Services["vote"].Entrypoint.Values)
 	}
 	if s.Services["vote"].Replicas != 2 {
 		t.Errorf("'vote.deploy.replicas' was not parsed: %+v", s)
@@ -211,11 +211,11 @@ services:
 	if s.Services["vote"].Build.Context != "vote" {
 		t.Errorf("'vote.build' was not parsed: %+v", s.Services["vote"].Build)
 	}
-	if len(s.Services["vote"].Entrypoint.Values) != 3 {
-		t.Errorf("'vote.entrypoint' was not parsed: %+v", s)
+	if len(s.Services["vote"].Entrypoint.Values) != 2 {
+		t.Errorf("'vote.entrypoint' was not parsed: %+v", s.Services["vote"].Entrypoint.Values)
 	}
-	if s.Services["vote"].Entrypoint.Values[0] != "sh" || s.Services["vote"].Entrypoint.Values[1] != "-c" || s.Services["vote"].Entrypoint.Values[2] != "python app.py" {
-		t.Errorf("'vote.entrypoint' was not parsed: %+v", s)
+	if s.Services["vote"].Entrypoint.Values[0] != "python" && s.Services["vote"].Entrypoint.Values[0] != "app.py" {
+		t.Errorf("'vote.entrypoint' was not parsed: %+v", s.Services["vote"].Entrypoint.Values)
 	}
 	if s.Services["vote"].Replicas != 2 {
 		t.Errorf("'vote.deploy.replicas' was not parsed: %+v", s)


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1441 

## Proposed changes
- Split entrypoint, command and args instead of using the prefix "sh -c"
