### PR TITLE
Add support for single env file

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -277,6 +277,9 @@ type Annotations map[string]string
 // Environment is a list of environment variables (key, value pairs).
 type Environment []EnvVar
 
+// EnvFiles is a list of environment files
+type EnvFiles []string
+
 //Get returns a Dev object from a given file
 func Get(devPath string) (*Dev, error) {
 	b, err := ioutil.ReadFile(devPath)

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -632,3 +632,24 @@ func getKeyValue(unmarshal func(interface{}) error) (map[string]string, error) {
 	}
 	return result, nil
 }
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (envFiles *EnvFiles) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	result := make(EnvFiles, 0)
+	var single string
+	err := unmarshal(&single)
+	if err != nil {
+		var multi []string
+		err := unmarshal(&multi)
+		if err != nil {
+			return err
+		}
+		result = multi
+		*envFiles = result
+		return nil
+	}
+
+	result = append(result, single)
+	*envFiles = result
+	return nil
+}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -750,3 +750,36 @@ func TestAnnotationsUnmashalling(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvFileUnmashalling(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected EnvFiles
+	}{
+		{
+			"single value",
+			[]byte(`.env`),
+			EnvFiles{".env"},
+		},
+		{
+			"env files list",
+			[]byte("\n  - .env\n  - .env2"),
+			EnvFiles{".env", ".env2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := make(EnvFiles, 0)
+
+			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("didn't unmarshal correctly. Actual %+v, Expected %+v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -50,7 +50,7 @@ type Service struct {
 	CapDrop    []apiv1.Capability `yaml:"cap_drop,omitempty"`
 	Entrypoint Entrypoint         `yaml:"entrypoint,omitempty"`
 	Command    Command            `yaml:"command,omitempty"`
-	EnvFiles   []string           `yaml:"env_file,omitempty"`
+	EnvFiles   EnvFiles           `yaml:"env_file,omitempty"`
 
 	Environment     Environment   `yaml:"environment,omitempty"`
 	Expose          []int32       `yaml:"expose,omitempty"`

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -50,8 +50,8 @@ type ServiceRaw struct {
 	Command                  Args               `yaml:"command,omitempty"`
 	Entrypoint               Command            `yaml:"entrypoint,omitempty"`
 	Args                     Args               `yaml:"args,omitempty"`
-	EnvFilesSneakCase        []string           `yaml:"env_file,omitempty"`
-	EnvFiles                 []string           `yaml:"envFile,omitempty"`
+	EnvFilesSneakCase        EnvFiles           `yaml:"env_file,omitempty"`
+	EnvFiles                 EnvFiles           `yaml:"envFile,omitempty"`
 	Environment              *RawMessage        `yaml:"environment,omitempty"`
 	Expose                   *RawMessage        `yaml:"expose,omitempty"`
 	Image                    string             `yaml:"image,omitempty"`

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -584,3 +584,45 @@ func Test_restartFile(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateEnvFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest []byte
+		EnvFiles EnvFiles
+	}{
+		{
+			name:     "sneak case single file",
+			manifest: []byte("services:\n  app:\n    env_file: .env\n    public: true\n    image: okteto/vote:1"),
+			EnvFiles: EnvFiles{".env"},
+		},
+		{
+			name:     "sneak case list",
+			manifest: []byte("services:\n  app:\n    env_file:\n    - .env\n    - .env2\n    image: okteto/vote:1"),
+			EnvFiles: EnvFiles{".env", ".env2"},
+		},
+		{
+			name:     "camel case single file",
+			manifest: []byte("services:\n  app:\n    envFile: .env\n    image: okteto/vote:1"),
+			EnvFiles: EnvFiles{".env"},
+		},
+		{
+			name:     "camel case list",
+			manifest: []byte("services:\n  app:\n    envFile:\n    - .env\n    - .env2\n    image: okteto/vote:1"),
+			EnvFiles: EnvFiles{".env", ".env2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := ReadStack(tt.manifest, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if svc, ok := s.Services["app"]; ok {
+				if !reflect.DeepEqual(tt.EnvFiles, svc.EnvFiles) {
+					t.Fatalf("expected %v but got %v", tt.EnvFiles, svc.EnvFiles)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #

## Proposed changes
-  Adds support for using single notation for the env files
-  
