### PR TITLE
Upgrade remote dependency

### DIFF
--- a/images/bin/Dockerfile
+++ b/images/bin/Dockerfile
@@ -1,5 +1,5 @@
 FROM syncthing/syncthing:1.14.0 AS syncthing
-FROM okteto/remote:0.4.1 AS remote
+FROM okteto/remote:0.4.2 AS remote
 FROM okteto/supervisor:0.1.8 AS supervisor
 FROM okteto/clean:0.1.6 AS clean
 

--- a/images/bin/Makefile
+++ b/images/bin/Makefile
@@ -1,4 +1,4 @@
-tag = 1.2.26
+tag = 1.2.27
 
 .PHONY: push
 push:

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -96,7 +96,7 @@ const (
 
 var (
 	//OktetoBinImageTag image tag with okteto internal binaries
-	OktetoBinImageTag = "okteto/bin:1.2.26"
+	OktetoBinImageTag = "okteto/bin:1.2.27"
 
 	errBadName = fmt.Errorf("Invalid name: must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character")
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

This fixes an issue where the okteto terminal gets frozen after running `CTRL + D`