### PR TITLE
Simplify image name from registry

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -3,6 +3,7 @@ package up
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
@@ -310,7 +311,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context)
 			case "Killing":
 				return errors.ErrDevPodDeleted
 			case "Pulling":
-				message := strings.Replace(e.Message, "Pulling", "pulling", 1)
+				message := getPullingMessage(e.Message)
 				spinner.Update(fmt.Sprintf("%s...", message))
 				if err := config.UpdateStateFile(up.Dev, config.Pulling); err != nil {
 					log.Infof("error updating state: %s", err.Error())
@@ -339,4 +340,10 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context)
 			return ctx.Err()
 		}
 	}
+}
+
+func getPullingMessage(message string) string {
+	var oktetoRegistryRegex = regexp.MustCompile(`registry\..*\.okteto\.net\/.*\/`)
+	message = oktetoRegistryRegex.ReplaceAllString(message, "okteto.dev/")
+	return message
 }

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -100,3 +100,35 @@ func Test_printDisplayContext(t *testing.T) {
 	}
 
 }
+
+func TestPullingImageMessage(t *testing.T) {
+	var tests = []struct {
+		name     string
+		message  string
+		expected string
+	}{
+		{
+			name:     "normal image",
+			message:  "Pulling image \"alpine\"",
+			expected: "Pulling image \"alpine\"",
+		},
+		{
+			name:     "okteto registry image",
+			message:  "Pulling image \"registry.user.dev.okteto.net/user/api:fd12423adsae12\"",
+			expected: "Pulling image \"okteto.dev/api:fd12423adsae12\"",
+		},
+		{
+			name:     "okteto cloud image",
+			message:  "Pulling image \"registry.cloud.okteto.net/user/api:fd12423adsae12\"",
+			expected: "Pulling image \"okteto.dev/api:fd12423adsae12\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if message := getPullingMessage(tt.message); message != tt.expected {
+				t.Errorf("Expected '%s', but '%s' found", tt.expected, message)
+			}
+		})
+	}
+}

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -100,35 +100,3 @@ func Test_printDisplayContext(t *testing.T) {
 	}
 
 }
-
-func TestPullingImageMessage(t *testing.T) {
-	var tests = []struct {
-		name     string
-		message  string
-		expected string
-	}{
-		{
-			name:     "normal image",
-			message:  "Pulling image \"alpine\"",
-			expected: "Pulling image \"alpine\"",
-		},
-		{
-			name:     "okteto registry image",
-			message:  "Pulling image \"registry.user.dev.okteto.net/user/api:fd12423adsae12\"",
-			expected: "Pulling image \"okteto.dev/api:fd12423adsae12\"",
-		},
-		{
-			name:     "okteto cloud image",
-			message:  "Pulling image \"registry.cloud.okteto.net/user/api:fd12423adsae12\"",
-			expected: "Pulling image \"okteto.dev/api:fd12423adsae12\"",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if message := getPullingMessage(tt.message); message != tt.expected {
-				t.Errorf("Expected '%s', but '%s' found", tt.expected, message)
-			}
-		})
-	}
-}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #

## Proposed changes
-  When the image that is pulling comes from the Okteto Registry, show okteto.dev/{image name} instead of full name registry
