### PR TITLE
Add buildkit service unavailable error

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -144,6 +144,10 @@ func translateBuildImages(ctx context.Context, s *model.Stack, forceBuild, noCac
 		log.Information("Building image for service '%s'...", name)
 		buildArgs := model.SerializeBuildArgs(svc.Build.Args)
 		if err := build.Run(ctx, s.Namespace, buildKitHost, isOktetoCluster, svc.Build.Context, svc.Build.Dockerfile, svc.Image, svc.Build.Target, noCache, svc.Build.CacheFrom, buildArgs, nil, "tty"); err != nil {
+			if uErr, ok := err.(errors.UserError); ok {
+				uErr.E = fmt.Errorf("error building image for '%s': %s", name, uErr.E)
+				return uErr
+			}
 			return fmt.Errorf("error building image for '%s': %s", name, err)
 		}
 		svc.SetLastBuiltAnnotation()

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/okteto/okteto/pkg/errors"
+	okErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/namespaces"
 	"github.com/okteto/okteto/pkg/log"
@@ -119,11 +120,36 @@ func IsTransientError(err error) bool {
 
 	switch {
 	case strings.Contains(err.Error(), "failed commit on ref") && strings.Contains(err.Error(), "500 Internal Server Error"),
-		strings.Contains(err.Error(), "transport is closing"):
+		strings.Contains(err.Error(), "transport is closing") && strings.Contains(err.Error(), "connect: connection refused"):
 		return true
 	default:
 		return false
 	}
+}
+
+func GetErrorMessage(err error, tag string) error {
+	if err == nil {
+		return nil
+	}
+	imageRegistry, imageTag := GetRegistryAndRepo(tag)
+	switch {
+	case IsLoggedIntoRegistryButDontHavePermissions(err):
+		err = okErrors.UserError{
+			E:    fmt.Errorf("You are not authorized to push image '%s'.", imageTag),
+			Hint: fmt.Sprintf("Please login into the registry '%s' with a user with push permissions to '%s' or use another image.", imageRegistry, imageTag),
+		}
+	case IsNotLoggedIntoRegistry(err):
+		err = okErrors.UserError{
+			E:    fmt.Errorf("You are not authorized to push image '%s'.", imageTag),
+			Hint: fmt.Sprintf("Login into the registry '%s' and verify that you have permissions to push the image '%s'.", imageRegistry, imageTag),
+		}
+	case IsBuildkitServiceUnavailable(err):
+		err = okErrors.UserError{
+			E:    fmt.Errorf("Buildkit service is not available at the moment."),
+			Hint: fmt.Sprintf("Please try again later."),
+		}
+	}
+	return err
 }
 
 // IsLoggedIntoRegistryButDontHavePermissions returns true when the error is because the user is logged into the registry but doesn't have permissions to push the image
@@ -134,6 +160,10 @@ func IsLoggedIntoRegistryButDontHavePermissions(err error) bool {
 // IsNotLoggedIntoRegistry returns true when the error is because the user is not logged into the registry
 func IsNotLoggedIntoRegistry(err error) bool {
 	return strings.Contains(err.Error(), "failed to authorize: failed to fetch anonymous token")
+}
+
+func IsBuildkitServiceUnavailable(err error) bool {
+	return strings.Contains(err.Error(), "connect: connection refused") || strings.Contains(err.Error(), "500 Internal Server Error")
 }
 
 // SplitRegistryAndImage returns image tag and the registry to push the image


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1464

## Proposed changes
-  If buildkit service is unavailable, retry the connection, if the error persist returns an error to the user
-  Show verbose errors from buildkit
-  Show hints for the errors returned by buildkit
