### PR TITLE
Add exposed ports from images without exposed port

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -348,5 +348,5 @@ func getPullingMessage(message, namespace string) string {
 		return message
 	}
 	toReplace := fmt.Sprintf("%s/%s", registry, namespace)
-	return strings.Replace(message, toReplace, "okteto.dev", 1)
+	return strings.Replace(message, toReplace, okteto.DevRegistry, 1)
 }

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -50,7 +50,7 @@ func Deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool)
 		return err
 	}
 
-	addHiddenExposedPorts(s)
+	addHiddenExposedPorts(ctx, s)
 	if err := translate(ctx, s, forceBuild, noCache); err != nil {
 		return err
 	}
@@ -276,10 +276,10 @@ func DisplayWarnings(s *model.Stack) {
 	}
 }
 
-func addHiddenExposedPorts(s *model.Stack) {
+func addHiddenExposedPorts(ctx context.Context, s *model.Stack) {
 	for _, svc := range s.Services {
 		if svc.Image != "" {
-			exposedPorts := registry.GetHiddenExposePorts(svc.Image)
+			exposedPorts := registry.GetHiddenExposePorts(ctx, s.Namespace, svc.Image)
 			for _, port := range exposedPorts {
 				if !svc.IsAlreadyAdded(port) {
 					svc.Ports = append(svc.Ports, model.Port{Port: port, Protocol: apiv1.ProtocolTCP})

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -26,6 +26,7 @@ import (
 	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/subosito/gotenv"
 	appsv1 "k8s.io/api/apps/v1"
@@ -127,7 +128,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, forceBuild, noCac
 		if !isOktetoCluster && svc.Image == "" {
 			return fmt.Errorf("'build' and 'image' fields of service '%s' cannot be empty", name)
 		}
-		if isOktetoCluster && !strings.HasPrefix(svc.Image, "okteto.dev") {
+		if isOktetoCluster && !strings.HasPrefix(svc.Image, okteto.DevRegistry) {
 			svc.Image = fmt.Sprintf("okteto.dev/%s-%s:okteto", s.Name, name)
 		}
 		if !forceBuild {

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -341,14 +341,14 @@ func (svc *Service) SetLastBuiltAnnotation() {
 //extendPorts adds the ports that are in expose field to the port list.
 func (svc *Service) extendPorts() {
 	for _, port := range svc.Expose {
-		if !svc.isAlreadyAdded(port) {
+		if !svc.IsAlreadyAdded(port) {
 			svc.Ports = append(svc.Ports, Port{Port: port, Protocol: apiv1.ProtocolTCP})
 		}
 	}
 }
 
 //isAlreadyAdded checks if a port is already on port list
-func (svc *Service) isAlreadyAdded(p int32) bool {
+func (svc *Service) IsAlreadyAdded(p int32) bool {
 	for _, port := range svc.Ports {
 		if port.Port == p {
 			return true

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
 )
 
 //GetRepoNameAndTag returns the image name without the tag and the tag
@@ -46,7 +47,7 @@ func GetRepoNameAndTag(name string) (string, string) {
 //GetImageTag returns the image tag to build for a given services
 func GetImageTag(image, service, namespace, oktetoRegistryURL string) string {
 	if oktetoRegistryURL != "" {
-		if strings.HasPrefix(image, "okteto.dev") {
+		if strings.HasPrefix(image, okteto.DevRegistry) {
 			return image
 		}
 		return fmt.Sprintf("%s/%s/%s:okteto", oktetoRegistryURL, namespace, service)

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -290,6 +290,12 @@ func Test_GetResgistryAndRepo(t *testing.T) {
 			expectedRegistry: "okteto.dev",
 			expectedRepo:     "ubuntu",
 		},
+		{
+			name:             "official-with-registry",
+			image:            "docker.io/ubuntu",
+			expectedRegistry: "docker.io",
+			expectedRepo:     "ubuntu",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -284,6 +284,12 @@ func Test_GetResgistryAndRepo(t *testing.T) {
 			expectedRegistry: "okteto.dev",
 			expectedRepo:     "test/ubuntu",
 		},
+		{
+			name:             "okteto-registry-only-two",
+			image:            "okteto.dev/ubuntu",
+			expectedRegistry: "okteto.dev",
+			expectedRepo:     "ubuntu",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -155,7 +155,7 @@ func GetRegistryAndRepo(tag string) (string, string) {
 	if len(splittedImage) == 1 {
 		imageTag = splittedImage[0]
 	} else if len(splittedImage) == 2 {
-		if splittedImage[0] == okteto.DevRegistry {
+		if strings.Contains(splittedImage[0], ".") {
 			return splittedImage[0], splittedImage[1]
 		}
 		imageTag = strings.Join(splittedImage[len(splittedImage)-2:], "/")

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -149,7 +149,7 @@ func IsNotLoggedIntoRegistry(err error) bool {
 // SplitRegistryAndImage returns image tag and the registry to push the image
 func GetRegistryAndRepo(tag string) (string, string) {
 	var imageTag string
-	registryTag := "https://docker.io"
+	registryTag := "docker.io"
 	splittedImage := strings.Split(tag, "/")
 
 	if len(splittedImage) == 1 {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -178,13 +178,13 @@ func GetHiddenExposePorts(image string) []int32 {
 
 	digest, err := c.ManifestV2(repoName, tag)
 	if err != nil {
-		log.Infof("error getting digest of %s/%s: %s", repoName, tag)
+		log.Infof("error getting digest of %s/%s: %s", repoName, tag, err.Error())
 		return exposedPorts
 	}
 
 	response, err := c.DownloadBlob(repoName, digest.Config.Digest)
 	if err != nil {
-		log.Infof("error getting digest of %s/%s: %s", repoName, tag)
+		log.Infof("error getting digest of %s/%s: %s", repoName, tag, err.Error())
 		return exposedPorts
 	}
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -178,13 +178,13 @@ func GetHiddenExposePorts(image string) []int32 {
 
 	digest, err := c.ManifestV2(repoName, tag)
 	if err != nil {
-		log.Infof("error getting digest of %s/%s: %s", err.Error())
+		log.Infof("error getting digest of %s/%s: %s", repoName, tag)
 		return exposedPorts
 	}
 
 	response, err := c.DownloadBlob(repoName, digest.Config.Digest)
 	if err != nil {
-		log.Infof("error getting digest of %s/%s: %s", err.Error())
+		log.Infof("error getting digest of %s/%s: %s", repoName, tag)
 		return exposedPorts
 	}
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: When you upload a docker-compose with a service without exposed ports, none of the ports are available in the cluster

## Proposed changes
-  Check docker registry to get the default exposed ports that an image must have
-  
