### PR TITLE
Fixes for 1.12.9 release

### DIFF
--- a/pkg/cmd/stack/destroy.go
+++ b/pkg/cmd/stack/destroy.go
@@ -186,6 +186,10 @@ func destroyServicesNotInStack(ctx context.Context, spinner *utils.Spinner, s *m
 		if _, ok := s.Endpoints[ingressesList[i].Name]; ok {
 			continue
 		}
+		if ingressesList[i].Labels[okLabels.StackEndpointNameLabel] == "" {
+			//ingress created with "public"
+			continue
+		}
 		if err := ingress.Destroy(ctx, ingressesList[i].Name, ingressesList[i].Namespace, c); err != nil {
 			return fmt.Errorf("error destroying ingress '%s': %s", ingressesList[i].Name, err)
 		}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -204,7 +204,7 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 							Ports:           translateContainerPorts(svc),
 							SecurityContext: translateSecurityContext(svc),
 							Resources:       translateResources(svc),
-							WorkingDir:      svc.WorkingDir,
+							WorkingDir:      svc.Workdir,
 						},
 					},
 				},
@@ -239,10 +239,10 @@ func translatePersistentVolumeClaims(name string, s *model.Stack) []apiv1.Persis
 				AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOnce},
 				Resources: apiv1.ResourceRequirements{
 					Requests: apiv1.ResourceList{
-						"storage": volumeSpec.Storage.Size.Value,
+						"storage": volumeSpec.Size.Value,
 					},
 				},
-				StorageClassName: translateStorageClass(volumeSpec.Storage.Class),
+				StorageClassName: translateStorageClass(volumeSpec.Class),
 			},
 		}
 		result = append(result, pvc)
@@ -295,7 +295,7 @@ func translateStatefulSet(name string, s *model.Stack) *appsv1.StatefulSet {
 							SecurityContext: translateSecurityContext(svc),
 							VolumeMounts:    translateVolumeMounts(name, svc),
 							Resources:       translateResources(svc),
-							WorkingDir:      svc.WorkingDir,
+							WorkingDir:      svc.Workdir,
 						},
 					},
 					Volumes: translateVolumes(name, svc),
@@ -327,10 +327,10 @@ func getInitContainerCommandAndVolumeMounts(svc model.Service) ([]string, []apiv
 			if !addedDataVolume {
 				volumeMounts = append(volumeMounts, apiv1.VolumeMount{Name: volumeName, MountPath: "/data"})
 				if command == "" {
-					command = "chmod 777 /data/"
+					command = "chmod 777 /data/*"
 					addedDataVolume = true
 				} else {
-					command += " && chmod 777 /data/"
+					command += " && chmod 777 /data/*"
 				}
 			}
 		}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -322,7 +322,7 @@ func Test_translateStatefulSet(t *testing.T) {
 	initContainer := apiv1.Container{
 		Name:    fmt.Sprintf("init-%s", "svcName"),
 		Image:   "busybox",
-		Command: []string{"sh", "-c", "chmod 777 /data/"},
+		Command: []string{"sh", "-c", "chmod 777 /data/*"},
 		VolumeMounts: []apiv1.VolumeMount{
 			{
 				MountPath: "/data",

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -133,7 +133,7 @@ type Dev struct {
 	Healthchecks         bool                  `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
 	Probes               *Probes               `json:"probes,omitempty" yaml:"probes,omitempty"`
 	Lifecycle            *Lifecycle            `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
-	WorkDir              string                `json:"workdir,omitempty" yaml:"workdir,omitempty"`
+	Workdir              string                `json:"workdir,omitempty" yaml:"workdir,omitempty"`
 	MountPath            string                `json:"mountpath,omitempty" yaml:"mountpath,omitempty"`
 	SubPath              string                `json:"subpath,omitempty" yaml:"subpath,omitempty"`
 	SecurityContext      *SecurityContext      `json:"securityContext,omitempty" yaml:"securityContext,omitempty"`
@@ -802,7 +802,7 @@ func (dev *Dev) ToTranslationRule(main *Dev, reset bool) *TranslationRule {
 		ImagePullPolicy:  dev.ImagePullPolicy,
 		Environment:      dev.Environment,
 		Secrets:          dev.Secrets,
-		WorkDir:          dev.WorkDir,
+		WorkDir:          dev.Workdir,
 		PersistentVolume: main.PersistentVolumeEnabled(),
 		Volumes:          []VolumeMount{},
 		SecurityContext:  dev.SecurityContext,

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -134,13 +134,10 @@ func (c *Command) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(single, " && ") {
+		if strings.Contains(single, " ") {
 			c.Values = []string{"sh", "-c", single}
 		} else {
-			c.Values, err = shellquote.Split(single)
-			if err != nil {
-				return err
-			}
+			c.Values = []string{single}
 		}
 	} else {
 		c.Values = multi
@@ -166,14 +163,7 @@ func (a *Args) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(single, " && ") {
-			a.Values = []string{"sh", "-c", single}
-		} else {
-			a.Values, err = shellquote.Split(single)
-			if err != nil {
-				return err
-			}
-		}
+		a.Values = []string{single}
 	} else {
 		a.Values = multi
 	}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -184,7 +184,7 @@ func TestCommandUnmashalling(t *testing.T) {
 		{
 			"single-space",
 			[]byte("start.sh arg"),
-			Command{Values: []string{"start.sh", "arg"}},
+			Command{Values: []string{"sh", "-c", "start.sh arg"}},
 		},
 		{
 			"double-command",

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -61,7 +61,7 @@ type Service struct {
 	Ports           []Port        `yaml:"ports,omitempty"`
 	StopGracePeriod int64         `yaml:"stop_grace_period,omitempty"`
 	Volumes         []StackVolume `yaml:"volumes,omitempty"`
-	WorkingDir      string        `yaml:"working_dir,omitempty"`
+	Workdir         string        `yaml:"workdir,omitempty"`
 
 	Public    bool            `yaml:"public,omitempty"`
 	Replicas  int32           `yaml:"replicas,omitempty"`
@@ -74,10 +74,10 @@ type StackVolume struct {
 }
 
 type VolumeSpec struct {
-	Name        string            `yaml:"name,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`
-	Storage     StorageResource   `json:"storage,omitempty" yaml:"storage,omitempty"`
+	Size        Quantity          `json:"size,omitempty" yaml:"size,omitempty"`
+	Class       string            `json:"class,omitempty" yaml:"class,omitempty"`
 }
 type Envs struct {
 	List Environment
@@ -121,8 +121,13 @@ type Endpoint struct {
 	Rules       []EndpointRule `yaml:"rules,omitempty"`
 }
 
-//Endpoints represents an okteto stack command
+//CommandStack represents an okteto stack command
 type CommandStack struct {
+	Values []string
+}
+
+//ArgsStack represents an okteto stack args
+type ArgsStack struct {
 	Values []string
 }
 
@@ -229,8 +234,8 @@ func ReadStack(bytes []byte, isCompose bool) (*Stack, error) {
 
 	}
 	for _, volume := range s.Volumes {
-		if volume.Storage.Size.Value.Cmp(resource.MustParse("0")) == 0 {
-			volume.Storage.Size.Value = resource.MustParse("1Gi")
+		if volume.Size.Value.Cmp(resource.MustParse("0")) == 0 {
+			volume.Size.Value = resource.MustParse("1Gi")
 		}
 	}
 	return s, nil
@@ -389,10 +394,6 @@ func GroupWarningsBySvc(fields []string) []string {
 }
 
 func isInVolumesTopLevelSection(volumeName string, s *Stack) bool {
-	for _, volume := range s.Volumes {
-		if volume.Name == volumeName {
-			return true
-		}
-	}
-	return false
+	_, ok := s.Volumes[volumeName]
+	return ok
 }

--- a/pkg/model/volumes.go
+++ b/pkg/model/volumes.go
@@ -23,8 +23,8 @@ import (
 )
 
 func (dev *Dev) translateDeprecatedVolumeFields() error {
-	if dev.WorkDir == "" && dev.MountPath == "" && len(dev.Sync.Folders) == 0 {
-		dev.WorkDir = "/okteto"
+	if dev.Workdir == "" && dev.MountPath == "" && len(dev.Sync.Folders) == 0 {
+		dev.Workdir = "/okteto"
 	}
 	if err := dev.translateDeprecatedMountPath(nil); err != nil {
 		return err
@@ -70,19 +70,19 @@ func (dev *Dev) translateDeprecatedMountPath(main *Dev) error {
 }
 
 func (dev *Dev) translateDeprecatedWorkdir(main *Dev) error {
-	if dev.WorkDir == "" || len(dev.Sync.Folders) > 0 {
+	if dev.Workdir == "" || len(dev.Sync.Folders) > 0 {
 		return nil
 	}
 	if main != nil && main.MountPath == "" {
 		return fmt.Errorf("'workdir' is not supported to define your synchronized folders in 'services'. Use the field 'sync' instead (%s)", syncFieldDocsURL)
 	}
 
-	dev.MountPath = dev.WorkDir
+	dev.MountPath = dev.Workdir
 	dev.Sync.Folders = append(
 		dev.Sync.Folders,
 		SyncFolder{
 			LocalPath:  filepath.Join(".", dev.SubPath),
-			RemotePath: dev.WorkDir,
+			RemotePath: dev.Workdir,
 		},
 	)
 	return nil

--- a/pkg/model/volumes_test.go
+++ b/pkg/model/volumes_test.go
@@ -29,7 +29,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "none",
 			dev: &Dev{
-				WorkDir: "",
+				Workdir: "",
 				Volumes: []Volume{},
 				Sync: Sync{
 					Folders: []SyncFolder{},
@@ -37,7 +37,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 			},
 			result: &Dev{
 				Volumes: []Volume{},
-				WorkDir: "/okteto",
+				Workdir: "/okteto",
 				Sync: Sync{
 					Folders: []SyncFolder{
 						{
@@ -52,7 +52,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "workdir",
 			dev: &Dev{
-				WorkDir: "/workdir",
+				Workdir: "/workdir",
 				Volumes: []Volume{},
 				Sync: Sync{
 					Folders: []SyncFolder{},
@@ -96,7 +96,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "workdir-and-mountpath",
 			dev: &Dev{
-				WorkDir:   "/workdir",
+				Workdir:   "/workdir",
 				MountPath: "/mountpath",
 				Volumes:   []Volume{},
 				Sync: Sync{
@@ -119,7 +119,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "workdir-syncs",
 			dev: &Dev{
-				WorkDir: "/workdir",
+				Workdir: "/workdir",
 				Volumes: []Volume{},
 				Sync: Sync{
 					Folders: []SyncFolder{
@@ -177,7 +177,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "workdir-and-mountpath-syncs",
 			dev: &Dev{
-				WorkDir:   "/workdir",
+				Workdir:   "/workdir",
 				MountPath: "/mountpath",
 				Volumes:   []Volume{},
 				Sync: Sync{
@@ -209,7 +209,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "volumes-to-syncs",
 			dev: &Dev{
-				WorkDir:   "/workdir",
+				Workdir:   "/workdir",
 				MountPath: "/mountpath",
 				Volumes: []Volume{
 					{
@@ -241,14 +241,14 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "services-workdir",
 			dev: &Dev{
-				WorkDir: "/workdir1",
+				Workdir: "/workdir1",
 				Volumes: []Volume{},
 				Sync: Sync{
 					Folders: []SyncFolder{},
 				},
 				Services: []*Dev{
 					{
-						WorkDir: "/workdir2",
+						Workdir: "/workdir2",
 						Volumes: []Volume{},
 						Sync: Sync{
 							Folders: []SyncFolder{},
@@ -285,14 +285,14 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "services-workdir-subpath",
 			dev: &Dev{
-				WorkDir: "/workdir1",
+				Workdir: "/workdir1",
 				Volumes: []Volume{},
 				Sync: Sync{
 					Folders: []SyncFolder{},
 				},
 				Services: []*Dev{
 					{
-						WorkDir: "/workdir2",
+						Workdir: "/workdir2",
 						SubPath: "subpath",
 						Volumes: []Volume{},
 						Sync: Sync{
@@ -419,7 +419,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "services-workdir-error",
 			dev: &Dev{
-				WorkDir: "/workdir1",
+				Workdir: "/workdir1",
 				Sync: Sync{
 					Folders: []SyncFolder{
 						{
@@ -430,7 +430,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 				},
 				Services: []*Dev{
 					{
-						WorkDir: "/workdir1",
+						Workdir: "/workdir1",
 					},
 				},
 			},
@@ -440,7 +440,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "services-mountpath-error",
 			dev: &Dev{
-				WorkDir: "/mountpath1",
+				Workdir: "/mountpath1",
 				Sync: Sync{
 					Folders: []SyncFolder{
 						{
@@ -461,7 +461,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "services-workdir-syncs",
 			dev: &Dev{
-				WorkDir: "/workdir1",
+				Workdir: "/workdir1",
 				Volumes: []Volume{},
 				Sync: Sync{
 					Folders: []SyncFolder{
@@ -473,7 +473,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 				},
 				Services: []*Dev{
 					{
-						WorkDir: "/workdir2",
+						Workdir: "/workdir2",
 						Volumes: []Volume{},
 						Sync: Sync{
 							Folders: []SyncFolder{
@@ -577,7 +577,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "services-workdir-and-mountpath-syncs",
 			dev: &Dev{
-				WorkDir:   "/workdir1",
+				Workdir:   "/workdir1",
 				MountPath: "/mountpath1",
 				Volumes:   []Volume{},
 				Sync: Sync{
@@ -590,7 +590,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 				},
 				Services: []*Dev{
 					{
-						WorkDir:   "/workdir2",
+						Workdir:   "/workdir2",
 						MountPath: "/mountpath2",
 						Volumes:   []Volume{},
 						Sync: Sync{
@@ -641,7 +641,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 		{
 			name: "services-volumes-to-syncs",
 			dev: &Dev{
-				WorkDir: "/workdir1",
+				Workdir: "/workdir1",
 				Volumes: []Volume{
 					{
 						LocalPath:  "/local1",
@@ -653,7 +653,7 @@ func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
 				},
 				Services: []*Dev{
 					{
-						WorkDir: "/workdir2",
+						Workdir: "/workdir2",
 						Volumes: []Volume{
 							{
 								LocalPath:  "/local2",


### PR DESCRIPTION
## Proposed changes
-  Rename stack field `workingDir` to `workdir` to match the okteto manifest field.
-  Remove redundant stack volume field `name`. Just keep it for compose compatibility.
-  Remove `storage` indirection from stack volumes.
