### PR TITLE
Validate namespace name before creating it

### DIFF
--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -91,15 +91,15 @@ func translateAPIErr(err error) error {
 	case "not-authorized":
 		return errors.ErrNotLogged
 	case "namespace-quota-exceeded":
-		return fmt.Errorf("you have exceeded your namespace quota. Contact us at hello@okteto.com to learn more")
+		return fmt.Errorf("You have exceeded your namespace quota. Contact us at hello@okteto.com to learn more")
 	case "namespace-quota-exceeded-onpremises":
-		return fmt.Errorf("you have exceeded your namespace quota, please contact your administrator to increase it")
+		return fmt.Errorf("You have exceeded your namespace quota, please contact your administrator to increase it")
 	case "users-limit-exceeded":
-		return fmt.Errorf("license limit exceeded. Contact your administrator to update your license and try again")
+		return fmt.Errorf("License limit exceeded. Contact your administrator to update your license and try again")
 	case "internal-server-error":
-		return fmt.Errorf("server temporarily unavailable, please try again")
+		return fmt.Errorf("Server temporarily unavailable, please try again")
 	default:
-		log.Infof("unrecognized API error: %s", err)
+		log.Infof("Unrecognized API error: %s", err)
 		return fmt.Errorf(e)
 	}
 

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -16,6 +16,14 @@ package okteto
 import (
 	"context"
 	"fmt"
+	"regexp"
+
+	"github.com/okteto/okteto/pkg/errors"
+)
+
+const (
+	// Maximum number of characters allowed in a namespace name
+	MAX_ALLOWED_CHARS = 63
 )
 
 // CreateBody top body answer
@@ -41,6 +49,9 @@ type Namespace struct {
 
 // CreateNamespace creates a namespace
 func CreateNamespace(ctx context.Context, namespace string) (string, error) {
+	if err := validateNamespace(namespace); err != nil {
+		return "", err
+	}
 	q := fmt.Sprintf(`mutation{
 		createSpace(name: "%s"){
 			id
@@ -109,4 +120,21 @@ func DeleteNamespace(ctx context.Context, namespace string) error {
 
 	var body DeleteBody
 	return query(ctx, q, &body)
+}
+
+func validateNamespace(namespace string) error {
+	if len(namespace) > MAX_ALLOWED_CHARS {
+		return errors.UserError{
+			E:    fmt.Errorf("Failed to create namespace '%s': Exceeded number of character.", namespace),
+			Hint: "Please try to shorten namespace name.",
+		}
+	}
+	nameValidationRegex := regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+	if !nameValidationRegex.MatchString(namespace) {
+		return errors.UserError{
+			E:    fmt.Errorf("Failed to create namespace '%s': Malformed namespace name.", namespace),
+			Hint: "Namespace must start with an alphanumeric character and only supports lowercase and '-'",
+		}
+	}
+	return nil
 }

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -125,15 +125,15 @@ func DeleteNamespace(ctx context.Context, namespace string) error {
 func validateNamespace(namespace string) error {
 	if len(namespace) > MAX_ALLOWED_CHARS {
 		return errors.UserError{
-			E:    fmt.Errorf("Failed to create namespace '%s': Exceeded number of character.", namespace),
-			Hint: "Please try to shorten namespace name.",
+			E:    fmt.Errorf("Invalid namespace name."),
+			Hint: "Namespace name must be shorter than 63 characters.",
 		}
 	}
 	nameValidationRegex := regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 	if !nameValidationRegex.MatchString(namespace) {
 		return errors.UserError{
-			E:    fmt.Errorf("Failed to create namespace '%s': Malformed namespace name.", namespace),
-			Hint: "Namespace must start with an alphanumeric character and only supports lowercase and '-'",
+			E:    fmt.Errorf("Invalid namespace name."),
+			Hint: "Namespace name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character",
 		}
 	}
 	return nil

--- a/pkg/okteto/namespace_test.go
+++ b/pkg/okteto/namespace_test.go
@@ -13,7 +13,11 @@
 
 package okteto
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func Test_membersToString(t *testing.T) {
 	expected := ""
@@ -35,5 +39,60 @@ func Test_membersToString(t *testing.T) {
 
 	if expected != got {
 		t.Errorf("got %s, expected %s", got, expected)
+	}
+}
+
+func Test_validateNamespaceName(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespace     string
+		expectedError bool
+		errorMessage  string
+	}{
+		{
+			name:          "ok-namespace-starts-with-letter",
+			namespace:     "argo-yournamespace",
+			expectedError: false,
+			errorMessage:  "",
+		},
+		{
+			name:          "ok-namespace-starts-with-number",
+			namespace:     "1-argo-yournamespace",
+			expectedError: false,
+			errorMessage:  "",
+		},
+		{
+			name:          "wrong-namespace-starts-with-unsupported-character",
+			namespace:     "-argo-yournamespace",
+			expectedError: true,
+			errorMessage:  "Malformed namespace name",
+		},
+		{
+			name:          "wrong-namespace-unsupported-character",
+			namespace:     "argo/test-yournamespace",
+			expectedError: true,
+			errorMessage:  "Malformed namespace name",
+		},
+		{
+			name:          "wrong-namespace-exceeded-char-limit",
+			namespace:     fmt.Sprintf("%s-yournamespace", strings.Repeat("test", 20)),
+			expectedError: true,
+			errorMessage:  "Exceeded number of character",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNamespace(tt.namespace)
+			if err != nil && !tt.expectedError {
+				t.Errorf("Expected error but no error found")
+			}
+			if err != nil && !tt.expectedError {
+				if !strings.Contains(err.Error(), tt.errorMessage) {
+					t.Errorf("Expected %s, but got %s", tt.errorMessage, err.Error())
+				}
+			}
+
+		})
 	}
 }


### PR DESCRIPTION
Fixes #1452

## Proposed changes
-  Checks if namespace length is larger than the accepted
-  Check if the namespace is malformed (have unsupported characters such as uppercase)
