### PR TITLE
Jlopezbarb/autogenerate env file

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -67,13 +67,13 @@ func translate(ctx context.Context, s *model.Stack, forceBuild, noCache bool) er
 func translateStackEnvVars(ctx context.Context, s *model.Stack) error {
 	var err error
 	isOktetoNamespace := namespaces.IsOktetoNamespaceFromName(ctx, s.Namespace)
-	for _, svc := range s.Services {
+	for svcName, svc := range s.Services {
 		svc.Image, err = model.ExpandEnv(svc.Image)
 		if err != nil {
 			return err
 		}
 		for _, envFilepath := range svc.EnvFiles {
-			if err := translateServiceEnvFile(ctx, svc, envFilepath, isOktetoNamespace); err != nil {
+			if err := translateServiceEnvFile(ctx, svc, svcName, envFilepath, isOktetoNamespace); err != nil {
 				return err
 			}
 		}
@@ -85,7 +85,7 @@ func translateStackEnvVars(ctx context.Context, s *model.Stack) error {
 	return nil
 }
 
-func translateServiceEnvFile(ctx context.Context, svc *model.Service, filename string, isOktetoNamespace bool) error {
+func translateServiceEnvFile(ctx context.Context, svc *model.Service, svcName, filename string, isOktetoNamespace bool) error {
 	var err error
 	filename, err = model.ExpandEnv(filename)
 	if err != nil {
@@ -93,7 +93,7 @@ func translateServiceEnvFile(ctx context.Context, svc *model.Service, filename s
 	}
 
 	if filename == ".env" && isOktetoNamespace {
-		log.Information("[%s]: Detected '.env' file but will be skipped. You can set environment variables from https://cloud.okteto.com/#/settings/secrets.")
+		log.Information("[%s]: Detected '.env' file but will be skipped. You can set environment variables from https://cloud.okteto.com/#/settings/secrets.", svcName)
 		envList, err := okteto.GetSecrets(ctx)
 		if err != nil {
 			return err

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -86,7 +86,8 @@ func Test_translateEnvVars(t *testing.T) {
 			},
 		},
 	}
-	translateStackEnvVars(stack)
+	ctx := context.Background()
+	translateStackEnvVars(ctx, stack)
 	if stack.Services["1"].Image != "image" {
 		t.Errorf("Wrong image: %s", stack.Services["1"].Image)
 	}

--- a/pkg/k8s/namespaces/crud.go
+++ b/pkg/k8s/namespaces/crud.go
@@ -19,6 +19,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
 	"k8s.io/client-go/kubernetes"
 )
@@ -50,4 +51,16 @@ func Get(ctx context.Context, ns string, c *kubernetes.Clientset) (*apiv1.Namesp
 	}
 
 	return n, nil
+}
+
+func IsOktetoNamespaceFromName(ctx context.Context, namespace string) bool {
+	c, _, err := k8Client.GetLocal()
+	if err != nil {
+		return false
+	}
+	n, err := Get(ctx, namespace, c)
+	if err == nil {
+		return IsOktetoNamespace(n)
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
-  If an env file named '.env'(maybe we will need to do this for all the files independently of its name) is detected and is in Okteto namespace it will omit the content of the file and will get the environment from the Okteto secrets.
-  This behavior is good for when redeploying an Okteto stack/Docker compose from the UI where we don't have access to the files that the user may have when deploying it from the cli
