### PR TITLE
Add transient error when building

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -131,6 +131,8 @@ func IsTransientError(err error) bool {
 	case strings.Contains(err.Error(), "failed commit on ref") && strings.Contains(err.Error(), "500 Internal Server Error"),
 		strings.Contains(err.Error(), "transport is closing"):
 		return true
+	case strings.Contains(err.Error(), "failed to do request") && strings.Contains(err.Error(), "http: server closed idle connection"):
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: Most of the problems with integration tests comes by this error(`http: server closed idle connection`), the solution we were handling was retrying tests from failure.

## Proposed changes
-  Retry building when the mentioned error appears.
