### PR TITLE
Sanitize service names

### DIFF
--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -50,7 +50,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			analytics.TrackStackWarnings(s.Warnings)
+			analytics.TrackStackWarnings(s.Warnings.VolumeMountWarnings)
 
 			if err := s.UpdateNamespace(namespace); err != nil {
 				return err

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -262,17 +262,32 @@ func waitForPodsToBeRunning(ctx context.Context, s *model.Stack, c *kubernetes.C
 }
 
 func DisplayWarnings(s *model.Stack) {
-	if len(s.Warnings) > 0 {
-		if len(s.Warnings) == 1 {
-			log.Warning("'%s' field is not currently supported and will be ignored.", s.Warnings[0])
+	DisplayNotSupportedFieldsWarnings(model.GroupWarningsBySvc(s.Warnings.NotSupportedFields))
+	DisplayVolumeMountWarnings(s.Warnings.VolumeMountWarnings)
+	DisplaySanitizedServicesWarnings(s.Warnings.SanitizedServices)
+}
+
+func DisplayNotSupportedFieldsWarnings(warnings []string) {
+	if len(warnings) > 0 {
+		if len(warnings) == 1 {
+			log.Warning("'%s' field is not currently supported and will be ignored.", warnings[0])
 		} else {
-			notSupportedFields := strings.Join(model.GroupWarningsBySvc(s.Warnings), "\n  - ")
+			notSupportedFields := strings.Join(model.GroupWarningsBySvc(warnings), "\n  - ")
 			log.Warning("The following fields are not currently supported and will be ignored: \n  - %s", notSupportedFields)
 		}
 		log.Yellow("Help us to decide which fields to implement next by filing an issue in https://github.com/okteto/okteto/issues/new")
 	}
-	for _, warning := range s.VolumeMountWarnings {
+}
+
+func DisplayVolumeMountWarnings(warnings []string) {
+	for _, warning := range warnings {
 		log.Warning(warning)
+	}
+}
+
+func DisplaySanitizedServicesWarnings(previousToNewNameMap map[string]string) {
+	for previousName, newName := range previousToNewNameMap {
+		log.Warning("Service '%s' has been sanitized into '%s'. This may affect discovery service.", previousName, newName)
 	}
 }
 

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -33,15 +33,14 @@ var (
 
 //Stack represents an okteto stack
 type Stack struct {
-	Manifest            []byte                 `yaml:"-"`
-	Warnings            []string               `yaml:"-"`
-	VolumeMountWarnings []string               `yaml:"-"`
-	IsCompose           bool                   `yaml:"-"`
-	Name                string                 `yaml:"name"`
-	Volumes             map[string]*VolumeSpec `yaml:"volumes,omitempty"`
-	Namespace           string                 `yaml:"namespace,omitempty"`
-	Services            map[string]*Service    `yaml:"services,omitempty"`
-	Endpoints           EndpointSpec           `yaml:"endpoints,omitempty"`
+	Manifest  []byte                 `yaml:"-"`
+	Warnings  StackWarnings          `yaml:"-"`
+	IsCompose bool                   `yaml:"-"`
+	Name      string                 `yaml:"name"`
+	Volumes   map[string]*VolumeSpec `yaml:"volumes,omitempty"`
+	Namespace string                 `yaml:"namespace,omitempty"`
+	Services  map[string]*Service    `yaml:"services,omitempty"`
+	Endpoints EndpointSpec           `yaml:"endpoints,omitempty"`
 }
 
 //Service represents an okteto stack service
@@ -138,6 +137,12 @@ type EndpointRule struct {
 	Path    string `yaml:"path,omitempty"`
 	Service string `yaml:"service,omitempty"`
 	Port    int32  `yaml:"port,omitempty"`
+}
+
+type StackWarnings struct {
+	NotSupportedFields  []string          `yaml:"-"`
+	SanitizedServices   map[string]string `yaml:"-"`
+	VolumeMountWarnings []string          `yaml:"-"`
 }
 
 //GetStack returns an okteto stack object from a given file
@@ -281,7 +286,7 @@ func (s *Stack) validate() error {
 
 		for _, v := range svc.VolumeMounts {
 			if strings.HasPrefix(v.LocalPath, "/") {
-				s.VolumeMountWarnings = append(s.VolumeMountWarnings, fmt.Sprintf("[%s]: volume '%s:%s' will be ignored. You can synchronize code to your containers using 'okteto up'. More information available here: https://okteto.com/docs/reference/cli/index.html#up", name, v.LocalPath, v.RemotePath))
+				s.Warnings.VolumeMountWarnings = append(s.Warnings.VolumeMountWarnings, fmt.Sprintf("[%s]: volume '%s:%s' will be ignored. You can synchronize code to your containers using 'okteto up'. More information available here: https://okteto.com/docs/reference/cli/index.html#up", name, v.LocalPath, v.RemotePath))
 			}
 			if !strings.HasPrefix(v.RemotePath, "/") {
 				return fmt.Errorf(fmt.Sprintf("Invalid volume '%s' in service '%s': must be an absolute path", v.ToString(), name))

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -300,6 +300,16 @@ func Test_GroupNotSupportedFields(t *testing.T) {
 			input:    []string{"volumes", "networks", "service[app].cpus", "service[db].cpus"},
 			expected: []string{"volumes", "networks", "service[app, db].cpus"},
 		},
+		{
+			name:     "two-into-one",
+			input:    []string{"service[app].cpus", "service[db].cpus"},
+			expected: []string{"service[app, db].cpus"},
+		},
+		{
+			name:     "only-one",
+			input:    []string{"service[app].cpus"},
+			expected: []string{"service[app].cpus"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -639,8 +649,57 @@ func Test_restartFile(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(s.Warnings) == 0 && tt.isInList {
+			if len(s.Warnings.NotSupportedFields) == 0 && tt.isInList {
 				t.Fatalf("Expected to see a warning but there is no warning")
+			}
+		})
+	}
+}
+
+func Test_UnmarshalWarnings(t *testing.T) {
+	tests := []struct {
+		name            string
+		manifest        []byte
+		svcName         string
+		isSvcNameChange bool
+	}{
+		{
+			name:            "with underscore",
+			manifest:        []byte("services:\n  app_1:\n    ports:\n    - 9213\n    public: true\n    image: okteto/vote:1"),
+			svcName:         "app-1",
+			isSvcNameChange: true,
+		},
+		{
+			name:            "with whitespace",
+			manifest:        []byte("services:\n  app 1:\n    ports:\n    - 9213\n    public: true\n    image: okteto/vote:1"),
+			svcName:         "app-1",
+			isSvcNameChange: true,
+		},
+		{
+			name:            "with whitespace and underscore",
+			manifest:        []byte("services:\n  app_ 1:\n    ports:\n    - 9213\n    public: true\n    image: okteto/vote:1"),
+			svcName:         "app--1",
+			isSvcNameChange: true,
+		},
+		{
+			name:            "without whitespace or underscore",
+			manifest:        []byte("services:\n  app:\n    ports:\n    - 9213\n    public: true\n    image: okteto/vote:1"),
+			svcName:         "app",
+			isSvcNameChange: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			s, err := ReadStack(tt.manifest, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := s.Services[tt.svcName]; !ok {
+				t.Fatal("Service name not sanitized")
+			}
+			if tt.isSvcNameChange && len(s.Warnings.SanitizedServices) == 0 {
+				t.Fatal("Warning have not been recovered")
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1419

## Proposed changes
-  Services with underscore or whitespace are sanitized replacing those characters into -
-  Groups stack warnings(not supported fields, sanitized names and volume mount) into one struct instead of having three different fields for each warning 
