### PR TITLE
Set stack name to repository name if exists

### DIFF
--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/okteto/okteto/cmd/utils"
 )
 
 func Test_getRepositoryURL(t *testing.T) {
@@ -67,7 +68,7 @@ func Test_getRepositoryURL(t *testing.T) {
 			}
 			defer os.RemoveAll(dir)
 
-			if _, err := getRepositoryURL(context.TODO(), dir); err == nil {
+			if _, err := utils.GetRepositoryURL(context.TODO(), dir); err == nil {
 				t.Fatal("expected error when there's no github repo")
 			}
 
@@ -82,7 +83,7 @@ func Test_getRepositoryURL(t *testing.T) {
 				}
 			}
 
-			url, err := getRepositoryURL(context.TODO(), dir)
+			url, err := utils.GetRepositoryURL(context.TODO(), dir)
 			if tt.expectError {
 				if err == nil {
 					t.Error("expected error when calling getRepositoryURL")
@@ -114,7 +115,7 @@ func Test_getBranch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = getBranch(context.TODO(), dir)
+	_, err = utils.GetBranch(context.TODO(), dir)
 	if err == nil {
 		t.Fatal("expected no-branch error")
 	}
@@ -160,7 +161,7 @@ func Test_getBranch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b, err := getBranch(context.TODO(), dir)
+	b, err := utils.GetBranch(context.TODO(), dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +176,7 @@ func Test_getBranch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := getBranch(context.TODO(), dir); err == nil {
+	if _, err := utils.GetBranch(context.TODO(), dir); err == nil {
 		t.Fatal("didn't fail when getting a non branch")
 	}
 }

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -15,12 +15,16 @@ package stack
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/cmd/stack"
 	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/spf13/cobra"
 )
 
@@ -44,6 +48,20 @@ func Deploy(ctx context.Context) *cobra.Command {
 			ctx := context.Background()
 			if err := utils.LoadEnvironment(ctx, true); err != nil {
 				return err
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("failed to get the current working directory: %w", err)
+			}
+
+			if name == "" {
+				log.Info("inferring git repository URL")
+				repo, err := utils.GetRepositoryURL(ctx, cwd)
+				if err == nil {
+					repo = repo[strings.LastIndex(repo, "/")+1:]
+					name = model.ValidKubeNameRegex.ReplaceAllString(repo, "")
+				}
 			}
 
 			s, err := utils.LoadStack(name, stackPath)

--- a/cmd/utils/git.go
+++ b/cmd/utils/git.go
@@ -1,0 +1,71 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+)
+
+func GetRepositoryURL(ctx context.Context, path string) (string, error) {
+	repo, err := git.PlainOpen(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
+
+	origin, err := repo.Remote("origin")
+	if err != nil {
+		if err != git.ErrRemoteNotFound {
+			return "", fmt.Errorf("failed to get the git repo's remote configuration: %w", err)
+		}
+	}
+
+	if origin != nil {
+		return origin.Config().URLs[0], nil
+	}
+
+	remotes, err := repo.Remotes()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git repo's remote information: %w", err)
+	}
+
+	if len(remotes) == 0 {
+		return "", fmt.Errorf("git repo doesn't have any remote")
+	}
+
+	return remotes[0].Config().URLs[0], nil
+}
+
+func GetBranch(ctx context.Context, path string) (string, error) {
+	repo, err := git.PlainOpen(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("failed to infer the git repo's current branch: %w", err)
+	}
+
+	branch := head.Name()
+	if !branch.IsBranch() {
+		return "", fmt.Errorf("git repo is not on a valid branch")
+	}
+
+	name := strings.TrimPrefix(branch.String(), "refs/heads/")
+	return name, nil
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Error for deploying an stack from the UI or from deploy command where the name of the stacks was set to `src`

## Proposed changes
-  If the name of the stack is not set on the command, it checks if it's on a git repo and sets the name variable to the name of it. 
-  If its deploying a stack file with a name on it, that name will preserve over the git repo name.
-  If it's not on a git repo it will get the name of the containing folder.

For clarification, the order that will follow its:
1.- Okteto stack name field.
2.- Okteto stack name variable
3.- Repo name sanitized so it can be a kubernetes valid name. (sanitization will be removing all non valid characters)
4.- Container folder name.