### PR TITLE
Fix ssh name when inferencing from git

### DIFF
--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -76,14 +76,21 @@ func GetValidNameFromFolder(folder string) (string, error) {
 
 //GetValidNameFromFolder returns a valid kubernetes name for a folder
 func GetValidNameFromGitRepo(folder string) (string, error) {
-	var name string
 	repo, err := GetRepositoryURL(folder)
 	if err != nil {
 		return "", err
 	}
-	repo = repo[strings.LastIndex(repo, "/")+1:]
-	name = ValidKubeNameRegex.ReplaceAllString(repo, "")
+	name := translateURLToName(repo)
 	return name, nil
+}
+
+func translateURLToName(repo string) string {
+	repo = repo[strings.LastIndex(repo, "/")+1:]
+	if strings.HasSuffix(repo, ".git") {
+		repo = repo[:strings.LastIndex(repo, ".git")]
+	}
+	name := ValidKubeNameRegex.ReplaceAllString(repo, "-")
+	return name
 }
 
 func GetRepositoryURL(path string) (string, error) {

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -108,3 +108,26 @@ func Test_GetValidNameFromFolder(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetValidNameFromGitRepo(t *testing.T) {
+	var tests = []struct {
+		name     string
+		gitRepo  string
+		expected string
+	}{
+		{name: "https url", gitRepo: "https://github.com/okteto/stacks-getting-started", expected: "stacks-getting-started"},
+		{name: "ssh url", gitRepo: "git@github.com:okteto/stacks-getting-started.git", expected: "stacks-getting-started"},
+		{name: "https with dots", gitRepo: "https://github.com/okteto/stacks.getting.started", expected: "stacks-getting-started"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := translateURLToName(tt.gitRepo)
+
+			if result != tt.expected {
+				t.Errorf("'%s' got '%s' expected '%s'", tt.name, result, tt.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes An error produced inferencing a stack name from a git repo cloned by ssh

## Proposed changes
-  Remove .git from the URL when it's cloned by ssh
-  Add unit tests for translating URLs into the stack name
