### PR TITLE
Fix volume mounts error if folder/file exists

### DIFF
--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -395,7 +395,7 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 
 	svc.Volumes, svc.VolumeMounts = splitVolumesByType(serviceRaw.Volumes, stack)
 	for _, volume := range svc.VolumeMounts {
-		if !strings.HasPrefix(volume.LocalPath, ".") && !strings.HasPrefix(volume.LocalPath, "/") && volume.LocalPath != "" {
+		if volume.LocalPath != "" && !FileExists(volume.LocalPath) {
 			return nil, fmt.Errorf("Named volume '%s' is used in service '%s' but no declaration was found in the volumes section.", volume.ToString(), svcName)
 		}
 	}

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -395,7 +395,7 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 
 	svc.Volumes, svc.VolumeMounts = splitVolumesByType(serviceRaw.Volumes, stack)
 	for _, volume := range svc.VolumeMounts {
-		if volume.LocalPath != "" && !FileExists(volume.LocalPath) {
+		if volume.LocalPath != "" && !(!FileExists(volume.LocalPath) || !strings.HasPrefix(volume.LocalPath, "/")) {
 			return nil, fmt.Errorf("Named volume '%s' is used in service '%s' but no declaration was found in the volumes section.", volume.ToString(), svcName)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes An error when there was a volume declared without . at the beginning even if the file existed on the dir.

## Proposed changes
-  Instead of checking if the volume starts with . or / check if starts with / or if the file exists
