### PR TITLE
Add notation host to container in expose

### DIFF
--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -643,11 +643,23 @@ func unmarshalExpose(raw *RawMessage) ([]int32, error) {
 	}
 
 	for _, expose := range exposeInString {
-		portInInt, err := strconv.Atoi(expose)
+		if strings.Contains(expose, "-") {
+			return exposeInInt, fmt.Errorf("Can not convert %s. Range ports are not supported.", expose)
+		}
+		parts := strings.Split(expose, ":")
+		var portString string
+		if len(parts) == 1 {
+			portString = parts[0]
+		} else if len(parts) <= 3 {
+			portString = parts[len(parts)-1]
+		} else {
+			return exposeInInt, fmt.Errorf(malformedPortForward, expose)
+		}
+		port, err := strconv.Atoi(portString)
 		if err != nil {
 			return exposeInInt, err
 		}
-		exposeInInt = append(exposeInInt, int32(portInInt))
+		exposeInInt = append(exposeInInt, int32(port))
 	}
 	return exposeInInt, nil
 }

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -560,31 +560,49 @@ func Test_validateIngressCreationPorts(t *testing.T) {
 		name     string
 		manifest []byte
 		isPublic bool
+		ports    []Port
 	}{
 		{
 			name:     "Public-service",
 			manifest: []byte("services:\n  app:\n    ports:\n    - 9213\n    public: true\n    image: okteto/vote:1"),
 			isPublic: true,
+			ports:    []Port{{Port: 9213, Protocol: v1.ProtocolTCP}},
 		},
 		{
 			name:     "not-public-service",
 			manifest: []byte("services:\n  app:\n    ports:\n    - 9213\n    image: okteto/vote:1"),
 			isPublic: false,
+			ports:    []Port{{Port: 9213, Protocol: v1.ProtocolTCP}},
 		},
 		{
 			name:     "not-public-port-but-with-assignation",
 			manifest: []byte("services:\n  app:\n    ports:\n    - 9213:9213\n    image: okteto/vote:1"),
 			isPublic: true,
+			ports:    []Port{{Port: 9213, Protocol: v1.ProtocolTCP}},
 		},
 		{
 			name:     "mysql-port-forwarding",
 			manifest: []byte("services:\n  app:\n    ports:\n    - 3306:3306\n    image: okteto/vote:1"),
 			isPublic: false,
+			ports:    []Port{{Port: 3306, Protocol: v1.ProtocolTCP}},
 		},
 		{
 			name:     "mysql-port-forwarding-and-public",
 			manifest: []byte("services:\n  app:\n    ports:\n    - 3306:3306\n    image: okteto/vote:1\n    public: true"),
 			isPublic: true,
+			ports:    []Port{{Port: 3306, Protocol: v1.ProtocolTCP}},
+		},
+		{
+			name:     "mysql-expose-forwarding-and-public",
+			manifest: []byte("services:\n  app:\n    expose:\n    - 3306:3306\n    image: okteto/vote:1\n    public: true"),
+			isPublic: false,
+			ports:    []Port{{Port: 3306, Protocol: v1.ProtocolTCP}},
+		},
+		{
+			name:     "not-public-service-with-expose-and-ports",
+			manifest: []byte("services:\n  app:\n    ports:\n    - 9213\n    expose:\n    - 8213\n    image: okteto/vote:1"),
+			isPublic: false,
+			ports:    []Port{{Port: 9213, Protocol: v1.ProtocolTCP}, {Port: 8213, Protocol: v1.ProtocolTCP}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes When you try to deploy a compose with `HOST_PORT:CONTAINER_PORT` on docker it will allow you but it will only expose container port to the rest of services. 

## Proposed changes
-  Support `HOST_PORT:CONTAINER_PORT` syntax on expose field instead of failing with an `strconvert.Atoi` error
-  
