### PR TITLE
Support for okteto up with divert

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/errors"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
+	"github.com/okteto/okteto/pkg/k8s/diverts"
 	"github.com/okteto/okteto/pkg/k8s/volumes"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -91,6 +92,10 @@ func runDown(ctx context.Context, dev *model.Dev) error {
 
 	client, _, err := k8Client.GetLocalWithContext(dev.Context)
 	if err != nil {
+		return err
+	}
+
+	if err := diverts.Delete(ctx, dev, client); err != nil {
 		return err
 	}
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -95,8 +95,10 @@ func runDown(ctx context.Context, dev *model.Dev) error {
 		return err
 	}
 
-	if err := diverts.Delete(ctx, dev, client); err != nil {
-		return err
+	if dev.Divert != nil {
+		if err := diverts.Delete(ctx, dev, client); err != nil {
+			return err
+		}
 	}
 
 	d, err := deployments.Get(ctx, dev, dev.Namespace, client)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -209,7 +209,7 @@ func runPush(ctx context.Context, dev *model.Dev, autoDeploy bool, imageTag, okt
 	if !exists {
 		d.Spec.Template.Spec.Containers[0].Image = imageTag
 		deployments.SetLastBuiltAnnotation(d)
-		return deployments.Deploy(ctx, d, true, c)
+		return deployments.Create(ctx, d, c)
 	}
 
 	for _, tr := range trList {

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -143,7 +143,7 @@ func (up *upContext) activate(autoDeploy, build bool) error {
 				log.Infof("Using init image %s instead of default init image (%s)", up.Dev.InitContainer.Image, model.OktetoBinImageTag)
 			}
 		}
-		printDisplayContext(up.Dev)
+		printDisplayContext(ctx, up.Dev, up.Client)
 		up.CommandResult <- up.runCommand(ctx)
 	}()
 	prevError := up.waitUntilExitOrInterrupt()
@@ -216,12 +216,12 @@ func (up *upContext) createDevContainer(ctx context.Context, d *appsv1.Deploymen
 	}
 
 	for name := range trList {
-		if name == d.Name {
-			if err := deployments.Deploy(ctx, trList[name].Deployment, create, up.Client); err != nil {
+		if name == d.Name && create {
+			if err := deployments.Create(ctx, trList[name].Deployment, up.Client); err != nil {
 				return err
 			}
 		} else {
-			if err := deployments.Deploy(ctx, trList[name].Deployment, false, up.Client); err != nil {
+			if err := deployments.Update(ctx, trList[name].Deployment, up.Client); err != nil {
 				return err
 			}
 		}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -32,7 +32,6 @@ import (
 	k8sClient "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
 	"github.com/okteto/okteto/pkg/k8s/diverts"
-	"github.com/okteto/okteto/pkg/k8s/ingressesv1"
 	"github.com/okteto/okteto/pkg/k8s/namespaces"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -43,7 +42,6 @@ import (
 
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 // ReconnectingMessage is the message shown when we are trying to reconnect
@@ -236,8 +234,10 @@ func (up *upContext) start(autoDeploy, build bool) error {
 
 	up.isOktetoNamespace = namespaces.IsOktetoNamespace(ns)
 
-	if err := diverts.Create(ctx, up.Dev, up.isOktetoNamespace, up.Client); err != nil {
-		return err
+	if up.Dev.Divert != nil {
+		if err := diverts.Create(ctx, up.Dev, up.isOktetoNamespace, up.Client); err != nil {
+			return err
+		}
 	}
 
 	if err := createPIDFile(up.Dev.Namespace, up.Dev.Name); err != nil {
@@ -506,39 +506,32 @@ func (up *upContext) shutdown() {
 
 }
 
-func printDisplayContext(ctx context.Context, dev *model.Dev, c kubernetes.Interface) {
+func printDisplayContext(dev *model.Dev, divertURL string) {
 	if dev.Context != "" {
-		log.Println(fmt.Sprintf("    %s    %s", log.BlueString("Context:"), dev.Context))
+		log.Println(fmt.Sprintf("    %s   %s", log.BlueString("Context:"), dev.Context))
 	}
-	log.Println(fmt.Sprintf("    %s  %s", log.BlueString("Namespace:"), dev.Namespace))
-	log.Println(fmt.Sprintf("    %s       %s", log.BlueString("Name:"), dev.Name))
+	log.Println(fmt.Sprintf("    %s %s", log.BlueString("Namespace:"), dev.Namespace))
+	log.Println(fmt.Sprintf("    %s      %s", log.BlueString("Name:"), dev.Name))
 
 	if len(dev.Forward) > 0 {
 		for i := 0; i < len(dev.Forward); i++ {
 			if dev.Forward[i].Service {
-				log.Println(fmt.Sprintf("                %d -> %s:%d", dev.Forward[i].Local, dev.Forward[i].ServiceName, dev.Forward[i].Remote))
+				log.Println(fmt.Sprintf("               %d -> %s:%d", dev.Forward[i].Local, dev.Forward[i].ServiceName, dev.Forward[i].Remote))
 				continue
 			}
-			log.Println(fmt.Sprintf("                %d -> %d", dev.Forward[i].Local, dev.Forward[i].Remote))
+			log.Println(fmt.Sprintf("               %d -> %d", dev.Forward[i].Local, dev.Forward[i].Remote))
 		}
 	}
 
 	if len(dev.Reverse) > 0 {
-		log.Println(fmt.Sprintf("    %s      %d <- %d", log.BlueString("Reverse:"), dev.Reverse[0].Local, dev.Reverse[0].Remote))
+		log.Println(fmt.Sprintf("    %s     %d <- %d", log.BlueString("Reverse:"), dev.Reverse[0].Local, dev.Reverse[0].Remote))
 		for i := 1; i < len(dev.Reverse); i++ {
-			log.Println(fmt.Sprintf("                %d <- %d", dev.Reverse[i].Local, dev.Reverse[i].Remote))
+			log.Println(fmt.Sprintf("               %d <- %d", dev.Reverse[i].Local, dev.Reverse[i].Remote))
 		}
 	}
 
-	if dev.Divert != nil {
-		username := okteto.GetSanitizedUsername()
-		name := diverts.DivertName(username, dev.Divert.Ingress)
-		i, err := ingressesv1.Get(ctx, name, dev.Namespace, c)
-		if err != nil {
-			log.Infof("error getting diverted ingress %s: %s", name, err.Error())
-		} else if len(i.Spec.Rules) > 0 {
-			log.Println(fmt.Sprintf("    %s %s", log.BlueString("Divert URL:"), i.Spec.Rules[0].Host))
-		}
+	if divertURL != "" {
+		log.Println(fmt.Sprintf("    %s       %s", log.BlueString("URL:"), divertURL))
 	}
 	fmt.Println()
 }

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -14,7 +14,6 @@
 package up
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -94,10 +93,9 @@ func Test_printDisplayContext(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			printDisplayContext(ctx, tt.dev, nil)
+			printDisplayContext(tt.dev, "")
 		})
 	}
 

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -14,6 +14,7 @@
 package up
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -93,9 +94,10 @@ func Test_printDisplayContext(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			printDisplayContext(tt.dev)
+			printDisplayContext(ctx, tt.dev, nil)
 		})
 	}
 

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -132,13 +132,13 @@ func TrackResetDatabase(success bool) {
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
-func TrackUp(success bool, devName string, interactive, single, swap, remote bool) {
+func TrackUp(success bool, devName string, interactive, single, swap, divert bool) {
 	props := map[string]interface{}{
 		"name":          devName,
 		"interactive":   interactive,
 		"singleService": single,
 		"swap":          swap,
-		"remote":        remote,
+		"divert":        divert,
 	}
 	track(upEvent, success, props)
 }

--- a/pkg/cmd/down/run.go
+++ b/pkg/cmd/down/run.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Run runs the "okteto down" sequence
-func Run(dev *model.Dev, d *appsv1.Deployment, trList map[string]*model.Translation, wait bool, c *kubernetes.Clientset) error {
+func Run(dev *model.Dev, d *appsv1.Deployment, trList map[string]*model.Translation, wait bool, c kubernetes.Interface) error {
 	ctx := context.Background()
 	if len(trList) == 0 {
 		log.Info("no translations available in the deployment")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -83,6 +83,9 @@ var (
 
 	// ErrDevPodDeleted raised if dev pod is deleted in the middle of the "okteto up" sequence
 	ErrDevPodDeleted = fmt.Errorf("development container has been removed")
+
+	//ErrDivertNotSupported raised if the divert feature is not supported in the current cluster
+	ErrDivertNotSupported = fmt.Errorf("the 'divert' field is only supported in namespaces managed by Okteto")
 )
 
 // IsNotFound returns true if err is of the type not found

--- a/pkg/k8s/diverts/client.go
+++ b/pkg/k8s/diverts/client.go
@@ -1,0 +1,68 @@
+package diverts
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sScheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type DivertV1nterface interface {
+	Diverts(namespace string) DivertInterface
+}
+
+type DivertV1Client struct {
+	restClient rest.Interface
+	scheme     *runtime.Scheme
+}
+
+func NewForConfig(cfg *rest.Config) (*DivertV1Client, error) {
+	scheme := runtime.NewScheme()
+	SchemeBuilder := runtime.NewSchemeBuilder(addKnownTypes)
+	if err := SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	config := *cfg
+	config.GroupVersion = &SchemeGroupVersion
+	config.APIPath = "/apis"
+	config.ContentType = runtime.ContentTypeJSON
+	config.NegotiatedSerializer = k8sScheme.Codecs.WithoutConversion()
+
+	client, err := rest.RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return &DivertV1Client{restClient: client, scheme: scheme}, nil
+
+}
+
+func GetClient(thisContext string) (*DivertV1Client, error) {
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{
+			CurrentContext: thisContext,
+			ClusterInfo:    clientcmdapi.Cluster{Server: ""},
+		},
+	)
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize diverts client: %s", err.Error())
+	}
+
+	return c, nil
+}
+
+func (c *DivertV1Client) Diverts(namespace string) DivertInterface {
+	return &divertClient{
+		restClient: c.restClient,
+		scheme:     c.scheme,
+		ns:         namespace,
+	}
+}

--- a/pkg/k8s/diverts/crud.go
+++ b/pkg/k8s/diverts/crud.go
@@ -1,0 +1,189 @@
+package diverts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/deployments"
+	"github.com/okteto/okteto/pkg/k8s/ingressesv1"
+	"github.com/okteto/okteto/pkg/k8s/services"
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func Create(ctx context.Context, dev *model.Dev, isOktetoNamespace bool, c kubernetes.Interface) error {
+	if dev.Divert == nil {
+		return nil
+	}
+
+	if !isOktetoNamespace {
+		return errors.ErrDivertNotSupported
+	}
+
+	username := okteto.GetSanitizedUsername()
+
+	d, err := divertDeployment(ctx, dev, username, c)
+	if err != nil {
+		return err
+	}
+
+	s, err := divertService(ctx, dev, d, username, c)
+	if err != nil {
+		return err
+	}
+
+	i, err := divertIngress(ctx, dev, username, c)
+	if err != nil {
+		return err
+	}
+
+	if err := createDivertCRD(ctx, dev, username, i, s, c); err != nil {
+		return err
+	}
+
+	translateDev(username, dev, d)
+	return nil
+}
+
+func divertDeployment(ctx context.Context, dev *model.Dev, username string, c kubernetes.Interface) (*appsv1.Deployment, error) {
+	d, err := deployments.Get(ctx, dev, dev.Namespace, c)
+	if err != nil {
+		return nil, fmt.Errorf("error diverting deployment: %s", err.Error())
+	}
+
+	divertDeployment := translateDeployment(username, dev, d)
+	if err := deployments.Deploy(ctx, divertDeployment, c); err != nil {
+		return nil, fmt.Errorf("error creating diver deployment '%s': %s", divertDeployment.Name, err.Error())
+	}
+	return divertDeployment, nil
+}
+
+func divertService(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, username string, c kubernetes.Interface) (*apiv1.Service, error) {
+	s, err := services.Get(ctx, dev.Divert.Service, dev.Namespace, c)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("the divert service '%s' doesn't exist", dev.Divert.Service)
+		}
+		return nil, fmt.Errorf("error getting divert service '%s': %s", dev.Divert.Service, err.Error())
+	}
+
+	divertService, err := translateService(username, dev, d, s)
+	if err != nil {
+		return nil, err
+	}
+	if err := services.Deploy(ctx, divertService, c); err != nil {
+		return nil, fmt.Errorf("error creating divert service '%s': %s", divertService.Name, err.Error())
+	}
+	return divertService, nil
+}
+
+func divertIngress(ctx context.Context, dev *model.Dev, username string, c kubernetes.Interface) (*networkingv1.Ingress, error) {
+	i, err := ingressesv1.Get(ctx, dev.Divert.Ingress, dev.Namespace, c)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("the divert ingress '%s' doesn't exist", dev.Divert.Ingress)
+		}
+		return nil, fmt.Errorf("error getting divert ingress '%s': %s", dev.Divert.Ingress, err.Error())
+	}
+
+	divertIngress := translateIngress(username, dev, i)
+	if err := ingressesv1.Deploy(ctx, divertIngress, c); err != nil {
+		return nil, fmt.Errorf("error creating divert ingress '%s': %s", divertIngress.Name, err.Error())
+	}
+	return divertIngress, nil
+}
+
+func createDivertCRD(ctx context.Context, dev *model.Dev, username string, i *networkingv1.Ingress, s *apiv1.Service, c kubernetes.Interface) error {
+	dClient, err := GetClient(dev.Context)
+	if err != nil {
+		return fmt.Errorf("error creating divert CRD client: %s", err.Error())
+	}
+
+	divertCRD := translateDivertCRD(username, dev, s, i)
+
+	old, err := dClient.Diverts(divertCRD.Namespace).Get(ctx, divertCRD.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error getting divert CRD '%s'': %s", divertCRD.Name, err)
+	}
+
+	if old.Name == "" {
+		log.Infof("creating  divert CRD '%s'", divertCRD.Name)
+		_, err = dClient.Diverts(divertCRD.Namespace).Create(ctx, divertCRD)
+		if err != nil {
+			return fmt.Errorf("error creating divert CRD '%s': %s", divertCRD.Name, err)
+		}
+		log.Infof("created divert CRD '%s'", divertCRD.Name)
+	} else {
+		log.Infof("updating divert CRD '%s'", divertCRD.Name)
+		old.TypeMeta = divertCRD.TypeMeta
+		old.Annotations = divertCRD.Annotations
+		old.Labels = divertCRD.Labels
+		old.Spec = divertCRD.Spec
+		old.Status = DivertStatus{}
+		_, err = dClient.Diverts(divertCRD.Namespace).Update(ctx, old)
+		if err != nil {
+			return fmt.Errorf("error updating divert CRD '%s': %s", divertCRD.Name, err)
+		}
+		log.Infof("updated divert CRD '%s'.", divertCRD.Name)
+	}
+
+	return nil
+}
+
+func Delete(ctx context.Context, dev *model.Dev, c kubernetes.Interface) error {
+	if dev.Divert == nil {
+		return nil
+	}
+
+	username := okteto.GetSanitizedUsername()
+
+	d, err := deployments.Get(ctx, dev, dev.Namespace, c)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error getting deployment: %s", err.Error())
+	}
+	if d == nil {
+		d = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dev.Name,
+				Namespace: dev.Name,
+			},
+		}
+	}
+
+	dClient, err := GetClient(dev.Context)
+	if err != nil {
+		return fmt.Errorf("error creating divert CRD client: %s", err.Error())
+	}
+	divertCRDName := DivertName(username, dev.Divert.Service)
+	if err := dClient.Diverts(dev.Namespace).Delete(ctx, divertCRDName, metav1.DeleteOptions{}); err != nil {
+		if strings.Contains(err.Error(), "the server could not find the requested resource") {
+			return errors.ErrDivertNotSupported
+		}
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("error deleting divert CRD '%s': %s", divertCRDName, err.Error())
+		}
+	}
+
+	iName := DivertName(username, dev.Divert.Ingress)
+	if err := ingressesv1.Destroy(ctx, iName, dev.Namespace, c); err != nil {
+		return fmt.Errorf("error deleting divert ingress '%s': %s", iName, err.Error())
+	}
+
+	sName := DivertName(username, dev.Divert.Service)
+	if err := services.Destroy(ctx, sName, dev.Namespace, c); err != nil {
+		return fmt.Errorf("error deleting divert service '%s': %s", sName, err.Error())
+	}
+
+	divertDeployment := translateDeployment(username, dev, d)
+	translateDev(username, dev, divertDeployment)
+
+	return nil
+}

--- a/pkg/k8s/diverts/crud.go
+++ b/pkg/k8s/diverts/crud.go
@@ -20,10 +20,6 @@ import (
 )
 
 func Create(ctx context.Context, dev *model.Dev, isOktetoNamespace bool, c kubernetes.Interface) error {
-	if dev.Divert == nil {
-		return nil
-	}
-
 	if !isOktetoNamespace {
 		return errors.ErrDivertNotSupported
 	}
@@ -59,7 +55,7 @@ func divertDeployment(ctx context.Context, dev *model.Dev, username string, c ku
 		return nil, fmt.Errorf("error diverting deployment: %s", err.Error())
 	}
 
-	divertDeployment := translateDeployment(username, dev, d)
+	divertDeployment := translateDeployment(username, d)
 	if err := deployments.Deploy(ctx, divertDeployment, c); err != nil {
 		return nil, fmt.Errorf("error creating diver deployment '%s': %s", divertDeployment.Name, err.Error())
 	}
@@ -75,7 +71,7 @@ func divertService(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, us
 		return nil, fmt.Errorf("error getting divert service '%s': %s", dev.Divert.Service, err.Error())
 	}
 
-	divertService, err := translateService(username, dev, d, s)
+	divertService, err := translateService(username, d, s)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +90,7 @@ func divertIngress(ctx context.Context, dev *model.Dev, username string, c kuber
 		return nil, fmt.Errorf("error getting divert ingress '%s': %s", dev.Divert.Ingress, err.Error())
 	}
 
-	divertIngress := translateIngress(username, dev, i)
+	divertIngress := translateIngress(username, i)
 	if err := ingressesv1.Deploy(ctx, divertIngress, c); err != nil {
 		return nil, fmt.Errorf("error creating divert ingress '%s': %s", divertIngress.Name, err.Error())
 	}
@@ -139,10 +135,6 @@ func createDivertCRD(ctx context.Context, dev *model.Dev, username string, i *ne
 }
 
 func Delete(ctx context.Context, dev *model.Dev, c kubernetes.Interface) error {
-	if dev.Divert == nil {
-		return nil
-	}
-
 	username := okteto.GetSanitizedUsername()
 
 	d, err := deployments.Get(ctx, dev, dev.Namespace, c)
@@ -182,7 +174,7 @@ func Delete(ctx context.Context, dev *model.Dev, c kubernetes.Interface) error {
 		return fmt.Errorf("error deleting divert service '%s': %s", sName, err.Error())
 	}
 
-	divertDeployment := translateDeployment(username, dev, d)
+	divertDeployment := translateDeployment(username, d)
 	translateDev(username, dev, divertDeployment)
 
 	return nil

--- a/pkg/k8s/diverts/interface.go
+++ b/pkg/k8s/diverts/interface.go
@@ -1,0 +1,86 @@
+package diverts
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+)
+
+const divertsResource = "diverts"
+
+type DivertInterface interface {
+	List(ctx context.Context, opts metav1.ListOptions) (*DivertList, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*Divert, error)
+	Create(ctx context.Context, divert *Divert) (*Divert, error)
+	Update(ctx context.Context, divert *Divert) (*Divert, error)
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
+}
+
+type divertClient struct {
+	restClient rest.Interface
+	scheme     *runtime.Scheme
+	ns         string
+}
+
+func (c *divertClient) List(ctx context.Context, opts metav1.ListOptions) (*DivertList, error) {
+	result := DivertList{}
+	err := c.restClient.
+		Get().
+		Namespace(c.ns).
+		Resource(divertsResource).
+		VersionedParams(&opts, runtime.NewParameterCodec(c.scheme)).
+		Do(ctx).
+		Into(&result)
+	return &result, err
+}
+
+func (c *divertClient) Get(ctx context.Context, name string, opts metav1.GetOptions) (*Divert, error) {
+	result := Divert{}
+	err := c.restClient.
+		Get().
+		Namespace(c.ns).
+		Resource(divertsResource).
+		Name(name).
+		VersionedParams(&opts, runtime.NewParameterCodec(c.scheme)).
+		Do(ctx).
+		Into(&result)
+	return &result, err
+}
+
+func (c *divertClient) Create(ctx context.Context, divert *Divert) (*Divert, error) {
+	result := Divert{}
+	err := c.restClient.
+		Post().
+		Namespace(c.ns).
+		Resource(divertsResource).
+		Body(divert).
+		Do(ctx).
+		Into(&result)
+
+	return &result, err
+}
+
+func (c *divertClient) Update(ctx context.Context, divert *Divert) (*Divert, error) {
+	result := Divert{}
+	err := c.restClient.
+		Put().
+		Namespace(c.ns).
+		Resource(divertsResource).
+		Name(divert.Name).
+		Body(divert).
+		Do(ctx).
+		Into(&result)
+
+	return &result, err
+}
+
+func (c *divertClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return c.restClient.
+		Delete().
+		Namespace(c.ns).
+		Resource(divertsResource).
+		Name(name).
+		Do(ctx).Error()
+}

--- a/pkg/k8s/diverts/register.go
+++ b/pkg/k8s/diverts/register.go
@@ -1,0 +1,32 @@
+package diverts
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const GroupName = "weaver.okteto.com"
+const GroupVersion = "v1"
+
+var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
+
+var (
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
+)
+
+// Resource takes an unqualified resource and returns a Group-qualified GroupResource.
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&Divert{},
+		&DivertList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
+}

--- a/pkg/k8s/diverts/translate.go
+++ b/pkg/k8s/diverts/translate.go
@@ -1,0 +1,136 @@
+package diverts
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
+	"github.com/okteto/okteto/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type divertServiceModification struct {
+	ProxyProtocol      string `json:"proxy_port"`
+	OriginalPort       string `json:"original_port"`
+	OriginalTargetPort string `json:"original_target_port"`
+}
+
+// DivertName returns the name of the diverted version of a given resource
+func DivertName(username, name string) string {
+	return fmt.Sprintf("%s-%s", username, name)
+}
+
+func translateDeployment(username string, dev *model.Dev, d *appsv1.Deployment) *appsv1.Deployment {
+	result := d.DeepCopy()
+	result.UID = ""
+	result.Name = DivertName(username, dev.Name)
+	result.Labels = map[string]string{model.OktetoDivertLabel: username}
+	result.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			model.OktetoDivertLabel:      username,
+			okLabels.InteractiveDevLabel: result.Name,
+		},
+	}
+	result.Spec.Template.Labels = map[string]string{
+		model.OktetoDivertLabel:      username,
+		okLabels.InteractiveDevLabel: result.Name,
+	}
+	if result.Annotations == nil {
+		result.Annotations = map[string]string{}
+	}
+	result.Annotations[model.OktetoAutoCreateAnnotation] = model.OktetoUpCmd
+	result.ResourceVersion = ""
+	return result
+}
+
+func translateService(username string, dev *model.Dev, d *appsv1.Deployment, s *apiv1.Service) (*apiv1.Service, error) {
+	result := s.DeepCopy()
+	result.UID = ""
+	result.Name = DivertName(username, dev.Name)
+	result.Labels = map[string]string{model.OktetoDivertLabel: username}
+	if s.Annotations != nil {
+		modification := s.Annotations[model.OktetoDivertServiceModificationAnnotation]
+		if modification != "" {
+			var dsm divertServiceModification
+			if err := json.Unmarshal([]byte(modification), &dsm); err != nil {
+				return nil, fmt.Errorf("bad divert service modification: %s", modification)
+			}
+			for i := range result.Spec.Ports {
+				if strings.Compare(fmt.Sprint(result.Spec.Ports[i].Port), dsm.OriginalPort) == 0 {
+					result.Spec.Ports[i].TargetPort = intstr.FromString(dsm.OriginalTargetPort)
+				}
+			}
+		}
+	}
+	delete(result.Annotations, okLabels.OktetoAutoIngressAnnotation)
+	delete(result.Annotations, model.OktetoDivertServiceModificationAnnotation)
+	result.Spec.Selector = map[string]string{
+		model.OktetoDivertLabel:      username,
+		okLabels.InteractiveDevLabel: d.Name,
+	}
+	result.ResourceVersion = ""
+	return result, nil
+}
+
+func translateIngress(username string, dev *model.Dev, i *networkingv1.Ingress) *networkingv1.Ingress {
+	result := i.DeepCopy()
+	result.UID = ""
+	result.Name = DivertName(username, dev.Name)
+	result.Labels = map[string]string{model.OktetoDivertLabel: username}
+	if result.Annotations == nil {
+		result.Annotations = map[string]string{}
+	}
+	if host := result.Annotations[okLabels.OktetoIngressAutoGenerateHost]; host != "" {
+		if host != "true" {
+			result.Annotations[okLabels.OktetoIngressAutoGenerateHost] = fmt.Sprintf("%s-%s", username, host)
+		}
+	} else {
+		result.Annotations[okLabels.OktetoIngressAutoGenerateHost] = "true"
+	}
+	result.ResourceVersion = ""
+	return result
+}
+
+func translateDivertCRD(username string, dev *model.Dev, s *apiv1.Service, i *networkingv1.Ingress) *Divert {
+	return &Divert{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Divert",
+			APIVersion: "weaver.okteto.com/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.Name,
+			Namespace: dev.Namespace,
+		},
+		Spec: DivertSpec{
+			Ingress: IngressDivertSpec{
+				Name:      i.Name,
+				Namespace: dev.Namespace,
+				Value:     username,
+			},
+			FromService: ServiceDivertSpec{
+				Name:      dev.Divert.Service,
+				Namespace: dev.Namespace,
+				Port:      dev.Divert.Port,
+			},
+			ToService: ServiceDivertSpec{
+				Name:      s.Name,
+				Namespace: dev.Namespace,
+				Port:      dev.Divert.Port,
+			},
+			Deployment: DeploymentDivertSpec{
+				Name:      dev.Name,
+				Namespace: dev.Namespace,
+			},
+		},
+	}
+}
+
+func translateDev(username string, dev *model.Dev, d *appsv1.Deployment) {
+	dev.Name = d.Name
+	dev.Labels = nil
+}

--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Test_translateDeployment(t *testing.T) {
-	dev := &model.Dev{Name: "dev"}
 	original := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             types.UID("id"),
@@ -40,10 +39,10 @@ func Test_translateDeployment(t *testing.T) {
 			},
 		},
 	}
-	translated := translateDeployment("cindy", dev, original)
+	translated := translateDeployment("cindy", original)
 	expected := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cindy-dev",
+			Name:      "cindy-name",
 			Namespace: "namespace",
 			Annotations: map[string]string{
 				"annotation1":                    "value1",
@@ -54,15 +53,13 @@ func Test_translateDeployment(t *testing.T) {
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					model.OktetoDivertLabel:      "cindy",
-					okLabels.InteractiveDevLabel: "cindy-dev",
+					model.OktetoDivertLabel: "cindy",
 				},
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						model.OktetoDivertLabel:      "cindy",
-						okLabels.InteractiveDevLabel: "cindy-dev",
+						model.OktetoDivertLabel: "cindy",
 					},
 				},
 			},
@@ -76,10 +73,9 @@ func Test_translateDeployment(t *testing.T) {
 }
 
 func Test_translateServiceNotDiverted(t *testing.T) {
-	dev := &model.Dev{Name: "dev"}
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cindy-dev",
+			Name: "cindy-name",
 		},
 	}
 	original := &apiv1.Service{
@@ -95,6 +91,7 @@ func Test_translateServiceNotDiverted(t *testing.T) {
 			ResourceVersion: "version",
 		},
 		Spec: apiv1.ServiceSpec{
+			ClusterIP: "10.52.11.123",
 			Selector: map[string]string{
 				"app": "value",
 			},
@@ -106,13 +103,13 @@ func Test_translateServiceNotDiverted(t *testing.T) {
 			},
 		},
 	}
-	translated, err := translateService("cindy", dev, d, original)
+	translated, err := translateService("cindy", d, original)
 	if err != nil {
 		t.Fatalf("error translating service: %s", err.Error())
 	}
 	expected := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cindy-dev",
+			Name:      "cindy-name",
 			Namespace: "namespace",
 			Annotations: map[string]string{
 				"annotation1": "value1",
@@ -122,7 +119,7 @@ func Test_translateServiceNotDiverted(t *testing.T) {
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{
 				model.OktetoDivertLabel:      "cindy",
-				okLabels.InteractiveDevLabel: "cindy-dev",
+				okLabels.InteractiveDevLabel: "cindy-name",
 			},
 			Ports: []apiv1.ServicePort{
 				{
@@ -140,10 +137,9 @@ func Test_translateServiceNotDiverted(t *testing.T) {
 }
 
 func Test_translateServiceDiverted(t *testing.T) {
-	dev := &model.Dev{Name: "dev"}
 	d := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "cindy-dev",
+			Name: "cindy-name",
 		},
 	}
 	original := &apiv1.Service{
@@ -160,6 +156,7 @@ func Test_translateServiceDiverted(t *testing.T) {
 			ResourceVersion: "version",
 		},
 		Spec: apiv1.ServiceSpec{
+			ClusterIP: "10.52.11.123",
 			Selector: map[string]string{
 				"app": "value",
 			},
@@ -171,13 +168,13 @@ func Test_translateServiceDiverted(t *testing.T) {
 			},
 		},
 	}
-	translated, err := translateService("cindy", dev, d, original)
+	translated, err := translateService("cindy", d, original)
 	if err != nil {
 		t.Fatalf("error translating service: %s", err.Error())
 	}
 	expected := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cindy-dev",
+			Name:      "cindy-name",
 			Namespace: "namespace",
 			Annotations: map[string]string{
 				"annotation1": "value1",
@@ -187,12 +184,12 @@ func Test_translateServiceDiverted(t *testing.T) {
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{
 				model.OktetoDivertLabel:      "cindy",
-				okLabels.InteractiveDevLabel: "cindy-dev",
+				okLabels.InteractiveDevLabel: "cindy-name",
 			},
 			Ports: []apiv1.ServicePort{
 				{
 					Port:       8080,
-					TargetPort: intstr.FromString("8080"),
+					TargetPort: intstr.FromInt(8080),
 				},
 			},
 		},
@@ -205,7 +202,6 @@ func Test_translateServiceDiverted(t *testing.T) {
 }
 
 func Test_translateIngressGenerateHostTrue(t *testing.T) {
-	dev := &model.Dev{Name: "dev"}
 	original := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       types.UID("id"),
@@ -219,10 +215,10 @@ func Test_translateIngressGenerateHostTrue(t *testing.T) {
 			ResourceVersion: "version",
 		},
 	}
-	translated := translateIngress("cindy", dev, original)
+	translated := translateIngress("cindy", original)
 	expected := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cindy-dev",
+			Name:      "cindy-name",
 			Namespace: "namespace",
 			Annotations: map[string]string{
 				"annotation1":                          "value1",
@@ -239,7 +235,6 @@ func Test_translateIngressGenerateHostTrue(t *testing.T) {
 }
 
 func Test_translateIngressCustomGenerateHost(t *testing.T) {
-	dev := &model.Dev{Name: "dev"}
 	original := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       types.UID("id"),
@@ -253,10 +248,10 @@ func Test_translateIngressCustomGenerateHost(t *testing.T) {
 			ResourceVersion: "version",
 		},
 	}
-	translated := translateIngress("cindy", dev, original)
+	translated := translateIngress("cindy", original)
 	expected := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cindy-dev",
+			Name:      "cindy-name",
 			Namespace: "namespace",
 			Annotations: map[string]string{
 				"annotation1":                          "value1",

--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -1,0 +1,273 @@
+package diverts
+
+import (
+	"testing"
+
+	okLabels "github.com/okteto/okteto/pkg/k8s/labels"
+	"github.com/okteto/okteto/pkg/model"
+	yaml "gopkg.in/yaml.v2"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func Test_translateDeployment(t *testing.T) {
+	dev := &model.Dev{Name: "dev"}
+	original := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:             types.UID("id"),
+			Name:            "name",
+			Namespace:       "namespace",
+			Annotations:     map[string]string{"annotation1": "value1"},
+			Labels:          map[string]string{"label1": "value1"},
+			ResourceVersion: "version",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "value",
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "value",
+					},
+				},
+			},
+		},
+	}
+	translated := translateDeployment("cindy", dev, original)
+	expected := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cindy-dev",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1":                    "value1",
+				model.OktetoAutoCreateAnnotation: model.OktetoUpCmd,
+			},
+			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					model.OktetoDivertLabel:      "cindy",
+					okLabels.InteractiveDevLabel: "cindy-dev",
+				},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						model.OktetoDivertLabel:      "cindy",
+						okLabels.InteractiveDevLabel: "cindy-dev",
+					},
+				},
+			},
+		},
+	}
+	marshalled, _ := yaml.Marshal(translated)
+	marshalledExpected, _ := yaml.Marshal(expected)
+	if string(marshalled) != string(marshalledExpected) {
+		t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
+	}
+}
+
+func Test_translateServiceNotDiverted(t *testing.T) {
+	dev := &model.Dev{Name: "dev"}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cindy-dev",
+		},
+	}
+	original := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("id"),
+			Name:      "name",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1":                        "value1",
+				okLabels.OktetoAutoIngressAnnotation: "true",
+			},
+			Labels:          map[string]string{"label1": "value1"},
+			ResourceVersion: "version",
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "value",
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+		},
+	}
+	translated, err := translateService("cindy", dev, d, original)
+	if err != nil {
+		t.Fatalf("error translating service: %s", err.Error())
+	}
+	expected := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cindy-dev",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1": "value1",
+			},
+			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				model.OktetoDivertLabel:      "cindy",
+				okLabels.InteractiveDevLabel: "cindy-dev",
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       8080,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+		},
+	}
+	marshalled, _ := yaml.Marshal(translated)
+	marshalledExpected, _ := yaml.Marshal(expected)
+	if string(marshalled) != string(marshalledExpected) {
+		t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
+	}
+}
+
+func Test_translateServiceDiverted(t *testing.T) {
+	dev := &model.Dev{Name: "dev"}
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cindy-dev",
+		},
+	}
+	original := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("id"),
+			Name:      "name",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1":                                   "value1",
+				okLabels.OktetoAutoIngressAnnotation:            "true",
+				model.OktetoDivertServiceModificationAnnotation: "{\"proxy_port\":\"1026\",\"original_port\":\"8080\",\"original_target_port\":\"8080\"}",
+			},
+			Labels:          map[string]string{"label1": "value1"},
+			ResourceVersion: "version",
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "value",
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       8080,
+					TargetPort: intstr.FromInt(1026),
+				},
+			},
+		},
+	}
+	translated, err := translateService("cindy", dev, d, original)
+	if err != nil {
+		t.Fatalf("error translating service: %s", err.Error())
+	}
+	expected := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cindy-dev",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1": "value1",
+			},
+			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				model.OktetoDivertLabel:      "cindy",
+				okLabels.InteractiveDevLabel: "cindy-dev",
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Port:       8080,
+					TargetPort: intstr.FromString("8080"),
+				},
+			},
+		},
+	}
+	marshalled, _ := yaml.Marshal(translated)
+	marshalledExpected, _ := yaml.Marshal(expected)
+	if string(marshalled) != string(marshalledExpected) {
+		t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
+	}
+}
+
+func Test_translateIngressGenerateHostTrue(t *testing.T) {
+	dev := &model.Dev{Name: "dev"}
+	original := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("id"),
+			Name:      "name",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1":                          "value1",
+				okLabels.OktetoIngressAutoGenerateHost: "true",
+			},
+			Labels:          map[string]string{"label1": "value1"},
+			ResourceVersion: "version",
+		},
+	}
+	translated := translateIngress("cindy", dev, original)
+	expected := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cindy-dev",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1":                          "value1",
+				okLabels.OktetoIngressAutoGenerateHost: "true",
+			},
+			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+		},
+	}
+	marshalled, _ := yaml.Marshal(translated.ObjectMeta)
+	marshalledExpected, _ := yaml.Marshal(expected.ObjectMeta)
+	if string(marshalled) != string(marshalledExpected) {
+		t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
+	}
+}
+
+func Test_translateIngressCustomGenerateHost(t *testing.T) {
+	dev := &model.Dev{Name: "dev"}
+	original := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("id"),
+			Name:      "name",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1":                          "value1",
+				okLabels.OktetoIngressAutoGenerateHost: "custom",
+			},
+			Labels:          map[string]string{"label1": "value1"},
+			ResourceVersion: "version",
+		},
+	}
+	translated := translateIngress("cindy", dev, original)
+	expected := &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cindy-dev",
+			Namespace: "namespace",
+			Annotations: map[string]string{
+				"annotation1":                          "value1",
+				okLabels.OktetoIngressAutoGenerateHost: "cindy-custom",
+			},
+			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+		},
+	}
+	marshalled, _ := yaml.Marshal(translated.ObjectMeta)
+	marshalledExpected, _ := yaml.Marshal(expected.ObjectMeta)
+	if string(marshalled) != string(marshalledExpected) {
+		t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
+	}
+}

--- a/pkg/k8s/diverts/types.go
+++ b/pkg/k8s/diverts/types.go
@@ -1,0 +1,142 @@
+package diverts
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type IngressDivertSpec struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Value     string `json:"value,omitempty"`
+}
+
+type ServiceDivertSpec struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Port      int    `json:"port"`
+}
+
+type DeploymentDivertSpec struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type DivertSpec struct {
+	Ingress     IngressDivertSpec    `json:"ingress"`
+	FromService ServiceDivertSpec    `json:"fromService"`
+	ToService   ServiceDivertSpec    `json:"toService"`
+	Deployment  DeploymentDivertSpec `json:"deployment"`
+}
+
+type DivertStatus struct {
+	OriginalPort       int    `json:"originalPort"`
+	ProxyListenerPort  int    `json:"proxyListenerPort"`
+	HeaderID           string `json:"headerID"`
+	NodeID             string `json:"nodeID"`
+	DestinationAddress string `json:"destinationAddress"`
+	DestinationPort    int    `json:"destinationPort"`
+}
+
+type Divert struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	Spec   DivertSpec   `json:"spec"`
+	Status DivertStatus `json:"status"`
+}
+
+type DivertList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Divert `json:"items"`
+}
+
+// DeepCopyInto a deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *Divert) DeepCopyInto(out *Divert) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	out.Spec = in.Spec
+	out.Status = in.Status
+}
+
+// DeepCopy a deepcopy function, copying the receiver, creating a new Divert.
+func (in *Divert) DeepCopy() *Divert {
+	if in == nil {
+		return nil
+	}
+	out := new(Divert)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyObject a deepcopy function, copying the receiver, creating a new runtime.Object.
+func (in *Divert) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+// DeepCopyInto a deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *DivertList) DeepCopyInto(out *DivertList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]Divert, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+// DeepCopy a deepcopy function, copying the receiver, creating a new DivertList.
+func (in *DivertList) DeepCopy() *DivertList {
+	if in == nil {
+		return nil
+	}
+	out := new(DivertList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyObject a deepcopy function, copying the receiver, creating a new runtime.Object.
+func (in *DivertList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+// DeepCopyInto a deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *DivertSpec) DeepCopyInto(out *DivertSpec) {
+	*out = *in
+}
+
+// DeepCopy a deepcopy function, copying the receiver, creating a new DivertSpec.
+func (in *DivertSpec) DeepCopy() *DivertSpec {
+	if in == nil {
+		return nil
+	}
+	out := new(DivertSpec)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyInto a deepcopy function, copying the receiver, writing into out. in must be non-nil.
+func (in *DivertStatus) DeepCopyInto(out *DivertStatus) {
+	*out = *in
+}
+
+// DeepCopy a deepcopy function, copying the receiver, creating a new DivertStatus.
+func (in *DivertStatus) DeepCopy() *DivertStatus {
+	if in == nil {
+		return nil
+	}
+	out := new(DivertStatus)
+	in.DeepCopyInto(out)
+	return out
+}

--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -219,7 +219,7 @@ func (p *PortForwardManager) buildForwarder(namespace, pod string, ports []strin
 }
 
 func (p *PortForwardManager) buildForwarderToService(ctx context.Context, namespace, service string) (*active, *portforward.PortForwarder, error) {
-	svc, err := services.Get(ctx, namespace, service, p.client)
+	svc, err := services.Get(ctx, service, namespace, p.client)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/k8s/ingressesv1/crud.go
+++ b/pkg/k8s/ingressesv1/crud.go
@@ -1,0 +1,73 @@
+package ingressesv1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/log"
+	"k8s.io/client-go/kubernetes"
+
+	networkingv1 "k8s.io/api/networking/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Deploy(ctx context.Context, i *networkingv1.Ingress, c kubernetes.Interface) error {
+	old, err := Get(ctx, i.Name, i.Namespace, c)
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("error getting kubernetes ingress: %s", err)
+	}
+
+	if old == nil || old.Name == "" {
+		log.Infof("creating ingress '%s'", i.Name)
+		_, err = c.NetworkingV1().Ingresses(i.Namespace).Create(ctx, i, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("error creating kubernetes ingress: %s", err)
+		}
+		log.Infof("created ingress '%s'", i.Name)
+	} else {
+		log.Infof("updating ingress '%s'", i.Name)
+		old.Annotations = i.Annotations
+		old.Labels = i.Labels
+		old.Spec = i.Spec
+		_, err = c.NetworkingV1().Ingresses(i.Namespace).Update(ctx, old, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("error updating kubernetes ingress: %s", err)
+		}
+		log.Infof("updated ingress '%s'.", i.Name)
+	}
+	return nil
+}
+
+func Get(ctx context.Context, name, namespace string, c kubernetes.Interface) (*networkingv1.Ingress, error) {
+	return c.NetworkingV1().Ingresses(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// List returns the list of deployments
+func List(ctx context.Context, namespace, labels string, c kubernetes.Interface) ([]networkingv1.Ingress, error) {
+	iList, err := c.NetworkingV1().Ingresses(namespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: labels,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return iList.Items, nil
+}
+
+// Destroy destroys a k8s deployment
+func Destroy(ctx context.Context, name, namespace string, c kubernetes.Interface) error {
+	log.Infof("deleting ingress '%s'", name)
+	err := c.NetworkingV1().Ingresses(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("error deleting kubernetes ingress: %s", err)
+	}
+	log.Infof("Ingress '%s' deleted", name)
+	return nil
+}

--- a/pkg/k8s/ingressesv1/crud_test.go
+++ b/pkg/k8s/ingressesv1/crud_test.go
@@ -1,0 +1,162 @@
+package ingressesv1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8sTesting "k8s.io/client-go/testing"
+)
+
+func TestDeployCreate(t *testing.T) {
+	ctx := context.Background()
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "test",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset()
+	err := Deploy(ctx, ingress, clientset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retrieved, err := clientset.NetworkingV1().Ingresses(ingress.Namespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(retrieved, ingress) {
+		t.Fatalf("Didn't created correctly")
+	}
+}
+
+func TestDeployUpdate(t *testing.T) {
+	ctx := context.Background()
+	labels := map[string]string{"key": "value"}
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "test",
+			Labels:    labels,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(ingress)
+
+	updatedLabels := map[string]string{"key": "value", "key2": "value2"}
+	updatedIngress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "test",
+			Labels:    updatedLabels,
+		},
+	}
+	err := Deploy(ctx, updatedIngress, clientset)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retrieved, err := clientset.NetworkingV1().Ingresses(ingress.Namespace).Get(ctx, ingress.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(retrieved, updatedIngress) {
+		t.Fatalf("Didn't updated correctly")
+	}
+}
+
+func TestList(t *testing.T) {
+	ctx := context.Background()
+	ingress := &networkingv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake",
+			Namespace: "test",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(ingress)
+	ingressList, err := List(ctx, ingress.Namespace, "", clientset)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ingressList) != 1 {
+		t.Fatal(fmt.Errorf("Expected 1 ingress, found %d", len(ingressList)))
+	}
+
+}
+
+func TestDestroy(t *testing.T) {
+	var tests = []struct {
+		name        string
+		ingressName string
+		namespace   string
+		ingress     *networkingv1.Ingress
+	}{
+		{
+			name:        "existent-ingress",
+			ingressName: "ingress-test",
+			namespace:   "test",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-test",
+					Namespace: "test",
+				},
+			},
+		},
+		{
+			name:        "ingress-not-found",
+			ingressName: "ingress-test",
+			namespace:   "test",
+			ingress: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "non-existent-ingress",
+					Namespace: "another-space",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			client := fake.NewSimpleClientset(tt.ingress)
+
+			err := Destroy(ctx, tt.ingressName, tt.namespace, client)
+
+			if err != nil {
+				t.Fatalf("unexpected error '%s'", err)
+			}
+		})
+	}
+}
+
+func TestDestroyWithError(t *testing.T) {
+	ctx := context.Background()
+	ingressName := "ingress-test"
+	namespace := "test"
+
+	kubernetesError := "something went wrong in the test"
+	client := fake.NewSimpleClientset()
+	client.Fake.PrependReactor("delete", "ingresses", func(action k8sTesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New(kubernetesError)
+	})
+
+	err := Destroy(ctx, ingressName, namespace, client)
+
+	if err == nil {
+		t.Fatal("an error was expected but no error was returned")
+	}
+	if !strings.Contains(err.Error(), kubernetesError) {
+		t.Fatalf("Got '%s' error but expected '%s'", err.Error(), kubernetesError)
+	}
+}

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -96,7 +96,7 @@ func Create(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset, s *syn
 }
 
 // Destroy deletes the syncthing config secret
-func Destroy(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset) error {
+func Destroy(ctx context.Context, dev *model.Dev, c kubernetes.Interface) error {
 	secretName := GetSecretName(dev)
 	err := c.CoreV1().Secrets(dev.Namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
 	if err != nil {

--- a/pkg/k8s/services/crud_test.go
+++ b/pkg/k8s/services/crud_test.go
@@ -34,7 +34,7 @@ func TestGet(t *testing.T) {
 	}
 
 	clientset := fake.NewSimpleClientset(svc)
-	s, err := Get(ctx, svc.GetNamespace(), svc.GetName(), clientset)
+	s, err := Get(ctx, svc.GetName(), svc.GetNamespace(), clientset)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestGet(t *testing.T) {
 		t.Fatalf("wrong service. Got %s, expected %s", s.Name, svc.GetName())
 	}
 
-	_, err = Get(ctx, "missing", "test", clientset)
+	_, err = Get(ctx, "test", "missing", clientset)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -79,6 +79,10 @@ const (
 	OktetoRestartAnnotation = "dev.okteto.com/restart"
 	//OktetoStignoreAnnotation indicates the hash of the stignore files to force redeployment
 	OktetoStignoreAnnotation = "dev.okteto.com/stignore"
+	//OktetoDivertLabel indicates the object is a diverted version
+	OktetoDivertLabel = "dev.okteto.com/divert"
+	//OktetoDivertServiceModificationAnnotation indicates the service modification done by diverting a service
+	OktetoDivertServiceModificationAnnotation = "divert.okteto.com/modification"
 
 	//OktetoInitContainer name of the okteto init container
 	OktetoInitContainer = "okteto-init"
@@ -157,6 +161,7 @@ type Dev struct {
 	InitContainer        InitContainer         `json:"initContainer,omitempty" yaml:"initContainer,omitempty"`
 	Timeout              time.Duration         `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	Docker               DinDContainer         `json:"docker,omitempty" yaml:"docker,omitempty"`
+	Divert               *Divert               `json:"divert,omitempty" yaml:"divert,omitempty"`
 }
 
 // Entrypoint represents the start command of a development container
@@ -292,6 +297,13 @@ type Probes struct {
 type Lifecycle struct {
 	PostStart bool `json:"postStart,omitempty" yaml:"postStart,omitempty"`
 	PostStop  bool `json:"postStop,omitempty" yaml:"postStop,omitempty"`
+}
+
+// Divert defines how to divert a given service
+type Divert struct {
+	Ingress string `yaml:"ingress,omitempty"`
+	Service string `yaml:"service,omitempty"`
+	Port    int    `yaml:"port,omitempty"`
 }
 
 // ResourceList is a set of (resource name, quantity) pairs.

--- a/pkg/okteto/auth.go
+++ b/pkg/okteto/auth.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/machinebox/graphql"
 	"github.com/okteto/okteto/pkg/config"
@@ -31,6 +33,8 @@ import (
 const (
 	tokenFile = ".token.json"
 )
+
+var reg = regexp.MustCompile("[^A-Za-z0-9]+")
 
 // Token contains the auth token and the URL it belongs to
 type Token struct {
@@ -204,6 +208,16 @@ func GetUsername() string {
 	}
 
 	return t.Username
+}
+
+// GetSanitizedUsername returns the username of the authenticated user sanitized to be DNS compatible
+func GetSanitizedUsername() string {
+	t, err := GetToken()
+	if err != nil {
+		return ""
+	}
+
+	return reg.ReplaceAllString(strings.ToLower(t.Username), "-")
 }
 
 // GetMachineID returns the userID of the authenticated user


### PR DESCRIPTION
Fixes #933

This PR adds support to divert a deployment on `okteto up`. Instead of replacing the original deployment, divert will create a new ingress, a new service, a service mesh layer, and a cloned deployment to develop without affecting the original deployment.

This feature requires CRDs and operators only available in Okteto Cloud/Enterprise.