### PR TITLE
Add new e2e test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/syncthing"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	yaml "gopkg.in/yaml.v2"
@@ -701,6 +702,23 @@ func getDeployment(ctx context.Context, ns, name string) (*appsv1.Deployment, er
 	}
 
 	return client.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+}
+
+func getStatefulset(ctx context.Context, ns, name string) (*appsv1.StatefulSet, error) {
+	client, _, err := k8Client.GetLocal()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.AppsV1().StatefulSets(ns).Get(ctx, name, metav1.GetOptions{})
+}
+
+func getVolume(ctx context.Context, ns, name string) (*corev1.PersistentVolumeClaim, error) {
+	client, _, err := k8Client.GetLocal()
+	if err != nil {
+		return nil, err
+	}
+	return client.CoreV1().PersistentVolumeClaims(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
 func compareDeployment(ctx context.Context, deployment *appsv1.Deployment) error {

--- a/integration/stacks_test.go
+++ b/integration/stacks_test.go
@@ -17,6 +17,7 @@ package integration
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -30,9 +31,11 @@ import (
 )
 
 const (
-	stackGitRepo   = "git@github.com:okteto/stacks-getting-started.git"
-	stackGitFolder = "stacks-getting-started"
-	stackManifest  = "okteto-stack.yml"
+	stackGitRepo     = "git@github.com:okteto/stacks-getting-started.git"
+	stackGitFolder   = "stacks-getting-started"
+	stackManifest    = "okteto-stack.yml"
+	composeGitRepo   = "git@github.com:okteto/flask-producer-consumer.git"
+	composeGitFolder = "flask-producer-consumer"
 )
 
 func TestStacks(t *testing.T) {
@@ -68,7 +71,7 @@ func TestStacks(t *testing.T) {
 
 		defer deleteGitRepo(ctx, stackGitFolder)
 
-		if err := deployStack(ctx, oktetoPath, stackManifest); err != nil {
+		if err := deployStack(ctx, oktetoPath, stackManifest, stackGitFolder); err != nil {
 			t.Fatal(err)
 		}
 
@@ -83,7 +86,7 @@ func TestStacks(t *testing.T) {
 		if !strings.Contains(content, "Cats vs Dogs!") {
 			t.Fatalf("wrong stack content: %s", content)
 		}
-		if err := destroyStack(ctx, oktetoPath, stackManifest); err != nil {
+		if err := destroyStack(ctx, oktetoPath, stackManifest, stackGitFolder); err != nil {
 			t.Fatal(err)
 		}
 
@@ -127,11 +130,11 @@ func deleteGitRepo(ctx context.Context, path string) error {
 	return nil
 }
 
-func deployStack(ctx context.Context, oktetoPath, stackPath string) error {
+func deployStack(ctx context.Context, oktetoPath, stackPath, dir string) error {
 	log.Printf("okteto stack deploy %s", stackPath)
 	cmd := exec.Command(oktetoPath, "stack", "deploy", "-f", stackPath, "--build", "--wait")
 	cmd.Env = os.Environ()
-	cmd.Dir = stackGitFolder
+	cmd.Dir = dir
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("okteto stack deploy failed: %s - %s", string(o), err)
@@ -140,15 +143,123 @@ func deployStack(ctx context.Context, oktetoPath, stackPath string) error {
 	return nil
 }
 
-func destroyStack(ctx context.Context, oktetoPath, stackManifest string) error {
+func destroyStack(ctx context.Context, oktetoPath, stackManifest, dir string) error {
 	log.Printf("okteto stack destroy")
 	cmd := exec.Command(oktetoPath, "stack", "destroy", "-f", stackManifest)
 	cmd.Env = os.Environ()
-	cmd.Dir = stackGitFolder
+	cmd.Dir = dir
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("okteto stack destroy failed: %s - %s", string(o), err)
 	}
 	log.Printf("okteto stack destroy success")
 	return nil
+}
+
+func TestCompose(t *testing.T) {
+	if mode == "client" {
+		t.Skip("this test is not required for client-side translation")
+		return
+	}
+
+	ctx := context.Background()
+	oktetoPath, err := getOktetoPath(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tName := fmt.Sprintf("TestStacks-%s", runtime.GOOS)
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	namespace := fmt.Sprintf("%s-%s", name, user)
+
+	t.Run(tName, func(t *testing.T) {
+		log.Printf("running %s \n", tName)
+		k8Client.Reset()
+	})
+	if err := createNamespace(ctx, oktetoPath, namespace); err != nil {
+		t.Fatal(err)
+	}
+
+	log.Printf("created namespace %s \n", namespace)
+
+	if err := cloneGitRepo(ctx, composeGitRepo); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := deployStack(ctx, oktetoPath, "docker-compose.yml", composeGitFolder); err != nil {
+		t.Fatal(err)
+	}
+	defer deleteGitRepo(ctx, composeGitFolder)
+
+	log.Printf("deployed stack using %s \n", "docker-compose.yml")
+
+	endpoint := fmt.Sprintf("https://nginx-%s.cloud.okteto.net/db", namespace)
+	content, err := getContent(endpoint, 150)
+	if err != nil {
+		t.Fatalf("failed to get stack content: %s", err)
+	}
+	var objmap map[string]json.RawMessage
+	err = json.Unmarshal([]byte(content), &objmap)
+
+	if strings.ToUpper(string(objmap["lower"])) != string(objmap["uppercase"]) {
+		t.Fatal("Not the right response")
+	}
+
+	if err := destroyStack(ctx, oktetoPath, "docker-compose.yml", composeGitFolder); err != nil {
+		t.Fatal(err)
+	}
+
+	log.Println("destroyed stack")
+
+	time.Sleep(5 * time.Second)
+	_, err = getDeployment(ctx, namespace, "api")
+	if err == nil {
+		t.Fatalf("'api' deployment not deleted after 'okteto stack destroy'")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error getting deployment 'api': %s", err.Error())
+	}
+	_, err = getDeployment(ctx, namespace, "producer")
+	if err == nil {
+		t.Fatalf("'producer' deployment not deleted after 'okteto stack destroy'")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error getting deployment 'producer': %s", err.Error())
+	}
+	_, err = getDeployment(ctx, namespace, "consumer")
+	if err == nil {
+		t.Fatalf("'consumer' deployment not deleted after 'okteto stack destroy'")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error getting deployment 'consumer': %s", err.Error())
+	}
+	_, err = getDeployment(ctx, namespace, "web-svc")
+	if err == nil {
+		t.Fatalf("'web-svc' deployment not deleted after 'okteto stack destroy'")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error getting deployment 'web-svc': %s", err.Error())
+	}
+
+	_, err = getStatefulset(ctx, namespace, "mongodb")
+	if err == nil {
+		t.Fatalf("'mongodb' statefulset not deleted after 'okteto stack destroy'")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error getting statefulset 'mongodb': %s", err.Error())
+	}
+
+	_, err = getStatefulset(ctx, namespace, "rabbitmq")
+
+	if err == nil {
+		t.Fatalf("'rabbitmq' statefulset not deleted after 'okteto stack destroy'")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error getting statefulset 'rabbitmq': %s", err.Error())
+	}
+	if err := deleteNamespace(ctx, oktetoPath, namespace); err != nil {
+		log.Printf("failed to delete namespace %s: %s\n", namespace, err)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
Adds e2e tests for compose that test:  
 - mounted volumes
 - named volumes relative path
 - non named volumes
 - Port inference from docker hub and external registry(ECR)
 - container name
 - Command split
 - service connection