### PR TITLE
Jlopezbarb/fix update volume error

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -230,15 +230,9 @@ func deployVolume(ctx context.Context, volumeName string, s *model.Stack, c *kub
 			return fmt.Errorf("name collision: the volume '%s' belongs to the stack '%s'", pvc.Name, old.Labels[okLabels.StackNameLabel])
 		}
 		if !volumes.IsEqual(&pvc, old) {
-			to, err := model.GetTimeout()
-			if err != nil {
-				return err
-			}
-			if err := volumes.Destroy(ctx, pvc.Name, pvc.Namespace, c, to); err != nil {
-				return fmt.Errorf("error updating volume of service '%s': %s", pvc.Name, err.Error())
-			}
-			if err := volumes.Create(ctx, &pvc, c); err != nil {
-				return fmt.Errorf("error creating volume '%s': %s", pvc.Name, err.Error())
+			old.Spec.Resources.Requests["storage"] = pvc.Spec.Resources.Requests["storage"]
+			if err := volumes.Update(ctx, old, c); err != nil {
+				return fmt.Errorf("error updating volume '%s': %s", old.Name, err.Error())
 			}
 		}
 

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -338,43 +338,6 @@ func translatePersistentVolumeClaim(volumeName string, s *model.Stack) apiv1.Per
 	}
 	return pvc
 }
-func translatePersistentVolumeClaims(name string, s *model.Stack) []apiv1.PersistentVolumeClaim {
-	svc := s.Services[name]
-	result := make([]apiv1.PersistentVolumeClaim, 0)
-	for _, volume := range svc.Volumes {
-		if volume.LocalPath == "" {
-			continue
-		}
-		volumeSpec := s.Volumes[volume.LocalPath]
-		labels := translateVolumeLabels(volume.LocalPath, s)
-		annotations := translateAnnotations(svc)
-		for key, value := range volumeSpec.Annotations {
-			annotations[key] = value
-		}
-
-		pvcName := getVolumeClaimName(&volume)
-		pvc := apiv1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        pvcName,
-				Namespace:   s.Namespace,
-				Labels:      labels,
-				Annotations: annotations,
-			},
-			Spec: apiv1.PersistentVolumeClaimSpec{
-				AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOnce},
-				Resources: apiv1.ResourceRequirements{
-					Requests: apiv1.ResourceList{
-						"storage": volumeSpec.Size.Value,
-					},
-				},
-				StorageClassName: translateStorageClass(volumeSpec.Class),
-			},
-		}
-		result = append(result, pvc)
-	}
-
-	return result
-}
 
 func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 	svc := s.Services[svcName]

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -316,7 +316,28 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 		},
 	}
 }
-
+func translatePersistentVolumeClaim(volumeName string, s *model.Stack) apiv1.PersistentVolumeClaim {
+	volumeSpec := s.Volumes[volumeName]
+	labels := translateVolumeLabels(volumeName, s)
+	pvc := apiv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        volumeName,
+			Namespace:   s.Namespace,
+			Labels:      labels,
+			Annotations: volumeSpec.Annotations,
+		},
+		Spec: apiv1.PersistentVolumeClaimSpec{
+			AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOnce},
+			Resources: apiv1.ResourceRequirements{
+				Requests: apiv1.ResourceList{
+					"storage": volumeSpec.Size.Value,
+				},
+			},
+			StorageClassName: translateStorageClass(volumeSpec.Class),
+		},
+	}
+	return pvc
+}
 func translatePersistentVolumeClaims(name string, s *model.Stack) []apiv1.PersistentVolumeClaim {
 	svc := s.Services[name]
 	result := make([]apiv1.PersistentVolumeClaim, 0)

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -178,3 +178,7 @@ func checkIfAttached(ctx context.Context, name, namespace string, c *kubernetes.
 
 	return nil
 }
+
+func IsEqual(one, another *apiv1.PersistentVolumeClaim) bool {
+	return one.Spec.Resources.Requests["storage"] == another.Spec.Resources.Requests["storage"]
+}


### PR DESCRIPTION
Fixes When there is a volume deployed and you want to update resources, it gives you a forbidden error, because the volume name and storage class name has change. These fields are given by Okteto cluster.

## Proposed changes
-  This PR checks if the requested resources are the same from the previous instance.
- If the resources are the same, it doesn't update the volume, but if they are not equal updates the volume with the volume name and storage class name set instead of the new one  
