### PR TITLE
Fix forbidden error when updating volumes stack

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -237,6 +237,9 @@ func deployVolume(ctx context.Context, volumeName string, s *model.Stack, c *kub
 		for key, value := range pvc.Annotations {
 			old.Annotations[key] = value
 		}
+		if pvc.Spec.StorageClassName != nil {
+			old.Spec.StorageClassName = pvc.Spec.StorageClassName
+		}
 
 		if err := volumes.Update(ctx, old, c); err != nil {
 			return fmt.Errorf("error updating volume '%s': %s", old.Name, err.Error())

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -229,11 +229,18 @@ func deployVolume(ctx context.Context, volumeName string, s *model.Stack, c *kub
 		if old.Labels[okLabels.StackNameLabel] != s.Name {
 			return fmt.Errorf("name collision: the volume '%s' belongs to the stack '%s'", pvc.Name, old.Labels[okLabels.StackNameLabel])
 		}
-		if !volumes.IsEqual(&pvc, old) {
-			old.Spec.Resources.Requests["storage"] = pvc.Spec.Resources.Requests["storage"]
-			if err := volumes.Update(ctx, old, c); err != nil {
-				return fmt.Errorf("error updating volume '%s': %s", old.Name, err.Error())
-			}
+
+		old.Spec.Resources.Requests["storage"] = pvc.Spec.Resources.Requests["storage"]
+		for key, value := range pvc.Labels {
+			old.Labels[key] = value
+		}
+		for key, value := range pvc.Annotations {
+			old.Annotations[key] = value
+		}
+
+		if err := volumes.Update(ctx, old, c); err != nil {
+			return fmt.Errorf("error updating volume '%s': %s", old.Name, err.Error())
+
 		}
 	}
 	return nil

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -178,6 +178,3 @@ func checkIfAttached(ctx context.Context, name, namespace string, c *kubernetes.
 
 	return nil
 }
-func IsEqual(one, another *apiv1.PersistentVolumeClaim) bool {
-	return one.Spec.Resources.Requests["storage"] == another.Spec.Resources.Requests["storage"]
-}

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -178,3 +178,6 @@ func checkIfAttached(ctx context.Context, name, namespace string, c *kubernetes.
 
 	return nil
 }
+func IsEqual(one, another *apiv1.PersistentVolumeClaim) bool {
+	return one.Spec.Resources.Requests["storage"] == another.Spec.Resources.Requests["storage"]
+}

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -667,6 +667,11 @@ func Test_unmarshalVolumes(t *testing.T) {
 			expectedVolume: &VolumeSpec{Size: Quantity{resource.MustParse("1Gi")}, Class: "standard", Labels: make(map[string]string), Annotations: make(map[string]string)},
 		},
 		{
+			name:           "volume with class",
+			manifest:       []byte("services:\n  app:\n    image: okteto/vote:1\nvolumes:\n  v1:\n    class: standard"),
+			expectedVolume: &VolumeSpec{Size: Quantity{resource.MustParse("1Gi")}, Class: "standard", Labels: make(map[string]string), Annotations: make(map[string]string)},
+		},
+		{
 			name:           "volume with labels",
 			manifest:       []byte("services:\n  app:\n    image: okteto/vote:1\nvolumes:\n  v1:\n    labels:\n      env: test"),
 			expectedVolume: &VolumeSpec{Size: Quantity{resource.MustParse("1Gi")}, Labels: Labels{}, Annotations: Annotations{"env": "test"}},


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: When there is a volume deployed and you want to update resources (Okteto stack deploy without running Okteto stack destroy), it gives you a forbidden error, because the volume name and storage class name are not set initially. These fields are given by Okteto cluster.

## Proposed changes
- This PR checks if the requested resources are the same from the previous instance.
- If the resources are the same, it doesn't update the volume, but if they are not equal updates the volume with the volume name and storage class name set instead of the new one
