### PR TITLE
Add new transient error

### DIFF
--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -59,6 +59,8 @@ func IsTransientError(err error) bool {
 		return true
 	case strings.Contains(err.Error(), "failed to do request") && strings.Contains(err.Error(), "tls: use of closed connection"):
 		return true
+	case strings.Contains(err.Error(), "Canceled desc") && strings.Contains(err.Error(), "the client connection is closing"):
+		return true
 	default:
 		return false
 	}

--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -57,6 +57,8 @@ func IsTransientError(err error) bool {
 		return true
 	case strings.Contains(err.Error(), "failed to do request") && strings.Contains(err.Error(), "http: server closed idle connection"):
 		return true
+	case strings.Contains(err.Error(), "failed to do request") && strings.Contains(err.Error(), "tls: use of closed connection"):
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Retry when buildkit returns `tls: use of closed connection`

## Proposed changes
-  Retry when `tls: use of closed connection` is returned by buildkit (This is one of the errors that is usually reported by windows tests)
-  
