### PR TITLE
Improve "okteto init" logic for interpreted languages

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -108,7 +108,7 @@ func Run(namespace, k8sContext, devPath, language, workDir string, overwrite boo
 		return err
 	}
 
-	dev, err := linguist.GetDevDefaults(language, workDir, checkForDeployment)
+	dev, err := linguist.GetDevDefaults(language, workDir)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func Run(namespace, k8sContext, devPath, language, workDir string, overwrite boo
 			suffix := fmt.Sprintf("Analyzing deployment '%s'...", d.Name)
 			spinner := utils.NewSpinner(suffix)
 			spinner.Start()
-			err = initCMD.SetDevDefaultsFromDeployment(ctx, dev, d, container)
+			err = initCMD.SetDevDefaultsFromDeployment(ctx, dev, d, container, language)
 			spinner.Stop()
 			if err == nil {
 				log.Success(fmt.Sprintf("Deployment '%s' successfully analyzed", d.Name))

--- a/pkg/cmd/init/run.go
+++ b/pkg/cmd/init/run.go
@@ -23,12 +23,15 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/pods"
 	"github.com/okteto/okteto/pkg/k8s/replicasets"
 	"github.com/okteto/okteto/pkg/k8s/services"
+	"github.com/okteto/okteto/pkg/linguist"
+	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 var (
@@ -36,19 +39,35 @@ var (
 )
 
 // SetDevDefaultsFromDeployment sets dev defaults from a running deployment
-func SetDevDefaultsFromDeployment(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, container string) error {
-	c, _, err := k8Client.GetLocalWithContext(dev.Context)
+func SetDevDefaultsFromDeployment(ctx context.Context, dev *model.Dev, d *appsv1.Deployment, container, language string) error {
+	c, config, err := k8Client.GetLocalWithContext(dev.Context)
 	if err != nil {
 		return err
 	}
-
-	setAnnotationsFromDeployment(dev, d)
-	setNameAndLabelsFromDeployment(ctx, dev, d)
 
 	pod, err := getRunningPod(ctx, d, container, c)
 	if err != nil {
 		return err
 	}
+
+	language = linguist.NormalizeLanguage(language)
+	updateImageFromPod := false
+	switch language {
+	case linguist.Javascript:
+		updateImageFromPod = pods.HasPackageJson(ctx, pod, container, config, c)
+	case linguist.Python, linguist.Ruby, linguist.Php:
+		updateImageFromPod = true
+	}
+
+	if updateImageFromPod {
+		dev.Image = nil
+		dev.SecurityContext = getSecurityContextFromPod(ctx, dev, pod, container, config, c)
+		dev.Sync.Folders[0].RemotePath = getWorkdirFromPod(ctx, dev, pod, container, config, c)
+		dev.Command.Values = getCommandFromPod(ctx, dev, pod, container, config, c)
+	}
+
+	setAnnotationsFromDeployment(dev, d)
+	setNameAndLabelsFromDeployment(ctx, dev, d)
 
 	if okteto.GetClusterContext() != client.GetSessionContext("") {
 		setResourcesFromPod(dev, pod, container)
@@ -81,6 +100,34 @@ func getRunningPod(ctx context.Context, d *appsv1.Deployment, container string, 
 		}
 	}
 	return pod, nil
+}
+
+func getSecurityContextFromPod(ctx context.Context, dev *model.Dev, pod *apiv1.Pod, container string, config *rest.Config, c *kubernetes.Clientset) *model.SecurityContext {
+	userID, err := pods.GetUserByPod(ctx, pod, container, config, c)
+	if err != nil {
+		log.Infof("error getting user of the deployment: %s", err)
+		return nil
+	}
+	if userID == 0 {
+		return nil
+	}
+	return &model.SecurityContext{RunAsUser: &userID}
+}
+
+func getWorkdirFromPod(ctx context.Context, dev *model.Dev, pod *apiv1.Pod, container string, config *rest.Config, c *kubernetes.Clientset) string {
+	workdir, err := pods.GetWorkdirByPod(ctx, pod, container, config, c)
+	if err != nil {
+		log.Infof("error getting workdir of the deployment: %s", err)
+		return dev.Workdir
+	}
+	return workdir
+}
+
+func getCommandFromPod(ctx context.Context, dev *model.Dev, pod *apiv1.Pod, container string, config *rest.Config, c *kubernetes.Clientset) []string {
+	if pods.CheckIfBashIsAvailable(ctx, pod, container, config, c) {
+		return []string{"bash"}
+	}
+	return []string{"sh"}
 }
 
 func setForwardsFromPod(ctx context.Context, dev *model.Dev, pod *apiv1.Pod, c *kubernetes.Clientset) error {

--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -177,6 +177,16 @@ func GetUserByPod(ctx context.Context, p *apiv1.Pod, container string, config *r
 	return userID, nil
 }
 
+//HasPackageJson returns if the container has node_modules
+func HasPackageJson(ctx context.Context, p *apiv1.Pod, container string, config *rest.Config, c *kubernetes.Clientset) bool {
+	cmd := []string{"sh", "-c", "[ -f 'package.json' ] && echo 'package.json exists'"}
+	out, err := execCommandInPod(ctx, p, container, cmd, config, c)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(out, "package.json exists")
+}
+
 //GetWorkdirByPod returns the workdir of a running pod
 func GetWorkdirByPod(ctx context.Context, p *apiv1.Pod, container string, config *rest.Config, c *kubernetes.Clientset) (string, error) {
 	cmd := []string{"sh", "-c", "echo $PWD"}

--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -23,6 +23,8 @@ import (
 
 type languageDefault struct {
 	image           string
+	path            string
+	command         []string
 	environment     []model.EnvVar
 	volumes         []model.Volume
 	forward         []model.Forward
@@ -32,16 +34,16 @@ type languageDefault struct {
 }
 
 const (
-	javascript = "javascript"
+	Javascript = "javascript"
 	golang     = "go"
-	python     = "python"
-	gradle     = "gradle"
-	maven      = "maven"
-	java       = "java"
-	ruby       = "ruby"
-	csharp     = "csharp"
-	php        = "php"
-	rust       = "rust"
+	Python     = "python"
+	Gradle     = "gradle"
+	Maven      = "maven"
+	Java       = "java"
+	Ruby       = "ruby"
+	Csharp     = "csharp"
+	Php        = "php"
+	Rust       = "rust"
 
 	// Unrecognized is the option returned when the linguist couldn't detect a language
 	Unrecognized = "other"
@@ -55,16 +57,17 @@ var (
 func init() {
 	languageDefaults = make(map[string]languageDefault)
 	forwardDefaults = make(map[string][]model.Forward)
-	languageDefaults[javascript] = languageDefault{
-		image: "okteto/node:12",
-		forward: []model.Forward{
+	languageDefaults[Javascript] = languageDefault{
+		image:   "okteto/node:14",
+		path:    "/usr/src/app",
+		command: []string{"bash"}, forward: []model.Forward{
 			{
 				Local:  9229,
 				Remote: 9229,
 			},
 		},
 	}
-	forwardDefaults[javascript] = []model.Forward{
+	forwardDefaults[Javascript] = []model.Forward{
 		{
 			Local:  3000,
 			Remote: 3000,
@@ -72,7 +75,9 @@ func init() {
 	}
 
 	languageDefaults[golang] = languageDefault{
-		image: "okteto/golang:1",
+		image:   "okteto/golang:1",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		securityContext: &model.SecurityContext{
 			Capabilities: &model.Capabilities{
 				Add: []apiv1.Capability{"SYS_PTRACE"},
@@ -100,8 +105,10 @@ func init() {
 		},
 	}
 
-	languageDefaults[rust] = languageDefault{
-		image: "okteto/rust:1",
+	languageDefaults[Rust] = languageDefault{
+		image:   "okteto/rust:1",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		volumes: []model.Volume{
 			{
 				RemotePath: "/usr/local/cargo/registry",
@@ -111,15 +118,17 @@ func init() {
 			},
 		},
 	}
-	forwardDefaults[golang] = []model.Forward{
+	forwardDefaults[Rust] = []model.Forward{
 		{
 			Local:  8080,
 			Remote: 8080,
 		},
 	}
 
-	languageDefaults[python] = languageDefault{
-		image: "okteto/python:3",
+	languageDefaults[Python] = languageDefault{
+		image:   "okteto/python:3",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		reverse: []model.Reverse{
 			{
 				Local:  9000,
@@ -132,15 +141,17 @@ func init() {
 			},
 		},
 	}
-	forwardDefaults[python] = []model.Forward{
+	forwardDefaults[Python] = []model.Forward{
 		{
 			Local:  8080,
 			Remote: 8080,
 		},
 	}
 
-	languageDefaults[gradle] = languageDefault{
-		image: "okteto/gradle:6.5",
+	languageDefaults[Gradle] = languageDefault{
+		image:   "okteto/gradle:6.5",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		forward: []model.Forward{
 			{
 				Local:  5005,
@@ -153,15 +164,17 @@ func init() {
 			},
 		},
 	}
-	forwardDefaults[gradle] = []model.Forward{
+	forwardDefaults[Gradle] = []model.Forward{
 		{
 			Local:  8080,
 			Remote: 8080,
 		},
 	}
 
-	languageDefaults[maven] = languageDefault{
-		image: "okteto/maven:3",
+	languageDefaults[Maven] = languageDefault{
+		image:   "okteto/maven:3",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		forward: []model.Forward{
 			{
 				Local:  5005,
@@ -174,15 +187,17 @@ func init() {
 			},
 		},
 	}
-	forwardDefaults[maven] = []model.Forward{
+	forwardDefaults[Maven] = []model.Forward{
 		{
 			Local:  8080,
 			Remote: 8080,
 		},
 	}
 
-	languageDefaults[ruby] = languageDefault{
-		image: "okteto/ruby:2",
+	languageDefaults[Ruby] = languageDefault{
+		image:   "okteto/ruby:2",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		forward: []model.Forward{
 			{
 				Local:  1234,
@@ -195,15 +210,17 @@ func init() {
 			},
 		},
 	}
-	forwardDefaults[ruby] = []model.Forward{
+	forwardDefaults[Ruby] = []model.Forward{
 		{
 			Local:  8080,
 			Remote: 8080,
 		},
 	}
 
-	languageDefaults[csharp] = languageDefault{
-		image: "okteto/dotnetcore:3",
+	languageDefaults[Csharp] = languageDefault{
+		image:   "okteto/dotnetcore:3",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		environment: []model.EnvVar{
 			{
 				Name:  "ASPNETCORE_ENVIRONMENT",
@@ -221,15 +238,17 @@ func init() {
 		forward: []model.Forward{},
 		remote:  22000,
 	}
-	forwardDefaults[csharp] = []model.Forward{
+	forwardDefaults[Csharp] = []model.Forward{
 		{
 			Local:  5000,
 			Remote: 5000,
 		},
 	}
 
-	languageDefaults[php] = languageDefault{
-		image: "okteto/php:7",
+	languageDefaults[Php] = languageDefault{
+		image:   "okteto/php:7",
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		reverse: []model.Reverse{
 			{
 				Local:  9000,
@@ -242,7 +261,7 @@ func init() {
 			},
 		},
 	}
-	forwardDefaults[php] = []model.Forward{
+	forwardDefaults[Php] = []model.Forward{
 		{
 			Local:  8080,
 			Remote: 8080,
@@ -251,6 +270,8 @@ func init() {
 
 	languageDefaults[Unrecognized] = languageDefault{
 		image:   model.DefaultImage,
+		path:    "/usr/src/app",
+		command: []string{"bash"},
 		forward: []model.Forward{},
 	}
 	forwardDefaults[Unrecognized] = []model.Forward{
@@ -277,8 +298,8 @@ func GetSupportedLanguages() []string {
 }
 
 // GetDevDefaults gets default values for the specified language
-func GetDevDefaults(language, workdir string, iAskingForDeployment bool) (*model.Dev, error) {
-	language = normalizeLanguage(language)
+func GetDevDefaults(language, workdir string) (*model.Dev, error) {
+	language = NormalizeLanguage(language)
 	vals := languageDefaults[language]
 
 	dev := &model.Dev{
@@ -286,7 +307,7 @@ func GetDevDefaults(language, workdir string, iAskingForDeployment bool) (*model
 			Name: vals.image,
 		},
 		Command: model.Command{
-			Values: []string{"bash"},
+			Values: vals.command,
 		},
 		Environment: vals.environment,
 		Volumes:     vals.volumes,
@@ -295,7 +316,7 @@ func GetDevDefaults(language, workdir string, iAskingForDeployment bool) (*model
 			Folders: []model.SyncFolder{
 				{
 					LocalPath:  ".",
-					RemotePath: "/usr/src/app",
+					RemotePath: vals.path,
 				},
 			},
 		},
@@ -315,7 +336,7 @@ func GetDevDefaults(language, workdir string, iAskingForDeployment bool) (*model
 
 // SetForwardDefaults set port forward default values for the specified language
 func SetForwardDefaults(dev *model.Dev, language string) {
-	language = normalizeLanguage(language)
+	language = NormalizeLanguage(language)
 	vals := forwardDefaults[language]
 	if dev.Forward == nil {
 		dev.Forward = []model.Forward{}
@@ -323,31 +344,31 @@ func SetForwardDefaults(dev *model.Dev, language string) {
 	dev.Forward = append(dev.Forward, vals...)
 }
 
-func normalizeLanguage(language string) string {
+func NormalizeLanguage(language string) string {
 	lower := strings.ToLower(language)
 	switch lower {
 	case "typescript", "javascript", "jsx", "node", "tsx":
-		return javascript
+		return Javascript
 	case "python":
-		return python
+		return Python
 	case "java":
-		return gradle
+		return Gradle
 	case "gradle":
-		return gradle
+		return Gradle
 	case "maven":
-		return maven
+		return Maven
 	case "ruby":
-		return ruby
+		return Ruby
 	case "go", "golang":
 		return golang
 	case "c#":
-		return csharp
+		return Csharp
 	case "csharp":
-		return csharp
+		return Csharp
 	case "php":
-		return php
+		return Php
 	case "rust":
-		return rust
+		return Rust
 	default:
 		return Unrecognized
 	}

--- a/pkg/linguist/linguist.go
+++ b/pkg/linguist/linguist.go
@@ -128,22 +128,22 @@ func ProcessDirectory(root string) (string, error) {
 	}
 	chosen := strings.ToLower(sorted[0])
 
-	if chosen == java {
+	if chosen == Java {
 		return refineJavaChoice(root), nil
 	}
 
-	return normalizeLanguage(chosen), nil
+	return NormalizeLanguage(chosen), nil
 }
 
 func refineJavaChoice(root string) string {
 	p := filepath.Join(root, "build.gradle")
 	_, err := os.Stat(p)
 	if err == nil {
-		return gradle
+		return Gradle
 	}
 
 	log.Infof("didn't found %s : %s", p, err)
-	return maven
+	return Maven
 }
 
 func readFile(path string, limit int64) ([]byte, error) {
@@ -180,7 +180,7 @@ func sortLanguagesByUsage(fSummary map[string][]string) []string {
 	fileValues := make(map[string]float64)
 
 	for fType, files := range fSummary {
-		if normalizeLanguage(fType) == Unrecognized {
+		if NormalizeLanguage(fType) == Unrecognized {
 			continue
 		}
 		val := float64(len(files))

--- a/pkg/linguist/linguist_test.go
+++ b/pkg/linguist/linguist_test.go
@@ -33,17 +33,17 @@ func TestProcessDirectory(t *testing.T) {
 		},
 		{
 			name:  "gradle",
-			want:  gradle,
+			want:  Gradle,
 			files: []string{"build.gradle", "main.java"},
 		},
 		{
 			name:  "maven",
-			want:  maven,
+			want:  Maven,
 			files: []string{"pom.xml", "main.java"},
 		},
 		{
 			name:  "java-default",
-			want:  maven,
+			want:  Maven,
 			files: []string{"main.java"},
 		},
 		{
@@ -53,17 +53,17 @@ func TestProcessDirectory(t *testing.T) {
 		},
 		{
 			name:  "python",
-			want:  python,
+			want:  Python,
 			files: []string{"api.py"},
 		},
 		{
 			name:  "javascript",
-			want:  javascript,
+			want:  Javascript,
 			files: []string{"Package.json", "index.js"},
 		},
 		{
 			name:  "ruby",
-			want:  ruby,
+			want:  Ruby,
 			files: []string{"Gemfile", "Rakefile", "application_controller.rb"},
 		},
 	}

--- a/pkg/linguist/syncthing.go
+++ b/pkg/linguist/syncthing.go
@@ -23,7 +23,7 @@ func init() {
 	// based on the list available at https://github.com/github/gitignore
 	stignore = make(map[string][]byte)
 
-	stignore[javascript] = []byte(`.git
+	stignore[Javascript] = []byte(`.git
 # Runtime data
 pids
 *.pid
@@ -101,7 +101,7 @@ vendor
 __debug_bin
 `)
 
-	stignore[python] = []byte(`.git
+	stignore[Python] = []byte(`.git
 # Byte-compiled / optimized / DLL files
 __pycache__
 *.py[cod]
@@ -204,7 +204,7 @@ dmypy.json
 .pyre
 `)
 
-	stignore[gradle] = []byte(`.git
+	stignore[Gradle] = []byte(`.git
 .gradle
 build
 
@@ -218,11 +218,11 @@ gradle-app.setting
 .gradletasknamecache
 `)
 
-	stignore[maven] = []byte(`.git
+	stignore[Maven] = []byte(`.git
 ?
 `)
 
-	stignore[ruby] = []byte(`.git
+	stignore[Ruby] = []byte(`.git
 *.gem
 *.rbc
 coverage
@@ -271,7 +271,7 @@ lib/bundler/man
 .rvmrc
 `)
 
-	stignore[csharp] = []byte(`.git
+	stignore[Csharp] = []byte(`.git
 out
 bin
 obj/Debug
@@ -283,7 +283,7 @@ core.*.*.*
 
 // GetSTIgnore returns a .stignore file for the specified language
 func GetSTIgnore(language string) []byte {
-	l := normalizeLanguage(language)
+	l := NormalizeLanguage(language)
 	if s, ok := stignore[l]; ok {
 		return s
 	}


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

For python, nodejs, php and ruby it is better to use the deployment image for development