### PR TITLE
Execute start hook if defined in cloudbin image

### DIFF
--- a/integration/stacks_test.go
+++ b/integration/stacks_test.go
@@ -217,7 +217,7 @@ func TestCompose(t *testing.T) {
 	if err := deployStack(ctx, oktetoPath, "docker-compose.yml", composeGitFolder); err != nil {
 		t.Fatal(err)
 	}
-	log.Println("Stack has been redeployed succesfully")
+	log.Println("Stack has been redeployed successfully")
 
 	if err := destroyStack(ctx, oktetoPath, "docker-compose.yml", composeGitFolder); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

This makes it possible to run a start.sh hook on every dev container in the cluster