### PR TITLE
Inject only secrets without dots in key

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -101,7 +101,9 @@ func translateServiceEnvFile(ctx context.Context, svc *model.Service, svcName, f
 		}
 
 		for _, e := range envList {
-			secrets[e.Name] = e.Value
+			if !strings.Contains(e.Name, ".") {
+				secrets[e.Name] = e.Value
+			}
 		}
 		for _, e := range svc.Environment {
 			delete(secrets, e.Name)

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -101,9 +101,7 @@ func translateServiceEnvFile(ctx context.Context, svc *model.Service, svcName, f
 		}
 
 		for _, e := range envList {
-			if !strings.Contains(e.Name, ".") {
-				secrets[e.Name] = e.Value
-			}
+			secrets[e.Name] = e.Value
 		}
 		for _, e := range svc.Environment {
 			delete(secrets, e.Name)

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -15,6 +15,7 @@ package okteto
 
 import (
 	"context"
+	"strings"
 )
 
 //Secrets represents a list of secrets
@@ -40,6 +41,11 @@ func GetSecrets(ctx context.Context) ([]Secret, error) {
 	if err := query(ctx, q, &body); err != nil {
 		return nil, err
 	}
-
-	return body.Secrets, nil
+	secrets := make([]Secret, 0)
+	for _, secret := range body.Secrets {
+		if !strings.Contains(secret.Name, ".") {
+			secrets = append(secrets, secret)
+		}
+	}
+	return secrets, nil
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #

## Proposed changes
-  When injecting an env file it inject Okteto env vars like the tokens. All these vars have dots in its name.
-  If a secret name has a dot in it it will not be injected into the container
