### PR TITLE
Fix syncthing zombie instance in windows10

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -308,6 +308,8 @@ func (up *upContext) activateLoop(autoDeploy, build bool) {
 			up.Exit <- err
 			return
 		}
+		up.Sy = syncthing.NewSyncthingWithHome(up.Dev)
+		up.Sy.HardTerminate()
 		up.Exit <- nil
 		return
 	}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -235,6 +235,13 @@ func New(dev *model.Dev) (*Syncthing, error) {
 	return s, nil
 }
 
+func NewSyncthingWithHome(dev *model.Dev) *Syncthing {
+	s := &Syncthing{
+		Home: config.GetDeploymentHome(dev.Namespace, dev.Name),
+	}
+	return s
+}
+
 func (s *Syncthing) initConfig() error {
 	if err := os.MkdirAll(s.Home, 0700); err != nil {
 		return fmt.Errorf("failed to create %s: %s", s.Home, err)


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1405 

If you run `Okteto down` inside an okteto container terminal on windows, It doesn't kill children process. This PR remove all synching instances before exiting to the user terminal.

## Proposed changes
-  When the activate loop finish, remove all synching instance that are still running.
