### PR TITLE
Terminate kills the proccess and subproccesses

### DIFF
--- a/pkg/syncthing/process.go
+++ b/pkg/syncthing/process.go
@@ -14,12 +14,37 @@
 package syncthing
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/shirou/gopsutil/process"
 )
 
 func terminate(p *process.Process, wait bool) error {
+	if runtime.GOOS == "windows" {
+		children, err := p.Children()
+		if err != nil {
+			return err
+		}
+		err = terminateProccess(p, wait)
+		if err != nil {
+			return err
+		}
+		for _, child := range children {
+			err = terminateProccess(child, wait)
+			if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+	err := terminateProccess(p, wait)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func terminateProccess(p *process.Process, wait bool) error {
 	if err := p.Terminate(); err != nil {
 		return err
 	}

--- a/pkg/syncthing/process.go
+++ b/pkg/syncthing/process.go
@@ -21,29 +21,31 @@ import (
 )
 
 func terminate(p *process.Process, wait bool) error {
-	if runtime.GOOS == "windows" {
-		children, err := p.Children()
-		if err != nil {
-			return err
-		}
-		err = terminateProccess(p, wait)
-		if err != nil {
-			return err
-		}
-		for _, child := range children {
-			err = terminateProccess(child, wait)
-			if err != nil {
-				return err
-			}
-		}
-		return err
-	}
-	err := terminateProccess(p, wait)
+
+	children, err := getChildren(p)
 	if err != nil {
 		return err
 	}
+	err = terminateProccess(p, wait)
+	if err != nil {
+		return err
+	}
+	for _, child := range children {
+		err := terminateProccess(child, wait)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
+
+func getChildren(p *process.Process) ([]*process.Process, error) {
+	if runtime.GOOS == "windows" {
+		return p.Children()
+	}
+	return make([]*process.Process, 0), nil
+}
+
 func terminateProccess(p *process.Process, wait bool) error {
 	if err := p.Terminate(); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Soft terminate wasn't killing all the sub children created by the process that have to terminate

## Proposed changes
-  Adds a new logic in which before killing the parent process, the children are extracted to kill them once the parent has finished. 
-  
