### PR TITLE
Keep deployed_by label for diverted deployments, services and ingress

### DIFF
--- a/pkg/k8s/diverts/translate.go
+++ b/pkg/k8s/diverts/translate.go
@@ -31,6 +31,9 @@ func translateDeployment(username string, d *appsv1.Deployment) *appsv1.Deployme
 	result.UID = ""
 	result.Name = DivertName(username, d.Name)
 	result.Labels = map[string]string{model.OktetoDivertLabel: username}
+	if d.Labels != nil && d.Labels[okLabels.DeployedByLabel] != "" {
+		result.Labels[okLabels.DeployedByLabel] = d.Labels[okLabels.DeployedByLabel]
+	}
 	result.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			model.OktetoDivertLabel: username,
@@ -52,6 +55,9 @@ func translateService(username string, d *appsv1.Deployment, s *apiv1.Service) (
 	result.UID = ""
 	result.Name = DivertName(username, s.Name)
 	result.Labels = map[string]string{model.OktetoDivertLabel: username}
+	if s.Labels != nil && s.Labels[okLabels.DeployedByLabel] != "" {
+		result.Labels[okLabels.DeployedByLabel] = s.Labels[okLabels.DeployedByLabel]
+	}
 	if s.Annotations != nil {
 		modification := s.Annotations[model.OktetoDivertServiceModificationAnnotation]
 		if modification != "" {
@@ -86,6 +92,9 @@ func translateIngress(username string, i *networkingv1.Ingress) *networkingv1.In
 	result.UID = ""
 	result.Name = DivertName(username, i.Name)
 	result.Labels = map[string]string{model.OktetoDivertLabel: username}
+	if i.Labels != nil && i.Labels[okLabels.DeployedByLabel] != "" {
+		result.Labels[okLabels.DeployedByLabel] = i.Labels[okLabels.DeployedByLabel]
+	}
 	if result.Annotations == nil {
 		result.Annotations = map[string]string{}
 	}
@@ -101,7 +110,7 @@ func translateIngress(username string, i *networkingv1.Ingress) *networkingv1.In
 }
 
 func translateDivertCRD(username string, dev *model.Dev, s *apiv1.Service, i *networkingv1.Ingress) *Divert {
-	return &Divert{
+	result := &Divert{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Divert",
 			APIVersion: "weaver.okteto.com/v1",
@@ -132,6 +141,10 @@ func translateDivertCRD(username string, dev *model.Dev, s *apiv1.Service, i *ne
 			},
 		},
 	}
+	if s.Labels != nil && s.Labels[okLabels.DeployedByLabel] != "" {
+		result.Labels = map[string]string{okLabels.DeployedByLabel: s.Labels[okLabels.DeployedByLabel]}
+	}
+	return result
 }
 
 func translateDev(username string, dev *model.Dev, d *appsv1.Deployment) {

--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -21,7 +21,7 @@ func Test_translateDeployment(t *testing.T) {
 			Name:            "name",
 			Namespace:       "namespace",
 			Annotations:     map[string]string{"annotation1": "value1"},
-			Labels:          map[string]string{"label1": "value1"},
+			Labels:          map[string]string{"label1": "value1", okLabels.DeployedByLabel: "cindy"},
 			ResourceVersion: "version",
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -48,7 +48,10 @@ func Test_translateDeployment(t *testing.T) {
 				"annotation1":                    "value1",
 				model.OktetoAutoCreateAnnotation: model.OktetoUpCmd,
 			},
-			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+			Labels: map[string]string{
+				okLabels.DeployedByLabel: "cindy",
+				model.OktetoDivertLabel:  "cindy",
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -87,7 +90,7 @@ func Test_translateServiceNotDiverted(t *testing.T) {
 				"annotation1":                        "value1",
 				okLabels.OktetoAutoIngressAnnotation: "true",
 			},
-			Labels:          map[string]string{"label1": "value1"},
+			Labels:          map[string]string{"label1": "value1", okLabels.DeployedByLabel: "cindy"},
 			ResourceVersion: "version",
 		},
 		Spec: apiv1.ServiceSpec{
@@ -114,7 +117,10 @@ func Test_translateServiceNotDiverted(t *testing.T) {
 			Annotations: map[string]string{
 				"annotation1": "value1",
 			},
-			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+			Labels: map[string]string{
+				okLabels.DeployedByLabel: "cindy",
+				model.OktetoDivertLabel:  "cindy",
+			},
 		},
 		Spec: apiv1.ServiceSpec{
 			Selector: map[string]string{
@@ -211,7 +217,7 @@ func Test_translateIngressGenerateHostTrue(t *testing.T) {
 				"annotation1":                          "value1",
 				okLabels.OktetoIngressAutoGenerateHost: "true",
 			},
-			Labels:          map[string]string{"label1": "value1"},
+			Labels:          map[string]string{"label1": "value1", okLabels.DeployedByLabel: "cindy"},
 			ResourceVersion: "version",
 		},
 	}
@@ -224,7 +230,10 @@ func Test_translateIngressGenerateHostTrue(t *testing.T) {
 				"annotation1":                          "value1",
 				okLabels.OktetoIngressAutoGenerateHost: "true",
 			},
-			Labels: map[string]string{model.OktetoDivertLabel: "cindy"},
+			Labels: map[string]string{
+				okLabels.DeployedByLabel: "cindy",
+				model.OktetoDivertLabel:  "cindy",
+			},
 		},
 	}
 	marshalled, _ := yaml.Marshal(translated.ObjectMeta)


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

This will make these resources be grouped by pipeline.
Also, if the pipeline is removed, all these resources will be removed too.