### PR TITLE
Check "InDevContainer" using "OKTETO_NAME" instead of "OKTETO_NAMESPACE"

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -61,7 +61,7 @@ var (
 	ErrSSHConnectError = fmt.Errorf("ssh start error")
 
 	// ErrNotInDevContainer is returned when an unsupported command is invoked from a dev container (e.g. okteto up)
-	ErrNotInDevContainer = fmt.Errorf("this command is not supported from inside an development container")
+	ErrNotInDevContainer = fmt.Errorf("'OKTETO_NAME' environment variable is defined. This command is not supported from inside a development container")
 
 	// ErrUnknownSyncError is returned when syncthing reports an unknown sync error
 	ErrUnknownSyncError = fmt.Errorf("unknown syncthing error")

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -171,7 +171,7 @@ func SetKubeConfig(cred *Credential, kubeConfigPath, namespace, userName, cluste
 
 // InDevContainer returns true if running in an okteto dev container
 func InDevContainer() bool {
-	if v, ok := os.LookupEnv("OKTETO_NAMESPACE"); ok && v != "" {
+	if v, ok := os.LookupEnv("OKTETO_NAME"); ok && v != "" {
 		return true
 	}
 

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -91,10 +91,10 @@ func TestSetKubeConfig(t *testing.T) {
 }
 
 func TestInDevContainer(t *testing.T) {
-	v := os.Getenv("OKTETO_NAMESPACE")
-	os.Setenv("OKTETO_NAMESPACE", "")
+	v := os.Getenv("OKTETO_NAME")
+	os.Setenv("OKTETO_NAME", "")
 	defer func() {
-		os.Setenv("OKTETO_NAMESPACE", v)
+		os.Setenv("OKTETO_NAME", v)
 	}()
 
 	in := InDevContainer()
@@ -102,13 +102,13 @@ func TestInDevContainer(t *testing.T) {
 		t.Errorf("in dev container when there was no marker env var")
 	}
 
-	os.Setenv("OKTETO_NAMESPACE", "")
+	os.Setenv("OKTETO_NAME", "")
 	in = InDevContainer()
 	if in {
 		t.Errorf("in dev container when there was an empty marker env var")
 	}
 
-	os.Setenv("OKTETO_NAMESPACE", "1")
+	os.Setenv("OKTETO_NAME", "1")
 	in = InDevContainer()
 	if !in {
 		t.Errorf("not in dev container when there was a marker env var")


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

We are using `OKTETO_NAMESPACE` for other things, checking for `OKTETO_NAME` is less error prone