### PR TITLE
Recreate pod forward in ssh connection fails

### DIFF
--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -16,6 +16,7 @@ package ssh
 import (
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -55,6 +56,7 @@ func getSSHClientConfig() (*ssh.ClientConfig, error) {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(keys),
 		},
+		Timeout: 10 * time.Second,
 	}
 
 	return clientConfig, nil

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -17,7 +17,9 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"time"
 
+	"github.com/okteto/okteto/pkg/errors"
 	k8sforward "github.com/okteto/okteto/pkg/k8s/forward"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -103,35 +105,57 @@ func (fm *ForwardManager) Add(f model.Forward) error {
 // Start starts a port-forward to the remote port and then starts forwards and reverse forwards as goroutines
 func (fm *ForwardManager) Start(devPod, namespace string) error {
 	log.Info("starting SSH forward manager")
-	if fm.pf != nil {
-		if err := fm.pf.Start(devPod, namespace); err != nil {
-			return fmt.Errorf("failed to start SSH port-forward: %w", err)
+
+	ticker := time.NewTicker(200 * time.Millisecond)
+	to := time.Now().Add(10 * time.Second)
+
+	for {
+		if fm.pf != nil {
+			if err := fm.pf.Start(devPod, namespace); err != nil {
+				return fmt.Errorf("failed to start SSH port-forward: %w", err)
+			}
+
+			log.Info("k8s port forward to dev pod connected")
 		}
 
-		log.Info("k8s port forward to dev pod connected")
-	}
+		c, err := getSSHClientConfig()
+		if err != nil {
+			return fmt.Errorf("failed to get SSH configuration: %s", err)
+		}
 
-	c, err := getSSHClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get SSH configuration: %s", err)
-	}
+		log.Infof("starting SSH connection pool on %s", fm.sshAddr)
+		pool, err := startPool(fm.ctx, fm.sshAddr, c)
+		if err == nil {
+			fm.pool = pool
+			break
+		}
+		log.Infof("error starting SSH connection pool on %s: %s", fm.sshAddr, err.Error())
+		if time.Now().After(to) {
+			return errors.ErrSSHConnectError
+		}
 
-	log.Infof("starting SSH connection pool on %s", fm.sshAddr)
-	pool, err := startPool(fm.ctx, fm.sshAddr, c)
-	if err != nil {
-		return err
-	}
+		if fm.pf != nil {
+			fm.pf.Stop()
+		}
 
-	fm.pool = pool
+		select {
+		case <-ticker.C:
+			continue
+		case <-fm.ctx.Done():
+			log.Infof("ForwardManager.Start cancelled")
+			return fmt.Errorf("ForwardManager.Start cancelled")
+		}
+
+	}
 
 	for _, ff := range fm.forwards {
-		ff.pool = pool
+		ff.pool = fm.pool
 		go ff.start(fm.ctx)
 
 	}
 
 	for _, rt := range fm.reverses {
-		rt.pool = pool
+		rt.pool = fm.pool
 		go rt.start(fm.ctx)
 	}
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

If the ssh connection fails because the ssh server is not yet ready, the kubectl port-forward is usually close and `okteto up` hangs for a long time and finally fails.

This PR refactor the ssh connection logic to recreate the port forward is ssh is not accessible.