### PR TITLE
Fix destroy service always on deploy

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -139,12 +139,12 @@ func deploy(ctx context.Context, s *model.Stack, wait bool, c *kubernetes.Client
 		spinner.Start()
 	}
 
-	if !wait {
-		return nil
-	}
-
 	if err := destroyServicesNotInStack(ctx, spinner, s, c); err != nil {
 		return err
+	}
+
+	if !wait {
+		return nil
 	}
 
 	spinner.Update("Waiting for services to be ready...")


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Destroy services that are no longer in stack when redeploying

## Proposed changes
-  
-  
