### PR TITLE
Support for update persistent volume size without destroying the volume

### DIFF
--- a/pkg/k8s/volumes/crud_test.go
+++ b/pkg/k8s/volumes/crud_test.go
@@ -87,7 +87,7 @@ func Test_checkPVCValues(t *testing.T) {
 			wantError: true,
 		},
 		{
-			name: "pvc-with-wrong-storage-size",
+			name: "pvc-with-more-storage-size",
 			pvc: &apiv1.PersistentVolumeClaim{
 				Spec: apiv1.PersistentVolumeClaimSpec{
 					StorageClassName: &className,
@@ -101,6 +101,26 @@ func Test_checkPVCValues(t *testing.T) {
 			dev: &model.Dev{
 				PersistentVolumeInfo: &model.PersistentVolumeInfo{
 					Size:         "30Gi",
+					StorageClass: "class",
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "pvc-with-less-storage-size",
+			pvc: &apiv1.PersistentVolumeClaim{
+				Spec: apiv1.PersistentVolumeClaimSpec{
+					StorageClassName: &className,
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							"storage": resource.MustParse("20Gi"),
+						},
+					},
+				},
+			},
+			dev: &model.Dev{
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Size:         "10Gi",
 					StorageClass: "class",
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Most of the existing storage classes support in-place volume expansion. This makes it possible to resize the okteto persistent volume without destroying it