### PR TITLE
Upgrade to Syncthing 1.17.0

### DIFF
--- a/images/bin/Dockerfile
+++ b/images/bin/Dockerfile
@@ -1,4 +1,4 @@
-FROM syncthing/syncthing:1.16.1 AS syncthing
+FROM syncthing/syncthing:1.17.0 AS syncthing
 FROM okteto/remote:0.4.2 AS remote
 FROM okteto/supervisor:0.2.1 AS supervisor
 FROM okteto/clean:0.1.6 AS clean

--- a/images/bin/Makefile
+++ b/images/bin/Makefile
@@ -1,4 +1,4 @@
-tag = 1.3.1
+tag = 1.3.2
 
 .PHONY: push
 push:

--- a/pkg/syncthing/install.go
+++ b/pkg/syncthing/install.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	syncthingVersion       = "1.16.1"
+	syncthingVersion       = "1.17.0"
 	syncthingVersionEnvVar = "OKTETO_SYNCTHING_VERSION"
 )
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Bugfixes:

#7592: Web UI doesn't handle long machine names well
#7593: ChaCha priority detection logic broken
#7608: Files ignored on one remote do not get synced
#7649: Incorrect local and global states after ignoring and unignoring files
#7673: bug: cli subcommand is stuck on non-interactive shell
#7677: UTF-8 normalization doesn't work on macOS
#7685: CLI: strconv.ParseInt error when adding new device via CLI
#7699: Sharing receive encrypted folder as receive encrypted with yet another device creates conflicts
Enhancements:

#7471: Improve UDP hole punching
#7580: Improve logging for service failures
#7594: Consider removing support for TLS <1.3 on sync connections
#7600: Fast connect to new devices following config update
#7636: Improve QUIC performance