### PR TITLE
Add a minimum of retries before timing out "okteto up" loops

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -316,6 +316,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context)
 			if !ok {
 				watcherEvents, err = up.Client.CoreV1().Events(up.Dev.Namespace).Watch(ctx, optsWatchEvents)
 				if err != nil {
+					log.Infof("error watching events: %s", err.Error())
 					return err
 				}
 				continue
@@ -352,6 +353,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context)
 			if !ok {
 				watcherPod, err = up.Client.CoreV1().Pods(up.Dev.Namespace).Watch(ctx, optsWatchPod)
 				if err != nil {
+					log.Infof("error watching pod events: %s", err.Error())
 					return err
 				}
 				continue

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -118,6 +118,7 @@ func IsTransient(err error) bool {
 	case strings.Contains(err.Error(), "operation time out"),
 		strings.Contains(err.Error(), "operation timed out"),
 		strings.Contains(err.Error(), "i/o timeout"),
+		strings.Contains(err.Error(), "unknown (get events)"),
 		strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers"),
 		strings.Contains(err.Error(), "can't assign requested address"),
 		strings.Contains(err.Error(), "command exited without exit status or exit signal"),

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -262,7 +262,7 @@ func UpdateOktetoRevision(ctx context.Context, d *appsv1.Deployment, client *kub
 	ticker := time.NewTicker(200 * time.Millisecond)
 	to := time.Now().Add(timeout * 2) // 60 seconds
 
-	for i := 0; ; i++ {
+	for retries := 0; ; retries++ {
 		updated, err := client.AppsV1().Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get deployment %s/%s: %w", d.Namespace, d.Name, err)
@@ -274,7 +274,7 @@ func UpdateOktetoRevision(ctx context.Context, d *appsv1.Deployment, client *kub
 			return Update(ctx, d, client)
 		}
 
-		if time.Now().After(to) {
+		if time.Now().After(to) && retries >= 10 {
 			return fmt.Errorf("kubernetes is taking too long to update the '%s' annotation of the deployment '%s'. Please check for errors and try again", revisionAnnotation, d.Name)
 		}
 

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -108,8 +108,11 @@ func (fm *ForwardManager) Start(devPod, namespace string) error {
 
 	ticker := time.NewTicker(200 * time.Millisecond)
 	to := time.Now().Add(10 * time.Second)
+	retries := 0
 
 	for {
+		retries++
+		log.Infof("SSH forward manager retry %d", retries)
 		if fm.pf != nil {
 			if err := fm.pf.Start(devPod, namespace); err != nil {
 				return fmt.Errorf("failed to start SSH port-forward: %w", err)
@@ -130,7 +133,7 @@ func (fm *ForwardManager) Start(devPod, namespace string) error {
 			break
 		}
 		log.Infof("error starting SSH connection pool on %s: %s", fm.sshAddr, err.Error())
-		if time.Now().After(to) {
+		if time.Now().After(to) && retries > 10 {
 			return errors.ErrSSHConnectError
 		}
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

When laptop is suspended in the middle of a loop, the reconnection logic is broken because we return a timeout error.

Adding a minimum number of retries solves the issue, although we will need a better mechanism to handle this scenario