### PR TITLE
Set update strategy to Recreate in dev mode

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -141,6 +141,9 @@ func commonTranslation(t *model.Translation) {
 	}
 
 	t.Deployment.Spec.Replicas = &devReplicas
+	t.Deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
 }
 
 //GetDevContainer returns the dev container of a given deployment

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -87,6 +87,10 @@ services:
 		t.Fatal(err)
 	}
 	d1 := dev.GevSandbox()
+	d1.Spec.Replicas = pointer.Int32Ptr(2)
+	d1.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+	}
 	rule1 := dev.ToTranslationRule(dev, false)
 	tr1 := &model.Translation{
 		Interactive: true,
@@ -94,6 +98,10 @@ services:
 		Version:     model.TranslationVersion,
 		Deployment:  d1,
 		Rules:       []*model.TranslationRule{rule1},
+		Replicas:    2,
+		Strategy: appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+		},
 		Annotations: model.Annotations{"key": "value"},
 		Tolerations: []apiv1.Toleration{
 			{
@@ -346,6 +354,12 @@ services:
 	}
 	if d1Down.Spec.Template.Annotations["key"] != "" {
 		t.Fatalf("Wrong d1 pod annotations after down: '%s'", d1.Spec.Template.Annotations["key"])
+	}
+	if *d1Down.Spec.Replicas != 2 {
+		t.Fatalf("Wrong d1 replicas %d vs 2", *d1Down.Spec.Replicas)
+	}
+	if d1Down.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType {
+		t.Fatalf("Wrong d1 strategy %s", d1Down.Spec.Strategy.Type)
 	}
 
 	dev2 := dev.Services[0]

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -20,14 +20,15 @@ import (
 
 // Translation represents the information for translating a deployment
 type Translation struct {
-	Interactive bool               `json:"interactive"`
-	Name        string             `json:"name"`
-	Version     string             `json:"version"`
-	Deployment  *appsv1.Deployment `json:"-"`
-	Annotations Annotations        `json:"annotations,omitempty"`
-	Tolerations []apiv1.Toleration `json:"tolerations,omitempty"`
-	Replicas    int32              `json:"replicas"`
-	Rules       []*TranslationRule `json:"rules"`
+	Interactive bool                      `json:"interactive"`
+	Name        string                    `json:"name"`
+	Version     string                    `json:"version"`
+	Deployment  *appsv1.Deployment        `json:"-"`
+	Annotations Annotations               `json:"annotations,omitempty"`
+	Tolerations []apiv1.Toleration        `json:"tolerations,omitempty"`
+	Replicas    int32                     `json:"replicas"`
+	Strategy    appsv1.DeploymentStrategy `json:"strategy"`
+	Rules       []*TranslationRule        `json:"rules"`
 }
 
 // TranslationRule represents how to apply a container translation in a deployment


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Using `Recreate` in dev mode deployments has several advantages:

- It uses less resources because no additional pods are created during `okteto up`
- It makes `okteto up` work better with multi-node clusters not managed by okteto, because the old edv pod and the new dev pod can go to different nodes, and the okteto volume will be reattached
- It avoid syncthing issues when initializing the okteto volume from the content in the dev image, because no two pods can be running in parallel doing parallel write operations in the okteto volume