### PR TITLE
Fix okteto up recreation error

### DIFF
--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -1195,3 +1195,210 @@ func TestTranslateOktetoVolumes(t *testing.T) {
 		})
 	}
 }
+
+func Test_translateMultipleEnvVars(t *testing.T) {
+	manifest := []byte(`name: web
+namespace: n
+image: web:latest
+sync:
+  - .:/app
+environment:
+  key2: value2
+  key1: value1
+  key4: value4
+  key5: value5
+  key3: value3
+`)
+
+	dev, err := model.Read(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dev.Username = "cindy"
+	dev.RegistryURL = "registry.okteto.dev"
+	d := dev.GevSandbox()
+	rule := dev.ToTranslationRule(dev, false)
+	tr := &model.Translation{
+		Interactive: true,
+		Name:        dev.Name,
+		Version:     model.TranslationVersion,
+		Deployment:  d,
+		Rules:       []*model.TranslationRule{rule},
+	}
+	err = translate(tr, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dOK := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &devTerminationGracePeriodSeconds,
+					SecurityContext: &apiv1.PodSecurityContext{
+						FSGroup: pointer.Int64Ptr(0),
+					},
+					Volumes: []apiv1.Volume{
+						{
+							Name: oktetoSyncSecretVolume,
+							VolumeSource: apiv1.VolumeSource{
+								Secret: &apiv1.SecretVolumeSource{
+									SecretName: "okteto-web",
+									Items: []apiv1.KeyToPath{
+										{
+											Key:  "config.xml",
+											Path: "config.xml",
+											Mode: &mode444,
+										},
+										{
+											Key:  "cert.pem",
+											Path: "cert.pem",
+											Mode: &mode444,
+										},
+										{
+											Key:  "key.pem",
+											Path: "key.pem",
+											Mode: &mode444,
+										},
+									},
+								},
+							},
+						},
+						{
+							Name: dev.GetVolumeName(),
+							VolumeSource: apiv1.VolumeSource{
+								PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: dev.GetVolumeName(),
+									ReadOnly:  false,
+								},
+							},
+						},
+						{
+							Name: OktetoBinName,
+							VolumeSource: apiv1.VolumeSource{
+								EmptyDir: &apiv1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					InitContainers: []apiv1.Container{
+						{
+							Name:            OktetoBinName,
+							Image:           model.OktetoBinImageTag,
+							ImagePullPolicy: apiv1.PullIfNotPresent,
+							Command:         []string{"sh", "-c", "cp /usr/local/bin/* /okteto/bin"},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      OktetoBinName,
+									MountPath: "/okteto/bin",
+								},
+							},
+						},
+						{
+							Name:            OktetoInitVolumeContainerName,
+							Image:           "web:latest",
+							ImagePullPolicy: apiv1.PullIfNotPresent,
+							Command:         []string{"sh", "-c", "([ ! -f initialized ] && (cp -Rv /app/. /init-volume/1 || true) && touch initialized) || true"},
+							SecurityContext: &apiv1.SecurityContext{
+								RunAsUser:    &rootUser,
+								RunAsGroup:   &rootUser,
+								RunAsNonRoot: &falseBoolean,
+							},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: "/init-volume/1",
+									SubPath:   model.SourceCodeSubPath,
+								},
+							},
+						},
+					},
+					Containers: []apiv1.Container{
+						{
+							Name:            "dev",
+							Image:           "web:latest",
+							ImagePullPolicy: apiv1.PullAlways,
+							Command:         []string{"/var/okteto/bin/start.sh"},
+							Args:            []string{"-r", "-v"},
+							Env: []apiv1.EnvVar{
+								{
+									Name:  "key1",
+									Value: "value1",
+								},
+								{
+									Name:  "key2",
+									Value: "value2",
+								},
+								{
+									Name:  "key3",
+									Value: "value3",
+								},
+								{
+									Name:  "key4",
+									Value: "value4",
+								},
+								{
+									Name:  "key5",
+									Value: "value5",
+								},
+								{
+									Name:  "OKTETO_NAMESPACE",
+									Value: "n",
+								},
+								{
+									Name:  "OKTETO_NAME",
+									Value: "web",
+								},
+								{
+									Name:  "OKTETO_USERNAME",
+									Value: "cindy",
+								},
+							},
+							SecurityContext: &apiv1.SecurityContext{
+								RunAsUser:    &rootUser,
+								RunAsGroup:   &rootUser,
+								RunAsNonRoot: &falseBoolean,
+							},
+							VolumeMounts: []apiv1.VolumeMount{
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: "/var/syncthing",
+									SubPath:   model.SyncthingSubPath,
+								},
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: model.RemoteMountPath,
+									SubPath:   model.RemoteSubPath,
+								},
+								{
+									Name:      dev.GetVolumeName(),
+									ReadOnly:  false,
+									MountPath: "/app",
+									SubPath:   model.SourceCodeSubPath,
+								},
+								{
+									Name:      oktetoSyncSecretVolume,
+									ReadOnly:  false,
+									MountPath: "/var/syncthing/secret/",
+								},
+								{
+									Name:      OktetoBinName,
+									ReadOnly:  false,
+									MountPath: "/var/okteto/bin",
+								},
+							},
+							LivenessProbe:  nil,
+							ReadinessProbe: nil,
+						},
+					},
+				},
+			},
+		},
+	}
+	marshalled, _ := yaml.Marshal(d.Spec.Template.Spec)
+	marshalledOK, _ := yaml.Marshal(dOK.Spec.Template.Spec)
+	if string(marshalled) != string(marshalledOK) {
+		t.Fatalf("Wrong d generation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledOK))
+	}
+}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -16,6 +16,7 @@ package model
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -653,6 +654,9 @@ func (e *Environment) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	for key, value := range result {
 		envs = append(envs, EnvVar{Name: key, Value: value})
 	}
+	sort.SliceStable(envs, func(i, j int) bool {
+		return strings.Compare(envs[i].Name, envs[j].Name) < 0
+	})
 	*e = envs
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes an error where running okteto up was recreating the deployment even if it was the same 

## Proposed changes
-  Order environment variables while unmarshalling them to have them always in the same order
-  
