### PR TITLE
Reduce the time to display first message to user

### DIFF
--- a/cmd/utils/spinner.go
+++ b/cmd/utils/spinner.go
@@ -38,6 +38,7 @@ func NewSpinner(suffix string) *Spinner {
 	s := sp.New(sp.CharSets[14], 100*time.Millisecond)
 	s.HideCursor = true
 	s.Suffix = fmt.Sprintf(" %s", suffix)
+	s.FinalMSG = ""
 	return &Spinner{
 		sp: s,
 	}

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -50,9 +50,12 @@ func Deploy(ctx context.Context, s *model.Stack, forceBuild, wait, noCache bool)
 		return err
 	}
 
-	if err := translate(ctx, s, forceBuild, noCache); err != nil {
+	spinner := utils.NewSpinner("Checking image availability...")
+	spinner.Start()
+	if err := translate(ctx, s, forceBuild, noCache, spinner); err != nil {
 		return err
 	}
+	spinner.Stop()
 
 	cfg := translateConfigMap(s)
 	output := fmt.Sprintf("Deploying stack '%s'...", s.Name)

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -173,7 +173,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, forceBuild, noCac
 func buildServices(ctx context.Context, s *model.Stack, buildKitHost string, isOktetoCluster, forceBuild, noCache bool, spinner *utils.Spinner) (bool, error) {
 	hasBuiltSomething := false
 	for name, svc := range s.Services {
-		spinner.Update(fmt.Sprintf("Checking image availability of '%s'", name))
+		spinner.Update(fmt.Sprintf("Checking the availability of '%s' image", name))
 		if svc.Build == nil {
 			continue
 		}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/model"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -53,7 +54,7 @@ func Test_translate(t *testing.T) {
 			},
 		},
 	}
-	if err := translate(ctx, stack, false, false); err == nil {
+	if err := translate(ctx, stack, false, false, utils.NewSpinner("")); err == nil {
 		t.Fatalf("An error should be returned")
 	}
 }

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -29,23 +29,32 @@ type Secret struct {
 	Value string `json:"value,omitempty"`
 }
 
+var (
+	secrets          []Secret
+	retrievedSecrets bool
+)
+
 //GetSecrets returns the secrets from Okteto API
 func GetSecrets(ctx context.Context) ([]Secret, error) {
-	q := `query{
-		getGitDeploySecrets{
-			name,value
-		},
-	}`
+	if !retrievedSecrets {
+		q := `query{
+			getGitDeploySecrets{
+				name,value
+			},
+		}`
 
-	var body Secrets
-	if err := query(ctx, q, &body); err != nil {
-		return nil, err
-	}
-	secrets := make([]Secret, 0)
-	for _, secret := range body.Secrets {
-		if !strings.Contains(secret.Name, ".") {
-			secrets = append(secrets, secret)
+		var body Secrets
+		if err := query(ctx, q, &body); err != nil {
+			return nil, err
 		}
+		secrets = make([]Secret, 0)
+		for _, secret := range body.Secrets {
+			if !strings.Contains(secret.Name, ".") {
+				secrets = append(secrets, secret)
+			}
+		}
+		retrievedSecrets = true
+		return secrets, nil
 	}
 	return secrets, nil
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: When deploying a stack with lots of images that are already stored on the registry it didn't display any message to the user until all of them was checked.

## Proposed changes
-  Show a spinning message to the user saying `Checking the availability of the '{service}' image`.
-  Reduce the time of getting the secrets the second time by returning them if it has been already retrieved in the command runtime
