### PR TITLE
Fix bug when repo url finish with slash

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -164,7 +164,7 @@ func GetStack(name, stackPath string, isCompose bool) (*Stack, error) {
 	}
 	if s.Name == "" {
 		s.Name, err = GetValidNameFromGitRepo(filepath.Dir(stackPath))
-		if err != nil {
+		if err != nil || s.Name == "" {
 			s.Name, err = GetValidNameFromFolder(filepath.Dir(stackPath))
 			if err != nil {
 				return nil, err

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -85,14 +85,26 @@ func GetValidNameFromGitRepo(folder string) (string, error) {
 }
 
 func translateURLToName(repo string) string {
-	repo = strings.ToLower(repo[strings.LastIndex(repo, "/")+1:])
-	if strings.HasSuffix(repo, ".git") {
-		repo = repo[:strings.LastIndex(repo, ".git")]
+	repoName := findRepoName(repo)
+
+	if strings.HasSuffix(repoName, ".git") {
+		repoName = repoName[:strings.LastIndex(repoName, ".git")]
 	}
-	name := ValidKubeNameRegex.ReplaceAllString(repo, "-")
+	name := ValidKubeNameRegex.ReplaceAllString(repoName, "-")
 	return name
 }
-
+func findRepoName(repo string) string {
+	possibleName := strings.ToLower(repo[strings.LastIndex(repo, "/")+1:])
+	if possibleName == "" {
+		possibleName = repo
+		nthTrim := strings.Count(repo, "/")
+		for i := 0; i < nthTrim-1; i++ {
+			possibleName = strings.ToLower(possibleName[strings.Index(possibleName, "/")+1:])
+		}
+		possibleName = possibleName[:len(possibleName)-1]
+	}
+	return possibleName
+}
 func GetRepositoryURL(path string) (string, error) {
 	repo, err := git.PlainOpen(path)
 	if err != nil {

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -116,7 +116,9 @@ func Test_GetValidNameFromGitRepo(t *testing.T) {
 		expected string
 	}{
 		{name: "https url", gitRepo: "https://github.com/okteto/stacks-getting-started", expected: "stacks-getting-started"},
+		{name: "https with slash at the end", gitRepo: "https://github.com/okteto/stacks-getting-started/", expected: "stacks-getting-started"},
 		{name: "ssh url", gitRepo: "git@github.com:okteto/stacks-getting-started.git", expected: "stacks-getting-started"},
+		{name: "ssh url with slash at the end", gitRepo: "git@github.com:okteto/stacks-getting-started.git/", expected: "stacks-getting-started"},
 		{name: "https with dots", gitRepo: "https://github.com/okteto/stacks.getting.started", expected: "stacks-getting-started"},
 		{name: "URL with uppers", gitRepo: "https://github.com/okteto/StacksGettingStarted", expected: "stacksgettingstarted"},
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes a bug where if you try to deploy a stack repo with an url finishing with `/` it will return that name is empty

## Proposed changes
-  Return the correct name of the repo, when a url finish with slash.
-  If there is no error while getting the repo name from git but the name is still empty get the name from the parent folder
