### PR TITLE
Update integration tests timeout to 15 min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 
 .PHONY: integration
 integration:
-	 go test github.com/okteto/okteto/integration -tags=integration --count=1 -v
+	 go test github.com/okteto/okteto/integration -tags=integration --count=1 -v -timeout 15m
 
 .PHONY: build
 build:


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Integration tests

## Proposed changes
-  Update integration tests timeout to 15 min instead of 10min
-  
