### PR TITLE
Add support for healthchecks

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -278,6 +278,8 @@ func translateConfigMap(s *model.Stack) *apiv1.ConfigMap {
 func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 	svc := s.Services[svcName]
 
+	healthcheckProbe := getSvcProbe(svc)
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -311,6 +313,8 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 							SecurityContext: translateSecurityContext(svc),
 							Resources:       translateResources(svc),
 							WorkingDir:      svc.Workdir,
+							ReadinessProbe:  healthcheckProbe,
+							LivenessProbe:   healthcheckProbe,
 						},
 					},
 				},
@@ -345,7 +349,7 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 	svc := s.Services[svcName]
 
 	initContainers := getInitContainers(svcName, s)
-
+	healthcheckProbe := getSvcProbe(svc)
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -380,6 +384,8 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 							VolumeMounts:    translateVolumeMounts(svcName, svc),
 							Resources:       translateResources(svc),
 							WorkingDir:      svc.Workdir,
+							ReadinessProbe:  healthcheckProbe,
+							LivenessProbe:   healthcheckProbe,
 						},
 					},
 					Volumes: translateVolumes(svcName, svc),
@@ -394,6 +400,7 @@ func translateJob(svcName string, s *model.Stack) *batchv1.Job {
 	svc := s.Services[svcName]
 
 	initContainers := getInitContainers(svcName, s)
+	healthcheckProbe := getSvcProbe(svc)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -426,6 +433,8 @@ func translateJob(svcName string, s *model.Stack) *batchv1.Job {
 							VolumeMounts:    translateVolumeMounts(svcName, svc),
 							Resources:       translateResources(svc),
 							WorkingDir:      svc.Workdir,
+							ReadinessProbe:  healthcheckProbe,
+							LivenessProbe:   healthcheckProbe,
 						},
 					},
 					Volumes: translateVolumes(svcName, svc),
@@ -865,4 +874,32 @@ func translateResources(svc *model.Service) apiv1.ResourceRequirements {
 		}
 	}
 	return result
+}
+
+func getSvcProbe(svc *model.Service) *apiv1.Probe {
+	if svc.Healtcheck != nil {
+		var handler apiv1.Handler
+		if len(svc.Healtcheck.Test) != 0 {
+			handler = apiv1.Handler{
+				Exec: &apiv1.ExecAction{
+					Command: svc.Healtcheck.Test,
+				},
+			}
+		} else {
+			handler = apiv1.Handler{
+				HTTPGet: &apiv1.HTTPGetAction{
+					Path: svc.Healtcheck.HTTP.Path,
+					Port: intstr.IntOrString{IntVal: svc.Healtcheck.HTTP.Port},
+				},
+			}
+		}
+		return &apiv1.Probe{
+			Handler:             handler,
+			TimeoutSeconds:      int32(svc.Healtcheck.Timeout.Seconds()),
+			PeriodSeconds:       int32(svc.Healtcheck.Interval.Seconds()),
+			FailureThreshold:    int32(svc.Healtcheck.Retries),
+			InitialDelaySeconds: int32(svc.Healtcheck.StartPeriod.Seconds()),
+		}
+	}
+	return nil
 }

--- a/pkg/k8s/events/crud.go
+++ b/pkg/k8s/events/crud.go
@@ -1,0 +1,56 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func List(ctx context.Context, namespace, podName string, c kubernetes.Interface) ([]apiv1.Event, error) {
+	events, err := c.CoreV1().Events(namespace).List(
+		ctx,
+		metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("involvedObject.name=%s", podName),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return events.Items, err
+}
+
+func GetUnhealthyEventFailure(ctx context.Context, namespace, podName string, c kubernetes.Interface) string {
+	events, err := List(ctx, namespace, podName, c)
+	if err != nil {
+		return ""
+	}
+	previousKilling := false
+	for i := len(events) - 1; i >= 0; i-- {
+		if previousKilling {
+			if events[i].Reason == "Unhealthy" && strings.Contains(events[i].Message, "probe failed") {
+				return events[i].Message
+			}
+		}
+		if events[i].Reason == "Killing" && (strings.Contains(events[i].Message, "failed liveness probe") || strings.Contains(events[i].Message, "failed readiness probe")) {
+			previousKilling = true
+		}
+	}
+	return ""
+}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -63,6 +63,7 @@ type Service struct {
 	Volumes         []StackVolume       `yaml:"volumes,omitempty"`
 	Workdir         string              `yaml:"workdir,omitempty"`
 	BackOffLimit    int32               `yaml:"max_attempts,omitempty"`
+	Healtcheck      *HealthCheck        `yaml:"healthcheck,omitempty"`
 
 	Public    bool            `yaml:"public,omitempty"`
 	Replicas  int32           `yaml:"replicas,omitempty"`
@@ -85,6 +86,22 @@ type VolumeSpec struct {
 type Envs struct {
 	List Environment
 }
+type HealthCheck struct {
+	HTTP        *HTTPHealtcheck `yaml:"http,omitempty"`
+	Test        HealtcheckTest  `yaml:"test,omitempty"`
+	Interval    time.Duration   `yaml:"interval,omitempty"`
+	Timeout     time.Duration   `yaml:"timeout,omitempty"`
+	Retries     int             `yaml:"retries,omitempty"`
+	StartPeriod time.Duration   `yaml:"start_period,omitempty"`
+	Disable     bool            `yaml:"disable,omitempty"`
+}
+
+type HTTPHealtcheck struct {
+	Path string `yaml:"path,omitempty"`
+	Port int32  `yaml:"port,omitempty"`
+}
+
+type HealtcheckTest []string
 
 // StackResources represents an okteto stack resources
 type StackResources struct {

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	yaml "gopkg.in/yaml.v2"
 	apiv1 "k8s.io/api/core/v1"
@@ -208,6 +209,187 @@ func Test_DeployResourcesUnmarshalling(t *testing.T) {
 				t.Fatalf("expected %v but got %v", tt.expected, resources)
 			}
 
+		})
+	}
+}
+
+func Test_HealthcheckUnmarshalling(t *testing.T) {
+	tests := []struct {
+		name          string
+		manifest      []byte
+		expected      *HealthCheck
+		expectedError bool
+	}{
+		{
+			name:          "healthcheck http through test with https",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl https://0.0.0.0:8080/readiness\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/readiness", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck disable",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      disable: true\n      test: cat file.txt\n    image: okteto/vote:1"),
+			expected:      nil,
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck none",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: [\"NONE\"]\n    image: okteto/vote:1"),
+			expected:      nil,
+			expectedError: false,
+		},
+		{
+			name:          "just healthcheck command",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      test: cat file.txt\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{Test: []string{"cat", "file.txt"}},
+			expectedError: false,
+		},
+		{
+			name:          "normal healthcheck",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: cat file.txt\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{Test: []string{"cat", "file.txt"}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck without test",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n    image: okteto/vote:1"),
+			expected:      nil,
+			expectedError: true,
+		},
+		{
+			name:          "healthcheck with test and http",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: cat file.txt\n      http:\n        path: /\n        port: 8080\n    image: okteto/vote:1"),
+			expected:      nil,
+			expectedError: true,
+		},
+		{
+			name:          "healthcheck http path not starting with /",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      http:\n        path: db\n        port: 8080\n    image: okteto/vote:1"),
+			expected:      nil,
+			expectedError: true,
+		},
+		{
+			name:          "healthcheck http",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      http:\n        path: /\n        port: 8080\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck http through test without failing flag",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl 0.0.0.0:8080/readiness\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/readiness", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck http through test with -f",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl -f localhost:8080/\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck http through test with --fail",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080/\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck http through test without /",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expectedError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := ReadStack(tt.manifest, true)
+			if err != nil && !tt.expectedError {
+				t.Fatal(err)
+			} else if err == nil && tt.expectedError {
+				t.Fatal("error not thrown")
+			}
+			if !tt.expectedError {
+				if !reflect.DeepEqual(s.Services["app"].Healtcheck, tt.expected) {
+					t.Fatalf("Expected %v, but got %v", tt.expected, s.Services["app"].Healtcheck)
+				}
+			}
+
+		})
+	}
+}
+func Test_HealthcheckTestUnmarshalling(t *testing.T) {
+	tests := []struct {
+		name            string
+		healthcheckTest string
+		expected        HealtcheckTest
+		expectedError   bool
+	}{
+		{
+			name:            "empty list",
+			healthcheckTest: `[]`,
+			expected:        []string{},
+			expectedError:   true,
+		},
+		{
+			name:            "NONE simple",
+			healthcheckTest: `["NONE"]`,
+			expected:        []string{"NONE"},
+			expectedError:   false,
+		},
+		{
+			name:            "NONE with args",
+			healthcheckTest: `["NONE", "curl -f localhost:5000"]`,
+			expected:        []string{"NONE"},
+			expectedError:   false,
+		},
+		{
+			name:            "other than the three expected",
+			healthcheckTest: `["TEST", "curl -f localhost:5000"]`,
+			expected:        []string{},
+			expectedError:   true,
+		},
+		{
+			name:            "CMDSHELL",
+			healthcheckTest: `["CMD-SHELL", "curl -f localhost:5000"]`,
+			expected:        []string{"curl", "-f", "localhost:5000"},
+			expectedError:   false,
+		},
+		{
+			name:            "CMD",
+			healthcheckTest: `["CMD", "curl", "-f", "localhost:5000"]`,
+			expected:        []string{"curl", "-f", "localhost:5000"},
+			expectedError:   false,
+		},
+		{
+			name:            "direct",
+			healthcheckTest: `curl -f localhost:5000`,
+			expected:        []string{"curl", "-f", "localhost:5000"},
+			expectedError:   false,
+		},
+		{
+			name: "list",
+			healthcheckTest: `- CMD
+- curl
+- -f
+- localhost:5000`,
+			expected:      []string{"curl", "-f", "localhost:5000"},
+			expectedError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result HealtcheckTest
+			if err := yaml.Unmarshal([]byte(tt.healthcheckTest), &result); err != nil {
+				if !tt.expectedError {
+					t.Fatalf("unexpected error unmarshaling %s: %s", tt.name, err.Error())
+				}
+				return
+			}
+			if tt.expectedError {
+				t.Fatalf("expected error unmarshaling %s not thrown", tt.name)
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("didn't unmarshal correctly healthcheck test. Actual %v, Expected %v", result, tt.expected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1604

## Proposed changes
-  Adds full support for compose `healthcheck` field
```
healthcheck:
  test: service nginx status || exit 1
  interval: 45s
  timeout: 5m
  retries: 5
  start_period: 30s
```
-  Adds syntax for httpGet probes
```
healthcheck:
  http:
    path: /
    port: 8080
  interval: 1m30s
  timeout: 10s
  retries: 3
  start_period: 40s
```
- Translate typical compose httpGet probes into k8s httpGet probes. The example below will test for path `/api` on port `8080`:

```
healthcheck:
  test: ["CMD", "curl", "-f", "http://localhost:8080/api"]
  interval: 1m30s
  timeout: 10s
  retries: 3
  start_period: 40s
```