### PR TITLE
Fix databases created as jobs

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -161,7 +161,7 @@ func deploy(ctx context.Context, s *model.Stack, wait bool, c *kubernetes.Client
 }
 
 func deploySvc(ctx context.Context, stack *model.Stack, svcName string, client kubernetes.Interface, spinner *utils.Spinner) error {
-	if stack.Services[svcName].RestartPolicy != apiv1.RestartPolicyAlways {
+	if stack.Services[svcName].IsJob() {
 		if err := deployJob(ctx, svcName, stack, client); err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ func getDependingFailedJobs(ctx context.Context, stack *model.Stack, svcName str
 	svc := stack.Services[svcName]
 	dependingJobs := make([]string, 0)
 	for dependingSvc := range svc.DependsOn {
-		if stack.Services[dependingSvc].RestartPolicy != apiv1.RestartPolicyAlways {
+		if stack.Services[dependingSvc].IsJob() {
 			dependingJobs = append(dependingJobs, dependingSvc)
 		}
 	}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -264,7 +264,7 @@ func ReadStack(bytes []byte, isCompose bool) (*Stack, error) {
 			svc.Replicas = 1
 		}
 
-		if svc.RestartPolicy != apiv1.RestartPolicyAlways {
+		if svc.IsJob() {
 			for idx, volume := range svc.Volumes {
 				volumeName := fmt.Sprintf("pvc-%s-0", svcName)
 				if volume.LocalPath == "" {
@@ -449,11 +449,11 @@ func isInVolumesTopLevelSection(volumeName string, s *Stack) bool {
 }
 
 func (svc *Service) IsDeployment() bool {
-	return len(svc.Volumes) == 0 && svc.RestartPolicy == apiv1.RestartPolicyAlways
+	return len(svc.Volumes) == 0 && (svc.RestartPolicy == apiv1.RestartPolicyAlways || (svc.RestartPolicy == apiv1.RestartPolicyOnFailure && svc.BackOffLimit == 0))
 }
 func (svc *Service) IsStatefulset() bool {
-	return len(svc.Volumes) != 0 && svc.RestartPolicy == apiv1.RestartPolicyAlways
+	return len(svc.Volumes) != 0 && (svc.RestartPolicy == apiv1.RestartPolicyAlways || (svc.RestartPolicy == apiv1.RestartPolicyOnFailure && svc.BackOffLimit == 0))
 }
 func (svc *Service) IsJob() bool {
-	return svc.RestartPolicy != apiv1.RestartPolicyAlways
+	return svc.RestartPolicy == apiv1.RestartPolicyNever || (svc.RestartPolicy == apiv1.RestartPolicyOnFailure && svc.BackOffLimit != 0)
 }

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -969,7 +969,7 @@ func validateDependsOn(s *Stack) error {
 			if _, ok := s.Services[dependentSvc]; !ok {
 				return fmt.Errorf(" Service '%s' depends on service '%s' which is undefined.", svcName, dependentSvc)
 			}
-			if condition.Condition == DependsOnServiceCompleted && s.Services[dependentSvc].RestartPolicy == apiv1.RestartPolicyAlways {
+			if condition.Condition == DependsOnServiceCompleted && !s.Services[dependentSvc].IsJob() {
 				return fmt.Errorf(" Service '%s' is not a job. Please change the reset policy so that it is not always in service '%s' ", dependentSvc, dependentSvc)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes a problem where databases created with on failure restart policy where created as jobs

## Proposed changes
-  Set a service as a job when is on `restart_on_failure` if `max_attemps` field is set or if its `restart_never`
-  
