### PR TITLE
Trim long messages while spinning

### DIFF
--- a/cmd/utils/spinner.go
+++ b/cmd/utils/spinner.go
@@ -42,7 +42,7 @@ func NewSpinner(suffix string) *Spinner {
 	s.FinalMSG = s.Suffix
 	s.PreUpdate = func(s *sp.Spinner) {
 		width, _, _ := terminal.GetSize(int(os.Stdout.Fd()))
-		if width > 4 && len(s.FinalMSG) > width {
+		if width > 4 && len(s.FinalMSG)+2 > width {
 			s.Suffix = s.FinalMSG[:width-5] + "..."
 		} else {
 			s.Suffix = s.FinalMSG

--- a/cmd/utils/spinner.go
+++ b/cmd/utils/spinner.go
@@ -23,7 +23,7 @@ import (
 
 	sp "github.com/briandowns/spinner"
 	"github.com/okteto/okteto/pkg/log"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 var spinnerSupport bool
@@ -41,7 +41,7 @@ func NewSpinner(suffix string) *Spinner {
 	s.Suffix = fmt.Sprintf(" %s", suffix)
 	s.FinalMSG = s.Suffix
 	s.PreUpdate = func(s *sp.Spinner) {
-		width, _, _ := terminal.GetSize(int(os.Stdout.Fd()))
+		width, _, _ := term.GetSize(int(os.Stdout.Fd()))
 		if width > 4 && len(s.FinalMSG)+2 > width {
 			s.Suffix = s.FinalMSG[:width-5] + "..."
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 // indirect
 	google.golang.org/grpc v1.29.1
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -29,7 +29,7 @@ import (
 	"github.com/okteto/okteto/pkg/log"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // Exec executes the command over SSH
@@ -90,14 +90,14 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 		var termFD int
 		var ok bool
 		if termFD, ok = isTerminal(inR); ok {
-			width, height, err = terminal.GetSize(int(os.Stdout.Fd()))
+			width, height, err = term.GetSize(int(os.Stdout.Fd()))
 			log.Infof("terminal width %d height %d", width, height)
 			if err != nil {
 				log.Infof("request for terminal size failed: %s", err)
 			}
 		}
 
-		state, err := terminal.MakeRaw(termFD)
+		state, err := term.MakeRaw(termFD)
 		if err != nil {
 			log.Infof("request for raw terminal failed: %s", err)
 		}
@@ -107,7 +107,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 				return
 			}
 
-			if err := terminal.Restore(termFD, state); err != nil {
+			if err := term.Restore(termFD, state); err != nil {
 				log.Infof("failed to restore terminal: %s", err)
 			}
 
@@ -187,7 +187,7 @@ More information is available here: https://okteto.com/docs/reference/manifest#r
 func isTerminal(r io.Reader) (int, bool) {
 	switch v := r.(type) {
 	case *os.File:
-		return int(v.Fd()), terminal.IsTerminal(int(v.Fd()))
+		return int(v.Fd()), term.IsTerminal(int(v.Fd()))
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1596

![spinner](https://user-images.githubusercontent.com/25170843/122243632-909c3400-cec4-11eb-8712-6087e0272771.gif)

## Proposed changes
-  Use spinner final message as a variable to trim or expand the suffix, taking in count the terminal width
-  It works well if you don't resize the terminal in the process of running the command
-  It also works if you make the terminal larger
- When making the terminal smaller it will create the same behavior as its today because it doesn't have time to trim before adding the new line.

(PD. This PR needs to be test on windows) 
