### PR TITLE
Add update command

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/moby/term"
+	" github.com/moby/term"
 	initCMD "github.com/okteto/okteto/cmd/init"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -65,12 +65,12 @@ func Up() *cobra.Command {
 				return errors.ErrNotInDevContainer
 			}
 
-			u := upgradeAvailable()
+			u := utils.UpgradeAvailable()
 			if len(u) > 0 {
 				warningFolder := filepath.Join(config.GetOktetoHome(), ".warnings")
 				if utils.GetWarningState(warningFolder, "version") != u {
 					log.Yellow("Okteto %s is available. To upgrade:", u)
-					log.Yellow("    %s", getUpgradeCommand())
+					log.Yellow("    %s", utils.GetUpgradeCommand())
 					if err := utils.SetWarningState(warningFolder, "version", u); err != nil {
 						log.Infof("failed to set warning version state: %s", err.Error())
 					}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	" github.com/moby/term"
+	"github.com/moby/term"
 	initCMD "github.com/okteto/okteto/cmd/init"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,190 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/log"
+	"github.com/spf13/cobra"
+	"github.com/vbauerster/mpb/v7"
+	"github.com/vbauerster/mpb/v7/decor"
+)
+
+const (
+	LATEST_URL   = "https://github.com/okteto/okteto/releases/latest/download"
+	INSTALL_PATH = "/usr/local/bin/okteto"
+)
+
+//Update check if there is a new version available and updates it
+func Update() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "Updates okteto version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if isUpdateAvailable() {
+				err := updateVersion()
+				if err != nil {
+					return err
+				}
+				log.Success("The latest okteto version has been installed")
+			} else {
+				log.Success("The latest okteto version is already installed")
+			}
+
+			return nil
+		},
+	}
+}
+
+//isUpdateAvailable checks if there is a new version available
+func isUpdateAvailable() bool {
+	current, err := semver.NewVersion(config.VersionString)
+	if err != nil {
+		return false
+	}
+
+	v, err := utils.GetLatestVersionFromGithub()
+	if err != nil {
+		log.Infof("failed to get latest version from github: %s", err)
+		return false
+	}
+
+	if len(v) > 0 {
+		latest, err := semver.NewVersion(v)
+		if err != nil {
+			log.Infof("failed to parse latest version '%s': %s", v, err)
+			return false
+		}
+
+		if current.GreaterThan(latest) {
+			log.Infof("Installing okteto version %s", latest)
+			return true
+		}
+	}
+
+	return false
+}
+
+//updateVersion updates the version of the current okteto binary
+func updateVersion() error {
+	url, err := getDownloadURL()
+	if err != nil {
+		return err
+	}
+
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return fmt.Errorf("failed to create temp download dir")
+	}
+	downloadPath := fmt.Sprintf("%s/okteto", tempDir)
+	defer os.Remove(tempDir)
+
+	if err != nil {
+		return err
+	}
+
+	err = downloadLatestVersion(url, downloadPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(downloadPath, INSTALL_PATH)
+	if err != nil {
+		return err
+	}
+
+	err = os.Chmod(INSTALL_PATH, 0700)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//getDownloadURL gets the valid url for the current OS/ARCH
+func getDownloadURL() (string, error) {
+	switch {
+	case runtime.GOOS == "darwin":
+		switch {
+		case runtime.GOARCH == "x86_64" || runtime.GOARCH == "amd64":
+			return fmt.Sprintf("%s/okteto-Darwin-x86_64", LATEST_URL), nil
+		case runtime.GOARCH == "arm64":
+			return fmt.Sprintf("%s/okteto-Darwin-arm64", LATEST_URL), nil
+		default:
+			return "", fmt.Errorf("The architecture (%s) is not supported by this command. Please try installing it manually", runtime.GOARCH)
+		}
+	case runtime.GOOS == "linux":
+		switch {
+		case runtime.GOARCH == "x86_64":
+			return fmt.Sprintf("%s/okteto-Linux-x86_64", LATEST_URL), nil
+		case runtime.GOARCH == "amd64":
+			return fmt.Sprintf("%s/okteto-Linux-x86_64", LATEST_URL), nil
+		case runtime.GOARCH == "armv8":
+			return fmt.Sprintf("%s/okteto-Linux-arm64", LATEST_URL), nil
+		case runtime.GOARCH == "aarch64":
+			return fmt.Sprintf("%s/okteto-Linux-arm64", LATEST_URL), nil
+		default:
+			return "", fmt.Errorf("The architecture (%s) is not supported by this command. Please try installing it manually", runtime.GOARCH)
+		}
+	default:
+		return "", fmt.Errorf("The OS (%s) is not supported by this command. Please try installing it manually", runtime.GOOS)
+	}
+}
+
+//downloadLatestVersion downloads latest version from the url given into the dir given
+func downloadLatestVersion(url, dir string) error {
+	log.Infof("Downloading new okteto version from %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(dir)
+	if err != nil {
+		return err
+	}
+
+	p := mpb.New(
+		mpb.WithWidth(40),
+		mpb.WithRefreshRate(180*time.Millisecond),
+	)
+
+	bar := p.Add(resp.ContentLength,
+		mpb.NewBarFiller(mpb.BarStyle().Rbound("|").Tip(">").Filler("-").Padding("_")),
+		mpb.PrependDecorators(
+			decor.CountersKibiByte("% .2f / % .2f"),
+		),
+		mpb.AppendDecorators(
+			decor.EwmaETA(decor.ET_STYLE_GO, 90),
+			decor.Name(" ] "),
+			decor.EwmaSpeed(decor.UnitKiB, "% .2f", 60),
+		),
+	)
+	proxyReader := bar.ProxyReader(resp.Body)
+	defer proxyReader.Close()
+
+	io.Copy(out, proxyReader)
+	p.Wait()
+	return nil
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Okteto Authors
+// Copyright 2021 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -80,10 +80,12 @@ func displayUpdateSteps() {
 	switch {
 	case runtime.GOOS == "darwin" || runtime.GOOS == "linux":
 		fmt.Print(`# Using installation script:
-curl https://get.okteto.com -sSfL | sh
-
+curl https://get.okteto.com -sSfL | sh`)
+		if runtime.GOOS == "darwin" {
+			fmt.Print(`
 # Using brew:
 brew upgrade okteto`)
+		}
 	case runtime.GOOS == "windows":
 		fmt.Print(`# Using manual installation:
 1.- Download https://downloads.okteto.com/cli/okteto.exe

--- a/cmd/utils/syncthing.go
+++ b/cmd/utils/syncthing.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/vbauerster/mpb/v6"
-	decor "github.com/vbauerster/mpb/v6/decor"
+	"github.com/vbauerster/mpb/v7"
+	decor "github.com/vbauerster/mpb/v7/decor"
 )
 
 // SyncthingProgress tracks the progress of all the files syncthing
@@ -44,7 +44,7 @@ func (s *SyncthingProgress) initProgressBar() {
 			decor.OnComplete(decor.Name(" "), ""),
 			decor.OnComplete(s.ItemStartedDecorator(), ""),
 		),
-		mpb.BarExtender(NewLineBarFiller(mpb.NewBarFiller("[->_]"))),
+		mpb.BarExtender(mpb.NewBarFiller(mpb.BarStyle().Lbound("[").Filler("-").Tip(">").Padding("_").Rbound("]"))),
 		mpb.BarRemoveOnComplete(),
 	)
 }

--- a/cmd/utils/upgrade.go
+++ b/cmd/utils/upgrade.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package up
+package utils
 
 import (
 	"context"
@@ -24,7 +24,7 @@ import (
 	"github.com/okteto/okteto/pkg/log"
 )
 
-func upgradeAvailable() string {
+func UpgradeAvailable() string {
 	current, err := semver.NewVersion(config.VersionString)
 	if err != nil {
 		return ""
@@ -44,7 +44,7 @@ func upgradeAvailable() string {
 		}
 
 		// check if it's a minor or major change, we don't notify on revision
-		if shouldNotify(latest, current) {
+		if ShouldNotify(latest, current) {
 			return v
 		}
 	}
@@ -70,7 +70,7 @@ func GetLatestVersionFromGithub() (string, error) {
 	return "", fmt.Errorf("failed to find latest release")
 }
 
-func shouldNotify(latest, current *semver.Version) bool {
+func ShouldNotify(latest, current *semver.Version) bool {
 	if current.GreaterThan(latest) {
 		return false
 	}
@@ -87,7 +87,7 @@ func shouldNotify(latest, current *semver.Version) bool {
 	return false
 }
 
-func getUpgradeCommand() string {
+func GetUpgradeCommand() string {
 	if runtime.GOOS == "windows" {
 		return `https://github.com/okteto/okteto/releases/latest/download/okteto.exe`
 	}

--- a/cmd/utils/upgrade_test.go
+++ b/cmd/utils/upgrade_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package up
+package utils
 
 import (
 	"testing"
@@ -41,7 +41,7 @@ func Test_shouldNotify(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldNotify(tt.args.latest, tt.args.current); got != tt.want {
+			if got := ShouldNotify(tt.args.latest, tt.args.current); got != tt.want {
 				t.Errorf("shouldNotify() = %v, want %v", got, tt.want)
 			}
 		})

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	google.golang.org/grpc v1.29.1
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -46,12 +46,12 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/src-d/enry/v2 v2.1.0
 	github.com/subosito/gotenv v1.2.0
-	github.com/vbauerster/mpb/v6 v6.0.2
+	github.com/vbauerster/mpb/v7 v7.0.2
 	github.com/whilp/git-urls v1.0.0
 	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 // indirect
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 
 	google.golang.org/grpc v1.29.1
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIO
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
+github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
+github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/a8m/envsubst v1.2.0 h1:yvzAhJD2QKdo35Ut03wIfXQmg+ta3wC/1bskfZynz+Q=
 github.com/a8m/envsubst v1.2.0/go.mod h1:PpvLvNWa+Rvu/10qXmFbFiGICIU5hZvFJNPCCkUaObg=
@@ -879,6 +881,8 @@ github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.12.0 h1:u/x3mp++qUxvYfulZ4HKOvVO0JWhk7HtE8lWhbGz/Do=
@@ -1265,6 +1269,8 @@ github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOV
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vbauerster/mpb/v6 v6.0.2 h1:DWFnBOcgHi9GUNduC1MbQ936Z7B77wvOnZexP9Hjzcw=
 github.com/vbauerster/mpb/v6 v6.0.2/go.mod h1:JDNVbdx4oAMMxZNXodDH2DeDY5xBJC8bDGHNFZwRqQM=
+github.com/vbauerster/mpb/v7 v7.0.2 h1:eN6AD/ytv1nqCO7Dm8MO0/pGMKmMyH/WMnTJhAUuc/w=
+github.com/vbauerster/mpb/v7 v7.0.2/go.mod h1:Mnq3gESXJ9eQhccbGZDggJ1faTCrmaA4iN57fUloRGE=
 github.com/vdemeester/k8s-pkg-credentialprovider v1.17.4/go.mod h1:inCTmtUdr5KJbreVojo06krnTgaeAz/Z7lynpPk/Q2c=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
@@ -1529,6 +1535,8 @@ golang.org/x/sys v0.0.0-20201013081832-0aaa2718063a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
 golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210603125802-9665404d3644 h1:CA1DEQ4NdKphKeL70tvsWNdT5oFh1lOjihRcEDROi0I=
+golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	ps "github.com/mitchellh/go-ps"
-	upCmd "github.com/okteto/okteto/cmd/up"
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
 	k8Client "github.com/okteto/okteto/pkg/k8s/client"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -152,7 +152,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestGetVersion(t *testing.T) {
-	v, err := upCmd.GetLatestVersionFromGithub()
+	v, err := utils.GetLatestVersionFromGithub()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 	root.AddCommand(cmd.Doctor())
 	root.AddCommand(cmd.Exec())
 	root.AddCommand(cmd.Restart())
+	root.AddCommand(cmd.Update())
 
 	err := utils.RunWithRetry(root.Execute)
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1608

## Proposed changes
- Adds a new command where the users can update their okteto binary with just typing okteto update
- It's not compatible with windows
- Updates progress bar library to the latest version
