### PR TITLE
Updating divert service modification handling.

### DIFF
--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -155,7 +155,7 @@ func Test_translateServiceDiverted(t *testing.T) {
 			Annotations: map[string]string{
 				"annotation1":                                   "value1",
 				model.OktetoAutoIngressAnnotation:               "true",
-				model.OktetoDivertServiceModificationAnnotation: "{\"proxy_port\":\"1026\",\"original_port\":\"8080\",\"original_target_port\":\"8080\"}",
+				model.OktetoDivertServiceModificationAnnotation: "{\"proxy_port\":1026,\"original_port\":8080,\"original_target_port\":8080}",
 			},
 			Labels:          map[string]string{"label1": "value1"},
 			ResourceVersion: "version",
@@ -173,10 +173,7 @@ func Test_translateServiceDiverted(t *testing.T) {
 			},
 		},
 	}
-	translated, err := translateService("cindy", d, original)
-	if err != nil {
-		t.Fatalf("error translating service: %s", err.Error())
-	}
+
 	expected := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cindy-name",
@@ -199,11 +196,33 @@ func Test_translateServiceDiverted(t *testing.T) {
 			},
 		},
 	}
-	marshalled, _ := yaml.Marshal(translated)
-	marshalledExpected, _ := yaml.Marshal(expected)
-	if string(marshalled) != string(marshalledExpected) {
-		t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
-	}
+
+	t.Run("IntServiceModValues", func(t *testing.T) {
+		translated, err := translateService("cindy", d, original)
+		if err != nil {
+			t.Fatalf("error translating service: %s", err.Error())
+		}
+		marshalled, _ := yaml.Marshal(translated)
+		marshalledExpected, _ := yaml.Marshal(expected)
+		if string(marshalled) != string(marshalledExpected) {
+			t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
+		}
+	})
+
+	t.Run("StringServiceModValues", func(t *testing.T) {
+		stringMod := "{\"proxy_port\":\"1026\",\"original_port\":\"8080\",\"original_target_port\":\"8080\"}"
+		original.ObjectMeta.Annotations[model.OktetoDivertServiceModificationAnnotation] = stringMod
+
+		translated, err := translateService("cindy", d, original)
+		if err != nil {
+			t.Fatalf("error translating service: %s", err.Error())
+		}
+		marshalled, _ := yaml.Marshal(translated)
+		marshalledExpected, _ := yaml.Marshal(expected)
+		if string(marshalled) != string(marshalledExpected) {
+			t.Fatalf("Wrong translation.\nActual %+v, \nExpected %+v", string(marshalled), string(marshalledExpected))
+		}
+	})
 }
 
 func Test_translateIngressGenerateHostTrue(t *testing.T) {


### PR DESCRIPTION
The divert service modification annotation has changed
data types. The code added allows handling both the previous
version of the annotation and the current version.

Signed-off-by: Jacob MacElroy <30531294+jmacelroy@users.noreply.github.com>

Fixes #
An issue where new divert service modifications can not be marshaled.

## Proposed changes
Handle both variants of the modification by use of a function rather than direct unmarshaling.
