### PR TITLE
Fix missconfigured terminal after Ctrl+C

### DIFF
--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -16,7 +16,7 @@ package up
 import (
 	"context"
 
-	"github.com/docker/docker/pkg/term"
+	"github.com/moby/term"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/syncthing"
 	apiv1 "k8s.io/api/core/v1"

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -19,10 +19,11 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
-	"github.com/docker/docker/pkg/term"
+	"github.com/moby/term"
 	initCMD "github.com/okteto/okteto/cmd/init"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -142,6 +143,7 @@ func Up() *cobra.Command {
 					log.Infof("failed to save the state of the terminal: %s", err.Error())
 					return fmt.Errorf("failed to save the state of the terminal")
 				}
+				log.Infof("Terminal: %v", up.stateTerm)
 			}
 
 			err = up.start(autoDeploy, build)
@@ -482,6 +484,7 @@ func (up *upContext) shutdown() {
 		if err := term.RestoreTerminal(up.inFd, up.stateTerm); err != nil {
 			log.Infof("failed to restore terminal: %s", err.Error())
 		}
+		restoreCursor()
 	}
 
 	log.Infof("starting shutdown sequence")
@@ -509,6 +512,12 @@ func (up *upContext) shutdown() {
 	log.Info("completed shutdown sequence")
 	up.ShutdownCompleted <- true
 
+}
+
+func restoreCursor() {
+	if runtime.GOOS != "windows" {
+		fmt.Fprint(os.Stdin, "\033[?25h")
+	}
 }
 
 func printDisplayContext(dev *model.Dev, divertURL string) {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1569

The error was caused by [the spinner library we are using](https://github.com/briandowns/spinner), which is not setting back the cursor to the state it was.

## Proposed changes
- Make the cursor visible again in shutdown sequence
