### PR TITLE
Validate number of args in command

### DIFF
--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -24,6 +24,7 @@ import (
 func Analytics() *cobra.Command {
 	var disable bool
 	cmd := &cobra.Command{
+		Args:  cobra.NoArgs,
 		Use:   "analytics",
 		Short: "Enable / Disable analytics",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -14,6 +14,7 @@
 package cmd
 
 import (
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/log"
@@ -24,7 +25,7 @@ import (
 func Analytics() *cobra.Command {
 	var disable bool
 	cmd := &cobra.Command{
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#analytics"),
 		Use:   "analytics",
 		Short: "Enable / Disable analytics",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -38,7 +39,13 @@ func Build(ctx context.Context) *cobra.Command {
 	var secrets []string
 
 	cmd := &cobra.Command{
-		Use:   "build [PATH]",
+		Use: "build [PATH]",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) >= 2 {
+				return errors.New("okteto build requires one or no argument")
+			}
+			return nil
+		},
 		Short: "Build (and optionally push) a Docker image",
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -39,7 +39,7 @@ func Build(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "build [PATH]",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/index.html#build"),
 		Short: "Build (and optionally push) a Docker image",
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,7 +15,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -39,13 +38,8 @@ func Build(ctx context.Context) *cobra.Command {
 	var secrets []string
 
 	cmd := &cobra.Command{
-		Use: "build [PATH]",
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) >= 2 {
-				return errors.New("okteto build requires one or no argument")
-			}
-			return nil
-		},
+		Use:   "build [PATH]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Build (and optionally push) a Docker image",
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/config/view/url.go
+++ b/cmd/config/view/url.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -27,7 +28,7 @@ import (
 func URL(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "url",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted(""),
 		Short: "Returns the Okteto URL where the current user is authenticated",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			t, err := okteto.GetToken()

--- a/cmd/config/view/url.go
+++ b/cmd/config/view/url.go
@@ -27,6 +27,7 @@ import (
 func URL(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "url",
+		Args:  cobra.NoArgs,
 		Short: "Returns the Okteto URL where the current user is authenticated",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			t, err := okteto.GetToken()

--- a/cmd/config/view/username.go
+++ b/cmd/config/view/username.go
@@ -28,6 +28,7 @@ import (
 func Username(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "username",
+		Args:  cobra.NoArgs,
 		Short: "Returns the username of the authenticated user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			t, err := okteto.GetToken()

--- a/cmd/config/view/username.go
+++ b/cmd/config/view/username.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
@@ -28,7 +29,7 @@ import (
 func Username(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "username",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted(""),
 		Short: "Returns the username of the authenticated user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			t, err := okteto.GetToken()

--- a/cmd/config/view/view.go
+++ b/cmd/config/view/view.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -28,6 +29,7 @@ import (
 func View(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view",
+		Args:  utils.NoArgsAccepted(""),
 		Short: "Shows okteto configuration values of the authenticated user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			t, err := okteto.GetToken()

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/okteto/okteto/cmd/namespace"
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +26,7 @@ func Create(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Creates resources",
+		Args:  utils.NoArgsAccepted(""),
 	}
 	cmd.AddCommand(namespace.Create(ctx))
 	return cmd

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/okteto/okteto/cmd/namespace"
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +26,7 @@ func Delete(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Deletes resources",
+		Args:  utils.NoArgsAccepted(""),
 	}
 	cmd.AddCommand(namespace.Delete(ctx))
 	return cmd

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -34,6 +34,7 @@ func Doctor() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Generates a zip file with the okteto logs",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting doctor command")
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -34,7 +34,7 @@ func Doctor() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Generates a zip file with the okteto logs",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#doctor"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("starting doctor command")
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -41,7 +41,7 @@ func Down() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "down",
 		Short: "Deactivates your development container",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#down"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			dev, err := utils.LoadDev(devPath, namespace, k8sContext)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -41,6 +41,7 @@ func Down() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "down",
 		Short: "Deactivates your development container",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			dev, err := utils.LoadDev(devPath, namespace, k8sContext)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -76,12 +76,7 @@ func Exec() *cobra.Command {
 
 			return err
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) < 1 {
-				return fmt.Errorf("exec requires the COMMAND argument")
-			}
-			return nil
-		},
+		Args: utils.MinimumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/index.html#exec"),
 	}
 
 	cmd.Flags().StringVarP(&devPath, "file", "f", utils.DefaultDevManifest, "path to the manifest file")

--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -52,6 +52,7 @@ func Init() *cobra.Command {
 	var overwrite bool
 	cmd := &cobra.Command{
 		Use:   "init",
+		Args:  cobra.NoArgs,
 		Short: "Automatically generates your okteto manifest file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := os.Getenv("OKTETO_LANGUAGE")

--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -52,7 +52,7 @@ func Init() *cobra.Command {
 	var overwrite bool
 	cmd := &cobra.Command{
 		Use:   "init",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli#init"),
 		Short: "Automatically generates your okteto manifest file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			l := os.Getenv("OKTETO_LANGUAGE")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/okteto/okteto/cmd/namespace"
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +26,7 @@ func List(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List resources",
+		Args:  utils.NoArgsAccepted(""),
 	}
 	cmd.AddCommand(namespace.List(ctx))
 	return cmd

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -31,7 +31,7 @@ func Login() *cobra.Command {
 	token := ""
 	cmd := &cobra.Command{
 		Use:   "login [url]",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/index.html#login"),
 		Short: "Log into Okteto",
 		Long: `Log into Okteto
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -31,6 +31,7 @@ func Login() *cobra.Command {
 	token := ""
 	cmd := &cobra.Command{
 		Use:   "login [url]",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Log into Okteto",
 		Long: `Log into Okteto
 

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -15,10 +15,10 @@ package namespace
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/log"
@@ -42,12 +42,7 @@ func Create(ctx context.Context) *cobra.Command {
 			analytics.TrackCreateNamespace(err == nil)
 			return err
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("create namespace requires one argument")
-			}
-			return nil
-		},
+		Args: utils.ExactArgsAccepted(1, ""),
 	}
 
 	members = cmd.Flags().StringArrayP("members", "m", []string{}, "members of the namespace, it can the username or email")

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -15,9 +15,9 @@ package namespace
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/log"
@@ -39,12 +39,7 @@ func Delete(ctx context.Context) *cobra.Command {
 			analytics.TrackDeleteNamespace(err == nil)
 			return err
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("delete namespace requires one argument")
-			}
-			return nil
-		},
+		Args: utils.ExactArgsAccepted(1, ""),
 	}
 }
 

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/login"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
@@ -37,7 +38,7 @@ func List(ctx context.Context) *cobra.Command {
 			err := executeListNamespaces(ctx)
 			return err
 		},
-		Args: cobra.NoArgs,
+		Args: utils.NoArgsAccepted(""),
 	}
 }
 

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -37,9 +37,7 @@ func List(ctx context.Context) *cobra.Command {
 			err := executeListNamespaces(ctx)
 			return err
 		},
-		Args: func(cmd *cobra.Command, args []string) error {
-			return nil
-		},
+		Args: cobra.NoArgs,
 	}
 }
 

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -32,6 +32,7 @@ func Namespace(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace [name]",
 		Short: "Downloads k8s credentials for a namespace",
+		Args:  utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/cli#namespace"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			namespace := ""

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -46,7 +46,7 @@ func deploy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys an okteto pipeline",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#deploy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
 				return err

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -46,6 +46,7 @@ func deploy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploys an okteto pipeline",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
 				return err

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -37,7 +37,7 @@ func destroy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroys an okteto pipeline",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
 				return err

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -37,6 +37,7 @@ func destroy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroys an okteto pipeline",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
 				return err

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -16,6 +16,7 @@ package pipeline
 import (
 	"context"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +25,7 @@ func Pipeline(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
 		Short: "Pipeline management commands",
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#pipeline"),
 	}
 	cmd.AddCommand(deploy(ctx))
 	cmd.AddCommand(destroy(ctx))

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -49,6 +49,7 @@ func Push(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "push",
 		Short: "Builds, pushes and redeploys source code to the target deployment",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			if err := utils.LoadEnvironment(ctx, true); err != nil {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -49,7 +49,7 @@ func Push(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "push",
 		Short: "Builds, pushes and redeploys source code to the target deployment",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#push"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			if err := utils.LoadEnvironment(ctx, true); err != nil {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -36,7 +36,7 @@ func Restart() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restart",
 		Short: "Restarts the deployments listed in the services field of the okteto manifest",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#restart"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			dev, err := utils.LoadDev(devPath, namespace, k8sContext)

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -36,6 +36,7 @@ func Restart() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restart",
 		Short: "Restarts the deployments listed in the services field of the okteto manifest",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			dev, err := utils.LoadDev(devPath, namespace, k8sContext)

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -36,6 +36,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy <name>",
 		Short: "Deploys a stack",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
 				return err

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -34,7 +34,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	var noCache bool
 
 	cmd := &cobra.Command{
-		Use:   "deploy <name>",
+		Use:   "deploy",
 		Short: "Deploys a stack",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#deploy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -36,7 +36,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy <name>",
 		Short: "Deploys a stack",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#deploy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := login.WithEnvVarIfAvailable(ctx); err != nil {
 				return err

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -33,7 +33,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy <name>",
 		Short: "Destroys a stack",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/index.html#destroy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s, err := utils.LoadStack(name, stackPath)
 			if err != nil {

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -33,6 +33,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy <name>",
 		Short: "Destroys a stack",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s, err := utils.LoadStack(name, stackPath)
 			if err != nil {

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -16,6 +16,7 @@ package stack
 import (
 	"context"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -24,6 +25,7 @@ func Stack(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stack",
 		Short: "Stack management commands",
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#stack"),
 	}
 	cmd.AddCommand(Deploy(ctx))
 	cmd.AddCommand(Destroy(ctx))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -39,6 +39,7 @@ func Status() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Status of the synchronization process",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if okteto.InDevContainer() {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -39,7 +39,7 @@ func Status() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Status of the synchronization process",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#status"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if okteto.InDevContainer() {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -60,7 +60,7 @@ func Up() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "up",
 		Short: "Activates your development container",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#up"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {
 				return errors.ErrNotInDevContainer

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -60,6 +60,7 @@ func Up() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "up",
 		Short: "Activates your development container",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {
 				return errors.ErrNotInDevContainer

--- a/cmd/utils/args.go
+++ b/cmd/utils/args.go
@@ -1,0 +1,89 @@
+// Copyright 2020 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// NoArgsAccepted validates that the number of arguments given by the user is 0
+func NoArgsAccepted(url string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		var hint string
+		if url != "" {
+			hint = fmt.Sprintf("Visit %s for more information.", url)
+		}
+		if len(args) > 0 {
+			return errors.UserError{
+				E:    fmt.Errorf("Arguments are not supported for command %q.", cmd.CommandPath()),
+				Hint: hint,
+			}
+		}
+		return nil
+	}
+}
+
+// MaximumNArgsAccepted returns an error if there are more than N args.
+func MaximumNArgsAccepted(n int, url string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		var hint string
+		if url != "" {
+			hint = fmt.Sprintf("Visit %s for more information.", url)
+		}
+		if len(args) > n {
+			return errors.UserError{
+				E:    fmt.Errorf("%q accepts at most %d arg(s), but received %d", cmd.CommandPath(), n, len(args)),
+				Hint: hint,
+			}
+		}
+		return nil
+	}
+}
+
+// MaximumNArgsAccepted returns an error if there are more than N args.
+func MinimumNArgsAccepted(n int, url string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		var hint string
+		if url != "" {
+			hint = fmt.Sprintf("Visit %s for more information.", url)
+		}
+		if len(args) < n {
+			return errors.UserError{
+				E:    fmt.Errorf("%q requires at least %d arg(s), but only received %d", cmd.CommandPath(), n, len(args)),
+				Hint: hint,
+			}
+		}
+		return nil
+	}
+}
+
+// ExactArgs returns an error if there are not exactly n args.
+func ExactArgsAccepted(n int, url string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		var hint string
+		if url != "" {
+			hint = fmt.Sprintf("Visit %s for more information.", url)
+		}
+		if len(args) > n {
+			return errors.UserError{
+				E:    fmt.Errorf("%q accepts %d arg(s), but received %d", cmd.CommandPath(), n, len(args)),
+				Hint: hint,
+			}
+		}
+		return nil
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,6 +25,7 @@ func Version() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "View the version of the okteto binary",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("okteto version %s \n", config.VersionString)
 			return nil

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +26,7 @@ func Version() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "View the version of the okteto binary",
-		Args:  cobra.NoArgs,
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/index.html#version"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("okteto version %s \n", config.VersionString)
 			return nil


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1628

## Proposed changes
- Validates the number of arguments allowed to enter a command and returns an error with the help of the command.
-
