### PR TITLE
Ignore build argument on up if there is nothing to build

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -385,7 +385,7 @@ func (up *upContext) waitUntilExitOrInterrupt() error {
 func (up *upContext) buildDevImage(ctx context.Context, d *appsv1.Deployment, create bool) error {
 	if _, err := os.Stat(up.Dev.Image.Dockerfile); err != nil {
 		return errors.UserError{
-			E:    fmt.Errorf("'--build' argument given but there is no Dockerfile on cwd"),
+			E:    fmt.Errorf("'--build' argument given but there is no Dockerfile"),
 			Hint: "Try creating a Dockerfile or specify 'context' and 'dockerfile' fields.",
 		}
 	}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -383,6 +383,11 @@ func (up *upContext) waitUntilExitOrInterrupt() error {
 }
 
 func (up *upContext) buildDevImage(ctx context.Context, d *appsv1.Deployment, create bool) error {
+	if _, err := os.Stat(up.Dev.Image.Dockerfile); err != nil {
+		log.Warning("Ignoring '--build' argument. There is not 'build' primitives in your manifest")
+		return nil
+	}
+
 	oktetoRegistryURL := ""
 	if up.isOktetoNamespace {
 		var err error

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -384,8 +384,10 @@ func (up *upContext) waitUntilExitOrInterrupt() error {
 
 func (up *upContext) buildDevImage(ctx context.Context, d *appsv1.Deployment, create bool) error {
 	if _, err := os.Stat(up.Dev.Image.Dockerfile); err != nil {
-		log.Warning("Ignoring '--build' argument. There is not 'build' primitives in your manifest")
-		return nil
+		return errors.UserError{
+			E:    fmt.Errorf("'--build' argument given but there is no Dockerfile on cwd"),
+			Hint: "Try creating a Dockerfile or specify 'context' and 'dockerfile' fields.",
+		}
 	}
 
 	oktetoRegistryURL := ""


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes If the Dockerfile does not exists and the user has set `--build` flag it will be ignored instead of failing.

## Proposed changes

- Ignore build argument if there is nothing to build
-
