### PR TITLE
Update timeout on windows e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
             OKTETO_SKIP_CLEANUP: 'true'
             OKTETO_CLIENTSIDE_TRANSLATION: ''
           command: |
-            go test github.com/okteto/okteto/integration -tags=integration --count=1 -v
+            go test github.com/okteto/okteto/integration -tags=integration --count=1 -v -timeout 15m
       - run:
           name: Integration tests (clientside)
           environment:
@@ -147,7 +147,7 @@ jobs:
             OKTETO_CLIENTSIDE_TRANSLATION: 'true'
             OKTETO_SKIP_CLEANUP: 'true'
           command: |
-            go test github.com/okteto/okteto/integration -tags=integration --count=1 -v
+            go test github.com/okteto/okteto/integration -tags=integration --count=1 -v -timeout 15m
       - save_cache:
           key: v4-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
           paths:


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Update timeout on windows e2e tests

## Proposed changes
- Update timeout before panic for tests on windows
-
