### PR TITLE
Propagate hints on build errors

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -244,7 +244,7 @@ func buildImage(ctx context.Context, dev *model.Dev, imageTag, imageFromDeployme
 
 	buildArgs := model.SerializeBuildArgs(dev.Push.Args)
 	if err := build.Run(ctx, dev.Namespace, buildKitHost, isOktetoCluster, dev.Push.Context, dev.Push.Dockerfile, buildTag, dev.Push.Target, noCache, dev.Push.CacheFrom, buildArgs, nil, progress); err != nil {
-		return "", fmt.Errorf("error building image '%s': %s", buildTag, err)
+		return "", err
 	}
 
 	return buildTag, nil

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -417,7 +417,7 @@ func (up *upContext) buildDevImage(ctx context.Context, d *appsv1.Deployment, cr
 
 	buildArgs := model.SerializeBuildArgs(up.Dev.Image.Args)
 	if err := buildCMD.Run(ctx, up.Dev.Namespace, buildKitHost, isOktetoCluster, up.Dev.Image.Context, up.Dev.Image.Dockerfile, imageTag, up.Dev.Image.Target, false, up.Dev.Image.CacheFrom, buildArgs, nil, "tty"); err != nil {
-		return fmt.Errorf("error building dev image '%s': %s", imageTag, err)
+		return err
 	}
 	for _, s := range up.Dev.Services {
 		if s.Image.Name == up.Dev.Image.Name {

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -195,11 +195,7 @@ func buildServices(ctx context.Context, s *model.Stack, buildKitHost string, isO
 		log.Information("Building image for service '%s'...", name)
 		buildArgs := model.SerializeBuildArgs(svc.Build.Args)
 		if err := build.Run(ctx, s.Namespace, buildKitHost, isOktetoCluster, svc.Build.Context, svc.Build.Dockerfile, svc.Image, svc.Build.Target, noCache, svc.Build.CacheFrom, buildArgs, nil, "tty"); err != nil {
-			if uErr, ok := err.(errors.UserError); ok {
-				uErr.E = fmt.Errorf("error building image for '%s': %s", name, uErr.E)
-				return hasBuiltSomething, uErr
-			}
-			return hasBuiltSomething, fmt.Errorf("error building image for '%s': %s", name, err)
+			return hasBuiltSomething, err
 		}
 		svc.SetLastBuiltAnnotation()
 		s.Services[name] = svc
@@ -236,7 +232,7 @@ func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, buildKitHo
 			log.Information("Building image for service '%s' to include host volumes...", name)
 			buildArgs := model.SerializeBuildArgs(svc.Build.Args)
 			if err := build.Run(ctx, s.Namespace, buildKitHost, isOktetoCluster, svc.Build.Context, svc.Build.Dockerfile, svc.Image, svc.Build.Target, noCache, svc.Build.CacheFrom, buildArgs, nil, "tty"); err != nil {
-				return hasAddedAnyVolumeMounts, fmt.Errorf("error building image for '%s': %s", name, err)
+				return hasAddedAnyVolumeMounts, err
 			}
 			svc.SetLastBuiltAnnotation()
 			s.Services[name] = svc

--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -28,18 +28,22 @@ func GetErrorMessage(err error, tag string) error {
 	switch {
 	case IsLoggedIntoRegistryButDontHavePermissions(err):
 		err = okErrors.UserError{
-			E:    fmt.Errorf("You are not authorized to push image '%s'.", imageTag),
+			E:    fmt.Errorf("error building image '%s': You are not authorized to push image '%s'.", tag, imageTag),
 			Hint: fmt.Sprintf("Please log in into the registry '%s' with a user with push permissions to '%s' or use another image.", imageRegistry, imageTag),
 		}
 	case IsNotLoggedIntoRegistry(err):
 		err = okErrors.UserError{
-			E:    fmt.Errorf("You are not authorized to push image '%s'.", imageTag),
+			E:    fmt.Errorf("error building image '%s': You are not authorized to push image '%s'.", tag, imageTag),
 			Hint: fmt.Sprintf("Log in into the registry '%s' and verify that you have permissions to push the image '%s'.", imageRegistry, imageTag),
 		}
 	case IsBuildkitServiceUnavailable(err):
 		err = okErrors.UserError{
 			E:    fmt.Errorf("Buildkit service is not available at the moment."),
 			Hint: "Please try again later.",
+		}
+	default:
+		err = okErrors.UserError{
+			E: fmt.Errorf("error building image '%s': %s", tag, err.Error()),
 		}
 	}
 	return err


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Some commands were not propagating hints on errors because they were wrapping the error inside another error

## Proposed changes
- Propagate user error with the hint from the build error until its shown to the user
-
