### PR TITLE
Reduce the amount of logs during init container from image

### DIFF
--- a/pkg/k8s/deployments/translate.go
+++ b/pkg/k8s/deployments/translate.go
@@ -606,11 +606,11 @@ func TranslateOktetoInitFromImageContainer(spec *apiv1.PodSpec, rule *model.Tran
 			},
 		)
 		mounPath := path.Join(v.MountPath, ".")
-		command = fmt.Sprintf("%s && ( [ \"$(ls -A /init-volume/%d)\" ] || cp -Rv %s/. /init-volume/%d || true)", command, iVolume, mounPath, iVolume)
+		command = fmt.Sprintf("%s && ( [ \"$(ls -A /init-volume/%d)\" ] || cp -R %s/. /init-volume/%d || true)", command, iVolume, mounPath, iVolume)
 		iVolume++
 	}
 
-	c.Command = []string{"sh", "-c", command}
+	c.Command = []string{"sh", "-cx", command}
 	translateInitResources(c, rule.InitContainer.Resources)
 	TranslateContainerSecurityContext(c, rule.SecurityContext)
 	spec.InitContainers = append(spec.InitContainers, *c)

--- a/pkg/k8s/deployments/translate_test.go
+++ b/pkg/k8s/deployments/translate_test.go
@@ -202,7 +202,7 @@ services:
 							Name:            OktetoInitVolumeContainerName,
 							Image:           "web:latest",
 							ImagePullPolicy: apiv1.PullIfNotPresent,
-							Command:         []string{"sh", "-c", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -Rv /go/pkg/. /init-volume/1 || true) && ( [ \"$(ls -A /init-volume/2)\" ] || cp -Rv /root/.cache/go-build/. /init-volume/2 || true) && ( [ \"$(ls -A /init-volume/3)\" ] || cp -Rv /app/. /init-volume/3 || true) && ( [ \"$(ls -A /init-volume/4)\" ] || cp -Rv /path/. /init-volume/4 || true)"},
+							Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /go/pkg/. /init-volume/1 || true) && ( [ \"$(ls -A /init-volume/2)\" ] || cp -R /root/.cache/go-build/. /init-volume/2 || true) && ( [ \"$(ls -A /init-volume/3)\" ] || cp -R /app/. /init-volume/3 || true) && ( [ \"$(ls -A /init-volume/4)\" ] || cp -R /path/. /init-volume/4 || true)"},
 							SecurityContext: &apiv1.SecurityContext{
 								RunAsUser:  &runAsUser,
 								RunAsGroup: &runAsGroup,
@@ -725,7 +725,7 @@ docker:
 							Name:            OktetoInitVolumeContainerName,
 							Image:           "web:latest",
 							ImagePullPolicy: apiv1.PullIfNotPresent,
-							Command:         []string{"sh", "-c", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -Rv /app/. /init-volume/1 || true)"},
+							Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /app/. /init-volume/1 || true)"},
 							SecurityContext: &apiv1.SecurityContext{
 								RunAsUser:    &rootUser,
 								RunAsGroup:   &rootUser,
@@ -1295,7 +1295,7 @@ environment:
 							Name:            OktetoInitVolumeContainerName,
 							Image:           "web:latest",
 							ImagePullPolicy: apiv1.PullIfNotPresent,
-							Command:         []string{"sh", "-c", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -Rv /app/. /init-volume/1 || true)"},
+							Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /app/. /init-volume/1 || true)"},
 							SecurityContext: &apiv1.SecurityContext{
 								RunAsUser:    &rootUser,
 								RunAsGroup:   &rootUser,


### PR DESCRIPTION
We are using okteto with Docker containers that contain all our app code, including a PHP vendor/ directory with contains >100,000 files. Using the verbose copy flag is causing every one of those files to be logged when it's copied and overwhelming our log processor.

This removes logging every file in favor of only logging the commands run. This should hopefully still provide enough info to debug if something goes wrong during the copy and still show what top-level folders/files are copied.

## Proposed changes
- disable logging every file
- only log which commands run
