### PR TITLE
Fix arg length comprobation

### DIFF
--- a/cmd/utils/args.go
+++ b/cmd/utils/args.go
@@ -78,7 +78,7 @@ func ExactArgsAccepted(n int, url string) cobra.PositionalArgs {
 		if url != "" {
 			hint = fmt.Sprintf("Visit %s for more information.", url)
 		}
-		if len(args) > n {
+		if len(args) != n {
 			return errors.UserError{
 				E:    fmt.Errorf("%q accepts %d arg(s), but received %d", cmd.CommandPath(), n, len(args)),
 				Hint: hint,


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes a problem with exactly number of args commands comprobaron

## Proposed changes
- Fix the bug
-
