### PR TITLE
accept 0 or 1 args in the namespace command

### DIFF
--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -32,7 +32,7 @@ func Namespace(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace [name]",
 		Short: "Downloads k8s credentials for a namespace",
-		Args:  utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/cli/#namespace"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#namespace"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			namespace := ""


### PR DESCRIPTION
## Proposed changes

- allow `okteto namespace` without args
