### PR TITLE
Revert "Deprecate environment in favour of variables (#1684)"

### DIFF
--- a/pkg/cmd/doctor/run.go
+++ b/pkg/cmd/doctor/run.go
@@ -162,12 +162,12 @@ func generateManifestFile(ctx context.Context, devPath string) (string, error) {
 	}
 
 	dev := &model.Dev{
-		Image:     &model.BuildInfo{},
-		Push:      &model.BuildInfo{},
-		Variables: make([]model.EnvVar, 0),
-		Secrets:   make([]model.Secret, 0),
-		Forward:   make([]model.Forward, 0),
-		Volumes:   make([]model.Volume, 0),
+		Image:       &model.BuildInfo{},
+		Push:        &model.BuildInfo{},
+		Environment: make([]model.EnvVar, 0),
+		Secrets:     make([]model.Secret, 0),
+		Forward:     make([]model.Forward, 0),
+		Volumes:     make([]model.Volume, 0),
 		Sync: model.Sync{
 			Folders: make([]model.SyncFolder, 0),
 		},
@@ -178,7 +178,7 @@ func generateManifestFile(ctx context.Context, devPath string) (string, error) {
 		return "", err
 	}
 
-	dev.Variables = nil
+	dev.Environment = nil
 
 	if dev.Image != nil {
 		dev.Image.Args = nil
@@ -189,7 +189,7 @@ func generateManifestFile(ctx context.Context, devPath string) (string, error) {
 	}
 
 	for i := range dev.Services {
-		dev.Services[i].Variables = nil
+		dev.Services[i].Environment = nil
 
 		if dev.Services[i].Image != nil {
 			dev.Services[i].Image.Args = nil

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -357,7 +357,7 @@ func TranslateResources(c *apiv1.Container, r model.ResourceRequirements) {
 //TranslateEnvVars translates the variables attached to a container
 func TranslateEnvVars(c *apiv1.Container, rule *model.TranslationRule) {
 	unusedDevEnvVar := map[string]string{}
-	for _, val := range rule.Variables {
+	for _, val := range rule.Environment {
 		unusedDevEnvVar[val.Name] = val.Value
 	}
 	for i, envvar := range c.Env {
@@ -366,7 +366,7 @@ func TranslateEnvVars(c *apiv1.Container, rule *model.TranslationRule) {
 			delete(unusedDevEnvVar, envvar.Name)
 		}
 	}
-	for _, envvar := range rule.Variables {
+	for _, envvar := range rule.Environment {
 		if value, ok := unusedDevEnvVar[envvar.Name]; ok {
 			c.Env = append(c.Env, apiv1.EnvVar{Name: envvar.Name, Value: value})
 		}

--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -25,7 +25,7 @@ type languageDefault struct {
 	image           string
 	path            string
 	command         []string
-	variables       []model.EnvVar
+	environment     []model.EnvVar
 	volumes         []model.Volume
 	forward         []model.Forward
 	reverse         []model.Reverse
@@ -221,7 +221,7 @@ func init() {
 		image:   "okteto/dotnetcore:3",
 		path:    "/usr/src/app",
 		command: []string{"bash"},
-		variables: []model.EnvVar{
+		environment: []model.EnvVar{
 			{
 				Name:  "ASPNETCORE_ENVIRONMENT",
 				Value: "Development",
@@ -309,8 +309,8 @@ func GetDevDefaults(language, workdir string) (*model.Dev, error) {
 		Command: model.Command{
 			Values: vals.command,
 		},
-		Variables: vals.variables,
-		Volumes:   vals.volumes,
+		Environment: vals.environment,
+		Volumes:     vals.volumes,
 		Sync: model.Sync{
 			RescanInterval: model.DefaultSyncthingRescanInterval,
 			Folders: []model.SyncFolder{

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -215,7 +215,7 @@ forward:
 				t.Errorf("command was parsed: %+v", d)
 			}
 
-			for _, env := range d.Variables {
+			for _, env := range d.Environment {
 				found := false
 				for _, expectedEnv := range tt.expectedEnvironment {
 					if env.Name == expectedEnv.Name && env.Value == expectedEnv.Value {
@@ -224,7 +224,7 @@ forward:
 					}
 				}
 				if !found {
-					t.Errorf("environment was not parsed correctly:\n%+v\n%+v", d.Variables, tt.expectedEnvironment)
+					t.Errorf("environment was not parsed correctly:\n%+v\n%+v", d.Environment, tt.expectedEnvironment)
 				}
 			}
 
@@ -1159,8 +1159,8 @@ services:
 		t.Errorf("'tag' was not parsed: got %s, expected %s", main.Image.Name, "code/core:1.2")
 	}
 
-	if main.Variables[0].Value != "from-env-file" {
-		t.Errorf("'environment' was not parsed: got %s, expected %s", main.Variables[0].Value, "from-env-file")
+	if main.Environment[0].Value != "from-env-file" {
+		t.Errorf("'environment' was not parsed: got %s, expected %s", main.Environment[0].Value, "from-env-file")
 	}
 
 	if main.Services[0].Name != "deployment-secondary" {
@@ -1171,8 +1171,8 @@ services:
 		t.Errorf("'tag' was not parsed: got %s, expected %s", main.Services[0].Image.Name, "code/service:2.1")
 	}
 
-	if main.Services[0].Variables[0].Value != "from-env-file" {
-		t.Errorf("'variables' was not parsed: got %s, expected %s", main.Services[0].Variables[0].Value, "from-env-file")
+	if main.Services[0].Environment[0].Value != "from-env-file" {
+		t.Errorf("'environment' was not parsed: got %s, expected %s", main.Services[0].Environment[0].Value, "from-env-file")
 	}
 }
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -29,12 +29,12 @@ import (
 
 // BuildInfoRaw represents the build info for serialization
 type buildInfoRaw struct {
-	Name       string    `yaml:"name,omitempty"`
-	Context    string    `yaml:"context,omitempty"`
-	Dockerfile string    `yaml:"dockerfile,omitempty"`
-	CacheFrom  []string  `yaml:"cache_from,omitempty"`
-	Target     string    `yaml:"target,omitempty"`
-	Args       Variables `yaml:"args,omitempty"`
+	Name       string      `yaml:"name,omitempty"`
+	Context    string      `yaml:"context,omitempty"`
+	Dockerfile string      `yaml:"dockerfile,omitempty"`
+	CacheFrom  []string    `yaml:"cache_from,omitempty"`
+	Target     string      `yaml:"target,omitempty"`
+	Args       Environment `yaml:"args,omitempty"`
 }
 
 type syncRaw struct {
@@ -667,22 +667,6 @@ func (e *Environment) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return strings.Compare(envs[i].Name, envs[j].Name) < 0
 	})
 	*e = envs
-	return nil
-}
-
-func (v *Variables) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	envs := make(Variables, 0)
-	result, err := getKeyValue(unmarshal)
-	if err != nil {
-		return err
-	}
-	for key, value := range result {
-		envs = append(envs, EnvVar{Name: key, Value: value})
-	}
-	sort.SliceStable(envs, func(i, j int) bool {
-		return strings.Compare(envs[i].Name, envs[j].Name) < 0
-	})
-	*v = envs
 	return nil
 }
 

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -38,7 +38,7 @@ type TranslationRule struct {
 	Container         string               `json:"container,omitempty"`
 	Image             string               `json:"image,omitempty"`
 	ImagePullPolicy   apiv1.PullPolicy     `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
-	Variables         Variables            `json:"variables,omitempty"`
+	Environment       Environment          `json:"environment,omitempty"`
 	Secrets           []Secret             `json:"secrets,omitempty"`
 	Command           []string             `json:"command,omitempty"`
 	Args              []string             `json:"args,omitempty"`

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -66,7 +66,7 @@ services:
 		Args:              []string{"-r", "-v"},
 		Probes:            &Probes{},
 		Lifecycle:         &Lifecycle{},
-		Variables: Variables{
+		Environment: Environment{
 			{
 				Name:  "OKTETO_NAMESPACE",
 				Value: "n",
@@ -133,7 +133,7 @@ services:
 		Healthchecks:    true,
 		Probes:          &Probes{Readiness: true, Liveness: true, Startup: true},
 		Lifecycle:       &Lifecycle{PostStart: true, PostStop: false},
-		Variables:       make(Variables, 0),
+		Environment:     make(Environment, 0),
 		SecurityContext: &SecurityContext{
 			RunAsUser:  &rootUser,
 			RunAsGroup: &rootUser,
@@ -186,7 +186,7 @@ initContainer:
 		Args:              []string{"-r", "-v"},
 		Probes:            &Probes{},
 		Lifecycle:         &Lifecycle{},
-		Variables: Variables{
+		Environment: Environment{
 			{
 				Name:  "OKTETO_NAMESPACE",
 				Value: "n",
@@ -269,7 +269,7 @@ docker:
 		Args:              []string{"-r", "-v", "-d"},
 		Probes:            &Probes{},
 		Lifecycle:         &Lifecycle{},
-		Variables: Variables{
+		Environment: Environment{
 			{
 				Name:  "OKTETO_NAMESPACE",
 				Value: "n",
@@ -350,7 +350,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 	tests := []struct {
 		name     string
 		manifest *Dev
-		expected Variables
+		expected Environment
 	}{
 		{
 			name: "default",
@@ -358,7 +358,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				Image:         &BuildInfo{},
 				SSHServerPort: oktetoDefaultSSHServerPort,
 			},
-			expected: Variables{
+			expected: Environment{
 				{Name: "OKTETO_NAMESPACE", Value: ""},
 				{Name: "OKTETO_NAME", Value: ""},
 			},
@@ -369,7 +369,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				Image:         &BuildInfo{},
 				SSHServerPort: 22220,
 			},
-			expected: Variables{
+			expected: Environment{
 				{Name: "OKTETO_NAMESPACE", Value: ""},
 				{Name: "OKTETO_NAME", Value: ""},
 				{Name: oktetoSSHServerPortVariable, Value: "22220"},
@@ -379,7 +379,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 	for _, test := range tests {
 		t.Logf("test: %s", test.name)
 		rule := test.manifest.ToTranslationRule(test.manifest, false)
-		if e, a := test.expected, rule.Variables; !reflect.DeepEqual(e, a) {
+		if e, a := test.expected, rule.Environment; !reflect.DeepEqual(e, a) {
 			t.Errorf("expected environment:\n%#v\ngot:\n%#v", e, a)
 		}
 	}


### PR DESCRIPTION
This reverts commit 5199fcbe6bf1824bf9b83814375013553bcbcce6.

Thinking more in detail about this, `environment` is different than `variables` at the pipeline level, and it might create confusion. Let's keep `environment` for now while we have a clearer idea about the final pipeline manifest