### PR TITLE
Set the syncthing verbosity based on the "--loglevel" flag

### DIFF
--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -245,7 +245,7 @@ services:
 							Image:           "web:latest",
 							ImagePullPolicy: apiv1.PullAlways,
 							Command:         []string{"/var/okteto/bin/start.sh"},
-							Args:            []string{"-r", "-v", "-s", "remote:/remote"},
+							Args:            []string{"-r", "-s", "remote:/remote"},
 							WorkingDir:      "/app",
 							Env: []apiv1.EnvVar{
 								{
@@ -578,7 +578,7 @@ persistentVolume:
 							Image:           "web:latest",
 							ImagePullPolicy: apiv1.PullAlways,
 							Command:         []string{"/var/okteto/bin/start.sh"},
-							Args:            []string{"-r", "-e", "-v"},
+							Args:            []string{"-r", "-e"},
 							WorkingDir:      "",
 							Env: []apiv1.EnvVar{
 								{
@@ -757,7 +757,7 @@ docker:
 							Image:           "web:latest",
 							ImagePullPolicy: apiv1.PullAlways,
 							Command:         []string{"/var/okteto/bin/start.sh"},
-							Args:            []string{"-r", "-v", "-d"},
+							Args:            []string{"-r", "-d"},
 							Env: []apiv1.EnvVar{
 								{
 									Name:  "OKTETO_NAMESPACE",
@@ -1329,7 +1329,7 @@ environment:
 							Image:           "web:latest",
 							ImagePullPolicy: apiv1.PullAlways,
 							Command:         []string{"/var/okteto/bin/start.sh"},
-							Args:            []string{"-r", "-v"},
+							Args:            []string{"-r"},
 							Env: []apiv1.EnvVar{
 								{
 									Name:  "key1",

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -99,6 +99,11 @@ func SetLevel(level string) {
 	}
 }
 
+// IsDebug checks if the level of the main logger is DEBUG or TRACE
+func IsDebug() bool {
+	return log.out.GetLevel() >= logrus.DebugLevel
+}
+
 // Debug writes a debug-level log
 func Debug(args ...interface{}) {
 	log.out.Debug(args...)

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -183,14 +183,14 @@ func (sync *Sync) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var rawFolders []SyncFolder
 	err := unmarshal(&rawFolders)
 	if err == nil {
-		sync.Verbose = true
+		sync.Verbose = log.IsDebug()
 		sync.RescanInterval = DefaultSyncthingRescanInterval
 		sync.Folders = rawFolders
 		return nil
 	}
 
 	var rawSync syncRaw
-	rawSync.Verbose = true
+	rawSync.Verbose = log.IsDebug()
 	err = unmarshal(&rawSync)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Syncthing verbose logs are very noisy and they can create issues with worker nodes running out of space.

This PR sets the syncthing verbosity based on the `okteto` `--loglevel` flag