### PR TITLE
Fix display pulling events

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -348,11 +348,11 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
 				}
 				continue
 			}
-			pod, ok := event.Object.(*apiv1.Pod)
+			podEvent, ok := event.Object.(*apiv1.Event)
 			if !ok {
 				continue
 			}
-			if up.Pod.UID != pod.UID {
+			if up.Pod.UID != podEvent.InvolvedObject.UID {
 				continue
 			}
 			optsWatchEvents.ResourceVersion = e.ResourceVersion


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes a bug where we were not displaying pulling images events

## Proposed changes
- Instead of converting to a pod convert it to a event and get the UID of the involved object
-
