### PR TITLE
Add functionality to set runAsNonRoot to disable securityContext defaults

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -50,7 +50,6 @@ const (
 var (
 	devReplicas                      int32 = 1
 	devTerminationGracePeriodSeconds int64
-	falseBoolean                     = false
 )
 
 func translate(t *model.Translation, c *kubernetes.Clientset, isOktetoNamespace bool) error {
@@ -532,16 +531,14 @@ func TranslateContainerSecurityContext(c *apiv1.Container, s *model.SecurityCont
 
 	if s.RunAsUser != nil {
 		c.SecurityContext.RunAsUser = s.RunAsUser
-		if *s.RunAsUser == 0 {
-			c.SecurityContext.RunAsNonRoot = &falseBoolean
-		}
 	}
 
 	if s.RunAsGroup != nil {
 		c.SecurityContext.RunAsGroup = s.RunAsGroup
-		if *s.RunAsGroup == 0 {
-			c.SecurityContext.RunAsNonRoot = &falseBoolean
-		}
+	}
+
+	if s.RunAsNonRoot != nil {
+		c.SecurityContext.RunAsNonRoot = s.RunAsNonRoot
 	}
 
 	if s.Capabilities == nil {

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -463,9 +463,8 @@ services:
 							Command:         []string{"./run_worker.sh"},
 							Args:            []string{},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: &falseBoolean,
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
@@ -748,9 +747,8 @@ docker:
 							ImagePullPolicy: apiv1.PullIfNotPresent,
 							Command:         []string{"sh", "-c", "cp /usr/local/bin/* /okteto/bin"},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: pointer.BoolPtr(false),
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
@@ -765,9 +763,8 @@ docker:
 							ImagePullPolicy: apiv1.PullIfNotPresent,
 							Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /app/. /init-volume/1 || true)"},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: &falseBoolean,
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
@@ -817,9 +814,8 @@ docker:
 								},
 							},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: &falseBoolean,
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
@@ -1324,9 +1320,8 @@ environment:
 							Image:           model.OktetoBinImageTag,
 							ImagePullPolicy: apiv1.PullIfNotPresent,
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: pointer.BoolPtr(false),
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							Command: []string{"sh", "-c", "cp /usr/local/bin/* /okteto/bin"},
 							VolumeMounts: []apiv1.VolumeMount{
@@ -1342,9 +1337,8 @@ environment:
 							ImagePullPolicy: apiv1.PullIfNotPresent,
 							Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /app/. /init-volume/1 || true)"},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: &falseBoolean,
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
@@ -1398,9 +1392,8 @@ environment:
 								},
 							},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: &falseBoolean,
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{
@@ -1878,9 +1871,8 @@ services:
 							Command:         []string{"./run_worker.sh"},
 							Args:            []string{},
 							SecurityContext: &apiv1.SecurityContext{
-								RunAsUser:    &rootUser,
-								RunAsGroup:   &rootUser,
-								RunAsNonRoot: &falseBoolean,
+								RunAsUser:  &rootUser,
+								RunAsGroup: &rootUser,
 							},
 							VolumeMounts: []apiv1.VolumeMount{
 								{

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -900,6 +900,39 @@ func Test_validate(t *testing.T) {
         enabled: true`),
 			expectErr: true,
 		},
+		{
+			name: "runAsNonRoot-with-root-user",
+			manifest: []byte(`
+      name: deployment
+      sync:
+        - .:/app
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 0`),
+			expectErr: true,
+		},
+		{
+			name: "runAsNonRoot-with-non-root-user",
+			manifest: []byte(`
+      name: deployment
+      sync:
+        - .:/app
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101`),
+			expectErr: false,
+		},
+		{
+			name: "runAsNonRoot-with-root-group",
+			manifest: []byte(`
+      name: deployment
+      sync:
+        - .:/app
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 0`),
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -489,3 +489,110 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 		}
 	}
 }
+
+func TestDevToTranslationRuleRunAsNonRoot(t *testing.T) {
+	var falseBoolean = false
+	var trueBoolean = true
+	var runAsUser int64 = 100
+	var runAsGroup int64 = 101
+	var fsGroup int64 = 102
+
+	tests := []struct {
+		manifest   []byte
+		translated SecurityContext
+	}{
+		{
+			manifest: []byte(`name: non-root-user-without-overrides
+image: worker:latest
+namespace: n
+securityContext:
+   runAsNonRoot: true`),
+			translated: SecurityContext{
+				RunAsNonRoot: &trueBoolean,
+			},
+		},
+		{
+			manifest: []byte(`name: root-user-with-defaults
+image: worker:latest
+namespace: n
+securityContext:
+   runAsNonRoot: false`),
+			translated: SecurityContext{
+				RunAsUser:    &rootUser,
+				RunAsGroup:   &rootUser,
+				FSGroup:      &rootUser,
+				RunAsNonRoot: &falseBoolean,
+			},
+		},
+		{
+			manifest: []byte(`name: non-root-user-with-overrides
+image: worker:latest
+namespace: n
+securityContext:
+   runAsUser: 100
+   runAsGroup: 101
+   fsGroup: 102
+   runAsNonRoot: true`),
+			translated: SecurityContext{
+				RunAsUser:    &runAsUser,
+				RunAsGroup:   &runAsGroup,
+				FSGroup:      &fsGroup,
+				RunAsNonRoot: &trueBoolean,
+			},
+		},
+		{
+			manifest: []byte(`name: root-user-with-overrides
+image: worker:latest
+namespace: n
+securityContext:
+   runAsUser: 100
+   runAsGroup: 101
+   fsGroup: 102
+   runAsNonRoot: false`),
+			translated: SecurityContext{
+				RunAsUser:    &runAsUser,
+				RunAsGroup:   &runAsGroup,
+				FSGroup:      &fsGroup,
+				RunAsNonRoot: &falseBoolean,
+			},
+		},
+		{
+			manifest: []byte(`name: no-security-context
+image: worker:latest
+namespace: n`),
+			translated: SecurityContext{
+				RunAsUser:  &rootUser,
+				RunAsGroup: &rootUser,
+				FSGroup:    &rootUser,
+			},
+		},
+		{
+			manifest: []byte(`name: no-run-as-non-root
+image: worker:latest
+namespace: n
+securityContext:
+   runAsUser: 100
+   runAsGroup: 101
+   fsGroup: 102`),
+			translated: SecurityContext{
+				RunAsUser:  &runAsUser,
+				RunAsGroup: &runAsGroup,
+				FSGroup:    &fsGroup,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		dev, err := Read(test.manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rule := dev.ToTranslationRule(dev, false)
+		marshalled, _ := yaml.Marshal(rule.SecurityContext)
+		marshalledOK, _ := yaml.Marshal(test.translated)
+		if string(marshalled) != string(marshalledOK) {
+			t.Fatalf("Wrong rule generation for %s.\nActual %s, \nExpected %s", dev.Name, string(marshalled), string(marshalledOK))
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes #1658

## Proposed changes

Expose the `runAsNonRoot` option to the `securityContext` configuration of the manifest.

If this is set to true, Okteto will not set the defaults for `fsGroups`, `runAsUser`, `runAsGroup` instead delegating this to be by the container platform.

OpenShift automatically sets `fsGroup`, `runAsUser` and `runAsGroup` to a randomly generated UID if they are not given. By default, the UID is chosen from a range unique to the OpenShift project/namespace. Admins can also change this behaviour via [securityContextConstraints](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html). 

Okteto currently defaults to root unless specified which does not play well in a project/namespace per developer setup where manifests are stored in Git. You have to hard code the `fsGroups`, `runAsUser`, and `runAsGroup` fields with a valid user, which can be different across projects/namespaces. 

With this change, you could use the following manifest for development with non-root containers in OpenShift:

 ```
name: my-service
labels:
  app: my-service
workdir: /usr/src/app
securityContext:
  runAsNonRoot: true
remote: 2222
sync:
 - ./:/usr/src/app
 ```

Additionally, Kubernetes can default these variables for you based off the user in the docker image. This means that you could theoretically have your init and dev container image run as a specific UID or GID, and have Okteto run as that user without having to define it in your manifest.

By default, the option won't be set and Okteto will behave the same way as it did before this change.

To see how this change works, consider the following the manifests:

1. `runAsNonRoot=true` with no other `securityContext` overrides:
    ```
      name: non-root-user-without-overrides
      securityContext:
          runAsNonRoot: true
    ```
      In this case the container is run with `runAsNonRoot=true`, and the variables `runAsUser`, `runAsGroup`, and `fsGroup` are left to be set by the container platform. It's possible that container will not start correctly due to permissions though this a user configuration error that can only be detected at run time.
 
 2. `runAsNonRoot=false` with no other `securityContext` overrides:
     ```
        name: root-user-without-overrides
        securityContext:
           runAsNonRoot: false
    ```
    In this case Okteto will default to the root user.

    
3.  `runAsNonRoot=true` with `securityContext` overrides:
    ```
    name: non-root-user-with-overrides
    securityContext:
       runAsUser: 100
       runAsGroup: 101
       fsGroup: 102
       runAsNonRoot: true
    ```
    In this case Okteto will still set the values for `fsGroups`, `runAsUser`, `runAsGroup` from the manifest, and run the container with `runAsNonRoot=true`.

4.  `runAsNonRoot=false` with `securityContext` overrides:
    ```
     name: root-user-with-overrides
      securityContext:
         runAsUser: 100
         runAsGroup: 101
         fsGroup: 102
         runAsNonRoot: false
    ```
    This is actually a valid configuration and Okteto will still set the values for `fsGroups`, `runAsUser`, `runAsGroup` from the manifest while running with `runAsNonRoot=false` .

If you try to explicitly set `runAsNonRoot=true` and use the root user, you will get an error on `okteto up`.

As a side note, you will notice that I have also made it so you can set `runAsNonRoot=true`  and `runAsGroup=0`. This is also valid, and it is how all containers in OpenShift run by default.

It is my first time contributing to this project, so please let me know if there is anything I need to consider/fix. Let me know if you do not agree with this change, I am always open to feedback.


