### PR TITLE
Deploy dependant services not running

### DIFF
--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -27,7 +27,7 @@ import (
 
 // Deploy deploys a stack
 func Deploy(ctx context.Context) *cobra.Command {
-	options := stack.StackDeployOptions{}
+	options := &stack.StackDeployOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "deploy [service...]",

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -634,10 +634,10 @@ func validateDefinedServices(s *model.Stack, servicesToDeploy []string) error {
 func addDependentServicesIfNotPresent(ctx context.Context, s *model.Stack, options *StackDeployOptions, c kubernetes.Interface) {
 	added := make([]string, 0)
 	for _, svcToDeploy := range options.ServicesToDeploy {
-		for dependantSvc := range s.Services[svcToDeploy].DependsOn {
-			if !isSvcToBeDeployed(options.ServicesToDeploy, dependantSvc) && !isSvcRunning(ctx, s.Services[dependantSvc], s.Namespace, dependantSvc, c) {
-				options.ServicesToDeploy = append(options.ServicesToDeploy, dependantSvc)
-				added = append(added, dependantSvc)
+		for dependentSvc := range s.Services[svcToDeploy].DependsOn {
+			if !isSvcToBeDeployed(options.ServicesToDeploy, dependentSvc) && !isSvcRunning(ctx, s.Services[dependentSvc], s.Namespace, dependentSvc, c) {
+				options.ServicesToDeploy = append(options.ServicesToDeploy, dependentSvc)
+				added = append(added, dependentSvc)
 			}
 		}
 	}

--- a/pkg/cmd/stack/deploy_test.go
+++ b/pkg/cmd/stack/deploy_test.go
@@ -316,7 +316,7 @@ func Test_AddSomeServices(t *testing.T) {
 		expectedSvcsToBeDeployed []string
 	}{
 		{
-			name: "dependant service is job and not running",
+			name: "dependent service is job and not running",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -332,7 +332,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app", "job-not-running"},
 		},
 		{
-			name: "dependant service is sfs and not running",
+			name: "dependent service is sfs and not running",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -354,7 +354,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app", "sfs-not-running"},
 		},
 		{
-			name: "dependant service is deployment and not running",
+			name: "dependent service is deployment and not running",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -370,7 +370,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app", "dep-not-running"},
 		},
 		{
-			name: "dependant service is job and running",
+			name: "dependent service is job and running",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -386,7 +386,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app"},
 		},
 		{
-			name: "dependant service is job finished with errors",
+			name: "dependent service is job finished with errors",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -402,7 +402,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app", "job-failed"},
 		},
 		{
-			name: "dependant service is job finished successful",
+			name: "dependent service is job finished successful",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -418,7 +418,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app"},
 		},
 		{
-			name: "dependant service is sfs and running",
+			name: "dependent service is sfs and running",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -440,7 +440,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app"},
 		},
 		{
-			name: "dependant service is deployment and running",
+			name: "dependent service is deployment and running",
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
@@ -456,7 +456,7 @@ func Test_AddSomeServices(t *testing.T) {
 			expectedSvcsToBeDeployed: []string{"app"},
 		},
 		{
-			name: "dependant service is already on to be deployed",
+			name: "dependent service is already on to be deployed",
 			stack: &model.Stack{
 				Services: map[string]*model.Service{
 					"db": {},

--- a/pkg/cmd/stack/deploy_test.go
+++ b/pkg/cmd/stack/deploy_test.go
@@ -283,8 +283,8 @@ func Test_AddSomeServices(t *testing.T) {
 			Failed: 1,
 		},
 	}
-	jobSucceded := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
-		Name:      "job-succeded",
+	jobSucceeded := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "job-succeeded",
 		Namespace: "default",
 	},
 		Status: batchv1.JobStatus{
@@ -307,7 +307,7 @@ func Test_AddSomeServices(t *testing.T) {
 			ReadyReplicas: 1,
 		},
 	}
-	fakeClient := fake.NewSimpleClientset(jobActive, jobSucceded, jobFailed, sfs, dep)
+	fakeClient := fake.NewSimpleClientset(jobActive, jobSucceeded, jobFailed, sfs, dep)
 
 	var tests = []struct {
 		name                     string
@@ -406,11 +406,11 @@ func Test_AddSomeServices(t *testing.T) {
 			stack: &model.Stack{
 				Namespace: "default",
 				Services: map[string]*model.Service{
-					"job-succeded": {
+					"job-succeeded": {
 						RestartPolicy: corev1.RestartPolicyNever,
 					},
 					"app": {DependsOn: model.DependsOn{
-						"job-succeded": model.DependsOnConditionSpec{},
+						"job-succeeded": model.DependsOnConditionSpec{},
 					}},
 				},
 			},

--- a/pkg/cmd/stack/deploy_test.go
+++ b/pkg/cmd/stack/deploy_test.go
@@ -15,11 +15,14 @@ package stack
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/model"
-	v1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -41,7 +44,7 @@ func Test_deploySvc(t *testing.T) {
 				Services: map[string]*model.Service{
 					"test": {
 						Image:         "test_image",
-						RestartPolicy: v1.RestartPolicyAlways,
+						RestartPolicy: corev1.RestartPolicyAlways,
 					},
 				},
 			},
@@ -55,7 +58,7 @@ func Test_deploySvc(t *testing.T) {
 				Services: map[string]*model.Service{
 					"test": {
 						Image:         "test_image",
-						RestartPolicy: v1.RestartPolicyAlways,
+						RestartPolicy: corev1.RestartPolicyAlways,
 						Volumes: []model.StackVolume{
 							{
 								LocalPath:  "a",
@@ -78,7 +81,7 @@ func Test_deploySvc(t *testing.T) {
 				Services: map[string]*model.Service{
 					"test": {
 						Image:         "test_image",
-						RestartPolicy: v1.RestartPolicyNever,
+						RestartPolicy: corev1.RestartPolicyNever,
 					},
 				},
 			},
@@ -104,7 +107,7 @@ func Test_deployDeployment(t *testing.T) {
 		Services: map[string]*model.Service{
 			"test": {
 				Image:         "test_image",
-				RestartPolicy: v1.RestartPolicyAlways,
+				RestartPolicy: corev1.RestartPolicyAlways,
 			},
 		},
 	}
@@ -129,7 +132,7 @@ func Test_deployVolumes(t *testing.T) {
 		Services: map[string]*model.Service{
 			"test": {
 				Image:         "test_image",
-				RestartPolicy: v1.RestartPolicyAlways,
+				RestartPolicy: corev1.RestartPolicyAlways,
 				Volumes: []model.StackVolume{
 					{
 						LocalPath:  "a",
@@ -163,7 +166,7 @@ func Test_deploySfs(t *testing.T) {
 		Services: map[string]*model.Service{
 			"test": {
 				Image:         "test_image",
-				RestartPolicy: v1.RestartPolicyAlways,
+				RestartPolicy: corev1.RestartPolicyAlways,
 				Volumes: []model.StackVolume{
 					{
 						LocalPath:  "a",
@@ -197,7 +200,7 @@ func Test_deployJob(t *testing.T) {
 		Services: map[string]*model.Service{
 			"test": {
 				Image:         "test_image",
-				RestartPolicy: v1.RestartPolicyNever,
+				RestartPolicy: corev1.RestartPolicyNever,
 			},
 		},
 	}
@@ -215,7 +218,6 @@ func Test_deployJob(t *testing.T) {
 }
 
 func Test_ValidateDeploySomeServices(t *testing.T) {
-
 	var tests = []struct {
 		name             string
 		stack            *model.Stack
@@ -236,19 +238,6 @@ func Test_ValidateDeploySomeServices(t *testing.T) {
 			expectedErr:      true,
 		},
 		{
-			name: "not depending svc",
-			stack: &model.Stack{
-				Services: map[string]*model.Service{
-					"db": {},
-					"api": {DependsOn: model.DependsOn{
-						"db": model.DependsOnConditionSpec{},
-					}},
-				},
-			},
-			svcsToBeDeployed: []string{"api"},
-			expectedErr:      true,
-		},
-		{
 			name: "ok",
 			stack: &model.Stack{
 				Services: map[string]*model.Service{
@@ -265,12 +254,229 @@ func Test_ValidateDeploySomeServices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateServicesToDeploy(tt.stack, tt.svcsToBeDeployed)
+			err := validateDefinedServices(tt.stack, tt.svcsToBeDeployed)
 			if err == nil && tt.expectedErr {
 				t.Fatal("Expected err but not thrown")
 			}
 			if err != nil && !tt.expectedErr {
 				t.Fatal("Not Expected err but not thrown")
+			}
+		})
+	}
+}
+
+func Test_AddSomeServices(t *testing.T) {
+	ctx := context.Background()
+	jobActive := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "job-active",
+		Namespace: "default",
+	},
+		Status: batchv1.JobStatus{
+			Active: 1,
+		},
+	}
+	jobFailed := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "job-failed",
+		Namespace: "default",
+	},
+		Status: batchv1.JobStatus{
+			Failed: 1,
+		},
+	}
+	jobSucceded := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name:      "job-succeded",
+		Namespace: "default",
+	},
+		Status: batchv1.JobStatus{
+			Succeeded: 1,
+		},
+	}
+	sfs := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+		Name:      "sfs",
+		Namespace: "default",
+	},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 1,
+		},
+	}
+	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+		Name:      "dep",
+		Namespace: "default",
+	},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 1,
+		},
+	}
+	fakeClient := fake.NewSimpleClientset(jobActive, jobSucceded, jobFailed, sfs, dep)
+
+	var tests = []struct {
+		name                     string
+		stack                    *model.Stack
+		svcsToBeDeployed         []string
+		expectedSvcsToBeDeployed []string
+	}{
+		{
+			name: "dependant service is job and not running",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"job-not-running": {
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"job-not-running": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app", "job-not-running"},
+		},
+		{
+			name: "dependant service is sfs and not running",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"sfs-not-running": {
+						Volumes: []model.StackVolume{
+							{
+								LocalPath:  "/",
+								RemotePath: "/",
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"sfs-not-running": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app", "sfs-not-running"},
+		},
+		{
+			name: "dependant service is deployment and not running",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"dep-not-running": {
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"dep-not-running": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app", "dep-not-running"},
+		},
+		{
+			name: "dependant service is job and running",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"job-active": {
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"job-active": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app"},
+		},
+		{
+			name: "dependant service is job finished with errors",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"job-failed": {
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"job-failed": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app", "job-failed"},
+		},
+		{
+			name: "dependant service is job finished successful",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"job-succeded": {
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"job-succeded": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app"},
+		},
+		{
+			name: "dependant service is sfs and running",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"sfs": {
+						Volumes: []model.StackVolume{
+							{
+								LocalPath:  "/",
+								RemotePath: "/",
+							},
+						},
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"sfs": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app"},
+		},
+		{
+			name: "dependant service is deployment and running",
+			stack: &model.Stack{
+				Namespace: "default",
+				Services: map[string]*model.Service{
+					"dep": {
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+					"app": {DependsOn: model.DependsOn{
+						"dep": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"app"},
+			expectedSvcsToBeDeployed: []string{"app"},
+		},
+		{
+			name: "dependant service is already on to be deployed",
+			stack: &model.Stack{
+				Services: map[string]*model.Service{
+					"db": {},
+					"api": {DependsOn: model.DependsOn{
+						"db": model.DependsOnConditionSpec{},
+					}},
+				},
+			},
+			svcsToBeDeployed:         []string{"api", "db"},
+			expectedSvcsToBeDeployed: []string{"api", "db"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := &StackDeployOptions{ServicesToDeploy: tt.svcsToBeDeployed}
+			addDependentServicesIfNotPresent(ctx, tt.stack, options, fakeClient)
+
+			if !reflect.DeepEqual(tt.expectedSvcsToBeDeployed, options.ServicesToDeploy) {
+				t.Errorf("Expected %v but got %v", tt.expectedSvcsToBeDeployed, options.ServicesToDeploy)
 			}
 		})
 	}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -57,7 +57,7 @@ const (
 	pvcName = "pvc"
 )
 
-func translate(ctx context.Context, s *model.Stack, options StackDeployOptions) error {
+func translate(ctx context.Context, s *model.Stack, options *StackDeployOptions) error {
 	if err := translateStackEnvVars(ctx, s); err != nil {
 		return err
 	}
@@ -147,7 +147,7 @@ func translateServiceEnvFile(ctx context.Context, svc *model.Service, svcName, f
 	return nil
 }
 
-func translateBuildImages(ctx context.Context, s *model.Stack, options StackDeployOptions) error {
+func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDeployOptions) error {
 	buildKitHost, isOktetoCluster, err := build.GetBuildKitHost()
 	if err != nil {
 		return err
@@ -167,7 +167,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options StackDepl
 	return nil
 }
 
-func buildServices(ctx context.Context, s *model.Stack, buildKitHost string, isOktetoCluster bool, options StackDeployOptions) (bool, error) {
+func buildServices(ctx context.Context, s *model.Stack, buildKitHost string, isOktetoCluster bool, options *StackDeployOptions) (bool, error) {
 	hasBuiltSomething := false
 	for _, name := range options.ServicesToDeploy {
 		svc := s.Services[name]
@@ -203,7 +203,7 @@ func buildServices(ctx context.Context, s *model.Stack, buildKitHost string, isO
 	return hasBuiltSomething, nil
 }
 
-func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, buildKitHost string, isOktetoCluster bool, options StackDeployOptions, hasBuiltSomething bool) (bool, error) {
+func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, buildKitHost string, isOktetoCluster bool, options *StackDeployOptions, hasBuiltSomething bool) (bool, error) {
 	hasAddedAnyVolumeMounts := false
 	var err error
 	for name, svc := range s.Services {

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -54,7 +54,7 @@ func Test_translate(t *testing.T) {
 			},
 		},
 	}
-	if err := translate(ctx, stack, StackDeployOptions{ForceBuild: false, Wait: false}); err == nil {
+	if err := translate(ctx, stack, &StackDeployOptions{ForceBuild: false, Wait: false}); err == nil {
 		t.Fatalf("An error should be returned")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #

## Proposed changes
- Deploy dependant jobs if they have failed
- Deploy dependant services if they are not running
- Show user a warning message to show which services are going to be deployed
- Add unit test for these user cases
