### PR TITLE
Fix cache error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-pkg-cache-{{ checksum "go.sum" }}
+            - v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
       - run:
           command: go mod tidy && git diff --exit-code go.sum > /dev/null
       - run:
@@ -30,7 +30,7 @@ jobs:
           paths:
             - bin
       - save_cache:
-          key: v3-pkg-cache-{{ checksum "go.sum" }}
+          key: v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
             - /go/pkg
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-pkg-cache-{{ checksum "go.sum" }}
+            - v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
       - run:
@@ -75,7 +75,7 @@ jobs:
             OKTETO_CLIENTSIDE_TRANSLATION: 'true'
           command: make integration
       - save_cache:
-          key: v3-pkg-cache-{{ checksum "go.sum" }}
+          key: v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
             - /go/pkg
@@ -113,7 +113,7 @@ jobs:
       - checkout
       - run:
           name: Upgrade Golang
-          command: choco upgrade golang --version 1.16
+          command: choco upgrade golang --version 1.17
       - restore_cache:
           keys:
             - v4-pkg-cache-windows-1-15-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
     environment:
       OKTETO_USER: cindylopez
     docker:
-      - image: okteto/dev:latest
+      - image: okteto/dev:go1.17
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,9 @@ jobs:
       - image: okteto/dev:latest
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - run:
           command: go mod tidy && git diff --exit-code go.sum > /dev/null
       - run:
@@ -30,7 +30,7 @@ jobs:
           paths:
             - bin
       - save_cache:
-          key: v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
             - /go/pkg
@@ -49,7 +49,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
       - run:
@@ -75,7 +75,7 @@ jobs:
             OKTETO_CLIENTSIDE_TRANSLATION: 'true'
           command: make integration
       - save_cache:
-          key: v3-pkg-cache-go-1-17-{{ checksum "go.sum" }}
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
             - /go/pkg
@@ -116,7 +116,7 @@ jobs:
           command: choco upgrade golang --version 1.17
       - restore_cache:
           keys:
-            - v4-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
       - run:
           name: Test
           command: |
@@ -151,7 +151,7 @@ jobs:
           command: |
             go test github.com/okteto/okteto/integration -tags=integration --count=1 -v -timeout 30m
       - save_cache:
-          key: v4-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+          key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
           paths:
             - C:\Users\circleci\AppData\Local\go-build
             - C:\Users\circleci\go\pkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,7 @@ jobs:
       - image: okteto/golang-ci:1.17.3
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+
       - run:
           command: go mod tidy && git diff --exit-code go.sum > /dev/null
       - run:
@@ -47,9 +45,6 @@ jobs:
       - image: okteto/dev:latest
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
       - run:


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes e2e error because of getting go 1.15 cache go.sum

## Proposed changes

- Add prefix with Golang version to get always the newest cache
-
