### PR TITLE
Graphql introspection field validation

### DIFF
--- a/pkg/okteto/utils.go
+++ b/pkg/okteto/utils.go
@@ -1,0 +1,41 @@
+package okteto
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/machinebox/graphql"
+)
+
+// returns a filtered list of fields that are valid to query for the typeName given
+func queryAvailableFields(ctx context.Context, client *graphql.Client, typeName string, required string) []string {
+	var fields []string
+	var response map[string]map[string][]map[string]string
+
+	req := graphql.NewRequest(fmt.Sprintf(`query {
+		__type(name:"%s") {
+			fields {
+				name
+			}
+		}
+	}`, typeName))
+
+	if err := client.Run(ctx, req, &response); err != nil {
+		return fields
+	}
+
+	for _, v := range response["__type"]["fields"] {
+		fields = append(fields, v["name"])
+	}
+	var validated []string
+	for _, r := range strings.Split(required, ",") {
+		for _, a := range fields {
+			if r == a {
+				validated = append(validated, r)
+			}
+		}
+	}
+	return validated
+
+}


### PR DESCRIPTION
## Proposed changes

- instead of catching an error after a graphql query fails for field validation, retrieve prior to the query, the fields that are available from the list of fields required.
- use graphql introspection for this purpose


While developing this solution i noticed the introspection query for getting the fields that a schema has, is not protected by Bearer token, so this is available for any request of type introspection for a given model. Is this something we want? Reading about this, is not recommended to have the introspection queries open.