### PR TITLE
Fix stack service redeploy with another type

### DIFF
--- a/pkg/cmd/stack/destroy.go
+++ b/pkg/cmd/stack/destroy.go
@@ -138,13 +138,13 @@ func destroyServicesNotInStack(ctx context.Context, spinner *utils.Spinner, s *m
 	return nil
 }
 
-func destroyDeployments(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c *kubernetes.Clientset) error {
+func destroyDeployments(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c kubernetes.Interface) error {
 	dList, err := deployments.List(ctx, s.Namespace, s.GetLabelSelector(), c)
 	if err != nil {
 		return err
 	}
 	for i := range dList {
-		if _, ok := s.Services[dList[i].Name]; ok {
+		if _, ok := s.Services[dList[i].Name]; ok && s.Services[dList[i].Name].IsDeployment() {
 			continue
 		}
 		if err := deployments.Destroy(ctx, dList[i].Name, dList[i].Namespace, c); err != nil {
@@ -154,19 +154,23 @@ func destroyDeployments(ctx context.Context, spinner *utils.Spinner, s *model.St
 			return fmt.Errorf("error destroying service '%s': %s", dList[i].Name, err)
 		}
 		spinner.Stop()
-		log.Success("Destroyed service '%s'", dList[i].Name)
+		if _, ok := s.Services[dList[i].Name]; ok {
+			log.Success("Destroyed previous service '%s'", dList[i].Name)
+		} else {
+			log.Success("Destroyed service '%s'", dList[i].Name)
+		}
 		spinner.Start()
 	}
 	return nil
 }
 
-func destroyStatefulsets(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c *kubernetes.Clientset) error {
+func destroyStatefulsets(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c kubernetes.Interface) error {
 	sfsList, err := statefulsets.List(ctx, s.Namespace, s.GetLabelSelector(), c)
 	if err != nil {
 		return err
 	}
 	for i := range sfsList {
-		if _, ok := s.Services[sfsList[i].Name]; ok {
+		if _, ok := s.Services[sfsList[i].Name]; ok && s.Services[sfsList[i].Name].IsStatefulset() {
 			continue
 		}
 		if err := statefulsets.Destroy(ctx, sfsList[i].Name, sfsList[i].Namespace, c); err != nil {
@@ -176,18 +180,22 @@ func destroyStatefulsets(ctx context.Context, spinner *utils.Spinner, s *model.S
 			return fmt.Errorf("error destroying service '%s': %s", sfsList[i].Name, err)
 		}
 		spinner.Stop()
-		log.Success("Destroyed service '%s'", sfsList[i].Name)
+		if _, ok := s.Services[sfsList[i].Name]; ok {
+			log.Success("Destroyed previous service '%s'", sfsList[i].Name)
+		} else {
+			log.Success("Destroyed service '%s'", sfsList[i].Name)
+		}
 		spinner.Start()
 	}
 	return nil
 }
-func destroyJobs(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c *kubernetes.Clientset) error {
+func destroyJobs(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c kubernetes.Interface) error {
 	jobsList, err := jobs.List(ctx, s.Namespace, s.GetLabelSelector(), c)
 	if err != nil {
 		return err
 	}
 	for i := range jobsList {
-		if _, ok := s.Services[jobsList[i].Name]; ok {
+		if _, ok := s.Services[jobsList[i].Name]; ok && s.Services[jobsList[i].Name].IsJob() {
 			continue
 		}
 		if err := jobs.Destroy(ctx, jobsList[i].Name, jobsList[i].Namespace, c); err != nil {
@@ -197,7 +205,11 @@ func destroyJobs(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c 
 			return fmt.Errorf("error destroying service '%s': %s", jobsList[i].Name, err)
 		}
 		spinner.Stop()
-		log.Success("Destroyed service '%s'", jobsList[i].Name)
+		if _, ok := s.Services[jobsList[i].Name]; ok {
+			log.Success("Destroyed previous service '%s'", jobsList[i].Name)
+		} else {
+			log.Success("Destroyed service '%s'", jobsList[i].Name)
+		}
 		spinner.Start()
 	}
 	return nil

--- a/pkg/cmd/stack/destroy_test.go
+++ b/pkg/cmd/stack/destroy_test.go
@@ -1,0 +1,279 @@
+// Copyright 2021 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/k8s/deployments"
+	"github.com/okteto/okteto/pkg/k8s/jobs"
+	"github.com/okteto/okteto/pkg/k8s/statefulsets"
+	"github.com/okteto/okteto/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_destroyDeployments(t *testing.T) {
+	ctx := context.Background()
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns",
+			Labels:    map[string]string{model.StackNameLabel: "stack-test"},
+		},
+	}
+
+	client := fake.NewSimpleClientset(dep)
+	var tests = []struct {
+		name                string
+		stack               *model.Stack
+		expectedDeployments int
+	}{
+		{
+			name: "not destroy anything",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+				},
+			},
+			expectedDeployments: 1,
+		},
+		{
+			name: "destroy dep not in stack",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test-2": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+				},
+			},
+			expectedDeployments: 0,
+		},
+		{
+			name: "destroy dep which is not deployment anymore",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+			expectedDeployments: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spinner := utils.NewSpinner("testing")
+			err := destroyDeployments(ctx, spinner, tt.stack, client)
+			if err != nil {
+				t.Fatal("Not destroyed correctly")
+			}
+			depList, err := deployments.List(ctx, "ns", tt.stack.GetLabelSelector(), client)
+			if err != nil {
+				t.Fatal("could not retrieve list correctly")
+			}
+			if len(depList) != tt.expectedDeployments {
+				t.Fatal("Not destroyed correctly")
+			}
+		})
+	}
+}
+
+func Test_destroyStatefulsets(t *testing.T) {
+	ctx := context.Background()
+
+	sfs := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns",
+			Labels:    map[string]string{model.StackNameLabel: "stack-test"},
+		},
+	}
+
+	client := fake.NewSimpleClientset(sfs)
+	var tests = []struct {
+		name                string
+		stack               *model.Stack
+		expectedDeployments int
+	}{
+		{
+			name: "not destroy anything",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyAlways,
+						Volumes: []model.StackVolume{
+							{
+								LocalPath:  "/",
+								RemotePath: "/",
+							},
+						},
+					},
+				},
+			},
+			expectedDeployments: 1,
+		},
+		{
+			name: "destroy dep not in stack",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test-2": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyAlways,
+						Volumes: []model.StackVolume{
+							{
+								LocalPath:  "/",
+								RemotePath: "/",
+							},
+						},
+					},
+				},
+			},
+			expectedDeployments: 0,
+		},
+		{
+			name: "destroy dep which is not deployment anymore",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+			expectedDeployments: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spinner := utils.NewSpinner("testing")
+			err := destroyStatefulsets(ctx, spinner, tt.stack, client)
+			if err != nil {
+				t.Fatal("Not destroyed correctly")
+			}
+			sfsList, err := statefulsets.List(ctx, "ns", tt.stack.GetLabelSelector(), client)
+			if err != nil {
+				t.Fatal("could not retrieve list correctly")
+			}
+			if len(sfsList) != tt.expectedDeployments {
+				t.Fatal("Not destroyed correctly")
+			}
+		})
+	}
+}
+
+func Test_destroyJobs(t *testing.T) {
+	ctx := context.Background()
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns",
+			Labels:    map[string]string{model.StackNameLabel: "stack-test"},
+		},
+	}
+
+	client := fake.NewSimpleClientset(job)
+	var tests = []struct {
+		name                string
+		stack               *model.Stack
+		expectedDeployments int
+	}{
+		{
+			name: "not destroy anything",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+			expectedDeployments: 1,
+		},
+		{
+			name: "destroy dep not in stack",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test-2": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyNever,
+					},
+				},
+			},
+			expectedDeployments: 0,
+		},
+		{
+			name: "destroy dep which is not deployment anymore",
+			stack: &model.Stack{
+				Namespace: "ns",
+				Name:      "stack-test",
+				Services: map[string]*model.Service{
+					"test": {
+						Image:         "test_image",
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+				},
+			},
+			expectedDeployments: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spinner := utils.NewSpinner("testing")
+			err := destroyJobs(ctx, spinner, tt.stack, client)
+			if err != nil {
+				t.Fatal("Not destroyed correctly")
+			}
+			jobsList, err := jobs.List(ctx, "ns", tt.stack.GetLabelSelector(), client)
+			if err != nil {
+				t.Fatal("could not retrieve list correctly")
+			}
+			if len(jobsList) != tt.expectedDeployments {
+				t.Fatal("Not destroyed correctly")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: If you redeploy a service changing the type of it. It was not deleting previous service

## Proposed changes

- Check if its from the type it has to be deployed and if not delete it
-
