### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -16,7 +16,6 @@ package init
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -172,7 +171,7 @@ func Run(devPath, language, workDir string, overwrite bool) error {
 
 	if !model.FileExists(stignore) {
 		c := linguist.GetSTIgnore(language)
-		if err := ioutil.WriteFile(stignore, c, 0600); err != nil {
+		if err := os.WriteFile(stignore, c, 0600); err != nil {
 			log.Infof("failed to write stignore file: %s", err)
 		}
 	}

--- a/cmd/init/init_test.go
+++ b/cmd/init/init_test.go
@@ -15,7 +15,6 @@ package init
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +40,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRun(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +81,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunJustCreateNecessaryFields(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +93,7 @@ func TestRunJustCreateNecessaryFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, _ := ioutil.ReadFile(p)
+	file, _ := os.ReadFile(p)
 	var result map[string]interface{}
 	yaml.Unmarshal([]byte(file), &result)
 

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -14,7 +14,6 @@
 package pipeline
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -70,7 +69,7 @@ func Test_getRepositoryURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "")
+			dir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/up/pid_test.go
+++ b/cmd/up/pid_test.go
@@ -14,7 +14,6 @@
 package up
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -35,7 +34,7 @@ func TestCreatePIDFile(t *testing.T) {
 		t.Fatal("didn't create pid file")
 	}
 
-	filePID, err := ioutil.ReadFile(filePath)
+	filePID, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatal("pid file is corrupted")
 	}

--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -18,7 +18,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -129,7 +128,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 
 	if !stignoreDefaults {
 		stignoreContent := ""
-		if err := ioutil.WriteFile(stignorePath, []byte(stignoreContent), 0644); err != nil {
+		if err := os.WriteFile(stignorePath, []byte(stignoreContent), 0644); err != nil {
 			return fmt.Errorf("failed to create empty '%s': %s", stignorePath, err.Error())
 		}
 		return nil
@@ -140,14 +139,14 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 		return fmt.Errorf("failed to get language for '%s': %s", folder, err.Error())
 	}
 	c := linguist.GetSTIgnore(language)
-	if err := ioutil.WriteFile(stignorePath, c, 0600); err != nil {
+	if err := os.WriteFile(stignorePath, c, 0600); err != nil {
 		return fmt.Errorf("failed to write stignore file for '%s': %s", folder, err.Error())
 	}
 	return nil
 }
 
 func askIfUpdatingStignore(folder, stignorePath string) error {
-	stignoreBytes, err := ioutil.ReadFile(stignorePath)
+	stignoreBytes, err := os.ReadFile(stignorePath)
 	if err != nil {
 		return fmt.Errorf("failed to read '%s': %s", stignorePath, err.Error())
 	}
@@ -167,7 +166,7 @@ func askIfUpdatingStignore(folder, stignorePath string) error {
 	} else {
 		stignoreContent = fmt.Sprintf("// .git\n%s", stignoreContent)
 	}
-	if err := ioutil.WriteFile(stignorePath, []byte(stignoreContent), 0644); err != nil {
+	if err := os.WriteFile(stignorePath, []byte(stignoreContent), 0644); err != nil {
 		return fmt.Errorf("failed to update '%s': %s", stignorePath, err.Error())
 	}
 	return nil

--- a/cmd/up/watches.go
+++ b/cmd/up/watches.go
@@ -14,7 +14,7 @@
 package up
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -36,7 +36,7 @@ func checkLocalWatchesConfiguration() {
 	}
 
 	w := "/proc/sys/fs/inotify/max_user_watches"
-	f, err := ioutil.ReadFile(w)
+	f, err := os.ReadFile(w)
 	if err != nil {
 		log.Infof("Fail to read %s: %s", w, err)
 		return

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -15,7 +15,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -88,7 +87,7 @@ func Test_loadDevOrDefault(t *testing.T) {
 				return
 			}
 
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/utils/git_test.go
+++ b/cmd/utils/git_test.go
@@ -15,7 +15,6 @@ package utils
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,7 @@ import (
 )
 
 func Test_getBranch(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,7 +44,7 @@ func Test_getBranch(t *testing.T) {
 	}
 
 	filename := filepath.Join(dir, "example-git-file")
-	if err := ioutil.WriteFile(filename, []byte("hello world!"), 0644); err != nil {
+	if err := os.WriteFile(filename, []byte("hello world!"), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/utils/warnings.go
+++ b/cmd/utils/warnings.go
@@ -14,7 +14,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -24,7 +23,7 @@ import (
 //GetWarningState returns the value associated to a given warning
 func GetWarningState(path, name string) string {
 	filePath := filepath.Join(path, name)
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Infof("failed to read warning file '%s': %s", filePath, err)
 		return ""
@@ -40,5 +39,5 @@ func SetWarningState(path, name, value string) error {
 	}
 	filePath := filepath.Join(path, name)
 
-	return ioutil.WriteFile(filePath, []byte(value), 0644)
+	return os.WriteFile(filePath, []byte(value), 0644)
 }

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -132,14 +131,14 @@ func TestBuildActionPipeline(t *testing.T) {
 		t.Fatalf("Create namespace action failed: %s", err.Error())
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	log.Printf("created tempdir: %s", dir)
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine")
-	if err := ioutil.WriteFile(dockerfilePath, dockerfileContent, 0644); err != nil {
+	if err := os.WriteFile(dockerfilePath, dockerfileContent, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -319,13 +318,13 @@ func TestStacksActions(t *testing.T) {
 		t.Fatalf("Create namespace action failed: %s", err.Error())
 	}
 
-	dir, err := ioutil.TempDir("", namespace)
+	dir, err := os.MkdirTemp("", namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
 	log.Printf("created tempdir: %s", dir)
 	filePath := filepath.Join(dir, "okteto-stack.yaml")
-	if err := ioutil.WriteFile(filePath, []byte(stackFile), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(stackFile), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -493,7 +492,7 @@ func executeDestroyPipelineAction(ctx context.Context, namespace string) error {
 
 func executeApply(ctx context.Context, namespace string) error {
 
-	dir, err := ioutil.TempDir("", namespace)
+	dir, err := os.MkdirTemp("", namespace)
 	if err != nil {
 		return err
 	}
@@ -532,14 +531,14 @@ func executeApply(ctx context.Context, namespace string) error {
 }
 
 func executePushAction(ctx context.Context, namespace, user string) error {
-	dir, err := ioutil.TempDir("", namespace)
+	dir, err := os.MkdirTemp("", namespace)
 	if err != nil {
 		return err
 	}
 	log.Printf("created tempdir: %s", dir)
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine")
-	if err := ioutil.WriteFile(dockerfilePath, dockerfileContent, 0644); err != nil {
+	if err := os.WriteFile(dockerfilePath, dockerfileContent, 0644); err != nil {
 		return err
 	}
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -263,7 +263,7 @@ func TestAll(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir, err := ioutil.TempDir("", tName)
+	dir, err := os.MkdirTemp("", tName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestAll(t *testing.T) {
 	}
 
 	contentPath := filepath.Join(dir, "index.html")
-	if err := ioutil.WriteFile(contentPath, []byte(name), 0644); err != nil {
+	if err := os.WriteFile(contentPath, []byte(name), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -287,7 +287,7 @@ func TestAll(t *testing.T) {
 	}
 
 	stignorePath := filepath.Join(dir, ".stignore")
-	if err := ioutil.WriteFile(stignorePath, []byte("venv"), 0600); err != nil {
+	if err := os.WriteFile(stignorePath, []byte("venv"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -398,7 +398,7 @@ func TestAllStatefulset(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir, err := ioutil.TempDir("", tName)
+	dir, err := os.MkdirTemp("", tName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestAllStatefulset(t *testing.T) {
 	}
 
 	contentPath := filepath.Join(dir, "index.html")
-	if err := ioutil.WriteFile(contentPath, []byte(name), 0644); err != nil {
+	if err := os.WriteFile(contentPath, []byte(name), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -422,7 +422,7 @@ func TestAllStatefulset(t *testing.T) {
 	}
 
 	stignorePath := filepath.Join(dir, ".stignore")
-	if err := ioutil.WriteFile(stignorePath, []byte("venv"), 0600); err != nil {
+	if err := os.WriteFile(stignorePath, []byte("venv"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -610,25 +610,25 @@ func oktetoPipeline(ctx context.Context, oktetoPath, repo, folder string) error 
 
 func modifyDivertApp() error {
 
-	input, err := ioutil.ReadFile(filepath.Join(divertGitFolder, "health-checker", "cmd", "main.go"))
+	input, err := os.ReadFile(filepath.Join(divertGitFolder, "health-checker", "cmd", "main.go"))
 	if err != nil {
 		return err
 	}
 
 	output := bytes.Replace(input, []byte("&health.SimpleHealthClient"), []byte("&health.AdvancedHealthClient"), 1)
 
-	if err = ioutil.WriteFile(filepath.Join(divertGitFolder, "health-checker", "cmd", "main.go"), output, 0666); err != nil {
+	if err = os.WriteFile(filepath.Join(divertGitFolder, "health-checker", "cmd", "main.go"), output, 0666); err != nil {
 		return err
 	}
 
-	input, err = ioutil.ReadFile(filepath.Join(divertGitFolder, "health-checker", "okteto.yml"))
+	input, err = os.ReadFile(filepath.Join(divertGitFolder, "health-checker", "okteto.yml"))
 	if err != nil {
 		return err
 	}
 
 	output = bytes.Replace(input, []byte("command: bash"), []byte("command: go run cmd/main.go"), 1)
 
-	if err = ioutil.WriteFile(filepath.Join(divertGitFolder, "health-checker", "okteto.yml"), output, 0666); err != nil {
+	if err = os.WriteFile(filepath.Join(divertGitFolder, "health-checker", "okteto.yml"), output, 0666); err != nil {
 		return err
 	}
 	return nil
@@ -740,7 +740,7 @@ func getContent(endpoint string, timeout int, upErrorChannel chan error) (string
 			continue
 		}
 
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return "", err
 		}
@@ -822,9 +822,9 @@ func deleteNamespace(ctx context.Context, oktetoPath, namespace string) error {
 
 func testUpdateContent(content, contentPath string, timeout int, upErrorChannel chan error) error {
 	start := time.Now()
-	ioutil.WriteFile(contentPath, []byte(content), 0644)
+	os.WriteFile(contentPath, []byte(content), 0644)
 
-	if err := ioutil.WriteFile(contentPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(contentPath, []byte(content), 0644); err != nil {
 		return fmt.Errorf("failed to update %s: %s", contentPath, err.Error())
 	}
 
@@ -947,7 +947,7 @@ func down(ctx context.Context, namespace, name, manifestPath, oktetoPath string,
 
 	log.Printf("okteto down output:\n%s", string(o))
 	if err != nil {
-		m, _ := ioutil.ReadFile(manifestPath)
+		m, _ := os.ReadFile(manifestPath)
 		log.Printf("manifest: \n%s\n", string(m))
 		return fmt.Errorf("okteto down failed: %s", err)
 	}
@@ -1020,7 +1020,7 @@ func waitForReady(namespace, name string, upErrorChannel chan error) error {
 		if !isUpRunning(upErrorChannel) {
 			return fmt.Errorf("Okteto up exited before completion")
 		}
-		c, err := ioutil.ReadFile(state)
+		c, err := os.ReadFile(state)
 		if err != nil {
 			log.Printf("failed to read state file %s: %s", state, err)
 			if !os.IsNotExist(err) {

--- a/pkg/analytics/config.go
+++ b/pkg/analytics/config.go
@@ -16,7 +16,6 @@ package analytics
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/denisbrodbeck/machineid"
@@ -97,7 +96,7 @@ func get() *Analytics {
 		return &Analytics{Enabled: false, MachineID: ""}
 	}
 
-	b, err := ioutil.ReadFile(config.GetAnalyticsPath())
+	b, err := os.ReadFile(config.GetAnalyticsPath())
 	if err != nil {
 		log.Debugf("error reading analytics file: %s", err)
 		return &Analytics{Enabled: false, MachineID: ""}
@@ -137,7 +136,7 @@ func (a *Analytics) save() error {
 		}
 	}
 
-	if err := ioutil.WriteFile(analyticsPath, marshalled, 0600); err != nil {
+	if err := os.WriteFile(analyticsPath, marshalled, 0600); err != nil {
 		return fmt.Errorf("couldn't save analytics: %s", err)
 	}
 

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -14,7 +14,6 @@
 package analytics
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -66,7 +65,7 @@ func Test_getTrackID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "")
+			dir, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -143,7 +142,7 @@ func getBuildkitClient(ctx context.Context) (*client.Client, error) {
 			return nil, fmt.Errorf("certificate decoding error: %w", err)
 		}
 
-		if err := ioutil.WriteFile(config.GetCertificatePath(), certBytes, 0600); err != nil {
+		if err := os.WriteFile(config.GetCertificatePath(), certBytes, 0600); err != nil {
 			return nil, err
 		}
 

--- a/pkg/cmd/doctor/run.go
+++ b/pkg/cmd/doctor/run.go
@@ -17,7 +17,6 @@ import (
 	"compress/flate"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -114,7 +113,7 @@ func Run(ctx context.Context, dev *model.Dev, devPath string, c *kubernetes.Clie
 }
 
 func generateSummaryFile() (string, error) {
-	tempdir, _ := ioutil.TempDir("", "")
+	tempdir, _ := os.MkdirTemp("", "")
 	summaryPath := filepath.Join(tempdir, "okteto-summary.txt")
 	fileSummary, err := os.OpenFile(summaryPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
@@ -145,7 +144,7 @@ func generateStignoreFiles(dev *model.Dev) []string {
 }
 
 func generateManifestFile(devPath string) (string, error) {
-	tempdir, err := ioutil.TempDir("", "")
+	tempdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -156,7 +155,7 @@ func generateManifestFile(devPath string) (string, error) {
 	}
 	defer manifestFile.Close()
 
-	b, err := ioutil.ReadFile(devPath)
+	b, err := os.ReadFile(devPath)
 	if err != nil {
 		return "", err
 	}
@@ -225,7 +224,7 @@ func generatePodFile(ctx context.Context, dev *model.Dev, c *kubernetes.Clientse
 		return "", errors.ErrNotFound
 	}
 
-	tempdir, err := ioutil.TempDir("", "")
+	tempdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -279,7 +278,7 @@ func generateRemoteSyncthingLogsFile(ctx context.Context, dev *model.Dev, c *kub
 		return "", err
 	}
 
-	tempdir, _ := ioutil.TempDir("", "")
+	tempdir, _ := os.MkdirTemp("", "")
 	remoteLogsPath := filepath.Join(tempdir, "remote-syncthing.log")
 	fileRemoteLog, err := os.OpenFile(remoteLogsPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {

--- a/pkg/cmd/doctor/run_test.go
+++ b/pkg/cmd/doctor/run_test.go
@@ -14,7 +14,6 @@
 package doctor
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -62,7 +61,7 @@ func Test_generateManifestFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			file, err := ioutil.TempFile("", "okteto.yml")
+			file, err := os.CreateTemp("", "okteto.yml")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -60,11 +59,11 @@ func Test_translate(t *testing.T) {
 }
 
 func Test_translateEnvVars(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", ".env")
+	tmpFile, err := os.CreateTemp("", ".env")
 	if err != nil {
 		t.Fatalf("failed to create dynamic env file: %s", err.Error())
 	}
-	if err := ioutil.WriteFile(tmpFile.Name(), []byte(env), 0600); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), []byte(env), 0600); err != nil {
 		t.Fatalf("failed to write env file: %s", err.Error())
 	}
 	defer os.RemoveAll(tmpFile.Name())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -129,7 +128,7 @@ func UpdateStateFile(dev *model.Dev, state UpState) error {
 	}
 
 	s := filepath.Join(GetAppHome(dev.Namespace, dev.Name), stateFile)
-	if err := ioutil.WriteFile(s, []byte(state), 0644); err != nil {
+	if err := os.WriteFile(s, []byte(state), 0644); err != nil {
 		return fmt.Errorf("failed to update state file: %s", err)
 	}
 
@@ -162,7 +161,7 @@ func GetState(dev *model.Dev) (UpState, error) {
 	}
 
 	statePath := filepath.Join(GetAppHome(dev.Namespace, dev.Name), stateFile)
-	stateBytes, err := ioutil.ReadFile(statePath)
+	stateBytes, err := os.ReadFile(statePath)
 	if err != nil {
 		log.Infof("error reading state file: %s", err.Error())
 		return Failed, errors.UserError{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,7 +14,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +25,7 @@ func TestGetUserHomeDir(t *testing.T) {
 		t.Fatal("got an empty home value")
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +113,7 @@ func Test_homedirWindows(t *testing.T) {
 }
 
 func TestGetOktetoHome(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +131,7 @@ func TestGetOktetoHome(t *testing.T) {
 }
 
 func TestGetAppHome(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -16,7 +16,6 @@ package apps
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -39,7 +38,7 @@ var (
 )
 
 func Test_translateWithVolumes(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp", "okteto-secret-test")
+	file, err := os.CreateTemp("/tmp", "okteto-secret-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1436,7 +1435,7 @@ environment:
 }
 
 func Test_translateSfsWithVolumes(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp", "okteto-secret-test")
+	file, err := os.CreateTemp("/tmp", "okteto-secret-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 	"time"
@@ -208,7 +208,7 @@ func (p *PortForwardManager) buildForwarder(namespace, pod string, ports []strin
 		ports,
 		a.stopChan,
 		a.readyChan,
-		ioutil.Discard,
+		io.Discard,
 		a.out)
 
 	if err != nil {

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -16,7 +16,7 @@ package secrets
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/okteto/okteto/pkg/log"
@@ -69,7 +69,7 @@ func Create(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset, s *syn
 	}
 
 	for _, s := range dev.Secrets {
-		content, err := ioutil.ReadFile(s.LocalPath)
+		content, err := os.ReadFile(s.LocalPath)
 		if err != nil {
 			return fmt.Errorf("error reading secret '%s': %s", s.LocalPath, err)
 		}

--- a/pkg/linguist/linguist.go
+++ b/pkg/linguist/linguist.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -148,7 +147,7 @@ func refineJavaChoice(root string) string {
 
 func readFile(path string, limit int64) ([]byte, error) {
 	if limit <= 0 {
-		return ioutil.ReadFile(path)
+		return os.ReadFile(path)
 	}
 
 	f, err := os.Open(path)

--- a/pkg/linguist/linguist_test.go
+++ b/pkg/linguist/linguist_test.go
@@ -14,7 +14,6 @@
 package linguist
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -70,7 +69,7 @@ func TestProcessDirectory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmp, err := ioutil.TempDir("", "")
+			tmp, err := os.MkdirTemp("", "")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -16,7 +16,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -256,7 +255,7 @@ type EnvFiles []string
 
 // Get returns a Dev object from a given file
 func Get(devPath string) (*Dev, error) {
-	b, err := ioutil.ReadFile(devPath)
+	b, err := os.ReadFile(devPath)
 	if err != nil {
 		return nil, err
 	}
@@ -763,7 +762,7 @@ func (dev *Dev) Save(path string) error {
 		return fmt.Errorf("Failed to generate your manifest")
 	}
 
-	if err := ioutil.WriteFile(path, marshalled, 0600); err != nil {
+	if err := os.WriteFile(path, marshalled, 0600); err != nil {
 		log.Infof("failed to write okteto manifest at %s: %s", path, err)
 		return fmt.Errorf("Failed to write your manifest")
 	}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -15,7 +15,6 @@ package model
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -686,7 +685,7 @@ func Test_LoadForcePull(t *testing.T) {
 }
 
 func Test_validate(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp", "okteto-secret-test")
+	file, err := os.CreateTemp("/tmp", "okteto-secret-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/model/devrc.go
+++ b/pkg/model/devrc.go
@@ -3,7 +3,7 @@ package model
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 
@@ -32,7 +32,7 @@ type DevRC struct {
 
 // Get returns a Dev object from a given file
 func GetRc(devPath string) (*DevRC, error) {
-	b, err := ioutil.ReadFile(devPath)
+	b, err := os.ReadFile(devPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -15,7 +15,6 @@ package model
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -348,7 +347,7 @@ func TestLifecycleMashalling(t *testing.T) {
 }
 
 func TestSecretMashalling(t *testing.T) {
-	file, err := ioutil.TempFile("/tmp", "okteto-secret-test")
+	file, err := os.CreateTemp("/tmp", "okteto-secret-test")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -16,8 +16,8 @@ package model
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -183,7 +183,7 @@ const (
 
 // GetStack returns an okteto stack object from a given file
 func GetStack(name, stackPath string, isCompose bool) (*Stack, error) {
-	b, err := ioutil.ReadFile(stackPath)
+	b, err := os.ReadFile(stackPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -14,14 +14,13 @@
 package model
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestCopyFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +35,7 @@ func TestCopyFile(t *testing.T) {
 	}
 
 	content := []byte("hello-world")
-	if err := ioutil.WriteFile(from, content, 0600); err != nil {
+	if err := os.WriteFile(from, content, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -44,7 +43,7 @@ func TestCopyFile(t *testing.T) {
 		t.Fatalf("failed to copy from %s to %s: %s", from, to, err)
 	}
 
-	copied, err := ioutil.ReadFile(to)
+	copied, err := os.ReadFile(to)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +59,7 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +71,7 @@ func TestFileExists(t *testing.T) {
 		t.Errorf("fail to detect non-existing file")
 	}
 
-	if err := ioutil.WriteFile(p, []byte("hello-world"), 0600); err != nil {
+	if err := os.WriteFile(p, []byte("hello-world"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/okteto/auth.go
+++ b/pkg/okteto/auth.go
@@ -17,8 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -254,7 +254,7 @@ func (c *OktetoClient) deprecatedAuthUser(ctx context.Context, code string) (*Us
 func getTokenFromOktetoHome() (*Token, error) {
 	p := config.GetTokenPathDeprecated()
 
-	b, err := ioutil.ReadFile(p)
+	b, err := os.ReadFile(p)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -14,7 +14,6 @@
 package okteto
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -22,7 +21,7 @@ import (
 )
 
 func TestSetKubeConfig(t *testing.T) {
-	file, err := ioutil.TempFile("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err.Error())
 	}

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -169,7 +168,7 @@ func ContextStore() *OktetoContextStore {
 		return CurrentStore
 	}
 
-	b, err := ioutil.ReadFile(config.GetOktetoContextsStorePath())
+	b, err := os.ReadFile(config.GetOktetoContextsStorePath())
 	if err != nil {
 		log.Errorf("error reading okteto contexts: %v", err)
 		log.Fatalf(errors.ErrCorruptedOktetoContexts, config.GetOktetoHome())
@@ -351,7 +350,7 @@ func saveContextConfigInFile(c *OktetoContextStore) error {
 		}
 	}
 
-	if err := ioutil.WriteFile(contextConfigPath, marshalled, 0600); err != nil {
+	if err := os.WriteFile(contextConfigPath, marshalled, 0600); err != nil {
 		return fmt.Errorf("couldn't save context: %s", err)
 	}
 

--- a/pkg/registry/file.go
+++ b/pkg/registry/file.go
@@ -16,7 +16,6 @@ package registry
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -52,7 +51,7 @@ func getDockerfileWithCacheHandler(filename string) (string, error) {
 		return "", fmt.Errorf("failed to create %s: %s", dockerfileTmpFolder, err)
 	}
 
-	tmpFile, err := ioutil.TempFile(dockerfileTmpFolder, "buildkit-")
+	tmpFile, err := os.CreateTemp(dockerfileTmpFolder, "buildkit-")
 	if err != nil {
 		return "", err
 	}
@@ -116,7 +115,7 @@ func CreateDockerfileWithVolumeMounts(image string, volumes []model.StackVolume)
 		return build, fmt.Errorf("failed to create %s: %s", dockerfileTmpFolder, err)
 	}
 
-	tmpFile, err := ioutil.TempFile(dockerfileTmpFolder, "buildkit-")
+	tmpFile, err := os.CreateTemp(dockerfileTmpFolder, "buildkit-")
 	if err != nil {
 		return build, err
 	}

--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -15,7 +15,7 @@ package ssh
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -25,7 +25,7 @@ var clientConfig *ssh.ClientConfig
 
 func getPrivateKey() (ssh.Signer, error) {
 	_, private := getKeyPaths()
-	buf, err := ioutil.ReadFile(private)
+	buf, err := os.ReadFile(private)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load private key: %s", err)
 	}

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -131,7 +130,7 @@ func parse(r io.Reader) (*sshConfig, error) {
 		h *host
 	)
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +240,7 @@ func (config *sshConfig) writeToFilepath(p string) error {
 	}
 
 	dir := filepath.Dir(p)
-	temp, err := ioutil.TempFile(dir, "")
+	temp, err := os.CreateTemp(dir, "")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary config file: %s", err)
 	}

--- a/pkg/ssh/config_test.go
+++ b/pkg/ssh/config_test.go
@@ -16,7 +16,6 @@ package ssh
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +41,7 @@ func TestWriteToNewFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d, err := ioutil.TempDir("", "")
+	d, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ssh/key.go
+++ b/pkg/ssh/key.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/okteto/okteto/pkg/config"
@@ -72,11 +72,11 @@ func generateKeys(public, private string, bitSize int) error {
 
 	privateKeyBytes := encodePrivateKeyToPEM(privateKey)
 
-	if err := ioutil.WriteFile(public, publicKeyBytes, 0600); err != nil {
+	if err := os.WriteFile(public, publicKeyBytes, 0600); err != nil {
 		return fmt.Errorf("failed to write public SSH key: %s", err)
 	}
 
-	if err := ioutil.WriteFile(private, privateKeyBytes, 0600); err != nil {
+	if err := os.WriteFile(private, privateKeyBytes, 0600); err != nil {
 		return fmt.Errorf("failed to write private SSH key: %s", err)
 	}
 

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -14,7 +14,6 @@
 package ssh
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ import (
 
 func TestKeyExists(t *testing.T) {
 
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +56,7 @@ func TestKeyExists(t *testing.T) {
 }
 
 func TestGenerateKeys(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -16,7 +16,7 @@ package ssh
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -220,7 +220,7 @@ func callForwards(fm *ForwardManager) error {
 		}
 
 		defer r.Body.Close()
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			return fmt.Errorf("%s failed to read response: %w", f.String(), err)
 		}
@@ -248,7 +248,7 @@ func callReverseForwards(fm *ForwardManager) error {
 		}
 
 		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("%s failed to read response: %w", r.String(), err)
 		}

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -14,7 +14,6 @@
 package ssh
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,7 +23,7 @@ import (
 )
 
 func Test_addOnEmpty(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +55,7 @@ func Test_addOnEmpty(t *testing.T) {
 	}
 }
 func Test_add(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +225,7 @@ func Test_removeHost(t *testing.T) {
 }
 
 func TestGetPort(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 	"strings"
@@ -114,7 +114,7 @@ func (s *Syncthing) callWithRetry(ctx context.Context, url, method string, code 
 		return nil, nil
 	}
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response from syncthing [%s]: %w", url, err)
 	}

--- a/pkg/syncthing/install.go
+++ b/pkg/syncthing/install.go
@@ -15,7 +15,6 @@ package syncthing
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -61,7 +60,7 @@ func Install(p getter.ProgressTracker) error {
 		opts = []getter.ClientOption{getter.WithProgress(p)}
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return fmt.Errorf("failed to create temp download dir")
 	}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -244,11 +243,11 @@ func (s *Syncthing) initConfig() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(s.Home, certFile), cert, 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(s.Home, certFile), cert, 0700); err != nil {
 		return fmt.Errorf("failed to write syncthing certificate: %w", err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(s.Home, keyFile), key, 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(s.Home, keyFile), key, 0700); err != nil {
 		return fmt.Errorf("failed to write syncthing key: %w", err)
 	}
 
@@ -262,7 +261,7 @@ func (s *Syncthing) UpdateConfig() error {
 		return fmt.Errorf("failed to write syncthing configuration template: %w", err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(s.Home, configFile), buf.Bytes(), 0700); err != nil {
+	if err := os.WriteFile(filepath.Join(s.Home, configFile), buf.Bytes(), 0700); err != nil {
 		return fmt.Errorf("failed to write syncthing configuration file: %w", err)
 	}
 
@@ -721,7 +720,7 @@ func (s *Syncthing) SaveConfig(dev *model.Dev) error {
 	}
 
 	syncthingInfoFile := getInfoFile(dev.Namespace, dev.Name)
-	if err := ioutil.WriteFile(syncthingInfoFile, marshalled, 0600); err != nil {
+	if err := os.WriteFile(syncthingInfoFile, marshalled, 0600); err != nil {
 		return fmt.Errorf("failed to write syncthing info file: %w", err)
 	}
 
@@ -731,7 +730,7 @@ func (s *Syncthing) SaveConfig(dev *model.Dev) error {
 // Load loads the syncthing object from the dev home folder
 func Load(dev *model.Dev) (*Syncthing, error) {
 	syncthingInfoFile := getInfoFile(dev.Namespace, dev.Name)
-	b, err := ioutil.ReadFile(syncthingInfoFile)
+	b, err := os.ReadFile(syncthingInfoFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -14,7 +14,6 @@
 package syncthing
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ import (
 
 func TestGetFiles(t *testing.T) {
 
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Proposed changes

- The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since okteto has upgraded to Go 1.17 (#1734), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.
