### PR TITLE
Always get SSH port when running exec with remote enabled

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -132,19 +132,17 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 	}
 
 	if dev.RemoteModeEnabled() {
-		if dev.RemotePort == 0 {
-			p, err := ssh.GetPort(dev.Name)
-			if err != nil {
-				log.Infof("failed to get the SSH port for %s: %s", dev.Name, err)
-				return errors.UserError{
-					E:    fmt.Errorf("development mode is not enabled on your deployment"),
-					Hint: "Run 'okteto up' to enable it and try again",
-				}
+		p, err := ssh.GetPort(dev.Name)
+		if err != nil {
+			log.Infof("failed to get the SSH port for %s: %s", dev.Name, err)
+			return errors.UserError{
+				E:    fmt.Errorf("development mode is not enabled on your deployment"),
+				Hint: "Run 'okteto up' to enable it and try again",
 			}
-
-			dev.RemotePort = p
-			log.Infof("executing remote command over SSH port %d", dev.RemotePort)
 		}
+
+		dev.RemotePort = p
+		log.Infof("executing remote command over SSH port %d", dev.RemotePort)
 
 		dev.LoadRemote(ssh.GetPublicKey())
 


### PR DESCRIPTION
This fixes a bug where exec could not recover if the dev container was
stopped and restarted with a new SSH port. Getting the port every time
ensures the new SSH port is used

Signed-off-by: Adam Guthrie <guthrie@squareup.com>

Fixes n/a

## Proposed changes
- Always get SSH port when running exec with remote enabled
