### PR TITLE
Fix spinner bug

### DIFF
--- a/cmd/utils/syncthing.go
+++ b/cmd/utils/syncthing.go
@@ -44,7 +44,7 @@ func (s *SyncthingProgress) initProgressBar() {
 			decor.OnComplete(decor.Name(" "), ""),
 			decor.OnComplete(s.ItemStartedDecorator(), ""),
 		),
-		mpb.BarExtender(mpb.NewBarFiller(mpb.BarStyle().Lbound("[").Filler("-").Tip(">").Padding("_").Rbound("]"))),
+		mpb.BarExtender(NewLineBarFiller(mpb.NewBarFiller(mpb.BarStyle().Lbound("[").Filler("-").Tip(">").Padding("_").Rbound("]")))),
 		mpb.BarRemoveOnComplete(),
 	)
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes a bug where the spinner was not displayed properly

## Proposed changes
- After upgrading the library we were not writing the new line rune correctly
-
