### PR TITLE
Update --skip-if-exists to check commit being deployed

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -89,7 +89,7 @@ func deploy(ctx context.Context) *cobra.Command {
 			}
 
 			if skipIfExists {
-				variables = append(variables, "SKIP_COMMIT=true")
+				variables = append(variables, "OKTETO_SKIP_COMMIT_IF_DEPLOYED=true")
 			}
 
 			resp, err := deployPipeline(ctx, name, repository, branch, filename, variables)


### PR DESCRIPTION
Resolves https://github.com/okteto/app/issues/2813

## Proposed changes

- when the flag --skip-if-exists is enabled, a variable is passed to the pipeline so if the current commit was already deployed, is not re-deployed

