### PR TITLE
Fix empty en vars being injected

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -780,7 +780,9 @@ func translateStorageClass(className string) *string {
 func translateServiceEnvironment(svc *model.Service) []apiv1.EnvVar {
 	result := []apiv1.EnvVar{}
 	for _, e := range svc.Environment {
-		result = append(result, apiv1.EnvVar{Name: e.Name, Value: e.Value})
+		if e.Value != "" && e.Name != "" {
+			result = append(result, apiv1.EnvVar{Name: e.Name, Value: e.Value})
+		}
 	}
 	return result
 }

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1116,3 +1116,67 @@ func Test_translateSvcProbe(t *testing.T) {
 		})
 	}
 }
+
+func Test_translateServiceEnvironment(t *testing.T) {
+	tests := []struct {
+		name     string
+		svc      *model.Service
+		expected []apiv1.EnvVar
+	}{
+		{
+			name: "none",
+			svc: &model.Service{
+				Environment: model.Environment{},
+			},
+			expected: []apiv1.EnvVar{},
+		},
+		{
+			name: "empty value",
+			svc: &model.Service{
+				Environment: model.Environment{
+					model.EnvVar{
+						Name: "DEBUG",
+					},
+				},
+			},
+			expected: []apiv1.EnvVar{},
+		},
+		{
+			name: "empty name",
+			svc: &model.Service{
+				Environment: model.Environment{
+					model.EnvVar{
+						Value: "DEBUG",
+					},
+				},
+			},
+			expected: []apiv1.EnvVar{},
+		},
+		{
+			name: "ok env var",
+			svc: &model.Service{
+				Environment: model.Environment{
+					model.EnvVar{
+						Name:  "DEBUG",
+						Value: "true",
+					},
+				},
+			},
+			expected: []apiv1.EnvVar{
+				{
+					Name:  "DEBUG",
+					Value: "true",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envs := translateServiceEnvironment(tt.svc)
+			if !reflect.DeepEqual(tt.expected, envs) {
+				t.Fatal("Wrong translation")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #1831

## Proposed changes

- If a value or name is empty don't inject into k8s container
-
