### PR TITLE
Add local metrics for k8s

### DIFF
--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -295,9 +295,6 @@ func track(event string, success bool, props map[string]interface{}) {
 	if !get().Enabled {
 		return
 	}
-	if !okteto.Context().Analytics {
-		return
-	}
 	mpOS := ""
 	switch runtime.GOOS {
 	case "darwin":
@@ -320,6 +317,10 @@ func track(event string, success bool, props map[string]interface{}) {
 	props["version"] = config.VersionString
 	props["$referring_domain"] = okteto.Context().Name
 	props["machine_id"] = get().MachineID
+	if okteto.Context().ClusterType != "" {
+		props["clusterType"] = okteto.Context().ClusterType
+	}
+
 	props["origin"] = origin
 	props["success"] = success
 	props["contextType"] = getContextType(okteto.Context().Name)

--- a/pkg/okteto/k8s.go
+++ b/pkg/okteto/k8s.go
@@ -46,6 +46,7 @@ func getK8sClient(clientApiConfig *clientcmdapi.Config) (*kubernetes.Clientset, 
 
 	config.Timeout = getKubernetesTimeout()
 
+	Context().SetClusterType(config.Host)
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/okteto/k8s_test.go
+++ b/pkg/okteto/k8s_test.go
@@ -1,0 +1,87 @@
+package okteto
+
+import (
+	"testing"
+)
+
+func Test_IsLocalHostname(t *testing.T) {
+	var tests = []struct {
+		name     string
+		hostname string
+		expected bool
+	}{
+
+		{
+			name:     "cloud",
+			hostname: "https://cloud.okteto.com",
+			expected: false,
+		},
+		{
+			name:     "172 non rfc",
+			hostname: "https://172.15.1.2:16443",
+			expected: false,
+		},
+		{
+			name:     "192 non rfc",
+			hostname: "https://192.15.1.2:16443",
+			expected: false,
+		},
+		{
+			name:     "169 no unicast",
+			hostname: "https://169.15.1.2:16443",
+			expected: false,
+		},
+		{
+			name:     "microk8s",
+			hostname: "https://172.16.29.3:16443",
+			expected: true,
+		},
+		{
+			name:     "minikube",
+			hostname: "https://172.16.29.2:8443",
+			expected: true,
+		},
+		{
+			name:     "localhost",
+			hostname: "https://127.0.0.1",
+			expected: true,
+		},
+		{
+			name:     "localhost-ipv6",
+			hostname: "::1",
+			expected: true,
+		},
+		{
+			name:     "local-2",
+			hostname: "https://192.168.1.24:123",
+			expected: true,
+		},
+		{
+			name:     "local other computer",
+			hostname: "https://169.254.1.2:16443",
+			expected: true,
+		},
+		{
+			name:     "k3d",
+			hostname: "https://0.0.0.0",
+			expected: true,
+		},
+		{
+			name:     "docker",
+			hostname: "https://kubernetes.docker.internal:123",
+			expected: true,
+		},
+		{
+			name:     "localhost-ipv6-unicast",
+			hostname: "fe80::9656:d028:8652:66b6",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if isLocalHostname(tt.hostname) != tt.expected {
+				t.Fatal("not correct")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes

- Adds a new way of discovering if a host is local or not
- It ensures by net library that is not local or docker ip
- It works for ipv4 and ipv6
- tests with all the values that we have found on different distribution
