### PR TITLE
Fix initFromEnvVars to check first if OKTETO_URL or OKTETO_CONTEXT are set before setting the default value

### DIFF
--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -51,16 +51,8 @@ func (o *ContextOptions) initFromContext() {
 }
 
 func (o *ContextOptions) initFromEnvVars() {
-	okToken := os.Getenv("OKTETO_TOKEN")
 	if o.Token == "" {
-		o.Token = okToken
-	}
-
-	if o.Token != "" {
-		if o.Context == "" {
-			o.Context = okteto.CloudURL
-		}
-		o.Save = true
+		o.Token = os.Getenv("OKTETO_TOKEN")
 	}
 
 	if o.Context == "" && os.Getenv("OKTETO_URL") != "" {
@@ -70,6 +62,13 @@ func (o *ContextOptions) initFromEnvVars() {
 
 	if o.Context == "" && os.Getenv("OKTETO_CONTEXT") != "" {
 		o.Context = os.Getenv("OKTETO_CONTEXT")
+		o.Save = true
+	}
+
+	if o.Token != "" {
+		if o.Context == "" {
+			o.Context = okteto.CloudURL
+		}
 		o.Save = true
 	}
 

--- a/cmd/context/options_test.go
+++ b/cmd/context/options_test.go
@@ -194,6 +194,28 @@ func Test_initFromEnvVars(t *testing.T) {
 			},
 		},
 		{
+			name: "context-notin-options-with-token-in-options-and-with-envar-url",
+			in: &ContextOptions{
+				Token: "token",
+			},
+			env: map[string]string{"OKTETO_URL": "okteto-url"},
+			want: &ContextOptions{
+				Token:   "token",
+				Context: "okteto-url",
+				Save:    true,
+			},
+		},
+		{
+			name: "context-notin-options-and-with-envar-url-and-token",
+			in:   &ContextOptions{},
+			env:  map[string]string{"OKTETO_URL": "okteto-url", "OKTETO_TOKEN": "token-envvar"},
+			want: &ContextOptions{
+				Token:   "token-envvar",
+				Context: "okteto-url",
+				Save:    true,
+			},
+		},
+		{
 			name: "namespace-in-options-no-envar",
 			in: &ContextOptions{
 				Namespace: "namespace",


### PR DESCRIPTION
Signed-off-by: Nacho Fuertes <nacho@okteto.com>

Fixes #1857

## Proposed changes

- Check first if `OKTETO_URL` or `OKTETO_CONTEXT` environment variables are set before setting the default value
