### PR TITLE
Disable fsync on remote to improve disk performance

### DIFF
--- a/pkg/k8s/secrets/configXML.go
+++ b/pkg/k8s/secrets/configXML.go
@@ -34,6 +34,7 @@ const configXML = `<configuration version="32">
     <order>random</order>
     <ignoreDelete>false</ignoreDelete>
     <scanProgressIntervalS>1</scanProgressIntervalS>
+    <disableFsync>true</disableFsync>
     <pullerPauseS>0</pullerPauseS>
     <maxConflicts>0</maxConflicts>
     <disableSparseFiles>false</disableSparseFiles>


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes

[Disable syncthing fsync](https://docs.syncthing.net/advanced/folder-disable-fsync.html) on the dev container. This is safe because the source of true is the local filesystem, and improves disk performance on network filesystems
