### PR TITLE
No need to create okteto cloud before using it

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -83,6 +83,10 @@ func UseContext(ctx context.Context, ctxOptions *ContextOptions) error {
 		ctxOptions.isOkteto = true
 	}
 
+	if ctxOptions.Context == okteto.CloudURL {
+		ctxOptions.isOkteto = true
+	}
+
 	if !ctxOptions.isOkteto {
 		if !isValidCluster(ctxOptions.Context) {
 			log.Fail("%s: invalid okteto context", ctxOptions.Context)

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -56,7 +57,7 @@ Or show a list of available contexts with:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			if len(args) == 1 {
-				ctxOptions.Context = args[0]
+				ctxOptions.Context = strings.TrimSuffix(args[0], "/")
 			}
 
 			ctxOptions.isCtxCommand = true


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

No need to create Okteto Cloud context before using it

## Proposed changes
- Adds the ability to run `okteto context use https://cloud.okteto.com` without the need to run `okteto context create https://cloud.okteto.com`
-
