### PR TITLE
Don't show login/namespace command in help messages

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -27,9 +27,10 @@ import (
 func Login() *cobra.Command {
 	token := ""
 	cmd := &cobra.Command{
-		Use:   "login [url]",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#login"),
-		Short: "Log into Okteto",
+		Hidden: true,
+		Use:    "login [url]",
+		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#login"),
+		Short:  "Log into Okteto",
 		Long: `Log into Okteto
 
 Run

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -27,9 +27,10 @@ import (
 // Namespace fetch credentials for a cluster namespace
 func Namespace(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "namespace [name]",
-		Short: "Download k8s credentials for a namespace",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#namespace"),
+		Use:    "namespace [name]",
+		Hidden: true,
+		Short:  "Download k8s credentials for a namespace",
+		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#namespace"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			namespace := ""


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes

Don't show login/namespace command in help messages. We don't show deprecated messages yet, but it's very confusing to find different commands to do the same thing (or similar) when running `okteto --help`