### PR TITLE
Add "withArg" to the `okteto namespace` track event

### DIFF
--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -55,7 +55,7 @@ func Namespace(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			analytics.TrackNamespace(err == nil)
+			analytics.TrackNamespace(err == nil, len(args) > 0)
 			return err
 		},
 	}

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -98,8 +98,11 @@ func TrackKubeconfig(success bool) {
 }
 
 // TrackNamespace sends a tracking event to mixpanel when the user changes a namespace
-func TrackNamespace(success bool) {
-	track(namespaceEvent, success, nil)
+func TrackNamespace(success, withArg bool) {
+	props := map[string]interface{}{
+		"withArg": withArg,
+	}
+	track(namespaceEvent, success, props)
 }
 
 // TrackCreateNamespace sends a tracking event to mixpanel when the creates a namespace


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes

This helps to understand how many people is using `okteto namespace` to switch between namespaces.