### PR TITLE
Force redeploy on "okteto up" if sync folders change

### DIFF
--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -16,6 +16,7 @@ package up
 import (
 	"bufio"
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -93,6 +94,15 @@ func addStignoreSecrets(dev *model.Dev) error {
 		)
 	}
 	dev.Metadata.Annotations[model.OktetoStignoreAnnotation] = fmt.Sprintf("%x", md5.Sum([]byte(output)))
+	return nil
+}
+
+func addSyncFieldHash(dev *model.Dev) error {
+	output, err := json.Marshal(dev.Sync)
+	if err != nil {
+		return err
+	}
+	dev.Metadata.Annotations[model.OktetoSyncAnnotation] = fmt.Sprintf("%x", md5.Sum([]byte(output)))
 	return nil
 }
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -144,6 +144,10 @@ func Up() *cobra.Command {
 				return err
 			}
 
+			if err := addSyncFieldHash(dev); err != nil {
+				return err
+			}
+
 			if _, ok := os.LookupEnv("OKTETO_AUTODEPLOY"); ok {
 				upOptions.AutoDeploy = true
 			}

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -145,6 +145,8 @@ const (
 	OktetoAutoCreateAnnotation = "dev.okteto.com/auto-create"
 	//OktetoRestartAnnotation indicates the dev pod must be recreated to pull the latest version of its image
 	OktetoRestartAnnotation = "dev.okteto.com/restart"
+	//OktetoSyncAnnotation indicates the hash of the sync folders to force redeployment
+	OktetoSyncAnnotation = "dev.okteto.com/sync"
 	//OktetoStignoreAnnotation indicates the hash of the stignore files to force redeployment
 	OktetoStignoreAnnotation = "dev.okteto.com/stignore"
 	//OktetoDivertLabel indicates the object is a diverted version


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Otherwise, changes like updating the `compression` or the `syncthing `verbosity` are ignored. Or even worse, `okteto up` might just not finish the first sync