### PR TITLE
Youngestdev/stack progress display

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -79,7 +79,7 @@ func askForOktetoURL() string {
 		clusterURL = ctxStore.CurrentContext
 	}
 
-	log.Question("Enter your Okteto URL [%s]:", clusterURL)
+	log.Question("Enter your Okteto URL [%s]: ", clusterURL)
 	fmt.Scanln(&clusterURL)
 
 	url, err := url.Parse(clusterURL)

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -74,5 +74,6 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.Wait, "wait", "", false, "wait until a minimum number of containers are in a ready state for every service")
 	cmd.Flags().BoolVarP(&options.NoCache, "no-cache", "", false, "do not use cache when building the image")
 	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", (10 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
+	cmd.Flags().StringVarP(&options.Progress, "progress", "", "tty", "show plain/tty build output (default \"tty\")")
 	return cmd
 }

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -53,6 +53,7 @@ type StackDeployOptions struct {
 	NoCache          bool
 	Timeout          time.Duration
 	ServicesToDeploy []string
+	Progress         string
 }
 
 // Deploy deploys a stack

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -133,6 +133,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 
 func buildServices(ctx context.Context, s *model.Stack, options *StackDeployOptions) (bool, error) {
 	hasBuiltSomething := false
+
 	for _, name := range options.ServicesToDeploy {
 		svc := s.Services[name]
 		if svc.Build == nil {
@@ -170,7 +171,7 @@ func buildServices(ctx context.Context, s *model.Stack, options *StackDeployOpti
 			NoCache:    options.NoCache,
 			CacheFrom:  svc.Build.CacheFrom,
 			BuildArgs:  buildArgs,
-			OutputMode: "tty",
+			OutputMode: options.Progress,
 		}
 		if err := build.Run(ctx, buildOptions); err != nil {
 			return hasBuiltSomething, err
@@ -215,7 +216,7 @@ func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, options *S
 				NoCache:    options.NoCache,
 				CacheFrom:  svc.Build.CacheFrom,
 				BuildArgs:  buildArgs,
-				OutputMode: "tty",
+				OutputMode: options.Progress,
 			}
 			if err := build.Run(ctx, buildOptions); err != nil {
 				return hasAddedAnyVolumeMounts, err


### PR DESCRIPTION
Fixes #1889 

## Proposed changes

- Include `--progress` flag to allow a user to choose between `tty` and `plain`.
-
