### PR TITLE
Save only on ctx commands

### DIFF
--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -47,6 +47,7 @@ This will prompt you to select one of your existing contexts or to create a new 
 			}
 
 			ctxOptions.isCtxCommand = true
+			ctxOptions.Save = true
 			err := Run(ctx, ctxOptions)
 			analytics.TrackContext(err == nil)
 			return err

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -57,6 +57,7 @@ If you need to automate authentication or if you don't want to use browser-based
 			ctxOptions.Context = okteto.AddSchema(ctxOptions.Context)
 			ctxOptions.Context = strings.TrimSuffix(ctxOptions.Context, "/")
 			ctxOptions.isOkteto = true
+			ctxOptions.Save = true
 
 			err := UseContext(ctx, ctxOptions)
 			analytics.TrackContext(err == nil)
@@ -121,8 +122,10 @@ func UseContext(ctx context.Context, ctxOptions *ContextOptions) error {
 			return err
 		}
 	}
-	if err := okteto.WriteOktetoContextConfig(); err != nil {
-		return err
+	if ctxOptions.Save {
+		if err := okteto.WriteOktetoContextConfig(); err != nil {
+			return err
+		}
 	}
 	if created && ctxOptions.isOkteto {
 		log.Success("Context '%s' created", okteto.RemoveSchema(ctxOptions.Context))

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -26,6 +26,7 @@ type ContextOptions struct {
 	Builder      string
 	OnlyOkteto   bool
 	Show         bool
+	Save         bool
 	isCtxCommand bool
 	isOkteto     bool
 }

--- a/cmd/context/use-namespace.go
+++ b/cmd/context/use-namespace.go
@@ -34,6 +34,7 @@ func UseNamespace() *cobra.Command {
 			ctxOptions.Namespace = args[0]
 			ctxOptions.Context = okteto.Context().Name
 			ctxOptions.Show = true
+			ctxOptions.Save = true
 			err := Run(ctx, ctxOptions)
 			analytics.TrackContextUseNamespace(err == nil)
 			if err != nil {

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -102,6 +102,7 @@ func Run(ctx context.Context, ctxOptions *ContextOptions) error {
 		ctxOptions.Context = oktetoContext
 		ctxStore.CurrentContext = oktetoContext
 		ctxOptions.Show = false
+		ctxOptions.Save = true
 	}
 
 	if err := UseContext(ctx, ctxOptions); err != nil {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- Save context only when its a context command
-
