### PR TITLE
Fix "login" command when context doesn't exist

### DIFF
--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -46,7 +46,7 @@ This will prompt you to select one of your existing contexts or to create a new 
 				ctxOptions.Context = args[0]
 			}
 
-			ctxOptions.isCtxCommand = true
+			ctxOptions.IsCtxCommand = true
 			ctxOptions.Save = true
 			err := Run(ctx, ctxOptions)
 			analytics.TrackContext(err == nil)

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -56,7 +56,8 @@ If you need to automate authentication or if you don't want to use browser-based
 			ctxOptions.Context = args[0]
 			ctxOptions.Context = okteto.AddSchema(ctxOptions.Context)
 			ctxOptions.Context = strings.TrimSuffix(ctxOptions.Context, "/")
-			ctxOptions.isOkteto = true
+			ctxOptions.IsOkteto = true
+			ctxOptions.IsCtxCommand = true
 			ctxOptions.Save = true
 
 			err := UseContext(ctx, ctxOptions)
@@ -64,6 +65,7 @@ If you need to automate authentication or if you don't want to use browser-based
 			if err != nil {
 				return err
 			}
+			log.Information("Run 'okteto context update-kubeconfig' to update your kubectl credentials")
 			return nil
 		},
 	}
@@ -78,19 +80,19 @@ func UseContext(ctx context.Context, ctxOptions *ContextOptions) error {
 
 	ctxStore := okteto.ContextStore()
 	if okCtx, ok := ctxStore.Contexts[ctxOptions.Context]; ok && okCtx.IsOkteto {
-		ctxOptions.isOkteto = true
+		ctxOptions.IsOkteto = true
 	}
 
 	if okCtx, ok := ctxStore.Contexts[okteto.AddSchema(ctxOptions.Context)]; ok && okCtx.IsOkteto {
 		ctxOptions.Context = okteto.AddSchema(ctxOptions.Context)
-		ctxOptions.isOkteto = true
+		ctxOptions.IsOkteto = true
 	}
 
 	if ctxOptions.Context == okteto.CloudURL {
-		ctxOptions.isOkteto = true
+		ctxOptions.IsOkteto = true
 	}
 
-	if !ctxOptions.isOkteto {
+	if !ctxOptions.IsOkteto {
 		if !isValidCluster(ctxOptions.Context) {
 			return errors.UserError{E: fmt.Errorf("invalid okteto context '%s'", ctxOptions.Context),
 				Hint: "Please run 'okteto context' to select one context"}
@@ -99,7 +101,7 @@ func UseContext(ctx context.Context, ctxOptions *ContextOptions) error {
 		transformedCtx := okteto.K8sContextToOktetoUrl(ctx, ctxOptions.Context, ctxOptions.Namespace)
 		if transformedCtx != ctxOptions.Context {
 			ctxOptions.Context = transformedCtx
-			ctxOptions.isOkteto = true
+			ctxOptions.IsOkteto = true
 		}
 	}
 
@@ -113,7 +115,7 @@ func UseContext(ctx context.Context, ctxOptions *ContextOptions) error {
 
 	ctxStore.CurrentContext = ctxOptions.Context
 
-	if ctxOptions.isOkteto {
+	if ctxOptions.IsOkteto {
 		if err := initOktetoContext(ctx, ctxOptions); err != nil {
 			return err
 		}
@@ -127,11 +129,11 @@ func UseContext(ctx context.Context, ctxOptions *ContextOptions) error {
 			return err
 		}
 	}
-	if created && ctxOptions.isOkteto {
+	if created && ctxOptions.IsOkteto {
 		log.Success("Context '%s' created", okteto.RemoveSchema(ctxOptions.Context))
 	}
 
-	if ctxOptions.isCtxCommand {
+	if ctxOptions.IsCtxCommand {
 		log.Success("Using context %s @ %s", okteto.Context().Namespace, okteto.RemoveSchema(ctxStore.CurrentContext))
 	}
 

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -27,12 +27,12 @@ type ContextOptions struct {
 	OnlyOkteto   bool
 	Show         bool
 	Save         bool
-	isCtxCommand bool
-	isOkteto     bool
+	IsCtxCommand bool
+	IsOkteto     bool
 }
 
 func (o *ContextOptions) initFromContext() {
-	if o.isCtxCommand {
+	if o.IsCtxCommand {
 		return
 	}
 	if o.Context != "" {
@@ -48,7 +48,7 @@ func (o *ContextOptions) initFromContext() {
 		if o.Namespace == "" {
 			o.Namespace = okCtx.Namespace
 		}
-		o.isOkteto = okCtx.IsOkteto
+		o.IsOkteto = okCtx.IsOkteto
 	}
 }
 
@@ -59,7 +59,7 @@ func (o *ContextOptions) initFromEnvVars() {
 
 	if o.Context == "" && os.Getenv("OKTETO_URL") != "" {
 		o.Context = os.Getenv("OKTETO_URL")
-		o.isOkteto = true
+		o.IsOkteto = true
 	}
 
 	if o.Context == "" && os.Getenv("OKTETO_CONTEXT") != "" {
@@ -67,7 +67,7 @@ func (o *ContextOptions) initFromEnvVars() {
 	}
 
 	if o.Token != "" {
-		o.isOkteto = true
+		o.IsOkteto = true
 		if o.Context == "" {
 			o.Context = okteto.CloudURL
 		}

--- a/cmd/context/options_test.go
+++ b/cmd/context/options_test.go
@@ -131,7 +131,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			want: &ContextOptions{
 				Token:    "token",
 				Context:  okteto.CloudURL,
-				isOkteto: true,
+				IsOkteto: true,
 			},
 		},
 		{
@@ -143,7 +143,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			want: &ContextOptions{
 				Token:    "token",
 				Context:  okteto.CloudURL,
-				isOkteto: true,
+				IsOkteto: true,
 			},
 		},
 		{
@@ -153,7 +153,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			want: &ContextOptions{
 				Token:    "token",
 				Context:  okteto.CloudURL,
-				isOkteto: true,
+				IsOkteto: true,
 			},
 		},
 		{
@@ -189,7 +189,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			env:  map[string]string{"OKTETO_URL": "okteto-url"},
 			want: &ContextOptions{
 				Context:  "okteto-url",
-				isOkteto: true,
+				IsOkteto: true,
 			},
 		},
 		{
@@ -201,7 +201,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			want: &ContextOptions{
 				Token:    "token",
 				Context:  "okteto-url",
-				isOkteto: true,
+				IsOkteto: true,
 			},
 		},
 		{
@@ -211,7 +211,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			want: &ContextOptions{
 				Token:    "token-envvar",
 				Context:  "okteto-url",
-				isOkteto: true,
+				IsOkteto: true,
 			},
 		},
 		{

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -62,7 +62,7 @@ Or a Kubernetes context:
 				ctxOptions.Context = strings.TrimSuffix(args[0], "/")
 			}
 
-			ctxOptions.isCtxCommand = true
+			ctxOptions.IsCtxCommand = true
 			ctxOptions.Save = true
 			err := Run(ctx, ctxOptions)
 			analytics.TrackContext(err == nil)
@@ -92,7 +92,7 @@ func Run(ctx context.Context, ctxOptions *ContextOptions) error {
 	}
 
 	if ctxOptions.Context == "" {
-		if !ctxOptions.isCtxCommand {
+		if !ctxOptions.IsCtxCommand {
 			log.Information("Okteto context is not initialized")
 		}
 		log.Infof("authenticating with interactive context")
@@ -116,7 +116,7 @@ func Run(ctx context.Context, ctxOptions *ContextOptions) error {
 		log.Information("Using %s @ %s as context", okteto.Context().Namespace, okteto.RemoveSchema(okteto.Context().Name))
 	}
 
-	if ctxOptions.isCtxCommand {
+	if ctxOptions.IsCtxCommand {
 		log.Information("Run 'okteto context update-kubeconfig' to update your kubectl credentials")
 	}
 	return nil
@@ -128,11 +128,11 @@ func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error)
 	if err != nil {
 		return "", err
 	}
-	ctxOptions.isOkteto = isOkteto
+	ctxOptions.IsOkteto = isOkteto
 
 	if isCreateNewContextOption(oktetoContext) {
 		oktetoContext = askForOktetoURL()
-		ctxOptions.isOkteto = true
+		ctxOptions.IsOkteto = true
 	}
 
 	return oktetoContext, nil

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -50,9 +50,8 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 				args[0] = okteto.AddSchema(args[0])
 				args[0] = strings.TrimSuffix(args[0], "/")
 			}
-			contextCommand := contextCMD.Context()
+			contextCommand := contextCMD.CreateCMD()
 			contextCommand.Flags().Set("token", token)
-			contextCommand.Flags().Set("okteto", "true")
 			err := contextCommand.RunE(cmd, args)
 			if err != nil {
 				analytics.TrackLogin(false)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -14,11 +14,13 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
@@ -46,16 +48,23 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			ctxOptions := contextCMD.ContextOptions{
+				IsCtxCommand: true,
+				IsOkteto:     true,
+				Save:         true,
+			}
 			if len(args) == 1 {
 				args[0] = okteto.AddSchema(args[0])
 				args[0] = strings.TrimSuffix(args[0], "/")
+				ctxOptions.Context = args[0]
 			}
-			contextCommand := contextCMD.CreateCMD()
-			contextCommand.Flags().Set("token", token)
-			err := contextCommand.RunE(cmd, args)
+
+			ctx := context.Background()
+			err := contextCMD.UseContext(ctx, &ctxOptions)
 			if err != nil {
 				analytics.TrackLogin(false)
 			} else {
+				log.Information("Run 'okteto context update-kubeconfig' to update your kubectl credentials")
 				analytics.TrackLogin(true)
 			}
 			return err


### PR DESCRIPTION
## Proposed changes

Also, unify output for "context create", "context use" and "login" commands