### PR TITLE
feat: add support for multi line env files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
+	github.com/compose-spec/godotenv v1.1.0
 	github.com/containerd/console v1.0.3
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/docker/cli v20.10.8+incompatible
@@ -38,7 +39,6 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.2.1
 	github.com/src-d/enry/v2 v2.1.0
-	github.com/subosito/gotenv v1.2.0
 	github.com/theupdateframework/notary v0.7.0 // indirect
 	github.com/vbauerster/mpb/v7 v7.1.5
 	github.com/whilp/git-urls v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20160425231609-f8ad88b59a58/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/compose-spec/godotenv v1.1.0 h1:wzShe5P6L/Aw3wsV357eWlZdMcPaOe2V2+3+qGwMEL4=
+github.com/compose-spec/godotenv v1.1.0/go.mod h1:zF/3BOa18Z24tts5qnO/E9YURQanJTBUf7nlcCTNsyc=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59/go.mod h1:pA0z1pT8KYB3TCXK/ocprsh7MAkoW8bZVzPdih9snmM=
 github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340 h1:9atoWyI9RtXFwf7UDbme/6M8Ud0rFrx+Q3ZWgSnsxtw=

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -22,13 +22,13 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/compose-spec/godotenv"
 	"github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
-	"github.com/subosito/gotenv"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -92,7 +92,7 @@ func translateServiceEnvFile(ctx context.Context, svc *model.Service, svcName, f
 	}
 	defer f.Close()
 
-	envMap, err := gotenv.StrictParse(f)
+	envMap, err := godotenv.ParseWithLookup(f, os.LookupEnv)
 	if err != nil {
 		return fmt.Errorf("error parsing env_file %s: %s", filename, err.Error())
 	}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -40,7 +40,12 @@ const (
 
 B=$B
 
-C=3`
+C=3
+
+D="4
+5 $B
+\"6\"
+'7'"`
 )
 
 func Test_translate(t *testing.T) {
@@ -91,7 +96,7 @@ func Test_translateEnvVars(t *testing.T) {
 	if stack.Services["1"].Image != "image" {
 		t.Errorf("Wrong image: %s", stack.Services["1"].Image)
 	}
-	if len(stack.Services["1"].Environment) != 3 {
+	if len(stack.Services["1"].Environment) != 4 {
 		t.Errorf("Wrong environment: %v", stack.Services["1"].Environment)
 	}
 	for _, e := range stack.Services["1"].Environment {
@@ -103,6 +108,9 @@ func Test_translateEnvVars(t *testing.T) {
 		}
 		if e.Name == "C" && e.Value != "original" {
 			t.Errorf("Wrong environment variable C: %s", e.Value)
+		}
+		if e.Name == "D" && e.Value != "4\n5 2\n\"6\"\n'7'" {
+			t.Errorf("Wrong environment variable D: %s", e.Value)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Javier Provecho Fernández (Okteto) <92427625+jpf-okteto@users.noreply.github.com>

Fixes:
- https://github.com/okteto/okteto/issues/1941.

https://gist.github.com/jpf-okteto/f1842e62a9f64651a1921ffe3c851d63

## Proposed changes

- Replace [`github.com/subosito/gotenv`](https://github.com/subosito/gotenv) with [`github.com/compose-spec/godotenv`](https://github.com/compose-spec/godotenv) (Compose's fork of [`github.com/joho/godotenv`](https://github.com/joho/godotenv).