### PR TITLE
Add check for namespace access

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -122,6 +122,17 @@ func UseContext(ctx context.Context, ctxOptions *ContextOptions) error {
 			return err
 		}
 	}
+	if ctxOptions.isOkteto && ctxOptions.Save {
+		hasAccess, err := utils.HasAccessToNamespace(ctx, ctxOptions.Namespace)
+		if err != nil {
+			return err
+		}
+		if !hasAccess {
+			return errors.UserError{E: fmt.Errorf("namespace '%s' not found on context '%s'", ctxOptions.Namespace, ctxOptions.Context),
+				Hint: "Please verify that the namespace exists and that you have access to it.",
+			}
+		}
+	}
 	if ctxOptions.Save {
 		if err := okteto.WriteOktetoContextConfig(); err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com> 

## Proposed changes
- Check if the user has access to the namespace ONLY when there is a command that saves context
-
