### PR TITLE
Make the OKTETO_URL configurable in integration tests

### DIFF
--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -632,9 +632,13 @@ func executeLoginAction(ctx context.Context) error {
 	log.Printf("cloned repo %s \n", actionRepo)
 	defer deleteGitRepo(ctx, actionFolder)
 
-	log.Printf("login into %s", okteto.CloudURL)
+	oktetoURL := os.Getenv("OKTETO_URL")
+	if oktetoURL == "" {
+		oktetoURL = okteto.CloudURL
+	}
+	log.Printf("login into %s", oktetoURL)
 	command := fmt.Sprintf("%s/entrypoint.sh", actionFolder)
-	args := []string{token, okteto.CloudURL}
+	args := []string{token, oktetoURL}
 	cmd := exec.Command(command, args...)
 	cmd.Env = os.Environ()
 	o, err := cmd.CombinedOutput()
@@ -660,9 +664,13 @@ func executeContextAction(ctx context.Context) error {
 	log.Printf("cloned repo %s \n", actionRepo)
 	defer deleteGitRepo(ctx, actionFolder)
 
-	log.Printf("login into %s", okteto.CloudURL)
+	oktetoURL := os.Getenv("OKTETO_URL")
+	if oktetoURL == "" {
+		oktetoURL = okteto.CloudURL
+	}
+	log.Printf("login into %s", oktetoURL)
 	command := fmt.Sprintf("%s/entrypoint.sh", actionFolder)
-	args := []string{token, okteto.CloudURL}
+	args := []string{token, oktetoURL}
 	cmd := exec.Command(command, args...)
 	cmd.Env = os.Environ()
 	o, err := cmd.CombinedOutput()

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -68,7 +68,7 @@ func TestPush(t *testing.T) {
 
 		log.Printf("pushed using %s \n", pushManifest)
 
-		endpoint := fmt.Sprintf("https://react-getting-started-%s.cloud.okteto.net", namespace)
+		endpoint := fmt.Sprintf("https://react-getting-started-%s.%s", namespace, appsSubdomain)
 		content, err := getContent(endpoint, 150, nil)
 		if err != nil {
 			t.Fatalf("failed to get app content: %s", err)
@@ -83,7 +83,7 @@ func TestPush(t *testing.T) {
 			t.Fatalf("error getting 'react-getting-started' deployment: %s", err.Error())
 		}
 
-		imageName := fmt.Sprintf("registry.cloud.okteto.net/%s/react-getting-started:okteto", namespace)
+		imageName := fmt.Sprintf("registry.%s/%s/react-getting-started:okteto", appsSubdomain, namespace)
 		if d.Spec.Template.Spec.Containers[0].Image != imageName {
 			t.Fatalf("wrong image built for okteto push: expected '%s', got '%s'", imageName, d.Spec.Template.Spec.Containers[0].Image)
 		}

--- a/integration/stacks_test.go
+++ b/integration/stacks_test.go
@@ -73,7 +73,7 @@ func TestStacks(t *testing.T) {
 
 		log.Printf("deployed stack using %s\n", stackManifest)
 
-		endpoint := fmt.Sprintf("https://vote-%s.cloud.okteto.net", namespace)
+		endpoint := fmt.Sprintf("https://vote-%s.%s", namespace, appsSubdomain)
 		content, err := getContent(endpoint, 150, nil)
 		if err != nil {
 			t.Fatalf("failed to get stack content: %s", err)
@@ -183,13 +183,13 @@ func TestCompose(t *testing.T) {
 
 	log.Printf("deployed stack using %s \n", "docker-compose.yml")
 
-	jobEndpoint := fmt.Sprintf("https://nginx-%s.cloud.okteto.net/db/initialized", namespace)
+	jobEndpoint := fmt.Sprintf("https://nginx-%s.%s/db/initialized", namespace, appsSubdomain)
 	content, err := getContent(jobEndpoint, 150, nil)
 	if err != nil {
 		t.Fatalf("failed to get stack content: %s", err)
 	}
 
-	endpoint := fmt.Sprintf("https://nginx-%s.cloud.okteto.net/db", namespace)
+	endpoint := fmt.Sprintf("https://nginx-%s.%s/db", namespace, appsSubdomain)
 	content, err = getContent(endpoint, 150, nil)
 	if err != nil {
 		t.Fatalf("failed to get stack content: %s", err)

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -591,7 +591,7 @@ func TestDivert(t *testing.T) {
 	defer showUpLogs(name, namespace, t)
 
 	apiSvc := "catalog-chart"
-	originalContent, err := getContent(fmt.Sprintf("https://%s-%s.cloud.okteto.net/data", apiSvc, namespace), 150, upErrorChannel)
+	originalContent, err := getContent(fmt.Sprintf("https://%s-%s.%s/data", apiSvc, namespace, appsSubdomain), 150, upErrorChannel)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -672,7 +672,7 @@ func showUpLogs(name, namespace string, t *testing.T) {
 func waitForDivertedContent(originalContent, namespace, apiSvc string, upErrorChannel chan error, timeout int) error {
 	for i := 0; i < timeout; i++ {
 		apiDivertedSvc := fmt.Sprintf("%s-%s", apiSvc, user)
-		divertedContent, err := getContent(fmt.Sprintf("https://%s-%s.cloud.okteto.net/data", apiDivertedSvc, namespace), 3, upErrorChannel)
+		divertedContent, err := getContent(fmt.Sprintf("https://%s-%s.%s/data", apiDivertedSvc, namespace, appsSubdomain), 3, upErrorChannel)
 		if err != nil {
 			continue
 		}

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -38,6 +38,7 @@ type deployment struct {
 var (
 	user          = ""
 	kubectlBinary = "kubectl"
+	appsSubdomain = "cloud.okteto.net"
 )
 
 func TestMain(m *testing.M) {
@@ -46,6 +47,10 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	} else {
 		user = u
+	}
+
+	if v := os.Getenv("OKTETO_APPS_SUBDOMAIN"); v != "" {
+		appsSubdomain = v
 	}
 
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes

This makes it possible to run Okteto CLI integration tests on different environments