### PR TITLE
Solves #1966. Disable HTTP/2 when a SPDY request is detected in the okteto deploy proxy

### DIFF
--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -32,6 +32,7 @@ import (
 const (
 	parallelism int64 = 10
 	volumeKind        = "PersistentVolumeClaim"
+	jobKind           = "Job"
 )
 
 // DeleteAllOptions options for delete all operation
@@ -103,6 +104,13 @@ func (n *Namespaces) DestroyWithLabel(ctx context.Context, ns string, opts Delet
 			return err
 		}
 		deleteOpts := metav1.DeleteOptions{}
+
+		// It seems that by default, client-go don't delete pods scheduled by jobs, so we need to set the propation policy
+		if gvk.Kind == jobKind {
+			deletePropagation := metav1.DeletePropagationBackground
+			deleteOpts.PropagationPolicy = &deletePropagation
+		}
+
 		err = n.dynClient.
 			Resource(mapping.Resource).
 			Namespace(ns).


### PR DESCRIPTION
Signed-off-by: Nacho Fuertes <nacho@okteto.com>

Fixes #1966 

## Proposed changes

- When a SPDY request is detected in the proxy, I create a reverse proxy with HTTP/2 disabled and forward the request using that proxy. By default, the TLS config for *rest.Config uses HTTP/2 first which is incompatible with SPDY
