### PR TITLE
Jdm/stack healthcheck marshaling

### DIFF
--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -490,7 +490,6 @@ func validateHealthcheck(healthcheck *HealthCheck) error {
 }
 
 func translateHealtcheckCurlToHTTP(healthcheck *HealthCheck) {
-	fmt.Printf("HC %+v\n", healthcheck)
 	// Join and then split the strings by space to ensure that
 	// each element in the string slice is a contiguous string with
 	// no spaces.
@@ -527,14 +526,11 @@ func translateHealtcheckCurlToHTTP(healthcheck *HealthCheck) {
 	}
 
 	if checkURL == nil {
-		fmt.Println("NOT FOUND")
 		return
 	}
 
-	fmt.Printf("URL FOUND: %+v\n", checkURL)
 	p := checkURL.Port()
 	if p == "" {
-		fmt.Println("PORT")
 		return
 	}
 	port, err := strconv.Atoi(p)
@@ -551,7 +547,6 @@ func translateHealtcheckCurlToHTTP(healthcheck *HealthCheck) {
 
 	healthcheck.HTTP = &HTTPHealtcheck{Path: path, Port: int32(port)}
 	healthcheck.Test = make(HealtcheckTest, 0)
-	fmt.Printf("NEXT %+v\n", healthcheck)
 }
 
 func getSvcPorts(public bool, rawPorts, rawExpose []PortRaw) (bool, []Port, error) {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -15,7 +15,7 @@ package model
 
 import (
 	"fmt"
-	"regexp"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -490,45 +490,68 @@ func validateHealthcheck(healthcheck *HealthCheck) error {
 }
 
 func translateHealtcheckCurlToHTTP(healthcheck *HealthCheck) {
-	localPortTestRegex := `^curl ((-f|--fail) )?'?((http|https)://)?(localhost|0.0.0.0):\d+(\/\w*)?'?$`
-	regexp, err := regexp.Compile(localPortTestRegex)
+	fmt.Printf("HC %+v\n", healthcheck)
+	// Join and then split the strings by space to ensure that
+	// each element in the string slice is a contiguous string with
+	// no spaces.
+	s := strings.Join(healthcheck.Test, " ")
+	testStrings := strings.Split(s, " ")
+
+	// There should be at least two strings, the curl binary and url.
+	if len(testStrings) < 2 {
+		return
+	}
+
+	if testStrings[0] != "curl" {
+		return
+	}
+
+	var checkURL *url.URL
+	for _, possibleURL := range testStrings[1:] {
+		if possibleURL == "-f" || possibleURL == "--fail" {
+			continue
+		}
+
+		u, err := url.ParseRequestURI(possibleURL)
+		// It's possible to have a healthcheck url without the scheme. If
+		// that happens then we inject one and attempt parsing again.
+		if err != nil || u.Host == "" {
+			u, err = url.ParseRequestURI("https://" + possibleURL)
+			if err != nil {
+				u = nil
+				continue
+			}
+		}
+		checkURL = u
+		break
+	}
+
+	if checkURL == nil {
+		fmt.Println("NOT FOUND")
+		return
+	}
+
+	fmt.Printf("URL FOUND: %+v\n", checkURL)
+	p := checkURL.Port()
+	if p == "" {
+		fmt.Println("PORT")
+		return
+	}
+	port, err := strconv.Atoi(p)
 	if err != nil {
 		return
 	}
-	testString := strings.Join(healthcheck.Test, " ")
-	if regexp.MatchString(testString) {
-		var firstSlashIndex, portStart int
-		if strings.Contains(testString, "://") {
-			testStringCopy := testString
-			for i := 0; i < 3; i++ {
-				firstSlashIndex += strings.Index(testStringCopy[firstSlashIndex:], "/") + 1
-			}
-			testStringCopy = testString
-			for i := 0; i < 2; i++ {
-				portStart += strings.Index(testStringCopy[portStart:], ":") + 1
-			}
-			portStart--
-			firstSlashIndex--
-		} else {
-			firstSlashIndex = strings.Index(testString, "/")
-			portStart = strings.Index(testString, ":")
-		}
 
-		var port, path string
-		if firstSlashIndex != -1 {
-			port = testString[portStart+1 : firstSlashIndex]
-			path = testString[firstSlashIndex:]
-		} else {
-			port = testString[portStart+1:]
-			path = "/"
-		}
-		p, err := strconv.Atoi(port)
-		if err != nil {
-			return
-		}
-		healthcheck.HTTP = &HTTPHealtcheck{Path: path, Port: int32(p)}
-		healthcheck.Test = make(HealtcheckTest, 0)
+	var path string
+	if checkURL.Path == "" {
+		path = "/"
+	} else {
+		path = checkURL.Path
 	}
+
+	healthcheck.HTTP = &HTTPHealtcheck{Path: path, Port: int32(port)}
+	healthcheck.Test = make(HealtcheckTest, 0)
+	fmt.Printf("NEXT %+v\n", healthcheck)
 }
 
 func getSvcPorts(public bool, rawPorts, rawExpose []PortRaw) (bool, []Port, error) {


### PR DESCRIPTION
Fixes #1974 

I've attempted to swap out the regex and manual parsing of the curl healthchecks for stack manifests. This works on the existing test cases. I added another set of test cases that is closer to this logic and doesn't use the yaml parsing sections. If we like this I'm going to go back through and make sure I test all the known edge cases in both spots.