### PR TITLE
Fix "operation was canceled" retriable error

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -175,7 +175,7 @@ func IsTransient(err error) bool {
 		strings.Contains(err.Error(), "in the time allotted"),
 		strings.Contains(err.Error(), "broken pipe"),
 		strings.Contains(err.Error(), "No connection could be made"),
-		strings.Contains(err.Error(), "dial tcp: operation was canceled"),
+		strings.Contains(err.Error(), "operation was canceled"),
 		strings.Contains(err.Error(), "network is unreachable"),
 		strings.Contains(err.Error(), "development container has been removed"):
 		return true


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

A customer is reporting that this error isn't retried when his laptop goes to sleep:
```
failed to connect to the ssh server: dial tcp 0.0.0.0:22001: operation was canceled
```