### PR TITLE
test: revert #1972 (f5de696)

### DIFF
--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -535,7 +535,6 @@ func TestUpStatefulset(t *testing.T) {
 }
 
 func TestDivert(t *testing.T) {
-	t.Skip("This test is not required until fixing nginx rules")
 	tName := fmt.Sprintf("Test")
 	ctx := context.Background()
 	oktetoPath, err := getOktetoPath(ctx)


### PR DESCRIPTION
This PR re-enables divert integration test.

Reverted pr:
- https://github.com/okteto/okteto/pull/1972

Reverted commit:
- https://github.com/okteto/okteto/commit/f5de696e6c994868f553dd6efcf00a143cbcf97a