### PR TITLE
Use https://contrib.rocks to keep track of contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,51 +75,13 @@ Follow [@OktetoHQ](https://twitter.com/oktetohq) on Twitter for important announ
 
 We use GitHub [issues](https://github.com/okteto/okteto/issues) to track our roadmap. A [milestone](https://github.com/okteto/okteto/milestones) is created every month to track the work scheduled for that time period. Feedback and help are always appreciated!
 
-## Contributions
+## ✨  Contributions
 
 We ❤️ contributions big or small. [See our guide](contributing.md) on how to get started.
 
 ### Thanks to all our contributors!
 
-[//]: contributor-faces
-
-<a href="https://github.com/pchico83"><img src="https://avatars.githubusercontent.com/u/7474696?v=4" title="pchico83" width="80" height="80"></a>
-<a href="https://github.com/rberrelleza"><img src="https://avatars.githubusercontent.com/u/475313?v=4" title="rberrelleza" width="80" height="80"></a>
-<a href="https://github.com/jLopezbarb"><img src="https://avatars.githubusercontent.com/u/25170843?v=4" title="jLopezbarb" width="80" height="80"></a>
-<a href="https://github.com/apps/dependabot"><img src="https://avatars.githubusercontent.com/in/29110?v=4" title="dependabot[bot]" width="80" height="80"></a>
-<a href="https://github.com/jbampton"><img src="https://avatars.githubusercontent.com/u/418747?v=4" title="jbampton" width="80" height="80"></a>
-<a href="https://github.com/teresaromero"><img src="https://avatars.githubusercontent.com/u/40767058?v=4" title="teresaromero" width="80" height="80"></a>
-<a href="https://github.com/ifbyol"><img src="https://avatars.githubusercontent.com/u/3510171?v=4" title="ifbyol" width="80" height="80"></a>
-<a href="https://github.com/rlamana"><img src="https://avatars.githubusercontent.com/u/237819?v=4" title="rlamana" width="80" height="80"></a>
-<a href="https://github.com/irespaldiza"><img src="https://avatars.githubusercontent.com/u/11633327?v=4" title="irespaldiza" width="80" height="80"></a>
-<a href="https://github.com/jmacelroy"><img src="https://avatars.githubusercontent.com/u/30531294?v=4" title="jmacelroy" width="80" height="80"></a>
-<a href="https://github.com/marco2704"><img src="https://avatars.githubusercontent.com/u/12150248?v=4" title="marco2704" width="80" height="80"></a>
-<a href="https://github.com/Youngestdev"><img src="https://avatars.githubusercontent.com/u/31009679?v=4" title="Youngestdev" width="80" height="80"></a>
-<a href="https://github.com/adhaamehab"><img src="https://avatars.githubusercontent.com/u/13816742?v=4" title="adhaamehab" width="80" height="80"></a>
-<a href="https://github.com/danielhelfand"><img src="https://avatars.githubusercontent.com/u/34258252?v=4" title="danielhelfand" width="80" height="80"></a>
-<a href="https://github.com/glensc"><img src="https://avatars.githubusercontent.com/u/199095?v=4" title="glensc" width="80" height="80"></a>
-<a href="https://github.com/jpf-okteto"><img src="https://avatars.githubusercontent.com/u/92427625?v=4" title="jpf-okteto" width="80" height="80"></a>
-<a href="https://github.com/kivi"><img src="https://avatars.githubusercontent.com/u/366163?v=4" title="kivi" width="80" height="80"></a>
-<a href="https://github.com/aguthrie"><img src="https://avatars.githubusercontent.com/u/210097?v=4" title="aguthrie" width="80" height="80"></a>
-<a href="https://github.com/alanmbarr"><img src="https://avatars.githubusercontent.com/u/760506?v=4" title="alanmbarr" width="80" height="80"></a>
-<a href="https://github.com/AnesBenmerzoug"><img src="https://avatars.githubusercontent.com/u/27914730?v=4" title="AnesBenmerzoug" width="80" height="80"></a>
-<a href="https://github.com/Berreek"><img src="https://avatars.githubusercontent.com/u/20483152?v=4" title="Berreek" width="80" height="80"></a>
-<a href="https://github.com/borjaburgos"><img src="https://avatars.githubusercontent.com/u/3640206?v=4" title="borjaburgos" width="80" height="80"></a>
-<a href="https://github.com/Cirrith"><img src="https://avatars.githubusercontent.com/u/4418305?v=4" title="Cirrith" width="80" height="80"></a>
-<a href="https://github.com/ironcladlou"><img src="https://avatars.githubusercontent.com/u/298299?v=4" title="ironcladlou" width="80" height="80"></a>
-<a href="https://github.com/unthought"><img src="https://avatars.githubusercontent.com/u/1222558?v=4" title="unthought" width="80" height="80"></a>
-<a href="https://github.com/drodriguezhdez"><img src="https://avatars.githubusercontent.com/u/29516565?v=4" title="drodriguezhdez" width="80" height="80"></a>
-<a href="https://github.com/snitkdan"><img src="https://avatars.githubusercontent.com/u/15274429?v=4" title="snitkdan" width="80" height="80"></a>
-<a href="https://github.com/Juneezee"><img src="https://avatars.githubusercontent.com/u/20135478?v=4" title="Juneezee" width="80" height="80"></a>
-<a href="https://github.com/fermayo"><img src="https://avatars.githubusercontent.com/u/3635457?v=4" title="fermayo" width="80" height="80"></a>
-<a href="https://github.com/maroshii"><img src="https://avatars.githubusercontent.com/u/1316984?v=4" title="maroshii" width="80" height="80"></a>
-<a href="https://github.com/dekkers"><img src="https://avatars.githubusercontent.com/u/656182?v=4" title="dekkers" width="80" height="80"></a>
-<a href="https://github.com/thatnerdjosh"><img src="https://avatars.githubusercontent.com/u/5251847?v=4" title="thatnerdjosh" width="80" height="80"></a>
-<a href="https://github.com/freeman"><img src="https://avatars.githubusercontent.com/u/7547?v=4" title="freeman" width="80" height="80"></a>
-<a href="https://github.com/tommyto-whs"><img src="https://avatars.githubusercontent.com/u/59745049?v=4" title="tommyto-whs" width="80" height="80"></a>
-<a href="https://github.com/Wignesh"><img src="https://avatars.githubusercontent.com/u/26745858?v=4" title="Wignesh" width="80" height="80"></a>
-<a href="https://github.com/zdog234"><img src="https://avatars.githubusercontent.com/u/17930657?v=4" title="zdog234" width="80" height="80"></a>
-<a href="https://github.com/marov"><img src="https://avatars.githubusercontent.com/u/1968182?v=4" title="marov" width="80" height="80"></a>
-<a href="https://github.com/xinxinh2020"><img src="https://avatars.githubusercontent.com/u/13103635?v=4" title="xinxinh2020" width="80" height="80"></a>
-
-[//]: contributor-faces
+<a href="https://github.com/okteto/okteto/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=okteto/okteto" />
+</a>
+<!--  https://contrib.rocks -->

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Follow [@OktetoHQ](https://twitter.com/oktetohq) on Twitter for important announ
 
 We use GitHub [issues](https://github.com/okteto/okteto/issues) to track our roadmap. A [milestone](https://github.com/okteto/okteto/milestones) is created every month to track the work scheduled for that time period. Feedback and help are always appreciated!
 
-## ✨  Contributions
+## ✨ Contributions
 
 We ❤️ contributions big or small. [See our guide](contributing.md) on how to get started.
 


### PR DESCRIPTION
## Proposed changes

- Use a contrib.rocks link so we don't have to manually update the list every time.