### PR TITLE
Solves #2003. Add specific code to delete volumes created by statefulsets when an okteto destroy is executed

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -289,6 +289,7 @@ func getProxyHandler(name, token string, clusterConfig *rest.Config) (http.Handl
 				return
 			}
 
+			defer r.Body.Close()
 			if len(b) == 0 {
 				reverseProxy.ServeHTTP(rw, r)
 				return

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -99,7 +99,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			// Look for a free local port to start the proxy
 			port, err := model.GetAvailablePort("localhost")
 			if err != nil {
-				log.Errorf("could not find a free port to start proxy server: %s", err)
+				log.Infof("could not find a free port to start proxy server: %s", err)
 				return err
 			}
 			log.Debugf("found available port %d", port)
@@ -107,7 +107,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			// TODO for now, using self-signed certificates
 			cert, err := tls.X509KeyPair(cert, key)
 			if err != nil {
-				log.Errorf("could not read certificate: %s", err)
+				log.Infof("could not read certificate: %s", err)
 				return err
 			}
 
@@ -117,13 +117,13 @@ func Deploy(ctx context.Context) *cobra.Command {
 			kubeconfig := newKubeConfig()
 			clusterConfig, err := kubeconfig.Read()
 			if err != nil {
-				log.Errorf("could not read kubeconfig file: %s", err)
+				log.Infof("could not read kubeconfig file: %s", err)
 				return err
 			}
 
 			handler, err := getProxyHandler(options.Name, sessionToken, clusterConfig)
 			if err != nil {
-				log.Errorf("could not configure local proxy: %s", err)
+				log.Infof("could not configure local proxy: %s", err)
 				return err
 			}
 
@@ -167,14 +167,14 @@ func Deploy(ctx context.Context) *cobra.Command {
 func (dc *deployCommand) runDeploy(ctx context.Context, cwd string, opts *Options) error {
 	log.Debugf("creating temporal kubeconfig file '%s'", dc.tempKubeconfigFile)
 	if err := dc.kubeconfig.Modify(dc.proxy.GetPort(), dc.proxy.GetToken(), dc.tempKubeconfigFile); err != nil {
-		log.Errorf("could not create temporal kubeconfig %s", err)
+		log.Infof("could not create temporal kubeconfig %s", err)
 		return err
 	}
 
 	// Read manifest file with the commands to be executed
 	manifest, err := dc.getManifest(cwd, opts.Name, opts.ManifestPath)
 	if err != nil {
-		log.Errorf("could not find manifest file to be executed: %s", err)
+		log.Infof("could not find manifest file to be executed: %s", err)
 		return err
 	}
 
@@ -194,7 +194,7 @@ func (dc *deployCommand) runDeploy(ctx context.Context, cwd string, opts *Option
 
 	for _, command := range manifest.Deploy {
 		if err := dc.executor.Execute(command, opts.Variables); err != nil {
-			log.Errorf("error executing command '%s': %s", command, err.Error())
+			log.Infof("error executing command '%s': %s", command, err.Error())
 			return err
 		}
 	}
@@ -205,12 +205,12 @@ func (dc *deployCommand) runDeploy(ctx context.Context, cwd string, opts *Option
 func (dc *deployCommand) cleanUp(ctx context.Context) {
 	log.Debugf("removing temporal kubeconfig file '%s'", dc.tempKubeconfigFile)
 	if err := os.Remove(dc.tempKubeconfigFile); err != nil {
-		log.Errorf("could not remove temporal kubeconfig file: %s", err)
+		log.Infof("could not remove temporal kubeconfig file: %s", err)
 	}
 
 	log.Debugf("stopping local server...")
 	if err := dc.proxy.Shutdown(ctx); err != nil {
-		log.Errorf("could not stop local server: %s", err)
+		log.Infof("could not stop local server: %s", err)
 	}
 }
 
@@ -234,7 +234,7 @@ func getProxyHandler(name, token string, clusterConfig *rest.Config) (http.Handl
 	// By default we don't disable HTTP/2
 	trans, err := newProtocolTransport(clusterConfig, false)
 	if err != nil {
-		log.Errorf("could not get http transport from config: %s", err)
+		log.Infof("could not get http transport from config: %s", err)
 		return nil, err
 	}
 
@@ -272,7 +272,7 @@ func getProxyHandler(name, token string, clusterConfig *rest.Config) (http.Handl
 			// In case of a SPDY request, we create a new proxy with HTTP/2 disabled
 			t, err := newProtocolTransport(clusterConfig, true)
 			if err != nil {
-				log.Errorf("could not disabled HTTP/2: %s", err)
+				log.Infof("could not disabled HTTP/2: %s", err)
 				rw.WriteHeader(500)
 				return
 			}
@@ -284,7 +284,7 @@ func getProxyHandler(name, token string, clusterConfig *rest.Config) (http.Handl
 		if r.Method == "PUT" || r.Method == "POST" {
 			b, err := io.ReadAll(r.Body)
 			if err != nil {
-				log.Errorf("could not read the request body: %s", err)
+				log.Infof("could not read the request body: %s", err)
 				rw.WriteHeader(500)
 				return
 			}
@@ -297,21 +297,21 @@ func getProxyHandler(name, token string, clusterConfig *rest.Config) (http.Handl
 
 			var body map[string]json.RawMessage
 			if err := json.Unmarshal(b, &body); err != nil {
-				log.Errorf("could not unmarshal request: %s", err)
+				log.Infof("could not unmarshal request: %s", err)
 				rw.WriteHeader(500)
 				return
 			}
 
 			m, ok := body["metadata"]
 			if !ok {
-				log.Error("request body doesn't have metadata field")
+				log.Info("request body doesn't have metadata field")
 				rw.WriteHeader(500)
 				return
 			}
 
 			var metadata metav1.ObjectMeta
 			if err := json.Unmarshal(m, &metadata); err != nil {
-				log.Errorf("could not process resource's metadata: %s", err)
+				log.Infof("could not process resource's metadata: %s", err)
 				rw.WriteHeader(500)
 				return
 			}
@@ -323,7 +323,7 @@ func getProxyHandler(name, token string, clusterConfig *rest.Config) (http.Handl
 
 			metadataAsByte, err := json.Marshal(metadata)
 			if err != nil {
-				log.Errorf("could not process resource's metadata: %s", err)
+				log.Infof("could not process resource's metadata: %s", err)
 				rw.WriteHeader(500)
 				return
 			}
@@ -332,7 +332,7 @@ func getProxyHandler(name, token string, clusterConfig *rest.Config) (http.Handl
 
 			b, err = json.Marshal(body)
 			if err != nil {
-				log.Errorf("could not marshal modified body: %s", err)
+				log.Infof("could not marshal modified body: %s", err)
 				rw.WriteHeader(500)
 				return
 			}

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -57,7 +57,7 @@ func (p *proxy) Start() {
 	go func(s *http.Server) {
 		// Path to cert and key files are empty because cert is provisioned on the tls config struct
 		if err := s.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
-			log.Errorf("could not start proxy server: %s", err)
+			log.Infof("could not start proxy server: %s", err)
 		}
 	}(p.s)
 }

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -133,7 +133,7 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, cwd string, opts *Opti
 	manifest, err := dc.getManifest(cwd, opts.Name, opts.ManifestPath)
 	if err != nil {
 		// Log error message but application can still be deleted
-		log.Errorf("could not find manifest file to be executed: %s", err)
+		log.Infof("could not find manifest file to be executed: %s", err)
 		manifest = &utils.Manifest{
 			Destroy: []string{},
 		}
@@ -142,7 +142,7 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, cwd string, opts *Opti
 	var commandErr error
 	for _, command := range manifest.Destroy {
 		if err := dc.executor.Execute(command, opts.Variables); err != nil {
-			log.Errorf("error executing command '%s': %s", command, err.Error())
+			log.Infof("error executing command '%s': %s", command, err.Error())
 			if !opts.ForceDestroy {
 				return err
 			}
@@ -178,7 +178,7 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, cwd string, opts *Opti
 
 	log.Debugf("destroying resources with deployed-by label '%s'", deployedBySelector)
 	if err := dc.nsDestroyer.DestroyWithLabel(ctx, opts.Namespace, deleteOpts); err != nil {
-		log.Errorf("could not delete all the resources: %s", err)
+		log.Infof("could not delete all the resources: %s", err)
 		return err
 	}
 
@@ -209,7 +209,7 @@ func (dc *destroyCommand) destroyHelmReleasesIfPresent(ctx context.Context, opts
 		log.Debugf("uninstalling helm release %s", releaseName)
 		cmd := fmt.Sprintf(helmUninstallCommand, releaseName)
 		if err := dc.executor.Execute(cmd, opts.Variables); err != nil {
-			log.Errorf("could not uninstall helm release '%s': %s", releaseName, err)
+			log.Infof("could not uninstall helm release '%s': %s", releaseName, err)
 			if !opts.ForceDestroy {
 				return err
 			}

--- a/pkg/k8s/namespaces/namespace_test.go
+++ b/pkg/k8s/namespaces/namespace_test.go
@@ -1,0 +1,259 @@
+package namespaces
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDestroySFSVolumesIfNeeded(t *testing.T) {
+	ns := "test"
+	appName := "test-app"
+	tests := []struct {
+		name           string
+		includeVolumes bool
+		k8Resources    []runtime.Object
+		expectedPVCs   []apiv1.PersistentVolumeClaim
+	}{
+		{
+			name:           "WithoutVolumeClaimTemplates",
+			includeVolumes: true,
+			k8Resources: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sfs-1",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-1",
+						Namespace: ns,
+					},
+				},
+			},
+			expectedPVCs: []apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-1",
+						Namespace: ns,
+					},
+				},
+			},
+		},
+		{
+			name:           "WithOneVolumeClaimTemplate",
+			includeVolumes: true,
+			k8Resources: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sfs-1",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						VolumeClaimTemplates: []apiv1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "pvc",
+								},
+							},
+						},
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+					},
+				},
+			},
+			expectedPVCs: []apiv1.PersistentVolumeClaim{},
+		},
+		{
+			name:           "WithVolumeClaimTemplatesWithoutHavingToIncludeVolumes",
+			includeVolumes: false,
+			k8Resources: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sfs-1",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						VolumeClaimTemplates: []apiv1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "pvc",
+								},
+							},
+						},
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+					},
+				},
+			},
+			expectedPVCs: []apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+					},
+				},
+			},
+		},
+		{
+			name:           "WithVolumeClaimTemplatesButVolumeWithDeployedByLabel",
+			includeVolumes: true,
+			k8Resources: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sfs-1",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						VolumeClaimTemplates: []apiv1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "pvc",
+								},
+							},
+						},
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+				},
+			},
+			expectedPVCs: []apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "WithSeveralVolumeClaimTemplate",
+			includeVolumes: true,
+			k8Resources: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sfs-1",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						VolumeClaimTemplates: []apiv1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "pvc",
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "mysql",
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "redis",
+								},
+							},
+						},
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mysql-sfs-1-afahrret34",
+						Namespace: ns,
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "redis-sfs-1-jdtrtqwetq",
+						Namespace: ns,
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mongodb",
+						Namespace: ns,
+					},
+				},
+			},
+			expectedPVCs: []apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mongodb",
+						Namespace: ns,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			c := fake.NewSimpleClientset(tt.k8Resources...)
+
+			opts := DeleteAllOptions{
+				IncludeVolumes: tt.includeVolumes,
+				LabelSelector:  fmt.Sprintf("%s=%s", model.DeployedByLabel, appName),
+			}
+
+			n := &Namespaces{
+				k8sClient: c,
+			}
+
+			err := n.DestroySFSVolumes(ctx, ns, opts)
+			assert.NoError(t, err)
+
+			pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{})
+
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedPVCs, pvcList.Items)
+		})
+	}
+}

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -192,6 +192,21 @@ func Destroy(ctx context.Context, name, namespace string, c *kubernetes.Clientse
 
 }
 
+// DestroyWithoutTimeout destroys a PVC without checking if it was detached or not
+func DestroyWithoutTimeout(ctx context.Context, name, namespace string, c kubernetes.Interface) error {
+	vClient := c.CoreV1().PersistentVolumeClaims(namespace)
+	log.Infof("destroying volume '%s'", name)
+
+	err := vClient.Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("error deleting kubernetes volume: %s", err)
+		}
+	}
+
+	return nil
+}
+
 func checkIfAttached(ctx context.Context, name, namespace string, c *kubernetes.Clientset) error {
 	pods, err := c.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Nacho Fuertes <nacho@okteto.com>

Fixes #2003

## Proposed changes

- Include specific code to detect all PVCs created for statefulsets and delete them before delete anything else
