### PR TITLE
Run check only if is ctx command

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -111,11 +111,12 @@ func (c *ContextUse) UseContext(ctx context.Context, ctxOptions *ContextOptions)
 			return errors.UserError{E: fmt.Errorf("invalid okteto context '%s'", ctxOptions.Context),
 				Hint: "Please run 'okteto context' to select one context"}
 		}
-
-		transformedCtx := okteto.K8sContextToOktetoUrl(ctx, ctxOptions.Context, ctxOptions.Namespace, c.k8sClientProvider)
-		if transformedCtx != ctxOptions.Context {
-			ctxOptions.Context = transformedCtx
-			ctxOptions.IsOkteto = true
+		if ctxOptions.IsCtxCommand {
+			transformedCtx := okteto.K8sContextToOktetoUrl(ctx, ctxOptions.Context, ctxOptions.Namespace, c.k8sClientProvider)
+			if transformedCtx != ctxOptions.Context {
+				ctxOptions.Context = transformedCtx
+				ctxOptions.IsOkteto = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: It was checking if it's a vanilla cluster on every command calling the namespace API and waiting for the timeout

## Proposed changes
- Check only if it's a ctx command the one that was called
-
