### PR TITLE
Fix okteto dev registry replacement

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -196,5 +197,10 @@ func IsOktetoRegistry(tag string) bool {
 }
 
 func replaceRegistry(input, registryType, namespace string) string {
-	return strings.Replace(input, registryType, fmt.Sprintf("%s/%s", okteto.Context().Registry, namespace), 1)
+	// Check if the registryType is the start of the sentence or has a whitespace before it
+	var re = regexp.MustCompile(fmt.Sprintf(`(^|\s)(%s)`, registryType))
+	if re.MatchString(input) {
+		return strings.Replace(input, registryType, fmt.Sprintf("%s/%s", okteto.Context().Registry, namespace), 1)
+	}
+	return input
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -218,6 +218,38 @@ func Test_translateRegistry(t *testing.T) {
 			registry:     "registry.url",
 			want:         "docker.io/image",
 		},
+		{
+			name:         "is-dev-registry-with-okteto-dev-on-registry",
+			input:        "registry.okteto.dev/cindy/app",
+			registryType: okteto.DevRegistry,
+			namespace:    "cindy",
+			registry:     "registry.okteto.dev",
+			want:         "registry.okteto.dev/cindy/app",
+		},
+		{
+			name:         "is-global-registry-with-okteto-dev-on-registry-on-Dockerfile",
+			input:        "FROM okteto.global/image",
+			registryType: okteto.GlobalRegistry,
+			namespace:    "cindy",
+			registry:     "registry.okteto.dev",
+			want:         "FROM registry.okteto.dev/cindy/image",
+		},
+		{
+			name:         "is-dev-registry-with-okteto-dev-on-registry-on-Dockerfile-expand",
+			input:        "FROM okteto.dev/app",
+			registryType: okteto.DevRegistry,
+			namespace:    "cindy",
+			registry:     "registry.okteto.dev",
+			want:         "FROM registry.okteto.dev/cindy/app",
+		},
+		{
+			name:         "full-registry-on-Dockerfile",
+			input:        "FROM registry.okteto.dev/cindy/app",
+			registryType: okteto.DevRegistry,
+			namespace:    "cindy",
+			registry:     "registry.okteto.dev",
+			want:         "FROM registry.okteto.dev/cindy/app",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes okteto was failing to build when Okteto dev label was in the registry url

## Proposed changes
- Check if it's already a registry URL or not
- If it's not do the replacement
