### PR TITLE
Enable syncthing compression by default

### DIFF
--- a/pkg/model/devrc.go
+++ b/pkg/model/devrc.go
@@ -199,8 +199,8 @@ func MergeDevWithDevRc(dev *Dev, devRc *DevRC) {
 		dev.Selector[key] = value
 	}
 
-	if devRc.Sync.Compression {
-		dev.Sync.Compression = devRc.Sync.Compression
+	if !devRc.Sync.Compression {
+		dev.Sync.Compression = false
 	}
 	if devRc.Sync.Verbose {
 		dev.Sync.Verbose = devRc.Sync.Verbose

--- a/pkg/model/devrc_test.go
+++ b/pkg/model/devrc_test.go
@@ -51,6 +51,7 @@ resources:
 					},
 				},
 				Sync: Sync{
+					Compression:    true,
 					Verbose:        false,
 					RescanInterval: 300,
 					Folders: []SyncFolder{
@@ -96,6 +97,7 @@ resources:
 					},
 				},
 				Sync: Sync{
+					Compression:    true,
 					Verbose:        true,
 					RescanInterval: 300,
 					Folders: []SyncFolder{
@@ -458,11 +460,11 @@ func TestDevRCSync(t *testing.T) {
 				Compression: true,
 			}},
 			expected: Sync{
-				Compression: true,
+				Compression: false,
 			},
 		},
 		{
-			name: "compression",
+			name: "verbose",
 			dev: &Dev{Sync: Sync{
 				Verbose: true,
 			}},

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -252,6 +252,7 @@ func (sync *Sync) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var rawFolders []SyncFolder
 	err := unmarshal(&rawFolders)
 	if err == nil {
+		sync.Compression = true
 		sync.Verbose = log.IsDebug()
 		sync.RescanInterval = DefaultSyncthingRescanInterval
 		sync.Folders = rawFolders

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -922,6 +922,61 @@ resources: 30s
 	}
 }
 
+func TestSyncUnmashalling(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected Sync
+	}{
+		{
+			name: "only-folders",
+			data: []byte(`- .:/usr/src/app`),
+			expected: Sync{
+				Folders: []SyncFolder{
+					{
+						LocalPath:  ".",
+						RemotePath: "/usr/src/app"},
+				},
+				Compression:    true,
+				Verbose:        false,
+				RescanInterval: DefaultSyncthingRescanInterval,
+			},
+		},
+		{
+			name: "all",
+			data: []byte(`folders:
+  - .:/usr/src/app
+compression: false
+verbose: true
+rescanInterval: 10`),
+			expected: Sync{
+				Folders: []SyncFolder{
+					{
+						LocalPath:  ".",
+						RemotePath: "/usr/src/app"},
+				},
+				Compression:    false,
+				Verbose:        true,
+				RescanInterval: 10,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Sync{}
+
+			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("didn't unmarshal correctly. Actual %+v, Expected %+v", result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestSyncFoldersUnmashalling(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes

From Syncthing docs:
```
Compress all packets, including file data. This is recommended if the folders contents are mainly compressible data such as documents or text files.
```

