### PR TITLE
mentioning logs' location when okteto up fails

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/down"
+	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
@@ -62,6 +63,7 @@ func Down() *cobra.Command {
 
 			if err := runDown(ctx, dev, rm); err != nil {
 				analytics.TrackDown(false)
+				err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetAppHome(dev.Namespace, dev.Name))
 				return err
 			}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -181,7 +181,7 @@ func Up() *cobra.Command {
 				log.Infof("error deleting deprecated volume: %v", err)
 			}
 
-			err = fmt.Errorf("%w; Additional logs can be found at: $HOME/.okteto/okteto.log", err)
+			err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetOktetoHome())
 
 			return err
 		},

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -181,6 +181,8 @@ func Up() *cobra.Command {
 				log.Infof("error deleting deprecated volume: %v", err)
 			}
 
+			err = fmt.Errorf("%w; Additional logs can be found at: $HOME/.okteto/okteto.log", err)
+
 			return err
 		},
 	}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -181,7 +181,7 @@ func Up() *cobra.Command {
 				log.Infof("error deleting deprecated volume: %v", err)
 			}
 
-			err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetOktetoHome())
+			err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetAppHome(dev.Namespace, dev.Name))
 
 			return err
 		},


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

Fixes #1004 

## Proposed changes

- In the error which gets returned when `okteto up` fails, I've appended a message which points to the location of `okteto.log`

## Tests

I wasn't able to test this locally. Is there a way to force `okteto up` to fail? 
