### PR TITLE
Fix annotations restore original

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -111,6 +111,11 @@ func (tr *Translation) DevModeOff() error {
 	tr.App.SetReplicas(getPreviousAppReplicas(tr.App))
 	delete(tr.App.ObjectMeta().Annotations, model.AppReplicasAnnotation)
 
+	delete(tr.App.ObjectMeta().Annotations, model.OktetoStignoreAnnotation)
+	delete(tr.App.TemplateObjectMeta().Annotations, model.OktetoStignoreAnnotation)
+	delete(tr.App.ObjectMeta().Annotations, model.OktetoSyncAnnotation)
+	delete(tr.App.TemplateObjectMeta().Annotations, model.OktetoSyncAnnotation)
+
 	for k := range tr.Dev.Metadata.Annotations {
 		delete(tr.App.ObjectMeta().Annotations, k)
 		delete(tr.App.TemplateObjectMeta().Annotations, k)


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: With the addition of https://github.com/okteto/okteto/pull/2037 it was not cleaning some of the okteto annotations, which caused modifying the original deployment

## Proposed changes
- Remove those annotations when performing okteto down
-
