### PR TITLE
Fix empty env vars from env files not being injected

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -823,7 +823,7 @@ func translateStorageClass(className string) *string {
 func translateServiceEnvironment(svc *model.Service) []apiv1.EnvVar {
 	result := []apiv1.EnvVar{}
 	for _, e := range svc.Environment {
-		if e.Value != "" && e.Name != "" {
+		if e.Name != "" {
 			result = append(result, apiv1.EnvVar{Name: e.Name, Value: e.Value})
 		}
 	}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1365,7 +1365,11 @@ func Test_translateServiceEnvironment(t *testing.T) {
 					},
 				},
 			},
-			expected: []apiv1.EnvVar{},
+			expected: []apiv1.EnvVar{
+				{
+					Name: "DEBUG",
+				},
+			},
 		},
 		{
 			name: "empty name",

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -426,7 +426,12 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 		svc.EnvFiles = serviceRaw.EnvFilesSneakCase
 	}
 
-	svc.Environment = serviceRaw.Environment
+	svc.Environment = Environment{}
+	for _, env := range serviceRaw.Environment {
+		if env.Value != "" {
+			svc.Environment = append(svc.Environment, env)
+		}
+	}
 
 	svc.DependsOn = make(DependsOn)
 	for name, condition := range serviceRaw.DependsOn {

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -1574,6 +1575,11 @@ func Test_Environment(t *testing.T) {
 			environment: Environment{EnvVar{Name: "env", Value: "production"}},
 		},
 		{
+			name:        "empty envs",
+			manifest:    []byte("services:\n  app:\n    environment:\n      - env\n    image: okteto/vote:1"),
+			environment: Environment{},
+		},
+		{
 			name:        "noenvs",
 			manifest:    []byte("services:\n  app:\n    image: okteto/vote:1"),
 			environment: Environment{},
@@ -1586,6 +1592,7 @@ func Test_Environment(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			assert.Equal(t, tt.environment, s.Services["app"].Environment)
 			if len(s.Services["app"].Environment) != len(tt.environment) {
 				t.Fatalf("Bad unmarshal of envs")
 			}
@@ -1825,6 +1832,7 @@ func Test_ExtensionUnmarshalling(t *testing.T) {
 				Command: Command{
 					Values: []string{"bash"},
 				},
+				Environment: Environment{},
 			},
 			expectedError: false,
 		},
@@ -1844,9 +1852,7 @@ func Test_ExtensionUnmarshalling(t *testing.T) {
 				t.Fatal("error not thrown")
 			}
 			if !tt.expectedError {
-				if !reflect.DeepEqual(s.Services["app"].Environment, tt.expected.Environment) {
-					t.Fatalf("Expected %v, but got %v", tt.expected, s.Services["app"])
-				}
+				assert.Equal(t, tt.expected.Environment, s.Services["app"].Environment)
 			}
 
 		})


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2050. It seems that docker is not populating empty vars that are on environment field but it's importing them if they come from an env file

## Proposed changes
- Remove empty env vars that comes from environment fields.
- Support adding env vars that does not have value
