### PR TITLE
Local env var is preferred over secrets

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/compose-spec/godotenv"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/login"
@@ -128,6 +129,7 @@ func (c *ContextUse) UseContext(ctx context.Context, ctxOptions *ContextOptions)
 	}
 
 	ctxStore.CurrentContext = ctxOptions.Context
+	c.initEnvVars()
 
 	if ctxOptions.IsOkteto {
 		if err := c.initOktetoContext(ctx, ctxOptions); err != nil {
@@ -227,4 +229,12 @@ func (_ *ContextUse) initKubernetesContext(ctxOptions *ContextOptions) error {
 	okteto.Context().IsOkteto = false
 
 	return nil
+}
+
+func (*ContextUse) initEnvVars() {
+	if model.FileExists(".env") {
+		if err := godotenv.Load(); err != nil {
+			log.Infof("error loading .env file: %s", err.Error())
+		}
+	}
 }

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -148,7 +148,7 @@ func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error)
 
 func setSecrets(secrets []types.Secret) {
 	for _, secret := range secrets {
-		if os.Getenv(secret.Name) == "" {
+		if _, exists := os.LookupEnv(secret.Name); !exists {
 			os.Setenv(secret.Name, secret.Value)
 		}
 	}

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -148,7 +148,9 @@ func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error)
 
 func setSecrets(secrets []types.Secret) {
 	for _, secret := range secrets {
-		os.Setenv(secret.Name, secret.Value)
+		if os.Getenv(secret.Name) == "" {
+			os.Setenv(secret.Name, secret.Value)
+		}
 	}
 }
 

--- a/cmd/context/use_test.go
+++ b/cmd/context/use_test.go
@@ -1,0 +1,66 @@
+// Copyright 2021 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"os"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_setSecrets(t *testing.T) {
+	key := "key"
+	expectedValue := "value"
+	var tests = []struct {
+		name    string
+		secrets []types.Secret
+		envs    map[string]string
+	}{
+		{
+			name: "create new env var from secret",
+			secrets: []types.Secret{
+				{
+					Name:  key,
+					Value: expectedValue,
+				},
+			},
+			envs: map[string]string{},
+		},
+		{
+			name: "not overwrite env var from secret",
+			secrets: []types.Secret{
+				{
+					Name:  key,
+					Value: "random-value",
+				},
+			},
+			envs: map[string]string{
+				key: expectedValue,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				err := os.Setenv(k, v)
+				assert.NoError(t, err)
+			}
+			setSecrets(tt.secrets)
+			assert.Equal(t, expectedValue, os.Getenv(key))
+		})
+	}
+}

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/compose-spec/godotenv"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -35,12 +34,6 @@ func Deploy(ctx context.Context) *cobra.Command {
 		Use:   "deploy [service...]",
 		Short: "Deploy a stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			if model.FileExists(".env") {
-				if err := godotenv.Load(); err != nil {
-					log.Errorf("error loading .env file: %s", err.Error())
-				}
-			}
 
 			s, err := contextCMD.LoadStackWithContext(ctx, options.Name, options.Namespace, options.StackPath)
 			if err != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/compose-spec/godotenv"
 	"github.com/moby/term"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	initCMD "github.com/okteto/okteto/cmd/init"
@@ -91,13 +90,6 @@ func Up() *cobra.Command {
 			}
 
 			ctx := context.Background()
-
-			if model.FileExists(".env") {
-				err := godotenv.Load()
-				if err != nil {
-					log.Errorf("error loading .env file: %s", err.Error())
-				}
-			}
 
 			manifest, err := contextCMD.LoadManifestWithContext(ctx, upOptions.DevPath, upOptions.Namespace, upOptions.K8sContext)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/compose-spec/godotenv"
 	"github.com/okteto/okteto/cmd"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
@@ -68,6 +69,11 @@ func init() {
 	if bin := os.Getenv(model.OktetoBinEnvVar); bin != "" {
 		model.OktetoBinImageTag = bin
 		log.Infof("using %s as the bin image", bin)
+	}
+	if model.FileExists(".env") {
+		if err := godotenv.Load(); err != nil {
+			log.Errorf("error loading .env file: %s", err.Error())
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/compose-spec/godotenv"
 	"github.com/okteto/okteto/cmd"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
@@ -69,11 +68,6 @@ func init() {
 	if bin := os.Getenv(model.OktetoBinEnvVar); bin != "" {
 		model.OktetoBinImageTag = bin
 		log.Infof("using %s as the bin image", bin)
-	}
-	if model.FileExists(".env") {
-		if err := godotenv.Load(); err != nil {
-			log.Errorf("error loading .env file: %s", err.Error())
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes #2074

## Proposed changes
- Load `.env` at the begining of okteto
- Replace env vars by secrets if the env var is not set
