### PR TITLE
autocreate fail if app with the same name exists

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -63,6 +63,10 @@ func (up *upContext) activate() error {
 		return err
 	}
 
+	if v, ok := app.ObjectMeta().Annotations[model.OktetoAutoCreateAnnotation]; !ok || v != model.OktetoUpCmd {
+		return fmt.Errorf("resource '%s' already exists. Please consider changing the name of autocreate", up.Dev.Name)
+	}
+
 	if up.isRetry && !apps.IsDevModeOn(app) {
 		log.Information("Development container has been deactivated")
 		return nil

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -64,7 +64,10 @@ func (up *upContext) activate() error {
 	}
 
 	if v, ok := app.ObjectMeta().Annotations[model.OktetoAutoCreateAnnotation]; !ok || v != model.OktetoUpCmd {
-		return fmt.Errorf("resource '%s' already exists. Please consider changing the name of autocreate", up.Dev.Name)
+		return errors.UserError{
+			E:    fmt.Errorf("resource %s doesn't exist", up.Dev.Name),
+			Hint: "use a different name in your okteto.yaml, or remove the autocreate property",
+		}
 	}
 
 	if up.isRetry && !apps.IsDevModeOn(app) {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2075

## Proposed changes
- Check if okteto is deployed bu okteto up and fail if not
-
