### PR TITLE
Don't show okteto logs location for user command errors

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -174,7 +174,12 @@ func Up() *cobra.Command {
 			}
 
 			if err != nil {
-				err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetAppHome(dev.Namespace, dev.Name))
+				switch err.(type) {
+				default:
+					err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetAppHome(dev.Namespace, dev.Name))
+				case errors.CommandError:
+					log.Infof("CommandError: %v", err)
+				}
 
 			}
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes
Okteto logs location is only useful for dev environment provisioning issues.