### PR TITLE
fix: ctx create nil pointer exception

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -45,7 +45,7 @@ func CreateCMD() *cobra.Command {
 	ctxOptions := &ContextOptions{}
 	cmd := &cobra.Command{
 		Use:   "create [cluster-url]",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#create"),
+		Args:  utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/cli/#create"),
 		Short: "Add a context",
 		Long: `Add a context
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2116

It was happening every time we were running okteto ctx create without args, even when we had okteto ctx already set:

## Proposed changes
- Ask for the exact args instead of a maximum
