### PR TITLE
fix: fail if ctx show does not have ctx set

### DIFF
--- a/cmd/context/cmd_test.go
+++ b/cmd/context/cmd_test.go
@@ -1,0 +1,81 @@
+// Copyright 2021 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"testing"
+)
+
+func Test_NoArgsAcceptedCtx(t *testing.T) {
+	cmd := Show()
+	cmd.SetArgs([]string{"args"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Args not supported")
+	}
+}
+
+func Test_NoArgsAcceptedShow(t *testing.T) {
+	cmd := Context()
+	cmd.SetArgs([]string{"args"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Args not supported")
+	}
+}
+
+func Test_NoArgsAcceptedList(t *testing.T) {
+	cmd := List()
+	cmd.SetArgs([]string{"args"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Args not supported")
+	}
+}
+
+func Test_NoArgsAcceptedUpdateKubeConfig(t *testing.T) {
+	cmd := UpdateKubeconfigCMD()
+	cmd.SetArgs([]string{"args"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("MaxArgs not supported")
+	}
+}
+
+func Test_MaxArgsCreate(t *testing.T) {
+	cmd := CreateCMD()
+	cmd.SetArgs([]string{"args", "args"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("MaxArgs not supported")
+	}
+}
+
+func Test_MaxArgsUse(t *testing.T) {
+	cmd := Use()
+	cmd.SetArgs([]string{"args", "args"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Args not supported")
+	}
+}
+
+func Test_ExactArgsDelete(t *testing.T) {
+	cmd := DeleteCMD()
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("ExactArgs not supported")
+	}
+}

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -21,15 +21,16 @@ import (
 )
 
 type ContextOptions struct {
-	Token        string
-	Context      string
-	Namespace    string
-	Builder      string
-	OnlyOkteto   bool
-	Show         bool
-	Save         bool
-	IsCtxCommand bool
-	IsOkteto     bool
+	Token            string
+	Context          string
+	Namespace        string
+	Builder          string
+	OnlyOkteto       bool
+	Show             bool
+	Save             bool
+	IsCtxCommand     bool
+	IsOkteto         bool
+	raiseNotCtxError bool
 }
 
 func (o *ContextOptions) initFromContext() {

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -33,7 +33,7 @@ func Show() *cobra.Command {
 		Short: "Print the current context",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if err := Run(ctx, &ContextOptions{}); err != nil {
+			if err := Run(ctx, &ContextOptions{raiseNotCtxError: true}); err != nil {
 				return err
 			}
 			ctxStore := okteto.ContextStore()

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -94,8 +94,11 @@ func Run(ctx context.Context, ctxOptions *ContextOptions) error {
 	}
 
 	if ctxOptions.Context == "" {
-		if !ctxOptions.IsCtxCommand {
+		if !ctxOptions.IsCtxCommand && !ctxOptions.raiseNotCtxError {
 			log.Information("Okteto context is not initialized")
+		}
+		if ctxOptions.raiseNotCtxError {
+			return errors.ErrCtxNotSet
 		}
 		log.Infof("authenticating with interactive context")
 		oktetoContext, err := getContext(ctx, ctxOptions)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -48,6 +48,9 @@ var (
 	// ErrNotLogged is raised when we can't get the user token
 	ErrNotLogged = "your token is invalid. Please run 'okteto context use %s' and try again"
 
+	// ErrCtxNotSet is raised when we don't have ctx set
+	ErrCtxNotSet = fmt.Errorf("your context is not set. Please run 'okteto context use' and and select your context")
+
 	// ErrNotOktetoCluster is raised when we a command is only available on an okteto cluster
 	ErrNotOktetoCluster = fmt.Errorf("user is not logged in okteto cluster. Please run 'okteto context use' and select your context")
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -49,7 +49,7 @@ var (
 	ErrNotLogged = "your token is invalid. Please run 'okteto context use %s' and try again"
 
 	// ErrCtxNotSet is raised when we don't have ctx set
-	ErrCtxNotSet = fmt.Errorf("your context is not set. Please run 'okteto context use' and and select your context")
+	ErrCtxNotSet = fmt.Errorf("your context is not set. Please run 'okteto context' and select your context")
 
 	// ErrNotOktetoCluster is raised when we a command is only available on an okteto cluster
 	ErrNotOktetoCluster = fmt.Errorf("user is not logged in okteto cluster. Please run 'okteto context use' and select your context")


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2117

## Proposed changes
- I created a new ctxOption which is raiseCtxNotSet. I think its better to have a default value on every command and only use that new option on `context show`
- 
