### PR TITLE
fix: skip env file if it does not exists

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -70,6 +70,9 @@ func translateStackEnvVars(ctx context.Context, s *model.Stack) error {
 		for i := len(svc.EnvFiles) - 1; i >= 0; i-- {
 			envFilepath := svc.EnvFiles[i]
 			if err := translateServiceEnvFile(ctx, svc, svcName, envFilepath); err != nil {
+				if envFilepath == ".env" {
+					continue
+				}
 				return err
 			}
 		}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -70,7 +71,8 @@ func translateStackEnvVars(ctx context.Context, s *model.Stack) error {
 		for i := len(svc.EnvFiles) - 1; i >= 0; i-- {
 			envFilepath := svc.EnvFiles[i]
 			if err := translateServiceEnvFile(ctx, svc, svcName, envFilepath); err != nil {
-				if envFilepath == ".env" {
+				if filepath.Base(envFilepath) == ".env" {
+					log.Warning("Skipping '.env' file from %s service", svcName)
 					continue
 				}
 				return err


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2102

## Proposed changes
- Skip env file if it's default name for environment variables

