### PR TITLE
fix: volume mount translation

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -277,7 +277,6 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 	svc := s.Services[svcName]
 
 	healthcheckProbe := getSvcProbe(svc)
-
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -300,6 +299,8 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 				},
 				Spec: apiv1.PodSpec{
 					TerminationGracePeriodSeconds: pointer.Int64Ptr(svc.StopGracePeriod),
+					Volumes:                       translateVolumes(svcName, svc),
+					InitContainers:                getInitContainers(svcName, s),
 					Containers: []apiv1.Container{
 						{
 							Name:            svcName,
@@ -310,6 +311,7 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 							Ports:           translateContainerPorts(svc),
 							SecurityContext: translateSecurityContext(svc),
 							Resources:       translateResources(svc),
+							VolumeMounts:    translateVolumeMounts(svcName, svc),
 							WorkingDir:      svc.Workdir,
 							ReadinessProbe:  healthcheckProbe,
 							LivenessProbe:   healthcheckProbe,
@@ -320,6 +322,7 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 		},
 	}
 }
+
 func translatePersistentVolumeClaim(volumeName string, s *model.Stack) apiv1.PersistentVolumeClaim {
 	volumeSpec := s.Volumes[volumeName]
 	labels := translateVolumeLabels(volumeName, s)
@@ -450,15 +453,55 @@ func getInitContainers(svcName string, s *model.Stack) []apiv1.Container {
 	if len(svc.Volumes) > 0 {
 		addPermissionsContainer := getAddPermissionsInitContainer(svcName, svc)
 		initContainers = append(initContainers, addPermissionsContainer)
+		initializationContainer := getInitializeVolumeContentContainer(svcName, svc)
+		if initializationContainer != nil {
+			initContainers = append(initContainers, *initializationContainer)
+		}
 	}
-	initializationContainer := getInitializeVolumeContentContainer(svcName, svc)
-	if initializationContainer != nil {
-		initContainers = append(initContainers, *initializationContainer)
+
+	if len(svc.VolumeMounts) > 0 {
+		initializeVolumeMount := getInitializeVolumeMountsContainer(svcName, svc)
+		if initializeVolumeMount != nil {
+			initContainers = append(initContainers, *initializeVolumeMount)
+		}
 	}
 
 	return initContainers
 }
 
+func getInitializeVolumeMountsContainer(svcName string, svc *model.Service) *apiv1.Container {
+	initContainerCommand, initContainerVolumeMounts := getVolumeMountsCommandAndVolumeMounts(*svc)
+	if len(initContainerVolumeMounts) == 0 {
+		return nil
+	}
+	initContainer := &apiv1.Container{
+		Name:         fmt.Sprintf("init-%s", svcName),
+		Image:        "busybox",
+		Command:      initContainerCommand,
+		VolumeMounts: initContainerVolumeMounts,
+	}
+	return initContainer
+}
+
+func getVolumeMountsCommandAndVolumeMounts(svc model.Service) ([]string, []apiv1.VolumeMount) {
+	volumeMounts := []apiv1.VolumeMount{}
+
+	var command string
+	for idx, volume := range svc.VolumeMounts {
+		if fs, err := os.Stat(volume.LocalPath); err == nil && !fs.IsDir() {
+			continue
+		}
+		volumeName := fmt.Sprintf("volume-mount-%d", idx)
+		volumeMounts = append(volumeMounts, apiv1.VolumeMount{Name: volumeName, MountPath: volume.RemotePath})
+		newCommand := fmt.Sprintf("mkdir -p %s && chmod 777 %s", volume.RemotePath, volume.RemotePath)
+
+		if len(command) > 0 {
+			newCommand = fmt.Sprintf(" && %s", newCommand)
+		}
+		command += newCommand
+	}
+	return []string{"sh", "-c", command}, volumeMounts
+}
 func getAddPermissionsInitContainer(svcName string, svc *model.Service) apiv1.Container {
 	initContainerCommand, initContainerVolumeMounts := getInitContainerCommandAndVolumeMounts(*svc)
 	initContainer := apiv1.Container{
@@ -565,6 +608,21 @@ func translateVolumes(svcName string, svc *model.Service) []apiv1.Volume {
 			VolumeSource: apiv1.VolumeSource{
 				PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
 					ClaimName: volume.LocalPath,
+				},
+			},
+		})
+	}
+	for idx, v := range svc.VolumeMounts {
+		if fs, err := os.Stat(v.LocalPath); err == nil && !fs.IsDir() {
+			continue
+		}
+		name := fmt.Sprintf("volume-mount-%d", idx)
+		maxSize := resource.MustParse("1Gi")
+		volumes = append(volumes, apiv1.Volume{
+			Name: name,
+			VolumeSource: apiv1.VolumeSource{
+				EmptyDir: &apiv1.EmptyDirVolumeSource{
+					SizeLimit: &maxSize,
 				},
 			},
 		})
@@ -805,6 +863,19 @@ func translateVolumeMounts(svcName string, svc *model.Service) []apiv1.VolumeMou
 				MountPath: v.RemotePath,
 				Name:      name,
 				SubPath:   subpath,
+			},
+		)
+	}
+	for idx, v := range svc.VolumeMounts {
+		if fs, err := os.Stat(v.LocalPath); err == nil && !fs.IsDir() {
+			continue
+		}
+		name := fmt.Sprintf("volume-mount-%d", idx)
+		result = append(
+			result,
+			apiv1.VolumeMount{
+				MountPath: v.RemotePath,
+				Name:      name,
 			},
 		)
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2119

## Proposed changes
- Add translation rules for volume mounts in deployments where we need to give permissions to the user/create the path in order to work
- In order to not use persistent volumes and be able to give permission, it's using EmptyDir as volumeSource for this kind of problem
