### PR TITLE
Expand sync folders env vars

### DIFF
--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -523,7 +523,10 @@ func (s *SyncFolder) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		s.RemotePath = parts[1]
+		s.RemotePath, err = ExpandEnv(parts[1])
+		if err != nil {
+			return err
+		}
 		return nil
 	} else if len(parts) == 3 {
 		windowsPath := fmt.Sprintf("%s:%s", parts[0], parts[1])
@@ -531,7 +534,10 @@ func (s *SyncFolder) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		s.RemotePath = parts[2]
+		s.RemotePath, err = ExpandEnv(parts[2])
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -981,6 +981,7 @@ rescanInterval: 10`),
 }
 
 func TestSyncFoldersUnmashalling(t *testing.T) {
+	os.Setenv("REMOTE_PATH", "/usr/src/app")
 	tests := []struct {
 		name     string
 		data     []byte
@@ -989,6 +990,11 @@ func TestSyncFoldersUnmashalling(t *testing.T) {
 		{
 			name:     "same dir",
 			data:     []byte(`.:/usr/src/app`),
+			expected: SyncFolder{LocalPath: ".", RemotePath: "/usr/src/app"},
+		},
+		{
+			name:     "same dir",
+			data:     []byte(`.:${REMOTE_PATH}`),
 			expected: SyncFolder{LocalPath: ".", RemotePath: "/usr/src/app"},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: Expand sync folder remote path

## Proposed changes
- Adds environment expansion for remote path on sync folders
-
