### PR TITLE
fix: use "go test -c" at "make build-integration"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build:
 
 .PHONY: build-integration
 build-integration:
-	go test github.com/okteto/okteto/integration -tags "common integration actions" -c -o ${BINDIR}/okteto-integration.test 
+	go test github.com/okteto/okteto/integration -tags "common integration actions" -c -o ${BINDIR}/okteto-integration.test
 
 .PHONY: dep
 dep:

--- a/Makefile
+++ b/Makefile
@@ -36,23 +36,23 @@ lint:
 
 .PHONY: test
 test:
-	 go test -p 4 -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -p 4 -coverprofile=coverage.txt -covermode=atomic ./...
 
 .PHONY: integration
 integration:
-	 go test github.com/okteto/okteto/integration -tags="common integration actions" --count=1 -v -timeout 45m
+	go test github.com/okteto/okteto/integration -tags="common integration actions" --count=1 -v -timeout 45m
 
 .PHONY: integration-actions
 integration-actions:
-	 go test github.com/okteto/okteto/integration -tags="common actions" --count=1 -v -timeout 15m
+	go test github.com/okteto/okteto/integration -tags="common actions" --count=1 -v -timeout 15m
 
 .PHONY: build
 build:
-	 $(BUILDCOMMAND) -o ${BINDIR}/okteto
+	$(BUILDCOMMAND) -o ${BINDIR}/okteto
 
 .PHONY: build-integration
 build-integration:
-	  $(BUILDCOMMAND) -tags "common integration actions" github.com/okteto/okteto/integration
+	go test github.com/okteto/okteto/integration -tags "common integration actions" -c -o ${BINDIR}/okteto-integration.test 
 
 .PHONY: dep
 dep:


### PR DESCRIPTION
Signed-off-by: Javier Provecho Fernández (Okteto) <jpf@okteto.com>

"go build" force exclude "*_test.go" source files, it can't be used for
compiling test source code.

"go test" has a specific flag for creating a test executable binary.

This PR changes the command used at build-integration makefile step,
introduced at #2134. It also removes unneeded whitespace at other
makefile steps.