### PR TITLE
Add security context to stack

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -822,7 +822,7 @@ func getVolumeClaimName(v *model.StackVolume) string {
 }
 
 func translateSecurityContext(svc *model.Service) *apiv1.SecurityContext {
-	if len(svc.CapAdd) == 0 && len(svc.CapDrop) == 0 {
+	if len(svc.CapAdd) == 0 && len(svc.CapDrop) == 0 && svc.SecurityContext == nil {
 		return nil
 	}
 	result := &apiv1.SecurityContext{Capabilities: &apiv1.Capabilities{}}
@@ -831,6 +831,10 @@ func translateSecurityContext(svc *model.Service) *apiv1.SecurityContext {
 	}
 	if len(svc.CapDrop) > 0 {
 		result.Capabilities.Drop = svc.CapDrop
+	}
+	if svc.SecurityContext != nil {
+		result.RunAsUser = svc.SecurityContext.RunAsUser
+		result.RunAsGroup = svc.SecurityContext.RunAsGroup
 	}
 	return result
 }

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -822,7 +822,7 @@ func getVolumeClaimName(v *model.StackVolume) string {
 }
 
 func translateSecurityContext(svc *model.Service) *apiv1.SecurityContext {
-	if len(svc.CapAdd) == 0 && len(svc.CapDrop) == 0 && svc.SecurityContext == nil {
+	if len(svc.CapAdd) == 0 && len(svc.CapDrop) == 0 && svc.User == nil {
 		return nil
 	}
 	result := &apiv1.SecurityContext{Capabilities: &apiv1.Capabilities{}}
@@ -832,9 +832,9 @@ func translateSecurityContext(svc *model.Service) *apiv1.SecurityContext {
 	if len(svc.CapDrop) > 0 {
 		result.Capabilities.Drop = svc.CapDrop
 	}
-	if svc.SecurityContext != nil {
-		result.RunAsUser = svc.SecurityContext.RunAsUser
-		result.RunAsGroup = svc.SecurityContext.RunAsGroup
+	if svc.User != nil {
+		result.RunAsUser = svc.User.RunAsUser
+		result.RunAsGroup = svc.User.RunAsGroup
 	}
 	return result
 }

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -66,7 +66,7 @@ type Service struct {
 	Workdir         string                `yaml:"workdir,omitempty"`
 	BackOffLimit    int32                 `yaml:"max_attempts,omitempty"`
 	Healtcheck      *HealthCheck          `yaml:"healthcheck,omitempty"`
-	SecurityContext *StackSecurityContext `yaml:"security_context,omitempty"`
+	User            *StackSecurityContext `yaml:"user,omitempty"`
 
 	Public    bool            `yaml:"public,omitempty"`
 	Replicas  int32           `yaml:"replicas,omitempty"`

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -55,17 +55,18 @@ type Service struct {
 	EnvFiles   EnvFiles           `yaml:"env_file,omitempty"`
 	DependsOn  DependsOn          `yaml:"depends_on,omitempty"`
 
-	Environment     Environment         `yaml:"environment,omitempty"`
-	Image           string              `yaml:"image,omitempty"`
-	Labels          Labels              `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations     Annotations         `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Ports           []Port              `yaml:"ports,omitempty"`
-	RestartPolicy   apiv1.RestartPolicy `yaml:"restart,omitempty"`
-	StopGracePeriod int64               `yaml:"stop_grace_period,omitempty"`
-	Volumes         []StackVolume       `yaml:"volumes,omitempty"`
-	Workdir         string              `yaml:"workdir,omitempty"`
-	BackOffLimit    int32               `yaml:"max_attempts,omitempty"`
-	Healtcheck      *HealthCheck        `yaml:"healthcheck,omitempty"`
+	Environment     Environment           `yaml:"environment,omitempty"`
+	Image           string                `yaml:"image,omitempty"`
+	Labels          Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations     Annotations           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	Ports           []Port                `yaml:"ports,omitempty"`
+	RestartPolicy   apiv1.RestartPolicy   `yaml:"restart,omitempty"`
+	StopGracePeriod int64                 `yaml:"stop_grace_period,omitempty"`
+	Volumes         []StackVolume         `yaml:"volumes,omitempty"`
+	Workdir         string                `yaml:"workdir,omitempty"`
+	BackOffLimit    int32                 `yaml:"max_attempts,omitempty"`
+	Healtcheck      *HealthCheck          `yaml:"healthcheck,omitempty"`
+	SecurityContext *StackSecurityContext `yaml:"security_context,omitempty"`
 
 	Public    bool            `yaml:"public,omitempty"`
 	Replicas  int32           `yaml:"replicas,omitempty"`
@@ -74,6 +75,11 @@ type Service struct {
 	VolumeMounts []StackVolume `yaml:"-"`
 }
 
+// StackSecurityContext defines which user and group use
+type StackSecurityContext struct {
+	RunAsUser  *int64 `json:"runAsUser,omitempty" yaml:"runAsUser,omitempty"`
+	RunAsGroup *int64 `json:"runAsGroup,omitempty" yaml:"runAsGroup,omitempty"`
+}
 type StackVolume struct {
 	LocalPath  string
 	RemotePath string

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kballard/go-shellquote"
 	apiv1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/pointer"
 )
 
 const (
@@ -703,24 +702,24 @@ func (sc *StackSecurityContext) UnmarshalYAML(unmarshal func(interface{}) error)
 		if strings.Contains(rawSecurityContext, ":") {
 			parts := strings.Split(rawSecurityContext, ":")
 			if len(parts) != 2 {
-				return fmt.Errorf("SecurityContext is malformed. Only 'dddd:dddd' is supported")
+				return fmt.Errorf("SecurityContext '%s' is malformed. Only 'dddd:dddd' is supported", rawSecurityContext)
 			}
-			runAsUser, err := strconv.Atoi(parts[0])
+			runAsUser, err := strconv.ParseInt(parts[0], 10, 64)
 			if err != nil {
-				return fmt.Errorf("Can not convert '%s' to a user", rawSecurityContext)
+				return fmt.Errorf("Can not obtain UID from '%s'", parts[0])
 			}
-			runAsGroup, err := strconv.Atoi(parts[1])
+			runAsGroup, err := strconv.ParseInt(parts[1], 10, 64)
 			if err != nil {
-				return fmt.Errorf("Can not convert '%s' to a user", rawSecurityContext)
+				return fmt.Errorf("Can not obtain GID from '%s'", parts[1])
 			}
-			sc.RunAsUser = pointer.Int64(int64(runAsUser))
-			sc.RunAsGroup = pointer.Int64(int64(runAsGroup))
+			sc.RunAsUser = &runAsUser
+			sc.RunAsGroup = &runAsGroup
 		} else {
-			runAsUser, err := strconv.Atoi(rawSecurityContext)
+			runAsUser, err := strconv.ParseInt(rawSecurityContext, 10, 64)
 			if err != nil {
-				return fmt.Errorf("Can not convert '%s' to a user", rawSecurityContext)
+				return fmt.Errorf("Can not obtain UID from '%s'", rawSecurityContext)
 			}
-			sc.RunAsUser = pointer.Int64(int64(runAsUser))
+			sc.RunAsUser = &runAsUser
 		}
 		return nil
 	}

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -54,41 +54,41 @@ type StackRaw struct {
 
 //Service represents an okteto stack service
 type ServiceRaw struct {
-	Deploy                   *DeployInfoRaw     `yaml:"deploy,omitempty"`
-	Build                    *BuildInfo         `yaml:"build,omitempty"`
-	CapAddSneakCase          []apiv1.Capability `yaml:"cap_add,omitempty"`
-	CapAdd                   []apiv1.Capability `yaml:"capAdd,omitempty"`
-	CapDropSneakCase         []apiv1.Capability `yaml:"cap_drop,omitempty"`
-	CapDrop                  []apiv1.Capability `yaml:"capDrop,omitempty"`
-	Command                  CommandStack       `yaml:"command,omitempty"`
-	CpuCount                 Quantity           `yaml:"cpu_count,omitempty"`
-	Cpus                     Quantity           `yaml:"cpus,omitempty"`
-	Entrypoint               CommandStack       `yaml:"entrypoint,omitempty"`
-	Args                     ArgsStack          `yaml:"args,omitempty"`
-	EnvFilesSneakCase        EnvFiles           `yaml:"env_file,omitempty"`
-	EnvFiles                 EnvFiles           `yaml:"envFile,omitempty"`
-	Environment              Environment        `yaml:"environment,omitempty"`
-	Expose                   []PortRaw          `yaml:"expose,omitempty"`
-	Healthcheck              *HealthCheck       `yaml:"healthcheck,omitempty"`
-	Image                    string             `yaml:"image,omitempty"`
-	Labels                   Labels             `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Annotations              Annotations        `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	MemLimit                 Quantity           `yaml:"mem_limit,omitempty"`
-	MemReservation           Quantity           `yaml:"mem_reservation,omitempty"`
-	Ports                    []PortRaw          `yaml:"ports,omitempty"`
-	Restart                  string             `yaml:"restart,omitempty"`
-	Scale                    *int32             `yaml:"scale"`
-	StopGracePeriodSneakCase *RawMessage        `yaml:"stop_grace_period,omitempty"`
-	StopGracePeriod          *RawMessage        `yaml:"stopGracePeriod,omitempty"`
-	Volumes                  []StackVolume      `yaml:"volumes,omitempty"`
-	WorkingDirSneakCase      string             `yaml:"working_dir,omitempty"`
-	Workdir                  string             `yaml:"workdir,omitempty"`
-	DependsOn                DependsOn          `yaml:"depends_on,omitempty"`
+	Deploy                   *DeployInfoRaw        `yaml:"deploy,omitempty"`
+	Build                    *BuildInfo            `yaml:"build,omitempty"`
+	CapAddSneakCase          []apiv1.Capability    `yaml:"cap_add,omitempty"`
+	CapAdd                   []apiv1.Capability    `yaml:"capAdd,omitempty"`
+	CapDropSneakCase         []apiv1.Capability    `yaml:"cap_drop,omitempty"`
+	CapDrop                  []apiv1.Capability    `yaml:"capDrop,omitempty"`
+	Command                  CommandStack          `yaml:"command,omitempty"`
+	CpuCount                 Quantity              `yaml:"cpu_count,omitempty"`
+	Cpus                     Quantity              `yaml:"cpus,omitempty"`
+	Entrypoint               CommandStack          `yaml:"entrypoint,omitempty"`
+	Args                     ArgsStack             `yaml:"args,omitempty"`
+	EnvFilesSneakCase        EnvFiles              `yaml:"env_file,omitempty"`
+	EnvFiles                 EnvFiles              `yaml:"envFile,omitempty"`
+	Environment              Environment           `yaml:"environment,omitempty"`
+	Expose                   []PortRaw             `yaml:"expose,omitempty"`
+	Healthcheck              *HealthCheck          `yaml:"healthcheck,omitempty"`
+	Image                    string                `yaml:"image,omitempty"`
+	Labels                   Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations              Annotations           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	MemLimit                 Quantity              `yaml:"mem_limit,omitempty"`
+	MemReservation           Quantity              `yaml:"mem_reservation,omitempty"`
+	Ports                    []PortRaw             `yaml:"ports,omitempty"`
+	Restart                  string                `yaml:"restart,omitempty"`
+	Scale                    *int32                `yaml:"scale"`
+	StopGracePeriodSneakCase *RawMessage           `yaml:"stop_grace_period,omitempty"`
+	StopGracePeriod          *RawMessage           `yaml:"stopGracePeriod,omitempty"`
+	User                     *StackSecurityContext `yaml:"user,omitempty"`
+	Volumes                  []StackVolume         `yaml:"volumes,omitempty"`
+	WorkingDirSneakCase      string                `yaml:"working_dir,omitempty"`
+	Workdir                  string                `yaml:"workdir,omitempty"`
+	DependsOn                DependsOn             `yaml:"depends_on,omitempty"`
 
-	Public          bool                  `yaml:"public,omitempty"`
-	Replicas        *int32                `yaml:"replicas"`
-	Resources       *StackResources       `yaml:"resources,omitempty"`
-	SecurityContext *StackSecurityContext `yaml:"security_context,omitempty"`
+	Public    bool            `yaml:"public,omitempty"`
+	Replicas  *int32          `yaml:"replicas"`
+	Resources *StackResources `yaml:"resources,omitempty"`
 
 	BlkioConfig       *WarningType `yaml:"blkio_config,omitempty"`
 	CpuPercent        *WarningType `yaml:"cpu_percent,omitempty"`
@@ -143,7 +143,6 @@ type ServiceRaw struct {
 	Tmpfs             *WarningType `yaml:"tmpfs,omitempty"`
 	Tty               *WarningType `yaml:"tty,omitempty"`
 	Ulimits           *WarningType `yaml:"ulimits,omitempty"`
-	User              *WarningType `yaml:"user,omitempty"`
 	UsernsMode        *WarningType `yaml:"userns_mode,omitempty"`
 	VolumesFrom       *WarningType `yaml:"volumes_from,omitempty"`
 
@@ -471,7 +470,7 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 		svc.Workdir = serviceRaw.WorkingDirSneakCase
 	}
 
-	svc.SecurityContext = serviceRaw.SecurityContext
+	svc.User = serviceRaw.User
 
 	svc.RestartPolicy, err = getRestartPolicy(svcName, serviceRaw.Deploy, serviceRaw.Restart)
 	if err != nil {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -1359,9 +1359,6 @@ func getServiceNotSupportedFields(svcName string, svcInfo *ServiceRaw) []string 
 	if svcInfo.Ulimits != nil {
 		notSupported = append(notSupported, fmt.Sprintf("services[%s].ulimits", svcName))
 	}
-	if svcInfo.User != nil {
-		notSupported = append(notSupported, fmt.Sprintf("services[%s].user", svcName))
-	}
 	if svcInfo.UsernsMode != nil {
 		notSupported = append(notSupported, fmt.Sprintf("services[%s].userns_mode", svcName))
 	}

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1859,7 +1859,7 @@ func Test_ExtensionUnmarshalling(t *testing.T) {
 	}
 }
 
-func Test_UnmarshalStackSecurityContext(t *testing.T) {
+func Test_UnmarshalStackUser(t *testing.T) {
 	tests := []struct {
 		name          string
 		manifest      []byte


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Add security context to a stack manifest

## Proposed changes
- Adds `security_context` as part of service specification
- Add tests for testing unmarshalling
