### PR TITLE
Return nil if build is successful

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -339,6 +339,8 @@ func buildIfImageNotFound(ctx context.Context, options build.BuildOptions) error
 			if err := build.Run(ctx, options); err != nil {
 				return err
 			}
+			log.Debugf("success building image before deploy %s", options.Tag)
+			return nil
 		}
 		return fmt.Errorf("error calling registry: %s", err.Error())
 	}


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #

## Proposed changes

- when checking the image before deploying, return nil if the build has been successful, not returning was causing the flow to break and returning not found error for the image

