### PR TITLE
Dockerignore not working as expected

### DIFF
--- a/pkg/registry/file.go
+++ b/pkg/registry/file.go
@@ -195,7 +195,7 @@ func copyDockerIgnore(originalPath, translatedPath string) error {
 				return err
 			}
 		} else {
-			log.Info("could not detect any .dockerignore on %s", originalDir)
+			log.Infof("could not detect any .dockerignore on %s", originalDir)
 		}
 	}
 	return nil
@@ -204,7 +204,7 @@ func copyDockerIgnore(originalPath, translatedPath string) error {
 func copyFile(orig, dest string) error {
 	input, err := ioutil.ReadFile(orig)
 	if err != nil {
-		log.Info("could not read %s dockerfile", orig)
+		log.Infof("could not read %s dockerfile", orig)
 		return err
 	}
 

--- a/pkg/registry/file.go
+++ b/pkg/registry/file.go
@@ -16,15 +16,21 @@ package registry
 import (
 	"bufio"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/pkg/errors"
+)
+
+const (
+	defaultDockerIgnore = ".dockerignore"
 )
 
 // GetDockerfile returns the dockerfile with the cache and registry translations
@@ -75,6 +81,10 @@ func getTranslatedDockerFile(filename string) (string, error) {
 		_, _ = datawriter.WriteString(translatedLine + "\n")
 	}
 	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	if err := copyDockerIgnore(filename, tmpFile.Name()); err != nil {
 		return "", err
 	}
 
@@ -157,4 +167,51 @@ func CreateDockerfileWithVolumeMounts(image string, volumes []model.StackVolume)
 
 	build.Dockerfile = tmpFile.Name()
 	return build, nil
+}
+
+func copyDockerIgnore(originalPath, translatedPath string) error {
+	originalPath, err := filepath.Abs(originalPath)
+	if err != nil {
+		log.Infof("could not load original dockerfile path")
+		return err
+	}
+	originalDir := filepath.Dir(originalPath)
+	originalName := filepath.Base(originalPath)
+	originalDockerIgnore := filepath.Join(originalDir, fmt.Sprintf("%s%s", originalName, defaultDockerIgnore))
+
+	translatedDir := filepath.Dir(translatedPath)
+	translatedName := filepath.Base(translatedPath)
+	newPath := filepath.Join(translatedDir, fmt.Sprintf("%s%s", translatedName, defaultDockerIgnore))
+	if fs, err := os.Stat(originalDockerIgnore); err == nil && !fs.IsDir() {
+		err := copyFile(originalDockerIgnore, newPath)
+		if err != nil {
+			return err
+		}
+	} else {
+		originalDockerIgnore := filepath.Join(originalDir, defaultDockerIgnore)
+		if fs, err := os.Stat(originalDockerIgnore); err == nil && !fs.IsDir() {
+			err := copyFile(originalDockerIgnore, newPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			log.Info("could not detect any .dockerignore on %s", originalDir)
+		}
+	}
+	return nil
+}
+
+func copyFile(orig, dest string) error {
+	input, err := ioutil.ReadFile(orig)
+	if err != nil {
+		log.Info("could not read %s dockerfile", orig)
+		return err
+	}
+
+	err = ioutil.WriteFile(dest, input, 0644)
+	if err != nil {
+		log.Infof("error creating %s: %s", dest, err)
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2098

## Proposed changes
- After translating docker files copy the docker ignore that must be applied with the new docker file prefix
-
