### PR TITLE
fix: second retry causing nil pointer exception

### DIFF
--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -194,7 +194,9 @@ func query(ctx context.Context, query interface{}, variables map[string]interfac
 		if isAPITransientErr(err) {
 			err = client.Query(ctx, query, variables)
 		}
-		return translateAPIErr(err)
+		if err != nil {
+			return translateAPIErr(err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes second attempt on queries could cause a nil pointer exception

## Proposed changes
- Check if the second attempt of the query returned an error
