### PR TITLE
skip showing deleting namespaces in okteto namespace command

### DIFF
--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -127,7 +127,7 @@ func getNamespacesSelection(ctx context.Context) ([]utils.SelectorItem, error) {
 
 	namespaces := []utils.SelectorItem{}
 	for _, space := range spaces {
-		if space.Status == "Active" {
+		if space.Status != "Deleting" {
 			namespaces = append(namespaces, utils.SelectorItem{
 				Name:   space.ID,
 				Label:  space.ID,

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -127,12 +127,13 @@ func getNamespacesSelection(ctx context.Context) ([]utils.SelectorItem, error) {
 
 	namespaces := []utils.SelectorItem{}
 	for _, space := range spaces {
-
-		namespaces = append(namespaces, utils.SelectorItem{
-			Name:   space.ID,
-			Label:  space.ID,
-			Enable: true,
-		})
+		if space.Status == "Active" {
+			namespaces = append(namespaces, utils.SelectorItem{
+				Name:   space.ID,
+				Label:  space.ID,
+				Enable: true,
+			})
+		}
 	}
 
 	namespaces = append(namespaces, []utils.SelectorItem{


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

Fixes #2140 

## Proposed changes

- filtering namespaces by status before adding them to the list

## Tests

Tested locally by deleting a namespace and running the `okteto namespace` command:

https://user-images.githubusercontent.com/56963264/150497775-e64f05fe-6492-47b7-b6e9-1a74f97d2c25.mov


