### PR TITLE
Global registry optimisation

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -162,15 +162,15 @@ func buildV2(m model.ManifestBuild, options build.BuildOptions, args []string) e
 
 		// check if image is at registry and skip
 		if build.ShouldOptimizeBuild(opts.Tag) {
-			log.Debug("found OKTETO_GIT_COMMIT, optimizing the build flow")
+			oktetoLog.Debug("found OKTETO_GIT_COMMIT, optimizing the build flow")
 			globalReference := strings.Replace(opts.Tag, okteto.DevRegistry, okteto.GlobalRegistry, 1)
 			if _, err := registry.GetImageTagWithDigest(globalReference); err == nil {
-				log.Information("skipping build: image already exists at global registry -  %s", globalReference)
+				oktetoLog.Information("skipping build: image already exists at global registry -  %s", globalReference)
 				return nil
 			}
 			// check if image already is at the registry
 			if _, err := registry.GetImageTagWithDigest(opts.Tag); err == nil {
-				log.Information("skipping build: image already exists at registry - %s", opts.Tag)
+				oktetoLog.Information("skipping build: image already exists at registry - %s", opts.Tag)
 				return nil
 			}
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -120,7 +120,7 @@ func keepOnlySelectedServices(service string, manifest *model.ManifestBuild) {
 	}
 }
 
-func buildV2(m model.ManifestBuild, options build.BuildOptions, args []string) error {
+func buildV2(manifest model.ManifestBuild, options build.BuildOptions, args []string) error {
 	service := ""
 	if len(args) == 1 {
 		service = args[0]
@@ -128,28 +128,28 @@ func buildV2(m model.ManifestBuild, options build.BuildOptions, args []string) e
 
 	// settings for single build
 	if service != "" {
-		_, ok := m[service]
+		_, ok := manifest[service]
 		if !ok {
 			return fmt.Errorf("invalid service name: %s", service)
 		}
 
-		keepOnlySelectedServices(service, &m)
+		keepOnlySelectedServices(service, &manifest)
 
 		if options.Target != "" {
-			m[service].Target = options.Target
+			manifest[service].Target = options.Target
 		}
 		if len(options.CacheFrom) != 0 {
-			m[service].CacheFrom = options.CacheFrom
+			manifest[service].CacheFrom = options.CacheFrom
 		}
 		if options.Tag != "" {
-			m[service].Image = options.Tag
+			manifest[service].Image = options.Tag
 		}
 
 	} else if options.Tag != "" || options.Target != "" || options.CacheFrom != nil || options.Secrets != nil {
 		return fmt.Errorf("flags are not allowed when building services from manifest")
 	}
 
-	for srv, manifestOptions := range m {
+	for srv, manifestOptions := range manifest {
 		if !okteto.Context().IsOkteto && manifestOptions.Image == "" {
 			oktetoLog.Errorf("image is required")
 			continue

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -112,7 +112,7 @@ func Build(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-func removeUnusedServicesFromManifest(service string, manifest *model.ManifestBuild) {
+func keepOnlySelectedServices(service string, manifest *model.ManifestBuild) {
 	for key := range *manifest {
 		if key != service {
 			delete(*manifest, key)
@@ -133,7 +133,7 @@ func buildV2(m model.ManifestBuild, options build.BuildOptions, args []string) e
 			return fmt.Errorf("invalid service name: %s", service)
 		}
 
-		removeUnusedServicesFromManifest(service, &m)
+		keepOnlySelectedServices(service, &m)
 
 		if options.Target != "" {
 			m[service].Target = options.Target

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -145,10 +145,8 @@ func buildV2(m model.ManifestBuild, options build.BuildOptions, args []string) e
 			m[service].Image = options.Tag
 		}
 
-	} else {
-		if options.Tag != "" || options.Target != "" || options.CacheFrom != nil || options.Secrets != nil {
-			return fmt.Errorf("flags are not allowed when building services from manifest")
-		}
+	} else if options.Tag != "" || options.Target != "" || options.CacheFrom != nil || options.Secrets != nil {
+		return fmt.Errorf("flags are not allowed when building services from manifest")
 	}
 
 	for srv, manifestOptions := range m {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -112,10 +112,10 @@ func Build(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-func keepOnlySelectedServices(service string, manifest *model.ManifestBuild) {
-	for key := range *manifest {
+func keepOnlySelectedServices(service string, manifest model.ManifestBuild) {
+	for key := range manifest {
 		if key != service {
-			delete(*manifest, key)
+			delete(manifest, key)
 		}
 	}
 }
@@ -133,7 +133,7 @@ func buildV2(manifest model.ManifestBuild, options build.BuildOptions, args []st
 			return fmt.Errorf("invalid service name: %s", service)
 		}
 
-		keepOnlySelectedServices(service, &manifest)
+		keepOnlySelectedServices(service, manifest)
 
 		if options.Target != "" {
 			manifest[service].Target = options.Target
@@ -146,12 +146,12 @@ func buildV2(manifest model.ManifestBuild, options build.BuildOptions, args []st
 		}
 
 	} else if options.Tag != "" || options.Target != "" || options.CacheFrom != nil || options.Secrets != nil {
-		return fmt.Errorf("flags are not allowed when building services from manifest")
+		return fmt.Errorf("flags only allowed when building a single image with `okteto build [NAME]`")
 	}
 
 	for srv, manifestOptions := range manifest {
 		if !okteto.Context().IsOkteto && manifestOptions.Image == "" {
-			oktetoLog.Errorf("image is required")
+			oktetoLog.Errorf("image is required for service %s", srv)
 			continue
 		}
 		if cwd, err := os.Getwd(); err == nil && manifestOptions.Name == "" {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -247,6 +247,7 @@ func (dc *deployCommand) runDeploy(ctx context.Context, cwd string, deployOption
 				} else if err != nil {
 					return fmt.Errorf("error checking image at registry %s: %v", opts.Tag, err)
 				} else {
+					log.Debug("image found, skipping build")
 					if err := setManifestEnvVars(service, imageWithDigest); err != nil {
 						return err
 					}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -236,6 +236,7 @@ func (dc *deployCommand) runDeploy(ctx context.Context, cwd string, deployOption
 					if err := checkImageAtGlobalAndSetEnvs(service, opts); err != nil {
 						return err
 					}
+					continue
 				}
 
 				if imageWithDigest, err := registry.GetImageTagWithDigest(opts.Tag); err == okErrors.ErrNotFound {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -548,12 +548,11 @@ func addEnvVars(ctx context.Context, cwd string) error {
 		if err != nil {
 			oktetoLog.Infof("could not status: %s", err)
 		}
-		if isClean {
-			os.Setenv(model.OktetoGitCommitEnvVar, sha)
-		} else {
-			sha := utils.GetRandomSHA(ctx, cwd)
-			os.Setenv(model.OktetoGitCommitEnvVar, sha)
+		if !isClean {
+			sha = utils.GetRandomSHA(ctx, cwd)
 		}
+		value := fmt.Sprintf("dev%s", sha)
+		os.Setenv(model.OktetoGitCommitEnvVar, value)
 	}
 	if os.Getenv(model.OktetoRegistryURLEnvVar) == "" {
 		os.Setenv(model.OktetoRegistryURLEnvVar, okteto.Context().Registry)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -571,7 +571,7 @@ func addEnvVars(ctx context.Context, cwd string) error {
 		if !isClean {
 			sha = utils.GetRandomSHA(ctx, cwd)
 		}
-		value := fmt.Sprintf("dev%s", sha)
+		value := fmt.Sprintf("%s%s", model.OktetoGitCommitPrefix, sha)
 		os.Setenv(model.OktetoGitCommitEnvVar, value)
 	}
 	if os.Getenv(model.OktetoRegistryURLEnvVar) == "" {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -34,7 +34,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/config"
-	okErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -240,7 +240,7 @@ func (dc *deployCommand) runDeploy(ctx context.Context, cwd string, deployOption
 					}
 				}
 
-				if imageWithDigest, err := registry.GetImageTagWithDigest(opts.Tag); err == okErrors.ErrNotFound {
+				if imageWithDigest, err := registry.GetImageTagWithDigest(opts.Tag); err == oktetoErrors.ErrNotFound {
 					oktetoLog.Debugf("image not found, building image %s", opts.Tag)
 					if err := runBuildAndSetEnvs(ctx, service, opts); err != nil {
 						return err
@@ -320,7 +320,7 @@ func checkImageAtGlobalAndSetEnvs(service string, options build.BuildOptions) (b
 	globalReference := strings.Replace(options.Tag, okteto.DevRegistry, okteto.GlobalRegistry, 1)
 
 	imageWithDigest, err := registry.GetImageTagWithDigest(globalReference)
-	if err == okErrors.ErrNotFound {
+	if err == oktetoErrors.ErrNotFound {
 		oktetoLog.Debug("image not found at global registry, not running optimization for deployment")
 		return false, nil
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -345,10 +345,7 @@ func runBuildAndSetEnvs(ctx context.Context, service string, options build.Build
 	if err != nil {
 		return fmt.Errorf("error checking image at registry %s: %v", options.Tag, err)
 	}
-	if err := setManifestEnvVars(service, imageWithDigest); err != nil {
-		return err
-	}
-	return nil
+	return setManifestEnvVars(service, imageWithDigest)
 }
 
 func setManifestEnvVars(service, reference string) error {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -305,11 +305,11 @@ func Test_setManifestEnvVars(t *testing.T) {
 		{
 			name:          "setting-variables",
 			service:       "frontend",
-			reference:     "registry.url/namespace/frontend@sha256",
+			reference:     "registry.url/namespace/frontend@sha256:7075f1094117e418764bb9b47a5dfc093466e714ec385223fb582d78220c7252",
 			expRegistry:   "registry.url",
 			expRepository: "namespace/frontend",
-			expImage:      "registry.url/namespace/frontend@sha256",
-			expTag:        "sha256",
+			expImage:      "registry.url/namespace/frontend@sha256:7075f1094117e418764bb9b47a5dfc093466e714ec385223fb582d78220c7252",
+			expTag:        "sha256:7075f1094117e418764bb9b47a5dfc093466e714ec385223fb582d78220c7252",
 		},
 		{
 			name:          "setting-variables-no-tag",

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -52,7 +52,7 @@ build:
 		testID           = strings.ToLower(fmt.Sprintf("TestBuildCommand-%s-%d", runtime.GOOS, time.Now().Unix()))
 		testNamespace    = fmt.Sprintf("%s-%s", testID, user)
 		originNamespace  = getCurrentNamespace()
-		expectedImageTag = fmt.Sprintf("%s/%s/%s:dev", okteto.Context().Registry, testNamespace, "app")
+		expectedImageTag = fmt.Sprintf("%s/%s/%s-app:okteto", okteto.Context().Registry, testNamespace, repoDir)
 	)
 
 	if err := cloneGitRepo(ctx, gitRepo); err != nil {
@@ -87,13 +87,13 @@ build:
 			t.Fatal("image is already at registry")
 		}
 
-		_, err := runOktetoBuild(ctx, oktetoPath, pathToManifestFile, repoDir)
+		output, err := runOktetoBuild(ctx, oktetoPath, pathToManifestFile, repoDir)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		if _, err := registry.GetImageTagWithDigest(expectedImageTag); err != nil {
-			t.Fatalf("image not pushed to registry: %v", err)
+			t.Fatalf("image not pushed to registry: %v \nbuild output: %s", err, output)
 		}
 
 	})

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -228,7 +228,7 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 	return opts
 }
 
-// ShouldOptimizeBuild returns if optimization should be aplied
+// ShouldOptimizeBuild returns if optimization should be applied
 func ShouldOptimizeBuild(image string) bool {
 	envGitCommit := os.Getenv(model.OktetoGitCommitEnvVar)
 	isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, "dev")

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -197,9 +197,10 @@ func translateDockerErr(err error) error {
 	return err
 }
 
+// OptsFromManifest returns the parsed options for the build from the manifest
 func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildOptions {
 	if okteto.Context().IsOkteto && b.Image == "" {
-		b.Image = fmt.Sprintf("%s/%s:%s", okteto.DevRegistry, service, "dev")
+		b.Image = fmt.Sprintf("%s/%s-%s:%s", okteto.DevRegistry, b.Name, service, "okteto")
 	}
 
 	opts := BuildOptions{

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -227,3 +227,12 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 	opts.OutputMode = setOutputMode(o.OutputMode)
 	return opts
 }
+
+// ShouldOptimizeBuild returns if optimization should be aplied
+func ShouldOptimizeBuild(image string) bool {
+	envGitCommit := os.Getenv(model.OktetoGitCommitEnvVar)
+	isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, "dev")
+	return registry.IsOktetoRegistry(image) &&
+		envGitCommit != "" &&
+		!isLocalEnvGitCommit
+}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -200,10 +200,10 @@ func translateDockerErr(err error) error {
 // OptsFromManifest returns the parsed options for the build from the manifest
 func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildOptions {
 	if okteto.Context().IsOkteto && b.Image == "" {
-		tag := "okteto"
+		tag := model.OktetoDefaultImageTag
 
 		envGitCommit := os.Getenv(model.OktetoGitCommitEnvVar)
-		isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, "dev")
+		isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, model.OktetoGitCommitPrefix)
 
 		if envGitCommit != "" && !isLocalEnvGitCommit {
 			tag = envGitCommit
@@ -231,7 +231,7 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 // ShouldOptimizeBuild returns if optimization should be applied
 func ShouldOptimizeBuild(image string) bool {
 	envGitCommit := os.Getenv(model.OktetoGitCommitEnvVar)
-	isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, "dev")
+	isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, model.OktetoGitCommitPrefix)
 	return registry.IsOktetoRegistry(image) &&
 		envGitCommit != "" &&
 		!isLocalEnvGitCommit

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -200,7 +200,16 @@ func translateDockerErr(err error) error {
 // OptsFromManifest returns the parsed options for the build from the manifest
 func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildOptions {
 	if okteto.Context().IsOkteto && b.Image == "" {
-		b.Image = fmt.Sprintf("%s/%s-%s:%s", okteto.DevRegistry, b.Name, service, "okteto")
+		tag := "okteto"
+
+		envGitCommit := os.Getenv(model.OktetoGitCommitEnvVar)
+		isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, "dev")
+
+		if envGitCommit != "" && !isLocalEnvGitCommit {
+			tag = envGitCommit
+		}
+
+		b.Image = fmt.Sprintf("%s/%s-%s:%s", okteto.DevRegistry, b.Name, service, tag)
 	}
 
 	opts := BuildOptions{

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -72,6 +73,26 @@ func Test_OptsFromManifest(t *testing.T) {
 			},
 		},
 		{
+			name:           "empty-values-is-okteto-local",
+			serviceName:    "service",
+			buildInfo:      &model.BuildInfo{Name: "movies"},
+			okGitCommitEnv: "dev1235466",
+			isOkteto:       true,
+			expected: BuildOptions{
+				Tag: "okteto.dev/movies-service:okteto",
+			},
+		},
+		{
+			name:           "empty-values-is-okteto-pipeline",
+			serviceName:    "service",
+			buildInfo:      &model.BuildInfo{Name: "movies"},
+			okGitCommitEnv: "1235466",
+			isOkteto:       true,
+			expected: BuildOptions{
+				Tag: "okteto.dev/movies-service:1235466",
+			},
+		},
+		{
 			name:        "empty-values-is-not-okteto",
 			serviceName: "service",
 			buildInfo:   &model.BuildInfo{Name: "movies"},
@@ -111,6 +132,7 @@ func Test_OptsFromManifest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv(model.OktetoGitCommitEnvVar)
 			okteto.CurrentStore = &okteto.OktetoContextStore{
 				Contexts: map[string]*okteto.OktetoContext{
 					"test": {
@@ -120,6 +142,7 @@ func Test_OptsFromManifest(t *testing.T) {
 				},
 				CurrentContext: "test",
 			}
+			os.Setenv(model.OktetoGitCommitEnvVar, tt.okGitCommitEnv)
 			result := OptsFromManifest(tt.serviceName, tt.buildInfo, tt.initialOpts)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -65,16 +65,16 @@ func Test_OptsFromManifest(t *testing.T) {
 		{
 			name:        "empty-values-is-okteto",
 			serviceName: "service",
-			buildInfo:   &model.BuildInfo{},
+			buildInfo:   &model.BuildInfo{Name: "movies"},
 			isOkteto:    true,
 			expected: BuildOptions{
-				Tag: "okteto.dev/service:dev",
+				Tag: "okteto.dev/movies-service:okteto",
 			},
 		},
 		{
 			name:        "empty-values-is-not-okteto",
 			serviceName: "service",
-			buildInfo:   &model.BuildInfo{},
+			buildInfo:   &model.BuildInfo{Name: "movies"},
 			isOkteto:    false,
 			expected:    BuildOptions{},
 		},
@@ -82,6 +82,7 @@ func Test_OptsFromManifest(t *testing.T) {
 			name:        "all-values-no-image",
 			serviceName: "service",
 			buildInfo: &model.BuildInfo{
+				Name:       "movies",
 				Context:    "service",
 				Dockerfile: "CustomDockerfile",
 				Target:     "build",
@@ -98,7 +99,7 @@ func Test_OptsFromManifest(t *testing.T) {
 			},
 			isOkteto: true,
 			expected: BuildOptions{
-				Tag:        "okteto.dev/service:dev",
+				Tag:        "okteto.dev/movies-service:okteto",
 				File:       filepath.Join("service", "CustomDockerfile"),
 				Target:     "build",
 				Path:       "service",

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -303,4 +303,10 @@ const (
 
 	// BuildkitProgressEnvVar defines the output of buildkit
 	BuildkitProgressEnvVar = "BUILDKIT_PROGRESS"
+
+	// OktetoGitCommitPrefix prefix added to OKTETO_GIT_COMMIT when inferred by cli
+	OktetoGitCommitPrefix = "dev"
+
+	// OktetoDefaultImageTag default tag assigned to image to build
+	OktetoDefaultImageTag = "okteto"
 )

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -78,3 +78,14 @@ func configForReference(reference string) (v1.Config, error) {
 
 	return configFile.Config, nil
 }
+
+// GetReferecenceEnvs returns the values to setup the image environment variables
+func GetReferecenceEnvs(reference string) (reg string, repo string, tag string, image string) {
+	ref, err := name.ParseReference(reference)
+	if err != nil {
+		log.Debugf("error parsing reference: %s - %v", reference, err)
+		return "", "", "", reference
+	}
+
+	return ref.Context().RegistryStr(), ref.Context().RepositoryStr(), ref.Identifier(), ref.Name()
+}

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -83,7 +83,7 @@ func configForReference(reference string) (v1.Config, error) {
 func GetReferecenceEnvs(reference string) (reg, repo, tag, image string) {
 	ref, err := name.ParseReference(reference)
 	if err != nil {
-		log.Debugf("error parsing reference: %s - %v", reference, err)
+		oktetoLog.Debugf("error parsing reference: %s - %v", reference, err)
 		return "", "", "", reference
 	}
 

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -80,7 +80,7 @@ func configForReference(reference string) (v1.Config, error) {
 }
 
 // GetReferecenceEnvs returns the values to setup the image environment variables
-func GetReferecenceEnvs(reference string) (reg string, repo string, tag string, image string) {
+func GetReferecenceEnvs(reference string) (reg, repo, tag, image string) {
 	ref, err := name.ParseReference(reference)
 	if err != nil {
 		log.Debugf("error parsing reference: %s - %v", reference, err)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -142,6 +142,7 @@ func IsOktetoRegistry(tag string) bool {
 	return IsDevRegistry(tag) || IsGlobalRegistry(tag)
 }
 
+// replaceRegistry replaces the short registry url with the okteto registry url
 func replaceRegistry(input, registryType, namespace string) string {
 	// Check if the registryType is the start of the sentence or has a whitespace before it
 	var re = regexp.MustCompile(fmt.Sprintf(`(^|\s)(%s)`, registryType))


### PR DESCRIPTION
Fixes #2155 

## Proposed changes

When running `okteto build` or `okteto deploy` as part of a pipeline with the env `OKTETO_GIT_COMMIT` using the okteto manifest:

- image tag assign to the service will be tagged with the commit
- before building the image: global registry is checked. If exists, is skipped. If not, dev registry is checked. If exists at dev, is skipped, if not, is built and pushed to the dev okteto registry.
- at deploy, if image exists at global, envs are set to this reference and this is deployed, if not current process will build image to dev okteto registry if not exist and set this as envs to deploy. when `okteto deploy --build` the image is built to okteto dev registry
