### PR TITLE
Add repo and branch flags in deploy command

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/namespace"
+	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/config"
@@ -57,6 +58,8 @@ type Options struct {
 	Timeout      time.Duration
 	Manifest     *model.Manifest
 	Build        bool
+	Repository   string
+	Branch       string
 }
 
 type kubeConfigHandler interface {
@@ -91,6 +94,20 @@ func Deploy(ctx context.Context) *cobra.Command {
 		Args:   utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#version"),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if shouldExecuteRemotely(options) {
+				remoteOpts := &pipeline.DeployOptions{
+					Branch:     options.Branch,
+					Repository: options.Repository,
+					Name:       options.Name,
+					Namespace:  options.Namespace,
+					Wait:       true,
+					File:       options.ManifestPath,
+					Variables:  options.Variables,
+					Timeout:    (5 * time.Minute),
+				}
+				return pipeline.ExecuteDeployPipeline(ctx, remoteOpts)
+			}
 			// This is needed because the deploy command needs the original kubeconfig configuration even in the execution within another
 			// deploy command. If not, we could be proxying a proxy and we would be applying the incorrect deployed-by label
 			os.Setenv(model.OktetoWithinDeployCommandContextEnvVar, "false")
@@ -188,6 +205,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&options.Name, "name", "", "application name")
 	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the okteto manifest file")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the application is deployed")
+	cmd.Flags().StringVarP(&options.Repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
+	cmd.Flags().StringVarP(&options.Branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
 
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
 	cmd.Flags().BoolVarP(&options.Build, "build", "", false, "force build of images when deploying the app")
@@ -564,4 +583,8 @@ func addEnvVars(ctx context.Context, cwd string) error {
 		os.Setenv(model.OktetoBuildkitHostURLEnvVar, okteto.Context().Builder)
 	}
 	return nil
+}
+
+func shouldExecuteRemotely(options *Options) bool {
+	return options.Branch != "" || options.Repository != ""
 }

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -55,11 +55,13 @@ type Options struct {
 	Name         string
 	Namespace    string
 	Variables    []string
-	Timeout      time.Duration
 	Manifest     *model.Manifest
 	Build        bool
-	Repository   string
-	Branch       string
+
+	Repository string
+	Branch     string
+	Wait       bool
+	Timeout    time.Duration
 }
 
 type kubeConfigHandler interface {
@@ -101,10 +103,10 @@ func Deploy(ctx context.Context) *cobra.Command {
 					Repository: options.Repository,
 					Name:       options.Name,
 					Namespace:  options.Namespace,
-					Wait:       true,
+					Wait:       options.Wait,
 					File:       options.ManifestPath,
 					Variables:  options.Variables,
-					Timeout:    (5 * time.Minute),
+					Timeout:    options.Timeout,
 				}
 				return pipeline.ExecuteDeployPipeline(ctx, remoteOpts)
 			}
@@ -205,12 +207,14 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&options.Name, "name", "", "application name")
 	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the okteto manifest file")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the application is deployed")
-	cmd.Flags().StringVarP(&options.Repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
-	cmd.Flags().StringVarP(&options.Branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
-
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
 	cmd.Flags().BoolVarP(&options.Build, "build", "", false, "force build of images when deploying the app")
 	cmd.Flags().MarkHidden("build")
+
+	cmd.Flags().StringVarP(&options.Repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
+	cmd.Flags().StringVarP(&options.Branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
+	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the pipeline finishes (defaults to false)")
+	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", (5 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
 
 	return cmd
 }

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -31,129 +31,138 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func deploy(ctx context.Context) *cobra.Command {
-	var branch string
-	var repository string
-	var name string
-	var namespace string
-	var wait bool
-	var skipIfExists bool
-	var timeout time.Duration
-	var variables []string
-	var file string
-	var filename string
+// DeployOptions options for deploy pipeline command
+type DeployOptions struct {
+	Branch       string
+	Repository   string
+	Name         string
+	Namespace    string
+	Wait         bool
+	SkipIfExists bool
+	Timeout      time.Duration
+	File         string
+	Variables    []string
 
+	//Deprecated fields
+	Filename string
+}
+
+func deploy(ctx context.Context) *cobra.Command {
+	opts := &DeployOptions{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy an okteto pipeline",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#deploy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			ctxResource := &model.ContextResource{}
-			if err := ctxResource.UpdateNamespace(namespace); err != nil {
-				return err
-			}
-
-			ctxOptions := &contextCMD.ContextOptions{
-				Namespace: ctxResource.Namespace,
-			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
-				return err
-			}
-
-			if !okteto.IsOkteto() {
-				return oktetoErrors.ErrContextIsNotOktetoCluster
-			}
-
-			cwd, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("failed to get the current working directory: %w", err)
-			}
-
-			if repository == "" {
-				oktetoLog.Info("inferring git repository URL")
-
-				repository, err = model.GetRepositoryURL(cwd)
-				if err != nil {
-					return err
-				}
-			}
-
-			if name == "" {
-				name = getPipelineName(repository)
-			}
-
-			if branch == "" {
-				oktetoLog.Info("inferring git repository branch")
-				b, err := utils.GetBranch(ctx, cwd)
-
-				if err != nil {
-					return err
-				}
-
-				branch = b
-			}
-
-			if skipIfExists {
-				oktetoClient, err := okteto.NewOktetoClient()
-				if err != nil {
-					return err
-				}
-				pipeline, err := oktetoClient.GetPipelineByRepository(ctx, repository)
-				if err == nil {
-					oktetoLog.Information("Pipeline URL: %s", getPipelineURL(pipeline.GitDeploy))
-					oktetoLog.Success("Pipeline '%s' was already deployed", name)
-					return nil
-				}
-				if !oktetoErrors.IsNotFound(err) {
-					return err
-				}
-			}
-
-			if filename != "" {
-				oktetoLog.Warning("the 'filename' flag is deprecated and will be removed in a future version. Please consider using 'file' flag")
-				if file == "" {
-					file = filename
-				} else {
-					oktetoLog.Warning("flags 'filename' and 'file' can not be used at the same time. 'file' flag will take precedence")
-				}
-			}
-
-			resp, err := deployPipeline(ctx, name, repository, branch, file, variables)
-			if err != nil {
-				return err
-			}
-			oktetoLog.Information("Pipeline URL: %s", getPipelineURL(resp.GitDeploy))
-
-			if !wait {
-				oktetoLog.Success("Pipeline '%s' scheduled for deployment", name)
-				return nil
-			}
-
-			if err := waitUntilRunning(ctx, name, resp.Action, timeout); err != nil {
-				return err
-			}
-			oktetoLog.Success("Pipeline '%s' successfully deployed", name)
-			return nil
+			return ExecuteDeployPipeline(ctx, opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the up command is executed (defaults to the current namespace)")
-	cmd.Flags().StringVarP(&repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
-	cmd.Flags().StringVarP(&branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
-	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "wait until the pipeline finishes (defaults to false)")
-	cmd.Flags().BoolVarP(&skipIfExists, "skip-if-exists", "", false, "skip the pipeline deployment if the pipeline already exists in the namespace (defaults to false)")
-	cmd.Flags().DurationVarP(&timeout, "timeout", "t", (5 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
-	cmd.Flags().StringArrayVarP(&variables, "var", "v", []string{}, "set a pipeline variable (can be set more than once)")
-	cmd.Flags().StringVarP(&file, "file", "f", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
-
-	cmd.Flags().StringVarP(&filename, "filename", "", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
+	cmd.Flags().StringVarP(&opts.Name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "namespace where the up command is executed (defaults to the current namespace)")
+	cmd.Flags().StringVarP(&opts.Repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
+	cmd.Flags().StringVarP(&opts.Branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
+	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "wait until the pipeline finishes (defaults to false)")
+	cmd.Flags().BoolVarP(&opts.SkipIfExists, "skip-if-exists", "", false, "skip the pipeline deployment if the pipeline already exists in the namespace (defaults to false)")
+	cmd.Flags().DurationVarP(&opts.Timeout, "timeout", "t", (5 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
+	cmd.Flags().StringArrayVarP(&opts.Variables, "var", "v", []string{}, "set a pipeline variable (can be set more than once)")
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
+	cmd.Flags().StringVarP(&opts.Filename, "filename", "", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
 	cmd.Flags().MarkHidden("filename")
 	return cmd
 }
 
-func deployPipeline(ctx context.Context, name, repository, branch, file string, variables []string) (*types.GitDeployResponse, error) {
+//ExecuteDeployPipeline executes deploy pipeline given a set of options
+func ExecuteDeployPipeline(ctx context.Context, opts *DeployOptions) error {
+	ctxResource := &model.ContextResource{}
+	if err := ctxResource.UpdateNamespace(opts.Namespace); err != nil {
+		return err
+	}
+
+	ctxOptions := &contextCMD.ContextOptions{
+		Namespace: ctxResource.Namespace,
+	}
+	if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+		return err
+	}
+
+	if !okteto.IsOkteto() {
+		return oktetoErrors.ErrContextIsNotOktetoCluster
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %w", err)
+	}
+
+	if opts.Repository == "" {
+		oktetoLog.Info("inferring git repository URL")
+
+		opts.Repository, err = model.GetRepositoryURL(cwd)
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.Name == "" {
+		opts.Name = getPipelineName(opts.Repository)
+	}
+
+	if opts.Branch == "" {
+		oktetoLog.Info("inferring git repository branch")
+		b, err := utils.GetBranch(ctx, cwd)
+
+		if err != nil {
+			return err
+		}
+
+		opts.Branch = b
+	}
+
+	if opts.SkipIfExists {
+		oktetoClient, err := okteto.NewOktetoClient()
+		if err != nil {
+			return err
+		}
+		pipeline, err := oktetoClient.GetPipelineByRepository(ctx, opts.Repository)
+		if err == nil {
+			oktetoLog.Information("Pipeline URL: %s", getPipelineURL(pipeline.GitDeploy))
+			oktetoLog.Success("Pipeline '%s' was already deployed", opts.Name)
+			return nil
+		}
+		if !oktetoErrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	if opts.Filename != "" {
+		oktetoLog.Warning("the 'filename' flag is deprecated and will be removed in a future version. Please consider using 'file' flag")
+		if opts.File == "" {
+			opts.File = opts.Filename
+		} else {
+			oktetoLog.Warning("flags 'filename' and 'file' can not be used at the same time. 'file' flag will take precedence")
+		}
+	}
+
+	resp, err := deployPipeline(ctx, opts)
+	if err != nil {
+		return err
+	}
+	oktetoLog.Information("Pipeline URL: %s", getPipelineURL(resp.GitDeploy))
+
+	if !opts.Wait {
+		oktetoLog.Success("Pipeline '%s' scheduled for deployment", opts.Name)
+		return nil
+	}
+
+	if err := waitUntilRunning(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
+		return err
+	}
+	oktetoLog.Success("Pipeline '%s' successfully deployed", opts.Name)
+	return nil
+}
+
+func deployPipeline(ctx context.Context, opts *DeployOptions) (*types.GitDeployResponse, error) {
 	spinner := utils.NewSpinner("Deploying your pipeline...")
 	spinner.Start()
 	defer spinner.Stop()
@@ -170,7 +179,7 @@ func deployPipeline(ctx context.Context, name, repository, branch, file string, 
 	}
 	go func() {
 		varList := []types.Variable{}
-		for _, v := range variables {
+		for _, v := range opts.Variables {
 			kv := strings.SplitN(v, "=", 2)
 			if len(kv) != 2 {
 				exit <- fmt.Errorf("invalid variable value '%s': must follow KEY=VALUE format", v)
@@ -182,9 +191,9 @@ func deployPipeline(ctx context.Context, name, repository, branch, file string, 
 			})
 		}
 		namespace := okteto.Context().Namespace
-		oktetoLog.Infof("deploy pipeline %s defined on file='%s' repository=%s branch=%s on namespace=%s", name, file, repository, branch, namespace)
+		oktetoLog.Infof("deploy pipeline %s defined on file='%s' repository=%s branch=%s on namespace=%s", opts.Name, opts.File, opts.Repository, opts.Branch, namespace)
 
-		resp, err = oktetoClient.DeployPipeline(ctx, name, repository, branch, file, varList)
+		resp, err = oktetoClient.DeployPipeline(ctx, opts.Name, opts.Repository, opts.Branch, opts.File, varList)
 		exit <- err
 	}()
 
@@ -204,6 +213,12 @@ func deployPipeline(ctx context.Context, name, repository, branch, file string, 
 
 func getPipelineName(repository string) string {
 	return model.TranslateURLToName(repository)
+}
+
+func getPipelineURL(gitDeploy *types.GitDeploy) string {
+	octx := okteto.Context()
+	pipelineURL := fmt.Sprintf("%s/#/spaces/%s?resourceId=%s", octx.Name, octx.Namespace, gitDeploy.ID)
+	return pipelineURL
 }
 
 func waitUntilRunning(ctx context.Context, name string, action *types.Action, timeout time.Duration) error {
@@ -328,10 +343,4 @@ func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.
 			}
 		}
 	}
-}
-
-func getPipelineURL(gitDeploy *types.GitDeploy) string {
-	octx := okteto.Context()
-	pipelineURL := fmt.Sprintf("%s/#/spaces/%s?resourceId=%s", octx.Name, octx.Namespace, gitDeploy.ID)
-	return pipelineURL
 }

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -30,75 +30,85 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// DestroyOptions options to destroy pipeline command
+type DestroyOptions struct {
+	Name           string
+	Namespace      string
+	Wait           bool
+	DestroyVolumes bool
+	Timeout        time.Duration
+}
+
 func destroy(ctx context.Context) *cobra.Command {
-	var name string
-	var namespace string
-	var wait bool
-	var destroyVolumes bool
-	var timeout time.Duration
+	opts := &DestroyOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy an okteto pipeline",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			return ExecuteDestroyPipeline(ctx, opts)
 
-			ctxResource := &model.ContextResource{}
-			if err := ctxResource.UpdateNamespace(namespace); err != nil {
-				return err
-			}
-
-			ctxOptions := &contextCMD.ContextOptions{
-				Namespace: ctxResource.Namespace,
-			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
-				return err
-			}
-
-			if !okteto.IsOkteto() {
-				return oktetoErrors.ErrContextIsNotOktetoCluster
-			}
-
-			if name == "" {
-				cwd, err := os.Getwd()
-				if err != nil {
-					return fmt.Errorf("failed to get the current working directory: %w", err)
-				}
-				repo, err := model.GetRepositoryURL(cwd)
-				if err != nil {
-					return err
-				}
-
-				name = getPipelineName(repo)
-			}
-
-			resp, err := destroyPipeline(ctx, name, destroyVolumes)
-			if err != nil {
-				return err
-			}
-
-			if !wait {
-				oktetoLog.Success("Pipeline '%s' scheduled for destruction", name)
-				return nil
-			}
-
-			if err := waitUntilDestroyed(ctx, name, resp.Action, timeout); err != nil {
-				oktetoLog.Information("Pipeline URL: %s", getPipelineURL(resp.GitDeploy))
-				return err
-			}
-
-			oktetoLog.Success("Pipeline '%s' successfully destroyed", name)
-
-			return nil
 		},
 	}
 
-	cmd.Flags().StringVarP(&name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the up command is executed (defaults to the current namespace)")
-	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "wait until the pipeline finishes (defaults to false)")
-	cmd.Flags().BoolVarP(&destroyVolumes, "volumes", "v", false, "destroy persistent volumes created by the pipeline (defaults to false)")
-	cmd.Flags().DurationVarP(&timeout, "timeout", "t", (5 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
+	cmd.Flags().StringVarP(&opts.Name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "namespace where the up command is executed (defaults to the current namespace)")
+	cmd.Flags().BoolVarP(&opts.Wait, "wait", "w", false, "wait until the pipeline finishes (defaults to false)")
+	cmd.Flags().BoolVarP(&opts.DestroyVolumes, "volumes", "v", false, "destroy persistent volumes created by the pipeline (defaults to false)")
+	cmd.Flags().DurationVarP(&opts.Timeout, "timeout", "t", (5 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
 	return cmd
+}
+
+//ExecuteDestroyPipeline executes destroy pipeline given a set of options
+func ExecuteDestroyPipeline(ctx context.Context, opts *DestroyOptions) error {
+	ctxResource := &model.ContextResource{}
+	if err := ctxResource.UpdateNamespace(opts.Namespace); err != nil {
+		return err
+	}
+
+	ctxOptions := &contextCMD.ContextOptions{
+		Namespace: ctxResource.Namespace,
+	}
+	if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+		return err
+	}
+
+	if !okteto.IsOkteto() {
+		return oktetoErrors.ErrContextIsNotOktetoCluster
+	}
+
+	if opts.Name == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get the current working directory: %w", err)
+		}
+		repo, err := model.GetRepositoryURL(cwd)
+		if err != nil {
+			return err
+		}
+
+		opts.Name = getPipelineName(repo)
+	}
+
+	resp, err := destroyPipeline(ctx, opts.Name, opts.DestroyVolumes)
+	if err != nil {
+		return err
+	}
+
+	if !opts.Wait {
+		oktetoLog.Success("Pipeline '%s' scheduled for destruction", opts.Name)
+		return nil
+	}
+
+	if err := waitUntilDestroyed(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
+		oktetoLog.Information("Pipeline URL: %s", getPipelineURL(resp.GitDeploy))
+		return err
+	}
+
+	oktetoLog.Success("Pipeline '%s' successfully destroyed", opts.Name)
+
+	return nil
 }
 
 func destroyPipeline(ctx context.Context, name string, destroyVolumes bool) (*types.GitDeployResponse, error) {


### PR DESCRIPTION
Fixes #2094

## Proposed changes
- Refactor pipeline deploy/destroy code (be able to execute from other commands and options are now a struct)
- If `okteto deploy` has branch or repository set it will be executed remotely
