### PR TITLE
Support for build global

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -109,6 +109,7 @@ func Build(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringArrayVar(&options.BuildArgs, "build-arg", nil, "set build-time variables")
 	cmd.Flags().StringArrayVar(&options.Secrets, "secret", nil, "secret files exposed to the build. Format: id=mysecret,src=/local/secret")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "", "", "namespace against which the image will be consumed. Default is the one defined at okteto context or okteto manifest")
+	cmd.Flags().BoolVarP(&options.BuildToGlobal, "global", "", false, "push the image to the global registry")
 	return cmd
 }
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -214,7 +214,13 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 			tag = fmt.Sprintf("%x", sha256.Sum256([]byte(params)))
 		}
 
-		b.Image = fmt.Sprintf("%s/%s-%s:%s", okteto.DevRegistry, b.Name, service, tag)
+		// if flag --global, point to global registry
+		targetRegistry := okteto.DevRegistry
+		if o.BuildToGlobal {
+			targetRegistry = okteto.GlobalRegistry
+		}
+
+		b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, b.Name, service, tag)
 	}
 
 	opts := BuildOptions{

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -35,16 +35,17 @@ import (
 
 //BuildOptions define the options available for build
 type BuildOptions struct {
-	BuildArgs  []string
-	CacheFrom  []string
-	File       string
-	NoCache    bool
-	OutputMode string
-	Path       string
-	Secrets    []string
-	Tag        string
-	Target     string
-	Namespace  string
+	BuildArgs     []string
+	CacheFrom     []string
+	File          string
+	NoCache       bool
+	OutputMode    string
+	Path          string
+	Secrets       []string
+	Tag           string
+	Target        string
+	Namespace     string
+	BuildToGlobal bool
 }
 
 // Run runs the build sequence


### PR DESCRIPTION
Fixes #2182 

## Proposed changes

- added `--global` boolean flag to `okteto build` command
- change target namespace when flag is enable to push to the global registry
