### PR TITLE
Jlopezbarb/fix tests e2e

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -276,8 +276,8 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	for _, command := range deployOptions.Manifest.Deploy.Commands {
 		oktetoLog.SetStage(command.Name)
 		if err := dc.Executor.Execute(command, deployOptions.Variables); err != nil {
-			oktetoLog.Infof("error executing command '%s': %s", command, err.Error())
-			return fmt.Errorf("error executing command '%s': %s", command, err.Error())
+			oktetoLog.Infof("error executing command '%s': %s", command.Name, err.Error())
+			return fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
 		}
 	}
 	oktetoLog.SetStage("")

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -513,12 +513,7 @@ func (dc *DeployCommand) showEndpoints(ctx context.Context, opts *Options) error
 		sort.Slice(eps, func(i, j int) bool {
 			return len(eps[i]) < len(eps[j])
 		})
-		switch oktetoLog.GetOutputFormat() {
-		case oktetoLog.TTYFormat:
-			oktetoLog.Printf("Endpoints available: %s\n", eps)
-		default:
-			oktetoLog.Information("Endpoints available:\n  - %s\n", strings.Join(eps, "\n  - "))
-		}
+		oktetoLog.Information("Endpoints available:\n  - %s\n", strings.Join(eps, "\n  - "))
 
 	}
 	return nil

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -152,10 +152,6 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
 		manifest.Namespace = okteto.Context().Namespace
 	}
 	os.Setenv(model.OktetoNameEnvVar, opts.Name)
-	manifest, err = manifest.ExpandEnvVars()
-	if err != nil {
-		return err
-	}
 
 	var commandErr error
 	for _, command := range manifest.Destroy {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -428,10 +428,9 @@ func (m *Manifest) ExpandEnvVars() (*Manifest, error) {
 			return m, err
 		}
 	}
-	manifestExpandedBytes, err := ExpandEnv(string(bytes))
-	if err != nil {
-		return m, err
-	}
+
+	manifestExpandedBytes := os.ExpandEnv(string(bytes))
+
 	result, err := Read([]byte(manifestExpandedBytes))
 	if err != nil {
 		return m, err

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -687,9 +687,8 @@ func (d *Manifest) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	manifest := manifestRaw{
-		Dev:    map[string]*Dev{},
-		Build:  map[string]*BuildInfo{},
-		Deploy: NewDeployInfo(),
+		Dev:   map[string]*Dev{},
+		Build: map[string]*BuildInfo{},
 	}
 	err = unmarshal(&manifest)
 	if err != nil {

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -687,8 +687,9 @@ func (d *Manifest) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	manifest := manifestRaw{
-		Dev:   map[string]*Dev{},
-		Build: map[string]*BuildInfo{},
+		Dev:    map[string]*Dev{},
+		Build:  map[string]*BuildInfo{},
+		Deploy: NewDeployInfo(),
 	}
 	err = unmarshal(&manifest)
 	if err != nil {
@@ -743,8 +744,20 @@ func (d *DeployInfo) MarshalYAML() (interface{}, error) {
 }
 
 func (d *DeployInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var commandsString []string
+	err := unmarshal(&commandsString)
+	if err == nil {
+		d.Commands = []DeployCommand{}
+		for _, cmdString := range commandsString {
+			d.Commands = append(d.Commands, DeployCommand{
+				Name:    cmdString,
+				Command: cmdString,
+			})
+		}
+		return nil
+	}
 	var commands []DeployCommand
-	err := unmarshal(&commands)
+	err = unmarshal(&commands)
 	if err == nil {
 		d.Commands = commands
 		return nil


### PR DESCRIPTION
Fixes e2e tests

## Proposed changes
- use os.ExpandEnv instead of envsubst because envsubst does not support dots in their variables
