### PR TITLE
Fix env vars expansion

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -327,10 +327,10 @@ func setManifestEnvVars(service, reference string) error {
 
 	oktetoLog.Debugf("envs registry=%s repository=%s image=%s tag=%s", reg, repo, image, tag)
 
-	os.Setenv(fmt.Sprintf("build.%s.registry", service), reg)
-	os.Setenv(fmt.Sprintf("build.%s.repository", service), repo)
-	os.Setenv(fmt.Sprintf("build.%s.image", service), reference)
-	os.Setenv(fmt.Sprintf("build.%s.tag", service), tag)
+	os.Setenv(fmt.Sprintf("OKTETO_BUILD_%s_REGISTRY", strings.ToUpper(service)), reg)
+	os.Setenv(fmt.Sprintf("OKTETO_BUILD_%s_REPOSITORY", strings.ToUpper(service)), repo)
+	os.Setenv(fmt.Sprintf("OKTETO_BUILD_%s_IMAGE", strings.ToUpper(service)), reference)
+	os.Setenv(fmt.Sprintf("OKTETO_BUILD_%s_TAG", strings.ToUpper(service)), tag)
 
 	oktetoLog.Debug("manifest env vars set")
 	return nil

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1,0 +1,80 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManifestExpandEnvs(t *testing.T) {
+	tests := []struct {
+		name            string
+		envs            map[string]string
+		manifest        []byte
+		expectedErr     bool
+		expectedCommand string
+	}{
+		{
+			name: "expand envs on command",
+			envs: map[string]string{
+				"OKTETO_GIT_COMMIT": "dev",
+			},
+			manifest: []byte(`icon: https://apps.okteto.com/movies/icon.png
+deploy:
+  - okteto build -t okteto.dev/api:${OKTETO_GIT_COMMIT} api
+  - okteto build -t okteto.dev/frontend:${OKTETO_GIT_COMMIT} frontend
+  - helm upgrade --install movies chart --set tag=${OKTETO_GIT_COMMIT}
+devs:
+  - api/okteto.yml
+  - frontend/okteto.yml`),
+			expectedCommand: "okteto build -t okteto.dev/api:dev api",
+		},
+		{
+			name: "expand envs on command without env var set",
+			envs: map[string]string{},
+			manifest: []byte(`icon: https://apps.okteto.com/movies/icon.png
+deploy:
+  - okteto build -t okteto.dev/api:${OKTETO_GIT_COMMIT:=dev} api
+  - okteto build -t okteto.dev/frontend:${OKTETO_GIT_COMMIT} frontend
+  - helm upgrade --install movies chart --set tag=${OKTETO_GIT_COMMIT}
+devs:
+  - api/okteto.yml
+  - frontend/okteto.yml`),
+			expectedCommand: "okteto build -t okteto.dev/api:dev api",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				os.Setenv(k, v)
+			}
+			m, err := Read(tt.manifest)
+			assert.NoError(t, err)
+
+			m, err = m.ExpandEnvVars()
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				assert.Equal(t, tt.expectedCommand, m.Deploy.Commands[0].Command)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes environment variable expansion was not working properly if an envvar uses dots inside

## Proposed changes
- Rename all the env vars from `build.{svc}.xxx` to `OKTETO_BUILD_{SVC}_XXX`
- Refactor expand variables and expand only commands from deploy/destroy
