### PR TITLE
stderr send warnings instead of errors

### DIFF
--- a/cmd/utils/executor.go
+++ b/cmd/utils/executor.go
@@ -150,7 +150,7 @@ func (e *jsonExecutorDisplayer) display(command string) {
 	go func() {
 		for e.stderrScanner.Scan() {
 			line := e.stderrScanner.Text()
-			oktetoLog.Fail(line)
+			oktetoLog.Warning(line)
 		}
 		wg.Done()
 	}()

--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -160,7 +160,10 @@ func (*JSONWriter) Question(format string, args ...interface{}) error {
 // Warning prints a message with the warning symbol first, and the text in yellow
 func (w *JSONWriter) Warning(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf("%s %s", warningSymbol, fmt.Sprintf(format, args...)))
+	msg := fmt.Sprintf("%s %s", warningSymbol, fmt.Sprintf(format, args...))
+	if msg != "" {
+		fmt.Fprintln(w.out.Out, convertToJSON("warn", log.stage, msg))
+	}
 }
 
 // Hint prints a message with the text in blue


### PR DESCRIPTION
Fixes #2236 

## Proposed changes
- Differentiate on plain execution between messages that comes from stderr and stdout
- Send stderr as warning messages 