### PR TITLE
Deploy build parallel

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -250,18 +250,15 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			close(toBuild)
 
 			for {
-				select {
-				case svc := <-toBuild:
-					if svc == "" {
-						break
-					}
-					mBuildInfo := deployOptions.Manifest.Build[svc]
-					if err := runBuildAndSetEnvs(ctx, svc, mBuildInfo); err != nil {
-						return err
-					}
-					continue
+				svc, ok := <-toBuild
+				if svc == "" || !ok {
+					fmt.Println("vacio", ok)
+					break
 				}
-				break
+				mBuildInfo := deployOptions.Manifest.Build[svc]
+				if err := runBuildAndSetEnvs(ctx, svc, mBuildInfo); err != nil {
+					return err
+				}
 			}
 
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -247,17 +247,19 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			if err := g.Wait(); err != nil {
 				return err
 			}
+			close(toBuild)
 
 			for {
 				select {
 				case svc := <-toBuild:
+					if svc == "" {
+						break
+					}
 					mBuildInfo := deployOptions.Manifest.Build[svc]
 					if err := runBuildAndSetEnvs(ctx, svc, mBuildInfo); err != nil {
 						return err
 					}
 					continue
-				default:
-					break
 				}
 				break
 			}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -249,11 +249,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			}
 			close(toBuild)
 
-			for {
-				svc, ok := <-toBuild
-				if svc == "" || !ok {
-					break
-				}
+			for svc := range toBuild {
 				mBuildInfo := deployOptions.Manifest.Build[svc]
 				if err := runBuildAndSetEnvs(ctx, svc, mBuildInfo); err != nil {
 					return err

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -236,11 +236,11 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			// check if images are at registry (global or dev) and set envs or send to build
 			toBuild := make(chan string, len(deployOptions.Manifest.Build))
 
-			g, gctx := errgroup.WithContext(ctx)
+			g, _ := errgroup.WithContext(ctx)
 			for service, mBuildInfo := range deployOptions.Manifest.Build {
 				service, mBuildInfo := service, mBuildInfo
 				g.Go(func() error {
-					return checkServicesToBuild(gctx, service, mBuildInfo, toBuild)
+					return checkServicesToBuild(service, mBuildInfo, toBuild)
 				})
 			}
 
@@ -252,7 +252,6 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			for {
 				svc, ok := <-toBuild
 				if svc == "" || !ok {
-					fmt.Println("vacio", ok)
 					break
 				}
 				mBuildInfo := deployOptions.Manifest.Build[svc]
@@ -698,7 +697,7 @@ func shouldExecuteRemotely(options *Options) bool {
 	return options.Branch != "" || options.Repository != ""
 }
 
-func checkServicesToBuild(ctx context.Context, service string, mOptions *model.BuildInfo, ch chan string) error {
+func checkServicesToBuild(service string, mOptions *model.BuildInfo, ch chan string) error {
 	opts := build.OptsFromManifest(service, mOptions, build.BuildOptions{})
 
 	if build.ShouldOptimizeBuild(opts.Tag) {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -231,10 +231,8 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 				}
 			}
 
-		} else {
-			if err := checkBuildFromManifest(ctx, deployOptions.Manifest.Build); err != nil {
-				return err
-			}
+		} else if err := checkBuildFromManifest(ctx, deployOptions.Manifest.Build); err != nil {
+			return err
 		}
 
 		oktetoLog.Information("Checking to deploy dependencies at manifest")

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -262,29 +262,27 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 
 		}
 
-	}
-
-	oktetoLog.Information("Checking to deploy dependencies at manifest")
-	for depName, dep := range deployOptions.Manifest.Dependencies {
-		pipOpts := &pipelineCMD.DeployOptions{
-			Name:       depName,
-			Repository: dep.Repository,
-			Branch:     dep.Branch,
-			File:       dep.ManifestPath,
-			Variables:  model.SerializeBuildArgs(dep.Variables),
-			Wait:       dep.Wait,
-			Timeout:    deployOptions.Timeout,
-		}
-		if deployOptions.Dependencies {
-			if err := pipelineCMD.ExecuteDeployPipeline(ctx, pipOpts); err != nil {
+		oktetoLog.Information("Checking to deploy dependencies at manifest")
+		for depName, dep := range deployOptions.Manifest.Dependencies {
+			pipOpts := &pipelineCMD.DeployOptions{
+				Name:       depName,
+				Repository: dep.Repository,
+				Branch:     dep.Branch,
+				File:       dep.ManifestPath,
+				Variables:  model.SerializeBuildArgs(dep.Variables),
+				Wait:       dep.Wait,
+				Timeout:    deployOptions.Timeout,
+			}
+			if deployOptions.Dependencies {
+				if err := pipelineCMD.ExecuteDeployPipeline(ctx, pipOpts); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := checkByNameAndDeployDependency(ctx, depName, pipOpts); err != nil {
 				return err
 			}
-			continue
 		}
-		if err := checkByNameAndDeployDependency(ctx, depName, pipOpts); err != nil {
-			return err
-		}
-
 	}
 
 	deployOptions.Manifest, err = deployOptions.Manifest.ExpandEnvVars()

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -205,6 +205,10 @@ func translateDockerErr(err error) error {
 
 // OptsFromManifest returns the parsed options for the build from the manifest
 func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildOptions {
+	if b.Name == "" {
+		b.Name = os.Getenv(model.OktetoNameEnvVar)
+	}
+
 	args := model.SerializeBuildArgs(b.Args)
 
 	if okteto.Context().IsOkteto && b.Image == "" {
@@ -236,6 +240,9 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 		BuildArgs: args,
 	}
 
+	if o.OutputMode == "" {
+		o.OutputMode = oktetoLog.GetOutputFormat()
+	}
 	opts.OutputMode = setOutputMode(o.OutputMode)
 	return opts
 }


### PR DESCRIPTION
Fixes #2174 

## Proposed changes

- When checking if an image has to be build when `okteto deploy`, this checks are done with a go-routine.
- if images has to be build, then they will be build sequentially  after.

