### PR TITLE
autodeploy on up if app doesn't exists

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -192,7 +192,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	}
 	oktetoLog.Debug("found okteto manifest")
 	if deployOptions.Manifest.Deploy == nil {
-		return fmt.Errorf("found okteto manifest, but no deploy commands where defined")
+		return oktetoErrors.ErrManifestFoundButNoDeployCommands
 	}
 	if deployOptions.Manifest.Context == "" {
 		deployOptions.Manifest.Context = okteto.Context().Name

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -163,6 +163,10 @@ func Up() *cobra.Command {
 				}
 				oktetoLog.Infof("Terminal: %v", up.stateTerm)
 			}
+			up.Client, up.RestConfig, err = okteto.GetK8sClient()
+			if err != nil {
+				return fmt.Errorf("failed to load okteto context '%s': %v", up.Dev.Context, err)
+			}
 
 			if upOptions.Deploy {
 				if err := up.deployApp(ctx); err != nil {
@@ -270,11 +274,6 @@ func (up *upContext) deployApp(ctx context.Context) error {
 }
 
 func (up *upContext) start() error {
-	var err error
-	up.Client, up.RestConfig, err = okteto.GetK8sClient()
-	if err != nil {
-		return fmt.Errorf("failed to load okteto context '%s': %v", up.Dev.Context, err)
-	}
 
 	ctx := context.Background()
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -573,7 +573,3 @@ func printDisplayContext(dev *model.Dev, divertURL string) {
 	}
 	oktetoLog.Println()
 }
-
-func (up *upContext) isAppRunning(ctx context.Context) {
-
-}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -75,6 +75,13 @@ func LoadManifest(devPath string) (*model.Manifest, error) {
 		}
 		manifest.Name = InferApplicationName(cwd)
 	}
+	if manifest.Namespace == "" {
+		manifest.Namespace = okteto.Context().Namespace
+	}
+
+	if manifest.Context == "" {
+		manifest.Context = okteto.Context().Name
+	}
 
 	for _, dev := range manifest.Dev {
 		if err := loadManifestRc(dev); err != nil {

--- a/pkg/cmd/pipeline/crud.go
+++ b/pkg/cmd/pipeline/crud.go
@@ -1,0 +1,31 @@
+// Copyright 2021 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+
+	"github.com/okteto/okteto/pkg/k8s/configmaps"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/kubernetes"
+)
+
+// IsDeployed checks if a pipeline has been
+func IsDeployed(ctx context.Context, name, namespace string, c kubernetes.Interface) bool {
+	cmap, err := configmaps.Get(ctx, TranslatePipelineName(name), namespace, c)
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return false
+	}
+	return cmap.Data[statusField] != ErrorStatus
+}

--- a/pkg/cmd/pipeline/crud_test.go
+++ b/pkg/cmd/pipeline/crud_test.go
@@ -1,0 +1,83 @@
+// Copyright 2021 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_IsDeployedPipeline(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test"
+
+	var tests = []struct {
+		name     string
+		status   string
+		create   bool
+		expected bool
+	}{
+		{
+			name:     "already deployed",
+			status:   DeployedStatus,
+			create:   true,
+			expected: true,
+		},
+		{
+			name:     "progressing",
+			status:   ProgressingStatus,
+			create:   true,
+			expected: true,
+		},
+		{
+			name:     "error",
+			status:   ErrorStatus,
+			create:   true,
+			expected: false,
+		},
+		{
+			name:     "not found",
+			create:   false,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fakeClient *fake.Clientset
+			cmap := &apiv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      TranslatePipelineName("test"),
+					Namespace: namespace,
+					Labels:    map[string]string{},
+				},
+				Data: map[string]string{
+					statusField: tt.status,
+				},
+			}
+			if tt.create {
+				fakeClient = fake.NewSimpleClientset(cmap)
+			} else {
+				fakeClient = fake.NewSimpleClientset()
+			}
+			result := IsDeployed(ctx, "test", namespace, fakeClient)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -131,6 +131,9 @@ var (
 
 	// ErrNoServicesinOktetoManifest raised when no services are defined in the okteto manifest
 	ErrNoServicesinOktetoManifest = fmt.Errorf("'okteto restart' is only supported when using the field 'services'")
+
+	// ErrManifestFoundButNoDeployCommands raised when a manifest is found but no deploy commands are defined
+	ErrManifestFoundButNoDeployCommands = errors.New("found okteto manifest, but no deploy commands where defined")
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -99,37 +99,37 @@ var (
 	// ErrDevPodDeleted raised if dev pod is deleted in the middle of the "okteto up" sequence
 	ErrDevPodDeleted = fmt.Errorf("development container has been removed")
 
-	//ErrDivertNotSupported raised if the divert feature is not supported in the current cluster
+	// ErrDivertNotSupported raised if the divert feature is not supported in the current cluster
 	ErrDivertNotSupported = fmt.Errorf("the 'divert' field is only supported in namespaces managed by Okteto")
 
-	//ContextIsNotOktetoCluster raised if the cluster connected is not managed by okteto
+	// ContextIsNotOktetoCluster raised if the cluster connected is not managed by okteto
 	ErrContextIsNotOktetoCluster = fmt.Errorf("this command is only available on Okteto Cloud or Okteto Enterprise")
 
-	//ErrTokenFlagNeeded is raised when the command is executed from inside a pod
+	// ErrTokenFlagNeeded is raised when the command is executed from inside a pod
 	ErrTokenFlagNeeded = fmt.Errorf("this command is not supported without the '--token' flag from inside a container")
 
-	//ErrNamespaceNotFound is raised when the namespace is not found on an okteto instance
+	// ErrNamespaceNotFound is raised when the namespace is not found on an okteto instance
 	ErrNamespaceNotFound = "namespace '%s' not found. Please verify that the namespace exists and that you have access to it"
 
-	//ErrKubernetesContextNotFound is raised when the kubernetes context is not found in kubeconfig
+	// ErrKubernetesContextNotFound is raised when the kubernetes context is not found in kubeconfig
 	ErrKubernetesContextNotFound = "context '%s' not found in '%s'"
 
-	//ErrNamespaceNotMatching is raised when the namespace arg doesn't match the manifest namespace
+	// ErrNamespaceNotMatching is raised when the namespace arg doesn't match the manifest namespace
 	ErrNamespaceNotMatching = fmt.Errorf("the namespace in the okteto manifest doesn't match your namespace argument")
 
-	//ErrContextNotMatching is raised when the context arg doesn't match the manifest context
+	// ErrContextNotMatching is raised when the context arg doesn't match the manifest context
 	ErrContextNotMatching = fmt.Errorf("the context in the okteto manifest doesn't match your context argument")
 
-	//ErrCorruptedOktetoContexts raised when the okteto context store is corrupted
+	// ErrCorruptedOktetoContexts raised when the okteto context store is corrupted
 	ErrCorruptedOktetoContexts = "okteto context store is corrupted. Delete the folder '%s' and try again"
 
-	//ErrIntSig raised if the we get an interrupt signal in the middle of a command
+	// ErrIntSig raised if the we get an interrupt signal in the middle of a command
 	ErrIntSig = fmt.Errorf("interrupt signal received")
 
-	//ErrKubernetesLongTimeToCreateDevContainer raised when the creation of the dev container times out
+	// ErrKubernetesLongTimeToCreateDevContainer raised when the creation of the dev container times out
 	ErrKubernetesLongTimeToCreateDevContainer = fmt.Errorf("kubernetes is taking too long to start your development container. Please check for errors and try again")
 
-	//ErrNoServicesinOktetoManifest raised when no services are defined in the okteto manifest
+	// ErrNoServicesinOktetoManifest raised when no services are defined in the okteto manifest
 	ErrNoServicesinOktetoManifest = fmt.Errorf("'okteto restart' is only supported when using the field 'services'")
 )
 


### PR DESCRIPTION
Fixes #1910 

## Proposed changes
- Checks if the app is not deployed or is in an error status and if so deploys the application
-  if the manifest is not a v2 manifest, skip deploying and run as it was