### PR TITLE
Remove manifest_v2 flag

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/build"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -38,15 +39,49 @@ func Build(ctx context.Context) *cobra.Command {
 	options := build.BuildOptions{}
 	cmd := &cobra.Command{
 		Use:   "build [PATH]",
-		Args:  utils.BuildMaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#build"),
 		Short: "Build (and optionally push) a Docker image",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
+			ctxOpts := &contextCMD.ContextOptions{}
+
+			manifest, err := model.GetManifestV2(options.File)
+			if err != nil {
 				return err
 			}
-			if okteto.IsOkteto() && options.Namespace != "" {
-				create, err := utils.ShouldCreateNamespace(ctx, options.Namespace)
+
+			isBuildV2 := options.Tag == "" &&
+				manifest.IsV2 &&
+				manifest.Type == "manifest" &&
+				len(manifest.Build) != 0
+
+			if isBuildV2 {
+				if manifest.Context != "" {
+					ctxOpts.Context = manifest.Context
+					if err := contextCMD.NewContextCommand().Run(ctx, ctxOpts); err != nil {
+						return err
+					}
+				}
+
+				if options.Namespace == "" && manifest.Namespace != "" {
+					ctxOpts.Namespace = manifest.Namespace
+				}
+			} else {
+				v1Args := 1
+				docsURL := "https://okteto.com/docs/reference/cli/#build"
+				if len(args) != v1Args {
+					return oktetoErrors.UserError{
+						E:    fmt.Errorf("%q requires %d arg(s), but received %d", cmd.CommandPath(), v1Args, len(args)),
+						Hint: fmt.Sprintf("Visit %s for more information.", docsURL),
+					}
+				}
+
+				if options.Namespace != "" {
+					ctxOpts.Namespace = options.Namespace
+				}
+			}
+
+			if okteto.IsOkteto() && ctxOpts.Namespace != "" {
+				create, err := utils.ShouldCreateNamespace(ctx, ctxOpts.Namespace)
 				if err != nil {
 					return err
 				}
@@ -55,39 +90,18 @@ func Build(ctx context.Context) *cobra.Command {
 					if err != nil {
 						return err
 					}
-					nsCmd.Create(ctx, &namespace.CreateOptions{Namespace: options.Namespace})
+					if err := nsCmd.Create(ctx, &namespace.CreateOptions{Namespace: ctxOpts.Namespace}); err != nil {
+						return err
+					}
 				}
-			}
-
-			ctxOpts := &contextCMD.ContextOptions{
-				Namespace: options.Namespace,
 			}
 
 			if err := contextCMD.NewContextCommand().Run(ctx, ctxOpts); err != nil {
 				return err
 			}
 
-			if utils.LoadBoolean(model.OktetoManifestV2Enabled) {
-				manifest, err := model.GetManifestV2(options.File)
-				if err != nil {
-					return err
-				}
-
-				if manifest.Namespace != "" {
-					ctxOpts.Namespace = manifest.Namespace
-				}
-				if manifest.Context != "" {
-					ctxOpts.Context = manifest.Context
-				}
-				if manifest.Namespace != "" || manifest.Context != "" {
-					if err := contextCMD.NewContextCommand().Run(ctx, ctxOpts); err != nil {
-						return err
-					}
-				}
-				if len(manifest.Build) != 0 {
-					return buildV2(manifest.Build, options, args)
-				}
-				oktetoLog.Information("Build manifest not found. Looking for Dockerfile to run the build")
+			if isBuildV2 {
+				return buildV2(manifest.Build, options, args)
 			}
 
 			return buildV1(options, args)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -51,7 +51,6 @@ func Build(ctx context.Context) *cobra.Command {
 
 			isBuildV2 := options.Tag == "" &&
 				manifest.IsV2 &&
-				manifest.Type == "manifest" &&
 				len(manifest.Build) != 0
 
 			if isBuildV2 {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -223,7 +223,9 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	}
 
 	if deployOptions.Build {
-		oktetoLog.Information("Building services at manifest")
+		if len(deployOptions.Manifest.Build) != 0 {
+			oktetoLog.Information("Building services at manifest")
+		}
 		for service, mBuildInfo := range deployOptions.Manifest.Build {
 			oktetoLog.Debug("force build from manifest definition")
 			if err := runBuildAndSetEnvs(ctx, service, mBuildInfo); err != nil {
@@ -235,7 +237,9 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		return err
 	}
 
-	oktetoLog.Information("Checking to deploy dependencies at manifest")
+	if len(deployOptions.Manifest.Dependencies) != 0 {
+		oktetoLog.Information("Checking to deploy dependencies at manifest")
+	}
 	for depName, dep := range deployOptions.Manifest.Dependencies {
 		pipOpts := &pipelineCMD.DeployOptions{
 			Name:       depName,
@@ -694,7 +698,10 @@ func checkServicesToBuild(service string, mOptions *model.BuildInfo, ch chan str
 }
 
 func checkBuildFromManifest(ctx context.Context, buildManifest model.ManifestBuild) error {
-	oktetoLog.Information("Checking to build services at manifest")
+	if len(buildManifest) != 0 {
+		oktetoLog.Information("Checking to build services at manifest")
+	}
+
 	// check if images are at registry (global or dev) and set envs or send to build
 	toBuild := make(chan string, len(buildManifest))
 	g, _ := errgroup.WithContext(ctx)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -219,7 +219,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	os.Setenv(model.OktetoNameEnvVar, deployOptions.Name)
 
 	if deployOptions.Dependencies && !okteto.IsOkteto() {
-		return fmt.Errorf("deploy of dependencies is only available for Okteto instances")
+		return fmt.Errorf("deploy of dependencies is only available in clusters managed by Okteto")
 	}
 
 	if deployOptions.Build {

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -203,19 +203,13 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
 	}
 	os.Setenv(model.OktetoNameEnvVar, opts.Name)
 
-	if utils.LoadBoolean(model.OktetoManifestV2Enabled) {
-
-		if len(manifest.Dependencies) > 0 {
-			for depName := range manifest.Dependencies {
-				destOpts := &pipelineCMD.DestroyOptions{
-					Name:           depName,
-					DestroyVolumes: opts.DestroyVolumes,
-				}
-				if err := pipelineCMD.ExecuteDestroyPipeline(ctx, destOpts); err != nil {
-					return err
-				}
-			}
-
+	for depName := range manifest.Dependencies {
+		destOpts := &pipelineCMD.DestroyOptions{
+			Name:           depName,
+			DestroyVolumes: opts.DestroyVolumes,
+		}
+		if err := pipelineCMD.ExecuteDestroyPipeline(ctx, destOpts); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/utils/args.go
+++ b/cmd/utils/args.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/model"
 	"github.com/spf13/cobra"
 )
 
@@ -57,17 +56,6 @@ func maxNArgs(cmd *cobra.Command, n int, url string, args []string) error {
 		}
 	}
 	return nil
-}
-
-// BuildMaximumNArgsAccepted returns an error if there are more than N args.
-func BuildMaximumNArgsAccepted(n int, url string) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
-		if LoadBoolean(model.OktetoManifestV2Enabled) {
-			return nil
-		}
-		return maxNArgs(cmd, n, url, args)
-	}
-
 }
 
 // MinimumNArgsAccepted returns an error if there are more than N args.

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -101,7 +101,6 @@ build:
 
 func runOktetoBuild(ctx context.Context, oktetoPath, pathToManifestFile, repoDir string) (string, error) {
 	cmd := exec.Command(oktetoPath, "build", "-f", pathToManifestFile, "-l", "debug")
-	cmd.Env = append(os.Environ(), "OKTETO_ENABLE_MANIFEST_V2=true")
 	cmd.Dir = repoDir
 	o, err := cmd.CombinedOutput()
 	if err != nil {

--- a/integration/deploy_manifest_test.go
+++ b/integration/deploy_manifest_test.go
@@ -320,7 +320,6 @@ spec:
 
 func runOktetoDeploy(oktetoPath, repoDir string) (string, error) {
 	cmd := exec.Command(oktetoPath, "deploy", "-l", "debug")
-	cmd.Env = append(os.Environ(), "OKTETO_ENABLE_MANIFEST_V2=true")
 	cmd.Dir = repoDir
 	o, err := cmd.CombinedOutput()
 	if err != nil {
@@ -331,7 +330,6 @@ func runOktetoDeploy(oktetoPath, repoDir string) (string, error) {
 
 func runOktetoDeployForceBuild(oktetoPath, repoDir string) (string, error) {
 	cmd := exec.Command(oktetoPath, "deploy", "--build", "-l", "debug")
-	cmd.Env = append(os.Environ(), "OKTETO_ENABLE_MANIFEST_V2=true")
 	cmd.Dir = repoDir
 	o, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -315,7 +315,4 @@ const (
 
 	// OktetoDefaultImageTag default tag assigned to image to build
 	OktetoDefaultImageTag = "okteto"
-
-	// OktetoManifestV2Enabled defines if manifest v2 is enabled
-	OktetoManifestV2Enabled = "OKTETO_ENABLE_MANIFEST_V2"
 )


### PR DESCRIPTION

## Proposed changes

- remove references to MANIFEST_V2 flag
- running buildv1 or buildv2 depending on manifest version and user input
