### PR TITLE
integrate compose with manifestv2

### DIFF
--- a/cmd/deploy/config.go
+++ b/cmd/deploy/config.go
@@ -33,12 +33,12 @@ func NewKubeConfig() *KubeConfig {
 
 //Read reads a kubeconfig from an apiConfig
 func (k *KubeConfig) Read() (*rest.Config, error) {
-	return clientcmd.BuildConfigFromKubeconfigGetter("", k.getCMDAPIConfig)
+	return clientcmd.BuildConfigFromKubeconfigGetter("", k.GetCMDAPIConfig)
 }
 
 //Modify modifies the kubeconfig object to inject the proxy
 func (k *KubeConfig) Modify(port int, sessionToken, destKubeconfigFile string) error {
-	clientCfg, err := k.getCMDAPIConfig()
+	clientCfg, err := k.GetCMDAPIConfig()
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (k *KubeConfig) Modify(port int, sessionToken, destKubeconfigFile string) e
 	return nil
 }
 
-func (*KubeConfig) getCMDAPIConfig() (*clientcmdapi.Config, error) {
+func (*KubeConfig) GetCMDAPIConfig() (*clientcmdapi.Config, error) {
 	if okteto.Context().Cfg == nil {
 		return nil, fmt.Errorf("okteto context not initialized")
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -377,14 +377,14 @@ func (dc *DeployCommand) deploy(ctx context.Context, opts *Options) error {
 
 	go func() {
 		if opts.Manifest.Deploy.Compose != nil {
-			oktetoLog.SetStage("Deploying stack")
+			oktetoLog.SetStage("Deploying compose")
 			reader, writer := io.Pipe()
 			oktetoLog.SetOutput(writer)
 			exit := make(chan error, 1)
 			stop := make(chan os.Signal, 1)
 			signal.Notify(stop, os.Interrupt)
 			d := displayer.NewDisplayer(oktetoLog.GetOutputFormat(), reader, nil)
-			d.Display("Deploying stack")
+			d.Display("Deploying compose")
 			go func() {
 				err := dc.deployStack(ctx, opts)
 				writer.Close()

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -282,6 +282,9 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		Icon:       deployOptions.Manifest.Icon,
 	}
 
+	if !deployOptions.Manifest.IsV2 && deployOptions.Manifest.Type == model.StackType {
+		data.Manifest = deployOptions.Manifest.Deploy.Compose.Stack.Manifest
+	}
 	k8sCfg := kubeconfig.Get(config.GetKubeconfigPath())
 	c, _, err := dc.K8sClientProvider.Provide(k8sCfg)
 	if err != nil {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -399,6 +399,7 @@ func (dc *DeployCommand) deploy(ctx context.Context, opts *Options) error {
 			}
 			oktetoLog.SetOutput(os.Stdout)
 		}
+		exitCompose <- nil
 	}()
 
 	select {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -75,7 +75,7 @@ func (*fakeKubeConfig) Read() (*rest.Config, error) {
 func (fc *fakeKubeConfig) Modify(_ int, _, _ string) error {
 	return fc.errOnModify
 }
-func (fc *fakeKubeConfig) GetModifiedCMDAPIConfig() (*clientcmdapi.Config, error) {
+func (*fakeKubeConfig) GetModifiedCMDAPIConfig() (*clientcmdapi.Config, error) {
 	return nil, nil
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -29,7 +29,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd/api"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -221,7 +220,7 @@ func TestDeployWithErrorExecutingCommands(t *testing.T) {
 	assert.True(t, p.shutdown)
 
 	//check if configmap has been created
-	fakeClient, _, err := c.K8sClientProvider.Provide(api.NewConfig())
+	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
 	if err != nil {
 		t.Fatal("could not create fake k8s client")
 	}
@@ -276,7 +275,7 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 	assert.True(t, p.started)
 
 	//check if configmap has been created
-	fakeClient, _, err := c.K8sClientProvider.Provide(api.NewConfig())
+	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
 	if err != nil {
 		t.Fatal("could not create fake k8s client")
 	}
@@ -326,7 +325,7 @@ func TestDeployWithErrorShuttingdownProxy(t *testing.T) {
 	assert.False(t, p.shutdown)
 
 	//check if configmap has been created
-	fakeClient, _, err := c.K8sClientProvider.Provide(api.NewConfig())
+	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
 	if err != nil {
 		t.Fatal("could not create fake k8s client")
 	}
@@ -374,7 +373,7 @@ func TestDeployWithoutErrors(t *testing.T) {
 	assert.True(t, p.shutdown)
 
 	//check if configmap has been created
-	fakeClient, _, err := c.K8sClientProvider.Provide(api.NewConfig())
+	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
 	if err != nil {
 		t.Fatal("could not create fake k8s client")
 	}

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 var fakeManifest *model.Manifest = &model.Manifest{
@@ -74,6 +75,9 @@ func (*fakeKubeConfig) Read() (*rest.Config, error) {
 
 func (fc *fakeKubeConfig) Modify(_ int, _, _ string) error {
 	return fc.errOnModify
+}
+func (fc *fakeKubeConfig) GetModifiedCMDAPIConfig() (*clientcmdapi.Config, error) {
+	return nil, nil
 }
 
 func (fk *fakeProxy) Start() {

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -48,7 +48,7 @@ func deploy(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "deploy [service...]",
-		Short: "Deploy a stack",
+		Short: "Deploy a compose",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.ServicesToDeploy = args
 
@@ -68,10 +68,10 @@ func deploy(ctx context.Context) *cobra.Command {
 			return dc.RunDeploy(ctx, s, options)
 		},
 	}
-	cmd.Flags().StringArrayVarP(&options.StackPaths, "file", "f", []string{}, "path to the stack manifest files. If more than one is passed the latest will overwrite the fields from the previous")
-	cmd.Flags().StringVarP(&options.Name, "name", "", "", "overwrites the stack name")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the stack namespace where the stack is deployed")
-	cmd.Flags().BoolVarP(&options.ForceBuild, "build", "", false, "build images before starting any Stack service")
+	cmd.Flags().StringArrayVarP(&options.StackPaths, "file", "f", []string{}, "path to the compose manifest files. If more than one is passed the latest will overwrite the fields from the previous")
+	cmd.Flags().StringVarP(&options.Name, "name", "", "", "overwrites the compose name")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the compose namespace where the compose is deployed")
+	cmd.Flags().BoolVarP(&options.ForceBuild, "build", "", false, "build images before starting any compose service")
 	cmd.Flags().BoolVarP(&options.Wait, "wait", "", false, "wait until a minimum number of containers are in a ready state for every service")
 	cmd.Flags().BoolVarP(&options.NoCache, "no-cache", "", false, "do not use cache when building the image")
 	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", (10 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
@@ -114,7 +114,7 @@ func (c *DeployCommand) RunDeploy(ctx context.Context, s *model.Stack, options *
 
 	analytics.TrackDeployStack(err == nil, s.IsCompose, utils.IsOktetoRepo())
 	if err == nil {
-		oktetoLog.Success("Stack '%s' successfully deployed", s.Name)
+		oktetoLog.Success("Compose '%s' successfully deployed", s.Name)
 	}
 
 	if !utils.LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) || !c.IsInsideDeploy {

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -33,7 +33,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 	var rm bool
 	cmd := &cobra.Command{
 		Use:   "destroy <name>",
-		Short: "Destroy a stack",
+		Short: "Destroy a compose",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#destroy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath)
@@ -54,9 +54,9 @@ func Destroy(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringArrayVarP(&stackPath, "file", "f", []string{}, "path to the stack manifest file")
-	cmd.Flags().StringVarP(&name, "name", "", "", "overwrites the stack name")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrites the stack namespace where the stack is destroyed")
+	cmd.Flags().StringArrayVarP(&stackPath, "file", "f", []string{}, "path to the compose manifest file")
+	cmd.Flags().StringVarP(&name, "name", "", "", "overwrites the compose name")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrites the compose namespace where the compose is destroyed")
 	cmd.Flags().BoolVarP(&rm, "volumes", "v", false, "remove persistent volumes")
 	return cmd
 }

--- a/cmd/stack/endpoints.go
+++ b/cmd/stack/endpoints.go
@@ -51,15 +51,15 @@ func Endpoints(ctx context.Context) *cobra.Command {
 			}
 
 			if err := stack.ListEndpoints(ctx, s, output); err != nil {
-				oktetoLog.Success("Stack '%s' successfully deployed", s.Name)
+				oktetoLog.Success("Compose '%s' successfully deployed", s.Name)
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVarP(&output, "output", "o", "", "output format. One of: ['json']")
-	cmd.Flags().StringArrayVarP(&stackPath, "file", "f", []string{}, "path to the stack manifest files. If more than one is passed the latest will overwrite the fields from the previous")
-	cmd.Flags().StringVarP(&name, "name", "", "", "overwrites the stack name")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrites the stack namespace where the stack is deployed")
+	cmd.Flags().StringArrayVarP(&stackPath, "file", "f", []string{}, "path to the compose manifest files. If more than one is passed the latest will overwrite the fields from the previous")
+	cmd.Flags().StringVarP(&name, "name", "", "", "overwrites the compose name")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrites the compose namespace where the compose is deployed")
 
 	return cmd
 }

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -27,7 +27,7 @@ func Stack(ctx context.Context) *cobra.Command {
 		Short: "Stack management commands",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#stack"),
 	}
-	cmd.AddCommand(Deploy(ctx))
+	cmd.AddCommand(deploy(ctx))
 	cmd.AddCommand(Destroy(ctx))
 	cmd.AddCommand(Endpoints(ctx))
 	return cmd

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -103,6 +103,13 @@ func Up() *cobra.Command {
 					return err
 				}
 			}
+			if manifest.Name == "" {
+				wd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				manifest.Name = utils.InferApplicationName(wd)
+			}
 
 			dev, err := utils.GetDevFromManifest(manifest)
 			if err != nil {
@@ -200,7 +207,7 @@ func Up() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&upOptions.DevPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
+	cmd.Flags().StringVarP(&upOptions.DevPath, "file", "f", "", "path to the manifest file")
 	cmd.Flags().StringVarP(&upOptions.Namespace, "namespace", "n", "", "namespace where the up command is executed")
 	cmd.Flags().StringVarP(&upOptions.K8sContext, "context", "c", "", "context where the up command is executed")
 	cmd.Flags().IntVarP(&upOptions.Remote, "remote", "r", 0, "configures remote execution on the specified port")
@@ -230,7 +237,7 @@ func LoadManifestWithInit(ctx context.Context, k8sContext, namespace, devPath st
 	}
 
 	oktetoLog.Success(fmt.Sprintf("okteto manifest (%s) created", devPath))
-	return utils.LoadManifest(devPath)
+	return model.GetManifestV2(devPath)
 }
 
 func loadManifestOverrides(dev *model.Dev, upOptions *UpOptions) error {
@@ -264,7 +271,7 @@ func (up *upContext) deployApp(ctx context.Context) error {
 	}
 
 	c := &deploy.DeployCommand{
-		GetManifest:        model.GetManifestV2,
+		GetManifest:        up.getManifest,
 		Kubeconfig:         kubeconfig,
 		Executor:           executor.NewExecutor(oktetoLog.GetOutputFormat()),
 		Proxy:              proxy,
@@ -275,9 +282,17 @@ func (up *upContext) deployApp(ctx context.Context) error {
 	return c.RunDeploy(ctx, &deploy.Options{
 		Name:         up.Manifest.Name,
 		ManifestPath: up.Manifest.Filename,
+		Timeout:      5 * time.Minute,
+		Build:        true,
 	})
 }
 
+func (up *upContext) getManifest(path string) (*model.Manifest, error) {
+	if up.Manifest != nil {
+		return up.Manifest, nil
+	}
+	return model.GetManifestV2(path)
+}
 func (up *upContext) start() error {
 
 	ctx := context.Background()

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -84,7 +84,7 @@ func LoadManifest(devPath string) (*model.Manifest, error) {
 	}
 
 	for _, dev := range manifest.Dev {
-		if err := loadManifestRc(dev); err != nil {
+		if err := LoadManifestRc(dev); err != nil {
 			return nil, err
 		}
 
@@ -95,7 +95,7 @@ func LoadManifest(devPath string) (*model.Manifest, error) {
 	return manifest, nil
 }
 
-func loadManifestRc(dev *model.Dev) error {
+func LoadManifestRc(dev *model.Dev) error {
 	defaultDevRcPath := filepath.Join(config.GetOktetoHome(), "okteto.yml")
 	secondaryDevRcPath := filepath.Join(config.GetOktetoHome(), "okteto.yaml")
 	var devRc *model.DevRC

--- a/cmd/utils/displayer/json.go
+++ b/cmd/utils/displayer/json.go
@@ -1,0 +1,88 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package displayer
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+)
+
+type jsonDisplayer struct {
+	stdoutScanner *bufio.Scanner
+	stderrScanner *bufio.Scanner
+
+	commandContext context.Context
+	cancel         context.CancelFunc
+}
+
+func newJSONDisplayer(stdout, stderr io.Reader) *jsonDisplayer {
+	var (
+		stdoutScanner *bufio.Scanner
+		stderrScanner *bufio.Scanner
+	)
+	if stdout != nil {
+		stdoutScanner = bufio.NewScanner(stdout)
+	}
+	if stderr != nil {
+		stderrScanner = bufio.NewScanner(stderr)
+	}
+
+	return &jsonDisplayer{
+		stdoutScanner: stdoutScanner,
+		stderrScanner: stderrScanner,
+	}
+}
+
+func (d *jsonDisplayer) Display(_ string) {
+	d.commandContext, d.cancel = context.WithCancel(context.Background())
+	if d.stdoutScanner != nil {
+		go func() {
+			for d.stdoutScanner.Scan() {
+				select {
+				case <-d.commandContext.Done():
+				default:
+					line := d.stdoutScanner.Text()
+					oktetoLog.FPrintln(os.Stdout, line)
+					continue
+				}
+				break
+			}
+		}()
+	}
+
+	if d.stderrScanner != nil {
+		go func() {
+			for d.stderrScanner.Scan() {
+				select {
+				case <-d.commandContext.Done():
+				default:
+					line := d.stderrScanner.Text()
+					oktetoLog.FWarning(os.Stdout, line)
+					continue
+				}
+				break
+			}
+		}()
+	}
+}
+
+// CleanUp stops displaying
+func (d *jsonDisplayer) CleanUp(_ error) {
+	d.cancel()
+	<-d.commandContext.Done()
+}

--- a/cmd/utils/displayer/plain.go
+++ b/cmd/utils/displayer/plain.go
@@ -1,0 +1,88 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package displayer
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+)
+
+type plainDisplayer struct {
+	stdoutScanner *bufio.Scanner
+	stderrScanner *bufio.Scanner
+
+	commandContext context.Context
+	cancel         context.CancelFunc
+}
+
+func newPlainDisplayer(stdout, stderr io.Reader) *plainDisplayer {
+	var (
+		stdoutScanner *bufio.Scanner
+		stderrScanner *bufio.Scanner
+	)
+	if stdout != nil {
+		stdoutScanner = bufio.NewScanner(stdout)
+	}
+	if stderr != nil {
+		stderrScanner = bufio.NewScanner(stderr)
+	}
+
+	return &plainDisplayer{
+		stdoutScanner: stdoutScanner,
+		stderrScanner: stderrScanner,
+	}
+}
+
+func (d *plainDisplayer) Display(_ string) {
+	d.commandContext, d.cancel = context.WithCancel(context.Background())
+	if d.stdoutScanner != nil {
+		go func() {
+			for d.stdoutScanner.Scan() {
+				select {
+				case <-d.commandContext.Done():
+				default:
+					line := d.stdoutScanner.Text()
+					oktetoLog.FPrintln(os.Stdout, line)
+					continue
+				}
+				break
+			}
+		}()
+	}
+
+	if d.stderrScanner != nil {
+		go func() {
+			for d.stderrScanner.Scan() {
+				select {
+				case <-d.commandContext.Done():
+				default:
+					line := d.stderrScanner.Text()
+					oktetoLog.FWarning(os.Stdout, line)
+					continue
+				}
+				break
+			}
+		}()
+	}
+}
+
+// CleanUp stops displaying
+func (d *plainDisplayer) CleanUp(_ error) {
+	d.cancel()
+	<-d.commandContext.Done()
+}

--- a/cmd/utils/displayer/tty.go
+++ b/cmd/utils/displayer/tty.go
@@ -1,0 +1,302 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package displayer
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/manifoldco/promptui"
+	"github.com/manifoldco/promptui/screenbuf"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"golang.org/x/term"
+)
+
+var (
+	spinnerChars = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	cursorUp     = "\x1b[1A"
+	resetLine    = "\x1b[0G"
+)
+
+// TTYDisplayer displays with a screenbuff
+type TTYDisplayer struct {
+	stdoutScanner *bufio.Scanner
+	stderrScanner *bufio.Scanner
+	screenbuf     *screenbuf.ScreenBuf
+
+	command        string
+	err            error
+	linesToDisplay []string
+	numberOfLines  int
+
+	commandContext context.Context
+	cancel         context.CancelFunc
+
+	isBuilding            bool
+	buildingpreviousLines int
+}
+
+func newTTYDisplayer(stdout, stderr io.Reader) *TTYDisplayer {
+	var (
+		stdoutScanner *bufio.Scanner
+		stderrScanner *bufio.Scanner
+	)
+	if stdout != nil {
+		stdoutScanner = bufio.NewScanner(stdout)
+	}
+	if stderr != nil {
+		stderrScanner = bufio.NewScanner(stderr)
+	}
+
+	return &TTYDisplayer{
+		numberOfLines:  25,
+		linesToDisplay: []string{},
+
+		stdoutScanner: stdoutScanner,
+		stderrScanner: stderrScanner,
+		screenbuf:     screenbuf.New(os.Stdout),
+	}
+}
+
+// Display displays a
+func (d *TTYDisplayer) Display(commandName string) {
+	d.command = commandName
+
+	d.hideCursor()
+	d.commandContext, d.cancel = context.WithCancel(context.Background())
+	go d.displayCommand()
+	if d.stdoutScanner != nil {
+		go d.displayStdout()
+	}
+	if d.stderrScanner != nil {
+		go d.displayStderr()
+	}
+}
+
+func (d *TTYDisplayer) displayCommand() {
+	t := time.NewTicker(50 * time.Millisecond)
+	for {
+		for i := 0; i < len(spinnerChars); i++ {
+			select {
+			case <-t.C:
+				commandLine := renderCommand(spinnerChars[i], d.command)
+				d.screenbuf.Write(commandLine)
+				lines := renderLines(d.linesToDisplay)
+				for _, line := range lines {
+					d.screenbuf.Write([]byte(line))
+				}
+				d.screenbuf.Flush()
+			case <-d.commandContext.Done():
+				return
+			}
+
+		}
+	}
+}
+
+func (d *TTYDisplayer) displayStdout() {
+	for d.stdoutScanner.Scan() {
+		select {
+		case <-d.commandContext.Done():
+		default:
+			line := strings.TrimSpace(d.stdoutScanner.Text())
+			if isTopDisplay(line) {
+				prevState := d.isBuilding
+				d.isBuilding = checkIfIsBuildingLine(line)
+				if d.isBuilding && d.isBuilding != prevState {
+					d.buildingpreviousLines = len(d.linesToDisplay)
+				}
+				sanitizedLine := strings.ReplaceAll(line, cursorUp, "")
+				sanitizedLine = strings.ReplaceAll(sanitizedLine, resetLine, "")
+				d.linesToDisplay = append(d.linesToDisplay[:d.buildingpreviousLines-1], sanitizedLine)
+			} else {
+				if len(d.linesToDisplay) == d.numberOfLines {
+					d.linesToDisplay = d.linesToDisplay[1:]
+				}
+				d.linesToDisplay = append(d.linesToDisplay, line)
+			}
+			oktetoLog.AddToBuffer(oktetoLog.InfoLevel, line)
+			continue
+		}
+		break
+	}
+	if d.stdoutScanner.Err() != nil {
+		oktetoLog.Infof("Error reading command output: %s", d.stdoutScanner.Err().Error())
+	}
+}
+
+func checkIfIsBuildingLine(line string) bool {
+	if strings.Contains(line, "Building") {
+		return !strings.Contains(line, "FINISHED")
+	}
+	return false
+}
+
+func (d *TTYDisplayer) displayStderr() {
+	for d.stderrScanner.Scan() {
+		select {
+		case <-d.commandContext.Done():
+		default:
+			line := strings.TrimSpace(d.stderrScanner.Text())
+			d.err = errors.New(line)
+			if len(d.linesToDisplay) == d.numberOfLines {
+				d.linesToDisplay = d.linesToDisplay[1:]
+			}
+			d.linesToDisplay = append(d.linesToDisplay, line)
+			oktetoLog.AddToBuffer(oktetoLog.WarningLevel, line)
+			continue
+		}
+		break
+	}
+	if d.stderrScanner.Err() != nil {
+		oktetoLog.Infof("Error reading command output: %s", d.stderrScanner.Err().Error())
+	}
+}
+
+func isTopDisplay(line string) bool {
+	return strings.Contains(line, fmt.Sprintf("%s%s", cursorUp, resetLine))
+}
+
+// CleanUp collapses and stop displaying
+func (d *TTYDisplayer) CleanUp(err error) {
+	if d.screenbuf == nil {
+		return
+	}
+	if d.command == "" {
+		return
+	}
+
+	var message []byte
+	if err == nil {
+		message = renderSuccessCommand(d.command)
+		d.screenbuf.Reset()
+		d.screenbuf.Clear()
+		d.screenbuf.Flush()
+		d.screenbuf.Write(message)
+		d.screenbuf.Flush()
+	} else {
+		message = renderFailCommand(d.command, err)
+		d.screenbuf.Reset()
+		d.screenbuf.Clear()
+		d.screenbuf.Flush()
+		d.screenbuf.Write(message)
+		lines := renderLines(d.linesToDisplay)
+		for _, line := range lines {
+			d.screenbuf.Write([]byte(line))
+		}
+		d.screenbuf.Flush()
+	}
+	d.cancel()
+	<-d.commandContext.Done()
+	d.reset()
+	d.showCursor()
+
+}
+
+func renderCommand(spinnerChar, command string) []byte {
+	commandTemplate := fmt.Sprintf(` %s {{ . | oktetoblue }}: `, spinnerChar)
+	funcMap := promptui.FuncMap
+	funcMap["oktetoblue"] = oktetoLog.BlueString
+	tpl, err := template.New("").Funcs(funcMap).Parse(commandTemplate)
+	if err != nil {
+		return []byte{}
+	}
+	command = fmt.Sprintf(" Running %s", command)
+	return render(tpl, command)
+}
+
+func renderSuccessCommand(command string) []byte {
+	commandTemplate := `{{ " ✓ " | bgGreen | black }} {{ . | green }}`
+	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(commandTemplate)
+	if err != nil {
+		return []byte{}
+	}
+
+	return render(tpl, command)
+}
+
+func renderFailCommand(command string, err error) []byte {
+	message := fmt.Sprintf("%s: %s", command, err.Error())
+	commandTemplate := `{{ " x " | bgRed | black }} {{ . | oktetored }}`
+	funcMap := promptui.FuncMap
+	funcMap["oktetored"] = oktetoLog.RedString
+	tpl, err := template.New("").Funcs(funcMap).Parse(commandTemplate)
+	if err != nil {
+		return []byte{}
+	}
+
+	return render(tpl, message)
+}
+
+func renderLines(queue []string) [][]byte {
+	lineTemplate := "{{ . | white }} "
+	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(lineTemplate)
+	if err != nil {
+		return [][]byte{}
+	}
+
+	result := [][]byte{}
+	for _, line := range queue {
+		width, _, _ := term.GetSize(int(os.Stdout.Fd()))
+		line = fmt.Sprintf("   %s", strings.TrimSpace(line))
+		if width > 4 && len(line)+2 > width {
+			result = append(result, render(tpl, fmt.Sprintf("%s...", line[:width-5])))
+		} else if line == "" {
+			result = append(result, []byte(""))
+		} else {
+			result = append(result, render(tpl, line))
+		}
+
+	}
+	return result
+}
+
+func render(tpl *template.Template, data interface{}) []byte {
+	var buf bytes.Buffer
+	err := tpl.Execute(&buf, data)
+	if err != nil {
+		return []byte(fmt.Sprintf("%v", data))
+	}
+	return buf.Bytes()
+}
+
+func (*TTYDisplayer) hideCursor() {
+	if runtime.GOOS != "windows" {
+		fmt.Print("\033[?25l")
+	}
+}
+
+func (*TTYDisplayer) showCursor() {
+	if runtime.GOOS != "windows" {
+		fmt.Print("\033[?25h")
+	}
+}
+
+func (d *TTYDisplayer) reset() {
+
+	d.command = ""
+	d.err = nil
+
+	d.linesToDisplay = []string{}
+	d.screenbuf.Reset()
+}

--- a/cmd/utils/displayer/tty.go
+++ b/cmd/utils/displayer/tty.go
@@ -135,7 +135,9 @@ func (d *TTYDisplayer) displayStdout() {
 				}
 				d.linesToDisplay = append(d.linesToDisplay, line)
 			}
-			oktetoLog.AddToBuffer(oktetoLog.InfoLevel, line)
+			if os.Stdout == oktetoLog.GetOutput() {
+				oktetoLog.AddToBuffer(oktetoLog.InfoLevel, line)
+			}
 			continue
 		}
 		break
@@ -163,7 +165,9 @@ func (d *TTYDisplayer) displayStderr() {
 				d.linesToDisplay = d.linesToDisplay[1:]
 			}
 			d.linesToDisplay = append(d.linesToDisplay, line)
-			oktetoLog.AddToBuffer(oktetoLog.WarningLevel, line)
+			if os.Stdout == oktetoLog.GetOutput() {
+				oktetoLog.AddToBuffer(oktetoLog.WarningLevel, line)
+			}
 			continue
 		}
 		break

--- a/cmd/utils/executor/executor.go
+++ b/cmd/utils/executor/executor.go
@@ -78,7 +78,9 @@ func (e *Executor) Execute(cmdInfo model.DeployCommand, env []string) error {
 
 // CleanUp cleans the execution lines
 func (e *Executor) CleanUp(err error) {
-	e.displayer.cleanUp(err)
+	if e.displayer != nil {
+		e.displayer.cleanUp(err)
+	}
 }
 
 func startCommand(cmd *exec.Cmd) error {

--- a/cmd/utils/executor/executor_windows.go
+++ b/cmd/utils/executor/executor_windows.go
@@ -26,18 +26,15 @@ import (
 )
 
 func (e *ttyExecutor) startCommand(cmd *exec.Cmd) error {
-	e.screenbuf = screenbuf.New(os.Stdout)
-
 	stdoutReader, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
-	e.stdoutScanner = bufio.NewScanner(stdoutReader)
 
 	stderrReader, err := cmd.StderrPipe()
 	if err != nil {
 		return err
 	}
-	e.stderrScanner = bufio.NewScanner(stderrReader)
+	e.displayer = displayer.NewDisplayer(oktetoLog.GetOutputFormat(), stdoutReader, stderrReader)
 	return startCommand(cmd)
 }

--- a/cmd/utils/executor/executor_windows.go
+++ b/cmd/utils/executor/executor_windows.go
@@ -18,11 +18,9 @@
 package executor
 
 import (
-	"bufio"
-	"os"
+	"github.com/okteto/okteto/cmd/utils/displayer"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"os/exec"
-
-	"github.com/manifoldco/promptui/screenbuf"
 )
 
 func (e *ttyExecutor) startCommand(cmd *exec.Cmd) error {

--- a/cmd/utils/executor/tty.go
+++ b/cmd/utils/executor/tty.go
@@ -14,38 +14,11 @@
 package executor
 
 import (
-	"bufio"
-	"bytes"
-	"context"
-	"errors"
-	"fmt"
-	"os"
-	"runtime"
-	"strings"
-	"text/template"
-	"time"
-
-	"github.com/manifoldco/promptui"
-	"github.com/manifoldco/promptui/screenbuf"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"golang.org/x/term"
+	"github.com/okteto/okteto/cmd/utils/displayer"
 )
 
 type ttyExecutor struct {
-	stdoutScanner *bufio.Scanner
-	stderrScanner *bufio.Scanner
-	screenbuf     *screenbuf.ScreenBuf
-
-	command        string
-	err            error
-	linesToDisplay []string
-	numberOfLines  int
-
-	commandContext context.Context
-	cancel         context.CancelFunc
-
-	isBuilding            bool
-	buildingpreviousLines int
+	displayer displayer.Displayer
 }
 
 var (
@@ -55,226 +28,15 @@ var (
 )
 
 func newTTYExecutor() *ttyExecutor {
-	return &ttyExecutor{
-		numberOfLines:  25,
-		linesToDisplay: []string{},
-	}
+	return &ttyExecutor{}
 }
 
 func (e *ttyExecutor) display(command string) {
-	e.command = command
-
-	e.hideCursor()
-
-	e.commandContext, e.cancel = context.WithCancel(context.Background())
-	go e.displayCommand()
-	go e.displayStdout()
-	go e.displayStderr()
-}
-
-func (e *ttyExecutor) displayCommand() {
-	t := time.NewTicker(50 * time.Millisecond)
-	for {
-		for i := 0; i < len(spinnerChars); i++ {
-			select {
-			case <-t.C:
-				commandLine := renderCommand(spinnerChars[i], e.command)
-				e.screenbuf.Write(commandLine)
-				lines := renderLines(e.linesToDisplay)
-				for _, line := range lines {
-					e.screenbuf.Write([]byte(line))
-				}
-				e.screenbuf.Flush()
-			case <-e.commandContext.Done():
-				return
-			}
-
-		}
-	}
-}
-
-func (e *ttyExecutor) displayStdout() {
-	for e.stdoutScanner.Scan() {
-		select {
-		case <-e.commandContext.Done():
-		default:
-			line := strings.TrimSpace(e.stdoutScanner.Text())
-			if isTopDisplay(line) {
-				prevState := e.isBuilding
-				e.isBuilding = checkIfIsBuildingLine(line)
-				if e.isBuilding && e.isBuilding != prevState {
-					e.buildingpreviousLines = len(e.linesToDisplay)
-				}
-				sanitizedLine := strings.ReplaceAll(line, cursorUp, "")
-				sanitizedLine = strings.ReplaceAll(sanitizedLine, resetLine, "")
-				e.linesToDisplay = append(e.linesToDisplay[:e.buildingpreviousLines-1], sanitizedLine)
-			} else {
-				if len(e.linesToDisplay) == e.numberOfLines {
-					e.linesToDisplay = e.linesToDisplay[1:]
-				}
-				e.linesToDisplay = append(e.linesToDisplay, line)
-			}
-			oktetoLog.AddToBuffer(oktetoLog.InfoLevel, line)
-			continue
-		}
-		break
-	}
-	if e.stdoutScanner.Err() != nil {
-		oktetoLog.Infof("Error reading command output: %s", e.stdoutScanner.Err().Error())
-	}
-}
-
-func checkIfIsBuildingLine(line string) bool {
-	if strings.Contains(line, "Building") {
-		return !strings.Contains(line, "FINISHED")
-	}
-	return false
-}
-
-func (e *ttyExecutor) displayStderr() {
-	for e.stderrScanner.Scan() {
-		select {
-		case <-e.commandContext.Done():
-		default:
-			line := strings.TrimSpace(e.stderrScanner.Text())
-			e.err = errors.New(line)
-			if len(e.linesToDisplay) == e.numberOfLines {
-				e.linesToDisplay = e.linesToDisplay[1:]
-			}
-			e.linesToDisplay = append(e.linesToDisplay, line)
-			oktetoLog.AddToBuffer(oktetoLog.WarningLevel, line)
-			continue
-		}
-		break
-	}
-	if e.stderrScanner.Err() != nil {
-		oktetoLog.Infof("Error reading command output: %s", e.stderrScanner.Err().Error())
-	}
-}
-
-func isTopDisplay(line string) bool {
-	return strings.Contains(line, fmt.Sprintf("%s%s", cursorUp, resetLine))
+	e.displayer.Display(command)
 }
 
 func (e *ttyExecutor) cleanUp(err error) {
-	if e.screenbuf == nil {
-		return
+	if e.displayer != nil {
+		e.displayer.CleanUp(err)
 	}
-	if e.command == "" {
-		return
-	}
-
-	var message []byte
-	if err == nil {
-		message = renderSuccessCommand(e.command)
-		e.screenbuf.Reset()
-		e.screenbuf.Clear()
-		e.screenbuf.Flush()
-		e.screenbuf.Write(message)
-		e.screenbuf.Flush()
-	} else {
-		message = renderFailCommand(e.command, err)
-		e.screenbuf.Reset()
-		e.screenbuf.Clear()
-		e.screenbuf.Flush()
-		e.screenbuf.Write(message)
-		lines := renderLines(e.linesToDisplay)
-		for _, line := range lines {
-			e.screenbuf.Write([]byte(line))
-		}
-		e.screenbuf.Flush()
-	}
-	e.cancel()
-	<-e.commandContext.Done()
-	e.reset()
-	e.showCursor()
-
-}
-
-func renderCommand(spinnerChar, command string) []byte {
-	commandTemplate := fmt.Sprintf(` %s {{ . | oktetoblue }}: `, spinnerChar)
-	funcMap := promptui.FuncMap
-	funcMap["oktetoblue"] = oktetoLog.BlueString
-	tpl, err := template.New("").Funcs(funcMap).Parse(commandTemplate)
-	if err != nil {
-		return []byte{}
-	}
-	command = fmt.Sprintf(" Running %s", command)
-	return render(tpl, command)
-}
-
-func renderSuccessCommand(command string) []byte {
-	commandTemplate := `{{ " ✓ " | bgGreen | black }} {{ . | green }}`
-	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(commandTemplate)
-	if err != nil {
-		return []byte{}
-	}
-
-	return render(tpl, command)
-}
-
-func renderFailCommand(command string, err error) []byte {
-	message := fmt.Sprintf("%s: %s", command, err.Error())
-	commandTemplate := `{{ " x " | bgRed | black }} {{ . | oktetored }}`
-	funcMap := promptui.FuncMap
-	funcMap["oktetored"] = oktetoLog.RedString
-	tpl, err := template.New("").Funcs(funcMap).Parse(commandTemplate)
-	if err != nil {
-		return []byte{}
-	}
-
-	return render(tpl, message)
-}
-
-func renderLines(queue []string) [][]byte {
-	lineTemplate := "{{ . | white }} "
-	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(lineTemplate)
-	if err != nil {
-		return [][]byte{}
-	}
-
-	result := [][]byte{}
-	for _, line := range queue {
-		width, _, _ := term.GetSize(int(os.Stdout.Fd()))
-		line = fmt.Sprintf("   %s", strings.TrimSpace(line))
-		if width > 4 && len(line)+2 > width {
-			result = append(result, render(tpl, fmt.Sprintf("%s...", line[:width-5])))
-		} else if line == "" {
-			result = append(result, []byte(""))
-		} else {
-			result = append(result, render(tpl, line))
-		}
-
-	}
-	return result
-}
-
-func render(tpl *template.Template, data interface{}) []byte {
-	var buf bytes.Buffer
-	err := tpl.Execute(&buf, data)
-	if err != nil {
-		return []byte(fmt.Sprintf("%v", data))
-	}
-	return buf.Bytes()
-}
-
-func (*ttyExecutor) hideCursor() {
-	if runtime.GOOS != "windows" {
-		fmt.Print("\033[?25l")
-	}
-}
-
-func (*ttyExecutor) showCursor() {
-	if runtime.GOOS != "windows" {
-		fmt.Print("\033[?25h")
-	}
-}
-
-func (e *ttyExecutor) reset() {
-
-	e.command = ""
-	e.err = nil
-
-	e.linesToDisplay = []string{}
-	e.screenbuf.Reset()
 }

--- a/cmd/utils/executor/tty.go
+++ b/cmd/utils/executor/tty.go
@@ -21,12 +21,6 @@ type ttyExecutor struct {
 	displayer displayer.Displayer
 }
 
-var (
-	spinnerChars = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-	cursorUp     = "\x1b[1A"
-	resetLine    = "\x1b[0G"
-)
-
 func newTTYExecutor() *ttyExecutor {
 	return &ttyExecutor{}
 }

--- a/cmd/utils/okteto.go
+++ b/cmd/utils/okteto.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 )
@@ -52,6 +53,7 @@ func HasAccessToNamespace(ctx context.Context, namespace string, oktetoClient ty
 	return false, nil
 }
 
+// LoadBoolean loads a boolean environment variable and returns it value
 func LoadBoolean(k string) bool {
 	v := os.Getenv(k)
 	if v == "" {
@@ -66,6 +68,7 @@ func LoadBoolean(k string) bool {
 	return h
 }
 
+// ShouldCreateNamespace checks if the namespace exists and if not ask the user if he wants to create it
 func ShouldCreateNamespace(ctx context.Context, ns string) (bool, error) {
 	c, err := okteto.NewOktetoClient()
 	if err != nil {
@@ -76,6 +79,9 @@ func ShouldCreateNamespace(ctx context.Context, ns string) (bool, error) {
 		return false, err
 	}
 	if !hasAccess {
+		if LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) {
+			return false, fmt.Errorf("cannot deploy on a namespace that doesn't exist. Please create %s and try again", ns)
+		}
 		create, err := AskYesNo(fmt.Sprintf("The namespace %s doesn't exist. Do you want to create it? [y/n] ", ns))
 		if err != nil {
 			return false, err

--- a/cmd/utils/stack.go
+++ b/cmd/utils/stack.go
@@ -39,7 +39,6 @@ var (
 		{".okteto", "docker-compose.yml"},
 		{".okteto", "docker-compose.yaml"},
 	}
-	deprecatedManifests = []string{"stack.yml", "stack.yaml"}
 )
 
 //LoadStackContext loads the namespace and context of an okteto stack manifest

--- a/cmd/utils/stack.go
+++ b/cmd/utils/stack.go
@@ -16,10 +16,8 @@ package utils
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 )
 
@@ -84,107 +82,4 @@ func LoadStackContext(stackPaths []string) (*model.ContextResource, error) {
 		}
 	}
 	return ctxResource, nil
-}
-
-// LoadStack loads an okteto stack manifest checking "yml" and "yaml"
-func LoadStack(name string, stackPaths []string) (*model.Stack, error) {
-	var resultStack *model.Stack
-
-	if len(stackPaths) == 0 {
-		stack, err := inferStack(name)
-		if err != nil {
-			return nil, err
-		}
-		resultStack = resultStack.Merge(stack)
-
-	} else {
-		for _, stackPath := range stackPaths {
-			if model.FileExists(stackPath) {
-				stack, err := getStack(name, stackPath)
-				if err != nil {
-					return nil, err
-				}
-
-				resultStack = resultStack.Merge(stack)
-				continue
-			}
-			return nil, fmt.Errorf("'%s' does not exist", stackPath)
-		}
-	}
-
-	if err := resultStack.Validate(); err != nil {
-		return nil, err
-	}
-	return resultStack, nil
-}
-
-func isPathAComposeFile(path string) bool {
-	base := filepath.Base(path)
-	return strings.HasPrefix(base, "docker-compose") || strings.HasPrefix(base, "okteto-compose")
-}
-
-func isDeprecatedExtension(stackPath string) bool {
-	base := filepath.Base(stackPath)
-	for _, deprecatedManifest := range deprecatedManifests {
-		if deprecatedManifest == base {
-			return true
-		}
-	}
-	return false
-}
-
-func getOverrideFile(stackPath string) (*model.Stack, error) {
-	extension := filepath.Ext(stackPath)
-	fileName := strings.TrimSuffix(stackPath, extension)
-	overridePath := fmt.Sprintf("%s.override%s", fileName, extension)
-	var isCompose bool
-	if model.FileExists(stackPath) {
-		if isPathAComposeFile(stackPath) {
-			isCompose = true
-		}
-		stack, err := model.GetStack("", overridePath, isCompose)
-		if err != nil {
-			return nil, err
-		}
-		return stack, nil
-	}
-	return nil, fmt.Errorf("override file not found")
-}
-func inferStack(name string) (*model.Stack, error) {
-	for _, possibleStackManifest := range possibleStackManifests {
-		manifestPath := filepath.Join(possibleStackManifest...)
-		if model.FileExists(manifestPath) {
-			stack, err := getStack(name, manifestPath)
-			if err != nil {
-				return nil, err
-			}
-
-			return stack, nil
-		}
-	}
-	return nil, oktetoErrors.UserError{
-		E:    fmt.Errorf("could not detect any stack file to deploy."),
-		Hint: "Try setting the flag '--file' pointing to your stack file",
-	}
-}
-
-func getStack(name, manifestPath string) (*model.Stack, error) {
-	var isCompose bool
-	if isDeprecatedExtension(manifestPath) {
-		deprecatedFile := filepath.Base(manifestPath)
-		oktetoLog.Warning("The file %s will be deprecated as a default stack file name in a future version. Please consider renaming your stack file to 'okteto-stack.yml'", deprecatedFile)
-	}
-	if isPathAComposeFile(manifestPath) {
-		isCompose = true
-	}
-	stack, err := model.GetStack(name, manifestPath, isCompose)
-	if err != nil {
-		return nil, err
-	}
-	overrideStack, err := getOverrideFile(manifestPath)
-	if err == nil {
-		oktetoLog.Info("override file detected. Merging it")
-		stack = stack.Merge(overrideStack)
-	}
-	return stack, nil
 }

--- a/cmd/utils/stack.go
+++ b/cmd/utils/stack.go
@@ -61,8 +61,8 @@ func LoadStackContext(stackPaths []string) (*model.ContextResource, error) {
 		}
 		if !found {
 			return nil, oktetoErrors.UserError{
-				E:    fmt.Errorf("could not detect any stack file to deploy"),
-				Hint: "Try setting the flag '--file' pointing to your stack file",
+				E:    fmt.Errorf("could not detect any compose file to deploy"),
+				Hint: "Try setting the flag '--file' pointing to your compose file",
 			}
 		}
 	}

--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -57,7 +57,7 @@ func Test_multipleStack(t *testing.T) {
 	}
 	paths = append(paths, path)
 
-	stack, err := LoadStack("", paths)
+	stack, err := model.LoadStack("", paths)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func Test_overrideFileStack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stack, err := LoadStack("", paths)
+	stack, err := model.LoadStack("", paths)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -622,7 +622,7 @@ func executeDestroyStackAction(ctx context.Context, namespace, filePath string) 
 	log.Printf("cloned repo %s \n", actionRepo)
 	defer deleteGitRepo(ctx, actionFolder)
 
-	log.Printf("Deleting stack %s", namespace)
+	log.Printf("Deleting compose %s", namespace)
 	command := fmt.Sprintf("%s/entrypoint.sh", actionFolder)
 	args := []string{namespace, "", filePath}
 	cmd := exec.Command(command, args...)
@@ -632,7 +632,7 @@ func executeDestroyStackAction(ctx context.Context, namespace, filePath string) 
 		return fmt.Errorf("%s %s: %s", command, strings.Join(args, " "), string(o))
 	}
 
-	log.Printf("destroy stack output: \n%s\n", string(o))
+	log.Printf("destroy compose output: \n%s\n", string(o))
 	return nil
 }
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -231,12 +231,16 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 		b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, b.Name, service, tag)
 	}
 
+	file := b.Dockerfile
+	if !filepath.IsAbs(b.Dockerfile) {
+		file = filepath.Join(b.Context, b.Dockerfile)
+	}
 	opts := BuildOptions{
 		CacheFrom: b.CacheFrom,
 		Target:    b.Target,
 		Path:      b.Context,
 		Tag:       b.Image,
-		File:      filepath.Join(b.Context, b.Dockerfile),
+		File:      file,
 		BuildArgs: args,
 	}
 

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -198,10 +198,15 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 		if progress == oktetoLog.TTYFormat {
 			if cn, err := console.ConsoleFromFile(os.Stdout); err == nil {
 				c = cn
+			} else {
+				oktetoLog.Debugf("could not create console from file: %s ", err)
+			}
+			if oktetoLog.GetOutput() != os.Stdout {
+				c = nil
 			}
 		}
 		// not using shared context to not disrupt display but let it finish reporting errors
-		return progressui.DisplaySolveStatus(context.TODO(), "", c, os.Stdout, ch)
+		return progressui.DisplaySolveStatus(context.TODO(), "", c, oktetoLog.GetOutput(), ch)
 	})
 
 	return eg.Wait()

--- a/pkg/cmd/stack/destroy.go
+++ b/pkg/cmd/stack/destroy.go
@@ -45,7 +45,7 @@ func Destroy(ctx context.Context, s *model.Stack, removeVolumes bool, timeout ti
 	}
 
 	cfg := translateConfigMap(s)
-	output := fmt.Sprintf("Destroying stack '%s'...", s.Name)
+	output := fmt.Sprintf("Destroying compose '%s'...", s.Name)
 	cfg.Data[statusField] = destroyingStatus
 	cfg.Data[outputField] = base64.StdEncoding.EncodeToString([]byte(output))
 	if err := configmaps.Deploy(ctx, cfg, s.Namespace, c); err != nil {
@@ -54,7 +54,7 @@ func Destroy(ctx context.Context, s *model.Stack, removeVolumes bool, timeout ti
 
 	err = destroy(ctx, s, removeVolumes, c, timeout)
 	if err != nil {
-		output = fmt.Sprintf("%s\nStack '%s' destruction failed: %s", output, s.Name, err.Error())
+		output = fmt.Sprintf("%s\nCompose '%s' destruction failed: %s", output, s.Name, err.Error())
 		cfg.Data[statusField] = errorStatus
 		cfg.Data[outputField] = base64.StdEncoding.EncodeToString([]byte(output))
 		if err := configmaps.Deploy(ctx, cfg, s.Namespace, c); err != nil {
@@ -67,7 +67,7 @@ func Destroy(ctx context.Context, s *model.Stack, removeVolumes bool, timeout ti
 }
 
 func destroy(ctx context.Context, s *model.Stack, removeVolumes bool, c *kubernetes.Clientset, timeout time.Duration) error {
-	spinner := utils.NewSpinner(fmt.Sprintf("Destroying stack '%s'...", s.Name))
+	spinner := utils.NewSpinner(fmt.Sprintf("Destroying compose '%s'...", s.Name))
 	spinner.Start()
 	defer spinner.Stop()
 

--- a/pkg/cmd/stack/destroy.go
+++ b/pkg/cmd/stack/destroy.go
@@ -112,7 +112,7 @@ func destroy(ctx context.Context, s *model.Stack, removeVolumes bool, c *kuberne
 	return nil
 }
 
-func destroyServicesNotInStack(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c *kubernetes.Clientset) error {
+func destroyServicesNotInStack(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c kubernetes.Interface) error {
 	if err := destroyDeployments(ctx, spinner, s, c); err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func destroyJobs(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c 
 	return nil
 }
 
-func destroyIngresses(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c *kubernetes.Clientset) error {
+func destroyIngresses(ctx context.Context, spinner *utils.Spinner, s *model.Stack, c kubernetes.Interface) error {
 	iClient, err := ingresses.GetClient(ctx, c)
 	if err != nil {
 		return fmt.Errorf("error getting ingress client: %s", err.Error())

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -206,7 +206,7 @@ func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, options *S
 				return hasAddedAnyVolumeMounts, err
 			}
 			svc.Build = svcBuild
-			if okteto.IsOkteto() && !registry.IsOktetoRegistry(svc.Image) {
+			if okteto.IsOkteto() {
 				svc.Image = fmt.Sprintf("okteto.dev/%s-%s:okteto-with-volume-mounts", s.Name, name)
 			}
 			if !options.ForceBuild {

--- a/pkg/k8s/ingresses/crud.go
+++ b/pkg/k8s/ingresses/crud.go
@@ -43,8 +43,8 @@ type Ingress struct {
 	V1Beta1 *networkingv1beta1.Ingress
 }
 
-func GetClient(ctx context.Context, c *kubernetes.Clientset) (*Client, error) {
-	rList, err := c.ServerResourcesForGroupVersion("networking.k8s.io/v1")
+func GetClient(ctx context.Context, c kubernetes.Interface) (*Client, error) {
+	rList, err := c.Discovery().ServerResourcesForGroupVersion("networking.k8s.io/v1")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/log/format.go
+++ b/pkg/log/format.go
@@ -13,6 +13,8 @@
 
 package log
 
+import "io"
+
 //OktetoWriter implements the interface of the writers
 type OktetoWriter interface {
 	Debug(args ...interface{})
@@ -33,11 +35,13 @@ type OktetoWriter interface {
 	Information(format string, args ...interface{})
 	Question(format string, args ...interface{}) error
 	Warning(format string, args ...interface{})
+	FWarning(w io.Writer, format string, args ...interface{})
 	Hint(format string, args ...interface{})
 
 	Println(args ...interface{})
+	FPrintln(w io.Writer, args ...interface{})
 	Print(args ...interface{})
-	Fprintf(format string, a ...interface{})
+	Fprintf(w io.Writer, format string, a ...interface{})
 	Printf(format string, a ...interface{})
 
 	IsInteractive() bool

--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -203,19 +203,21 @@ func (w *JSONWriter) Println(args ...interface{}) {
 func (w *JSONWriter) Fprintf(writer io.Writer, format string, a ...interface{}) {
 	msg := fmt.Sprintf(format, a...)
 	if strings.HasSuffix(format, "\n") {
-		w.Println(msg)
+		w.FPrintln(writer, msg)
 		return
 	}
-	msg = convertToJSON(InfoLevel, log.stage, msg)
-	log.buf.WriteString(msg)
-	log.buf.WriteString("\n")
+	if msg != "" && writer == w.out.Out {
+		msg = convertToJSON(InfoLevel, log.stage, msg)
+		log.buf.WriteString(msg)
+		log.buf.WriteString("\n")
+	}
 	fmt.Fprint(writer, msg)
 }
 
 // FPrintln prints a line with format
 func (w *JSONWriter) FPrintln(writer io.Writer, args ...interface{}) {
 	msg := fmt.Sprint(args...)
-	if msg != "" {
+	if msg != "" && writer == w.out.Out {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
 		log.buf.WriteString("\n")

--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -168,7 +168,7 @@ func (w *JSONWriter) Warning(format string, args ...interface{}) {
 }
 
 // FWarning prints a message with the warning symbol first, and the text in yellow
-func (w *JSONWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
+func (*JSONWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
 	log.out.Infof(format, args...)
 	msg := fmt.Sprintf("%s %s", warningSymbol, fmt.Sprintf(format, args...))
 	if msg != "" {

--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -16,6 +16,7 @@ package log
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -131,25 +132,25 @@ func (*JSONWriter) Fatalf(format string, args ...interface{}) {
 // Green writes a line in green
 func (w *JSONWriter) Green(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf(format, args...))
+	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Yellow writes a line in yellow
 func (w *JSONWriter) Yellow(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf(format, args...))
+	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Success prints a message with the success symbol first, and the text in green
 func (w *JSONWriter) Success(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf("%s %s", successSymbol, fmt.Sprintf(format, args...)))
+	w.FPrintln(w.out.Out, fmt.Sprintf("%s %s", successSymbol, fmt.Sprintf(format, args...)))
 }
 
 // Information prints a message with the information symbol first, and the text in blue
 func (w *JSONWriter) Information(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf("%s %s", informationSymbol, fmt.Sprintf(format, args...)))
+	w.FPrintln(w.out.Out, fmt.Sprintf("%s %s", informationSymbol, fmt.Sprintf(format, args...)))
 }
 
 // Question prints a message with the question symbol first, and the text in magenta
@@ -166,10 +167,19 @@ func (w *JSONWriter) Warning(format string, args ...interface{}) {
 	}
 }
 
+// FWarning prints a message with the warning symbol first, and the text in yellow
+func (w *JSONWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
+	log.out.Infof(format, args...)
+	msg := fmt.Sprintf("%s %s", warningSymbol, fmt.Sprintf(format, args...))
+	if msg != "" {
+		fmt.Fprintln(writer, convertToJSON("warn", log.stage, msg))
+	}
+}
+
 // Hint prints a message with the text in blue
 func (w *JSONWriter) Hint(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf(format, args...))
+	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Fail prints a message with the error symbol first, and the text in red
@@ -186,22 +196,30 @@ func (w *JSONWriter) Fail(format string, args ...interface{}) {
 
 // Println writes a line with colors
 func (w *JSONWriter) Println(args ...interface{}) {
-	w.Fprintln(args...)
+	w.FPrintln(w.out.Out, args...)
 }
 
 // Fprintf prints a line with format
-func (w *JSONWriter) Fprintf(format string, a ...interface{}) {
-	w.Printf(format, a...)
+func (w *JSONWriter) Fprintf(writer io.Writer, format string, a ...interface{}) {
+	msg := fmt.Sprintf(format, a...)
+	if strings.HasSuffix(format, "\n") {
+		w.Println(msg)
+		return
+	}
+	msg = convertToJSON(InfoLevel, log.stage, msg)
+	log.buf.WriteString(msg)
+	log.buf.WriteString("\n")
+	fmt.Fprint(writer, msg)
 }
 
-// Fprintln prints a line with format
-func (w *JSONWriter) Fprintln(args ...interface{}) {
+// FPrintln prints a line with format
+func (w *JSONWriter) FPrintln(writer io.Writer, args ...interface{}) {
 	msg := fmt.Sprint(args...)
 	if msg != "" {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
 		log.buf.WriteString("\n")
-		fmt.Fprintln(w.out.Out, msg)
+		fmt.Fprintln(writer, msg)
 	}
 }
 
@@ -215,15 +233,7 @@ func (w *JSONWriter) Print(args ...interface{}) {
 
 //Printf writes a line with format
 func (w *JSONWriter) Printf(format string, a ...interface{}) {
-	msg := fmt.Sprintf(format, a...)
-	if strings.HasSuffix(format, "\n") {
-		w.Println(msg)
-		return
-	}
-	msg = convertToJSON(InfoLevel, log.stage, msg)
-	log.buf.WriteString(msg)
-	log.buf.WriteString("\n")
-	fmt.Fprint(w.out.Out, msg)
+	w.Fprintf(w.out.Out, format, a...)
 }
 
 //IsInteractive checks if the writer is interactive

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -136,6 +136,11 @@ func GetOutputFormat() string {
 	return log.outputMode
 }
 
+// GetOutput returns the log output
+func GetOutput() io.Writer {
+	return log.out.Out
+}
+
 // SetOutput sets the log output
 func SetOutput(output io.Writer) {
 	log.out.SetOutput(output)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -131,9 +131,14 @@ func SetLevel(level string) {
 	}
 }
 
-//GetOutputFormat returns the output format of the command
+// GetOutputFormat returns the output format of the command
 func GetOutputFormat() string {
 	return log.outputMode
+}
+
+// SetOutput sets the log output
+func SetOutput(output io.Writer) {
+	log.out.SetOutput(output)
 }
 
 // SetOutputFormat sets the output format
@@ -231,6 +236,11 @@ func Warning(format string, args ...interface{}) {
 	log.writer.Warning(format, args...)
 }
 
+// FWarning prints a message with the warning symbol first, and the text in yellow to a specific writer
+func FWarning(w io.Writer, format string, args ...interface{}) {
+	log.writer.FWarning(w, format, args...)
+}
+
 // Hint prints a message with the text in blue
 func Hint(format string, args ...interface{}) {
 	log.writer.Hint(format, args...)
@@ -248,6 +258,13 @@ func Println(args ...interface{}) {
 	msg := fmt.Sprint(args...)
 	msg = redactMessage(msg)
 	log.writer.Println(msg)
+}
+
+// FPrintln writes a line with colors to specific writer
+func FPrintln(w io.Writer, args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	msg = redactMessage(msg)
+	log.writer.FPrintln(w, msg)
 }
 
 // Print writes a line with colors

--- a/pkg/log/plain.go
+++ b/pkg/log/plain.go
@@ -15,6 +15,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/sirupsen/logrus"
 )
@@ -93,51 +94,57 @@ func (*PlainWriter) Fatalf(format string, args ...interface{}) {
 // Green writes a line in green
 func (w *PlainWriter) Green(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf(format, args...))
+	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Yellow writes a line in yellow
 func (w *PlainWriter) Yellow(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(fmt.Sprintf(format, args...))
+	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Success prints a message with the success symbol first, and the text in green
 func (w *PlainWriter) Success(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s\n", successSymbol, fmt.Sprintf(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", successSymbol, fmt.Sprintf(format, args...))
 }
 
 // Information prints a message with the information symbol first, and the text in blue
 func (w *PlainWriter) Information(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s\n", informationSymbol, fmt.Sprintf(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", informationSymbol, fmt.Sprintf(format, args...))
 }
 
 // Question prints a message with the question symbol first, and the text in magenta
 func (w *PlainWriter) Question(format string, args ...interface{}) error {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s", questionSymbol, fmt.Sprintf(format, args...))
+	w.Fprintf(w.out.Out, "%s %s", questionSymbol, fmt.Sprintf(format, args...))
 	return nil
 }
 
 // Warning prints a message with the warning symbol first, and the text in yellow
 func (w *PlainWriter) Warning(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s\n", warningSymbol, fmt.Sprintf(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", warningSymbol, fmt.Sprintf(format, args...))
+}
+
+// FWarning prints a message with the warning symbol first, and the text in yellow into an specific writer
+func (w *PlainWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
+	log.out.Infof(format, args...)
+	w.Fprintf(writer, "%s %s\n", coloredWarningSymbol, yellowString(format, args...))
 }
 
 // Hint prints a message with the text in blue
 func (w *PlainWriter) Hint(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s\n", fmt.Sprintf(format, args...))
+	w.Fprintf(w.out.Out, "%s\n", fmt.Sprintf(format, args...))
 }
 
 // Fail prints a message with the error symbol first, and the text in red
 func (w *PlainWriter) Fail(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	log.out.Info(msg)
-	w.Fprintf("%s %s\n", errorSymbol, fmt.Sprintf(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", errorSymbol, fmt.Sprintf(format, args...))
 	if msg != "" {
 		msg = convertToJSON(ErrorLevel, log.stage, msg)
 		log.buf.WriteString(msg)
@@ -149,7 +156,7 @@ func (w *PlainWriter) Fail(format string, args ...interface{}) {
 func (w *PlainWriter) Println(args ...interface{}) {
 	msg := fmt.Sprint(args...)
 	log.out.Info(msg)
-	w.Fprintln(args...)
+	w.FPrintln(w.out.Out, args...)
 	if msg != "" {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
@@ -158,9 +165,9 @@ func (w *PlainWriter) Println(args ...interface{}) {
 }
 
 // Fprintf prints a line with format
-func (w *PlainWriter) Fprintf(format string, a ...interface{}) {
+func (w *PlainWriter) Fprintf(writer io.Writer, format string, a ...interface{}) {
 	msg := fmt.Sprintf(format, a...)
-	fmt.Fprint(w.out.Out, msg)
+	fmt.Fprint(writer, msg)
 	if msg != "" {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
@@ -168,10 +175,10 @@ func (w *PlainWriter) Fprintf(format string, a ...interface{}) {
 	}
 }
 
-// Fprintln prints a line with format
-func (w *PlainWriter) Fprintln(args ...interface{}) {
+// FPrintln prints a line with format
+func (w *PlainWriter) FPrintln(writer io.Writer, args ...interface{}) {
 	msg := fmt.Sprint(args...)
-	fmt.Fprintln(w.out.Out, args...)
+	fmt.Fprintln(writer, args...)
 	if msg != "" {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
@@ -192,7 +199,7 @@ func (w *PlainWriter) Print(args ...interface{}) {
 
 //Printf writes a line with format
 func (w *PlainWriter) Printf(format string, a ...interface{}) {
-	w.Fprintf(format, a...)
+	w.Fprintf(w.out.Out, format, a...)
 }
 
 //IsInteractive checks if the writer is interactive

--- a/pkg/log/plain.go
+++ b/pkg/log/plain.go
@@ -168,7 +168,7 @@ func (w *PlainWriter) Println(args ...interface{}) {
 func (w *PlainWriter) Fprintf(writer io.Writer, format string, a ...interface{}) {
 	msg := fmt.Sprintf(format, a...)
 	fmt.Fprint(writer, msg)
-	if msg != "" {
+	if msg != "" && writer == w.out.Out {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
 		log.buf.WriteString("\n")
@@ -179,7 +179,7 @@ func (w *PlainWriter) Fprintf(writer io.Writer, format string, a ...interface{})
 func (w *PlainWriter) FPrintln(writer io.Writer, args ...interface{}) {
 	msg := fmt.Sprint(args...)
 	fmt.Fprintln(writer, args...)
-	if msg != "" {
+	if msg != "" && writer == w.out.Out {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
 		log.buf.WriteString("\n")

--- a/pkg/log/tty.go
+++ b/pkg/log/tty.go
@@ -163,7 +163,7 @@ func (w *TTYWriter) Println(args ...interface{}) {
 func (w *TTYWriter) Fprintf(writer io.Writer, format string, a ...interface{}) {
 	msg := fmt.Sprintf(format, a...)
 	fmt.Fprint(writer, msg)
-	if msg != "" {
+	if msg != "" && writer == w.out.Out {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
 		log.buf.WriteString("\n")
@@ -175,7 +175,7 @@ func (w *TTYWriter) Fprintf(writer io.Writer, format string, a ...interface{}) {
 func (w *TTYWriter) FPrintln(writer io.Writer, args ...interface{}) {
 	msg := fmt.Sprint(args...)
 	fmt.Fprintln(writer, msg)
-	if msg != "" {
+	if msg != "" && writer == w.out.Out {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
 		log.buf.WriteString("\n")

--- a/pkg/log/tty.go
+++ b/pkg/log/tty.go
@@ -15,6 +15,7 @@ package log
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
@@ -94,51 +95,57 @@ func (*TTYWriter) Fatalf(format string, args ...interface{}) {
 // Green writes a line in green
 func (w *TTYWriter) Green(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(greenString(format, args...))
+	w.FPrintln(w.out.Out, greenString(format, args...))
 }
 
 // Yellow writes a line in yellow
 func (w *TTYWriter) Yellow(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintln(yellowString(format, args...))
+	w.FPrintln(w.out.Out, yellowString(format, args...))
 }
 
 // Success prints a message with the success symbol first, and the text in green
 func (w *TTYWriter) Success(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s\n", coloredSuccessSymbol, greenString(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", coloredSuccessSymbol, greenString(format, args...))
 }
 
 // Information prints a message with the information symbol first, and the text in blue
 func (w *TTYWriter) Information(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s\n", coloredInformationSymbol, blueString(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", coloredInformationSymbol, blueString(format, args...))
 }
 
 // Question prints a message with the question symbol first, and the text in magenta
 func (w *TTYWriter) Question(format string, args ...interface{}) error {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s", coloredQuestionSymbol, color.MagentaString(format, args...))
+	w.Fprintf(w.out.Out, "%s %s", coloredQuestionSymbol, color.MagentaString(format, args...))
 	return nil
 }
 
 // Warning prints a message with the warning symbol first, and the text in yellow
 func (w *TTYWriter) Warning(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s %s\n", coloredWarningSymbol, yellowString(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", coloredWarningSymbol, yellowString(format, args...))
+}
+
+// FWarning prints a message with the warning symbol first, and the text in yellow into an specific writer
+func (w *TTYWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
+	log.out.Infof(format, args...)
+	w.Fprintf(writer, "%s %s\n", coloredWarningSymbol, yellowString(format, args...))
 }
 
 // Hint prints a message with the text in blue
 func (w *TTYWriter) Hint(format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf("%s\n", blueString(format, args...))
+	w.Fprintf(w.out.Out, "%s\n", blueString(format, args...))
 }
 
 // Fail prints a message with the error symbol first, and the text in red
 func (w *TTYWriter) Fail(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	log.out.Info(msg)
-	w.Fprintf("%s %s\n", coloredErrorSymbol, redString(format, args...))
+	w.Fprintf(w.out.Out, "%s %s\n", coloredErrorSymbol, redString(format, args...))
 	if msg != "" {
 		msg = convertToJSON(ErrorLevel, log.stage, msg)
 		log.buf.WriteString(msg)
@@ -149,13 +156,13 @@ func (w *TTYWriter) Fail(format string, args ...interface{}) {
 // Println writes a line with colors
 func (w *TTYWriter) Println(args ...interface{}) {
 	log.out.Info(args...)
-	w.Fprintln(args...)
+	w.FPrintln(w.out.Out, args...)
 }
 
 // Fprintf prints a line with format
-func (w *TTYWriter) Fprintf(format string, a ...interface{}) {
+func (w *TTYWriter) Fprintf(writer io.Writer, format string, a ...interface{}) {
 	msg := fmt.Sprintf(format, a...)
-	fmt.Fprint(w.out.Out, msg)
+	fmt.Fprint(writer, msg)
 	if msg != "" {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
@@ -164,10 +171,10 @@ func (w *TTYWriter) Fprintf(format string, a ...interface{}) {
 
 }
 
-// Fprintln prints a line with format
-func (w *TTYWriter) Fprintln(args ...interface{}) {
+// FPrintln prints a line with format
+func (w *TTYWriter) FPrintln(writer io.Writer, args ...interface{}) {
 	msg := fmt.Sprint(args...)
-	fmt.Fprintln(w.out.Out, msg)
+	fmt.Fprintln(writer, msg)
 	if msg != "" {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
 		log.buf.WriteString(msg)
@@ -190,7 +197,7 @@ func (w *TTYWriter) Print(args ...interface{}) {
 
 //Printf writes a line with format
 func (w *TTYWriter) Printf(format string, a ...interface{}) {
-	w.Fprintf(format, a...)
+	w.Fprintf(w.out.Out, format, a...)
 }
 
 //IsInteractive checks if the writer is interactive

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -112,7 +112,9 @@ const (
 	StatefulSet = "StatefulSet"
 
 	//Localhost localhost
-	Localhost                   = "localhost"
+	Localhost = "localhost"
+	//PrivilegedLocalhost localhost
+	PrivilegedLocalhost         = "0.0.0.0"
 	oktetoSSHServerPortVariable = "OKTETO_REMOTE_PORT"
 	oktetoDefaultSSHServerPort  = 2222
 	//OktetoDefaultPVSize default volume size

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1250,3 +1250,10 @@ func DivertName(name, username string) string {
 func DevCloneName(name string) string {
 	return fmt.Sprintf("%s-okteto", name)
 }
+
+func getLocalhost() string {
+	if runtime.GOOS != "windows" {
+		return PrivilegedLocalhost
+	}
+	return Localhost
+}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -315,6 +316,10 @@ func NewDev() *Dev {
 		Probes:               &Probes{},
 		Lifecycle:            &Lifecycle{},
 		InitContainer:        InitContainer{Image: OktetoBinImageTag},
+		Metadata: &Metadata{
+			Labels:      Labels{},
+			Annotations: Annotations{},
+		},
 	}
 }
 
@@ -478,6 +483,9 @@ func (dev *Dev) SetDefaults() error {
 	}
 	if dev.Interface == "" {
 		dev.Interface = Localhost
+		if runtime.GOOS != "windows" {
+			dev.Interface = PrivilegedLocalhost
+		}
 	}
 	if dev.SSHServerPort == 0 {
 		dev.SSHServerPort = oktetoDefaultSSHServerPort

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -510,12 +510,6 @@ func (m *Manifest) InferFromStack() (*Manifest, error) {
 				d.Forward = append(d.Forward, fwd)
 			}
 		}
-		for _, p := range svcInfo.Ports {
-			if p.HostPort != 0 {
-				d.Forward = append(d.Forward, Forward{Local: int(p.HostPort), Remote: int(p.ContainerPort)})
-			}
-		}
-
 		for _, v := range svcInfo.VolumeMounts {
 			if pathExistsAndDir(v.LocalPath) {
 				d.Sync.Folders = append(d.Sync.Folders, SyncFolder{

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -197,13 +197,18 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 		}
 		if devManifest.IsV2 {
 			devManifest.Type = OktetoManifestType
-			s, err := LoadStack("", devManifest.Deploy.Compose.Manifest)
-			if err != nil {
-				return nil, err
+			if devManifest.Deploy != nil && devManifest.Deploy.Compose != nil && len(devManifest.Deploy.Compose.Manifest) > 0 {
+				s, err := LoadStack("", devManifest.Deploy.Compose.Manifest)
+				if err != nil {
+					return nil, err
+				}
+				devManifest.Deploy.Compose.Stack = s
+				s.Endpoints = devManifest.Deploy.Endpoints
+				devManifest, err = devManifest.InferFromStack()
+				if err != nil {
+					return nil, err
+				}
 			}
-			devManifest.Deploy.Compose.Stack = s
-			s.Endpoints = devManifest.Deploy.Endpoints
-			devManifest.InferFromStack()
 			return devManifest, nil
 		}
 	}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -152,15 +152,15 @@ func NewManifestFromDev(dev *Dev) *Manifest {
 
 // DeployInfo represents what must be deployed for the app to work
 type DeployInfo struct {
-	Commands []DeployCommand `json:"commands,omitempty" yaml:"commands,omitempty"`
-	Compose  *ComposeInfo    `json:"compose,omitempty" yaml:"compose,omitempty"`
+	Commands  []DeployCommand `json:"commands,omitempty" yaml:"commands,omitempty"`
+	Compose   *ComposeInfo    `json:"compose,omitempty" yaml:"compose,omitempty"`
+	Endpoints EndpointSpec    `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
 }
 
 // ComposeInfo represents information about compose file
 type ComposeInfo struct {
-	Manifest  []string     `json:"manifest,omitempty" yaml:"manifest,omitempty"`
-	Endpoints EndpointSpec `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
-	Stack     *Stack       `json:"-,omitempty" yaml:"-,omitempty"`
+	Manifest []string `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+	Stack    *Stack   `json:"-,omitempty" yaml:"-,omitempty"`
 }
 
 // DeployCommand represents a command to be executed
@@ -202,7 +202,7 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 				return nil, err
 			}
 			devManifest.Deploy.Compose.Stack = s
-			s.Endpoints = devManifest.Deploy.Compose.Endpoints
+			s.Endpoints = devManifest.Deploy.Endpoints
 			devManifest.InferFromStack()
 			return devManifest, nil
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -532,6 +532,7 @@ func (m *Manifest) InferFromStack() (*Manifest, error) {
 		m.Build[svcName] = buildInfo
 	}
 	m.setDefaults()
+	m.Manifest = m.Deploy.Compose.Stack.Manifest
 	return m, nil
 }
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -524,6 +524,5 @@ func (m *Manifest) InferFromStack() (*Manifest, error) {
 		m.Build[svcName] = buildInfo
 	}
 	m.setDefaults()
-	m.Manifest = m.Deploy.Compose.Stack.Manifest
 	return m, nil
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -495,19 +495,11 @@ type Dependency struct {
 
 // InferFromStack infers data from a stackfile
 func (m *Manifest) InferFromStack() (*Manifest, error) {
-	portsMapping := getPortMapping(m.Deploy.Compose.Stack)
 	for svcName, svcInfo := range m.Deploy.Compose.Stack.Services {
 		d := NewDev()
-		for portSvcName, portList := range portsMapping {
-			for _, p := range portList {
-				fwd := Forward{
-					Local:  int(p.HostPort),
-					Remote: int(p.ContainerPort),
-				}
-				if portSvcName != svcName {
-					fwd.ServiceName = portSvcName
-				}
-				d.Forward = append(d.Forward, fwd)
+		for _, p := range svcInfo.Ports {
+			if p.HostPort != 0 {
+				d.Forward = append(d.Forward, Forward{Local: int(p.HostPort), Remote: int(p.ContainerPort)})
 			}
 		}
 		for _, v := range svcInfo.VolumeMounts {
@@ -534,20 +526,4 @@ func (m *Manifest) InferFromStack() (*Manifest, error) {
 	m.setDefaults()
 	m.Manifest = m.Deploy.Compose.Stack.Manifest
 	return m, nil
-}
-
-func getPortMapping(stack *Stack) map[string][]Port {
-	result := map[string][]Port{}
-	for svcName, svc := range stack.Services {
-		for _, p := range svc.Ports {
-			if p.HostPort != 0 {
-				if _, ok := result[svcName]; ok {
-					result[svcName] = append(result[svcName], p)
-				} else {
-					result[svcName] = []Port{p}
-				}
-			}
-		}
-	}
-	return result
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -32,7 +32,7 @@ type Archetype string
 
 var (
 	// StackType represents a stack manifest type
-	StackType Archetype = "stack"
+	StackType Archetype = "compose"
 	// OktetoType represents a okteto manifest type
 	OktetoType Archetype = "okteto"
 	//OktetoType represents a okteto manifest type
@@ -268,7 +268,7 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 	}
 
 	if stackPath := getFilePath(cwd, stackFiles); stackPath != "" {
-		oktetoLog.Infof("Found okteto stack")
+		oktetoLog.Infof("Found okteto compose")
 		stackManifest := &Manifest{
 			Type: StackType,
 			Deploy: &DeployInfo{

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1120,7 +1120,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: Localhost,
+						Interface: getLocalhost(),
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1185,7 +1185,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: Localhost,
+						Interface: getLocalhost(),
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1265,7 +1265,7 @@ sync:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: Localhost,
+						Interface: getLocalhost(),
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1346,7 +1346,7 @@ services:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: Localhost,
+						Interface: getLocalhost(),
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1475,7 +1475,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: Localhost,
+						Interface: getLocalhost(),
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1560,7 +1560,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: Localhost,
+						Interface: getLocalhost(),
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1625,7 +1625,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: Localhost,
+						Interface: getLocalhost(),
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -280,7 +280,7 @@ func ReadStack(bytes []byte, isCompose bool) (*Stack, error) {
 	if err := yaml.UnmarshalStrict(bytes, s); err != nil {
 		if strings.HasPrefix(err.Error(), "yaml: unmarshal errors:") {
 			var sb strings.Builder
-			_, _ = sb.WriteString("Invalid stack manifest:\n")
+			_, _ = sb.WriteString("Invalid compose manifest:\n")
 			l := strings.Split(err.Error(), "\n")
 			for i := 1; i < len(l); i++ {
 				e := strings.TrimSuffix(l[i], "in type model.Stack")
@@ -292,7 +292,7 @@ func ReadStack(bytes []byte, isCompose bool) (*Stack, error) {
 			return nil, errors.New(sb.String())
 		}
 
-		msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", "invalid stack manifest:", 1)
+		msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", "invalid compose manifest:", 1)
 		msg = strings.TrimSuffix(msg, "in type model.Stack")
 		return nil, errors.New(msg)
 	}
@@ -340,7 +340,7 @@ func (svc *Service) IgnoreSyncVolumes(s *Stack) {
 
 func (s *Stack) Validate() error {
 	if err := validateStackName(s.Name); err != nil {
-		return fmt.Errorf("Invalid stack name: %s", err)
+		return fmt.Errorf("Invalid compose name: %s", err)
 	}
 	if len(s.Services) == 0 {
 		return fmt.Errorf("Invalid stack: 'services' cannot be empty")
@@ -671,8 +671,8 @@ func inferStack(name string) (*Stack, error) {
 		}
 	}
 	return nil, oktetoErrors.UserError{
-		E:    fmt.Errorf("could not detect any stack file to deploy"),
-		Hint: "Try setting the flag '--file' pointing to your stack file",
+		E:    fmt.Errorf("could not detect any compose file to deploy"),
+		Hint: "Try setting the flag '--file' pointing to your compose file",
 	}
 }
 
@@ -680,7 +680,7 @@ func getStack(name, manifestPath string) (*Stack, error) {
 	var isCompose bool
 	if isDeprecatedExtension(manifestPath) {
 		deprecatedFile := filepath.Base(manifestPath)
-		oktetoLog.Warning("The file %s will be deprecated as a default stack file name in a future version. Please consider renaming your stack file to 'okteto-stack.yml'", deprecatedFile)
+		oktetoLog.Warning("The file %s will be deprecated as a default compose file name in a future version. Please consider renaming your compose file to 'okteto-stack.yml'", deprecatedFile)
 	}
 	if isPathAComposeFile(manifestPath) {
 		isCompose = true

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -1494,9 +1494,9 @@ func validateExtensions(stack StackRaw) error {
 		}
 	}
 	if len(nonValidFields) == 1 {
-		return fmt.Errorf("Invalid stack manifest: Field '%s' is not supported.\n    More information is available here: https://okteto.com/docs/reference/stacks/", nonValidFields[0])
+		return fmt.Errorf("Invalid compose manifest: Field '%s' is not supported.\n    More information is available here: https://okteto.com/docs/reference/stacks/", nonValidFields[0])
 	} else if len(nonValidFields) > 1 {
-		return fmt.Errorf(`Invalid stack manifest: The following fields are not supported.
+		return fmt.Errorf(`Invalid compose manifest: The following fields are not supported.
     - %s
     More information is available here: https://okteto.com/docs/reference/stacks/`, strings.Join(nonValidFields, "\n    - "))
 	}


### PR DESCRIPTION
Fixes #2162

## Proposed changes
- Runs okteto stack deploy without running from a pseudo-terminal
- Support `okteto build svc`
- `okteto deploy` only builds the images if they are not found or if the command has the `--build` flag
- `okteto up svc` will set the svc into development mode
