### PR TITLE
fix: up was not working with args

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -38,9 +38,9 @@ type doctorOptions struct {
 func Doctor() *cobra.Command {
 	doctorOpts := &doctorOptions{}
 	cmd := &cobra.Command{
-		Use:   "doctor",
+		Use:   "doctor [svc]",
 		Short: "Generate a zip file with the okteto logs",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#doctor"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#doctor"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Info("starting doctor command")
 			ctx := context.Background()
@@ -59,7 +59,11 @@ func Doctor() *cobra.Command {
 				return err
 			}
 
-			dev, err := utils.GetDevFromManifest(manifest)
+			devName := ""
+			if len(args) == 1 {
+				devName = args[0]
+			}
+			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
 				return err
 			}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -45,9 +45,9 @@ func Down() *cobra.Command {
 	var rm bool
 
 	cmd := &cobra.Command{
-		Use:   "down",
+		Use:   "down [svc]",
 		Short: "Deactivate your development container",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#down"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#down"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
@@ -57,7 +57,11 @@ func Down() *cobra.Command {
 				return err
 			}
 
-			dev, err := utils.GetDevFromManifest(manifest)
+			devName := ""
+			if len(args) == 1 {
+				devName = args[0]
+			}
+			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
 				return err
 			}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -54,7 +54,7 @@ func Exec() *cobra.Command {
 				return err
 			}
 
-			dev, err := utils.GetDevFromManifest(manifest)
+			dev, err := utils.GetDevFromManifest(manifest, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/init/init_test.go
+++ b/cmd/init/init_test.go
@@ -62,7 +62,7 @@ func TestRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dev, err := utils.GetDevFromManifest(manifest)
+	dev, err := utils.GetDevFromManifest(manifest, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dev, err = utils.GetDevFromManifest(manifest)
+	dev, err = utils.GetDevFromManifest(manifest, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -52,9 +52,9 @@ type pushOptions struct {
 func Push(ctx context.Context) *cobra.Command {
 	pushOpts := &pushOptions{}
 	cmd := &cobra.Command{
-		Use:   "push",
+		Use:   "push [svc]",
 		Short: "Build, push and redeploy source code to the target app",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#push"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#push"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			ctxResource, err := utils.LoadManifestContext(pushOpts.DevPath)
@@ -88,7 +88,11 @@ func Push(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			dev, err := utils.GetDevFromManifest(manifest)
+			devName := ""
+			if len(args) == 1 {
+				devName = args[0]
+			}
+			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
 				return err
 			}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -38,9 +38,9 @@ func Restart() *cobra.Command {
 	var devPath string
 
 	cmd := &cobra.Command{
-		Use:   "restart",
+		Use:   "restart [svc]",
 		Short: "Restart the deployments listed in the services field of the okteto manifest",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#restart"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#restart"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
@@ -50,7 +50,11 @@ func Restart() *cobra.Command {
 				return err
 			}
 
-			dev, err := utils.GetDevFromManifest(manifest)
+			devName := ""
+			if len(args) == 1 {
+				devName = args[0]
+			}
+			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
 				return err
 			}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -41,7 +41,7 @@ func Status() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Status of the synchronization process",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#status"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#status"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if okteto.InDevContainer() {
@@ -56,7 +56,11 @@ func Status() *cobra.Command {
 				return err
 			}
 
-			dev, err := utils.GetDevFromManifest(manifest)
+			devName := ""
+			if len(args) == 1 {
+				devName = args[0]
+			}
+			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
 				return err
 			}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -64,9 +64,9 @@ type UpOptions struct {
 func Up() *cobra.Command {
 	upOptions := &UpOptions{}
 	cmd := &cobra.Command{
-		Use:   "up",
+		Use:   "up [svc]",
 		Short: "Activate your development container",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#up"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#up"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {
 				return oktetoErrors.ErrNotInDevContainer
@@ -103,8 +103,11 @@ func Up() *cobra.Command {
 					return err
 				}
 			}
-
-			dev, err := utils.GetDevFromManifest(manifest)
+			devName := ""
+			if len(args) == 1 {
+				devName = args[0]
+			}
+			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
 				return err
 			}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -163,11 +163,14 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 		}
 		return nil, fmt.Errorf("dev '%s' does not exists", devName)
 	}
-	devs := make([]string, 0)
+	devs := []SelectorItem{}
 	for k := range manifest.Dev {
-		devs = append(devs, k)
+		devs = append(devs, SelectorItem{
+			Name:  k,
+			Label: k,
+		})
 	}
-	devKey, err := AskForOptions(devs, "Select the dev you want to operate with:")
+	devKey, _, err := AskForOptionsOkteto(context.Background(), devs, "Select the dev you want to operate with:")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -143,15 +143,26 @@ func LoadManifestOrDefault(devPath, name string) (*model.Manifest, error) {
 	return nil, err
 }
 
-func GetDevFromManifest(manifest *model.Manifest) (*model.Dev, error) {
+func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, error) {
 	if len(manifest.Dev) == 0 {
 		return nil, fmt.Errorf("okteto manifest has no dev references")
 	} else if len(manifest.Dev) == 1 {
-		for _, dev := range manifest.Dev {
+		for name, dev := range manifest.Dev {
+			if devName != "" && devName != name {
+				return nil, fmt.Errorf("dev '%s' does not exists", devName)
+			}
 			return dev, nil
 		}
 	}
 
+	if devName != "" {
+		for k := range manifest.Dev {
+			if k == devName {
+				return manifest.Dev[devName], nil
+			}
+		}
+		return nil, fmt.Errorf("dev '%s' does not exists", devName)
+	}
 	devs := make([]string, 0)
 	for k := range manifest.Dev {
 		devs = append(devs, k)
@@ -160,6 +171,7 @@ func GetDevFromManifest(manifest *model.Manifest) (*model.Dev, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return manifest.Dev[devKey], nil
 }
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes up, status, doctor now accept an argument to select the dev directly instead of using the selector

## Proposed changes
- If an argument is introduced try to get the dev from it, if it's not found it returns an error
-
