### PR TITLE
Fix condition for using build v2 and max args at v1

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -50,7 +50,6 @@ func Build(ctx context.Context) *cobra.Command {
 			}
 
 			isBuildV2 := errManifest == nil &&
-				options.Tag == "" &&
 				manifest.IsV2 &&
 				len(manifest.Build) != 0
 
@@ -66,11 +65,11 @@ func Build(ctx context.Context) *cobra.Command {
 					ctxOpts.Namespace = manifest.Namespace
 				}
 			} else {
-				v1Args := 1
+				maxV1Args := 1
 				docsURL := "https://okteto.com/docs/reference/cli/#build"
-				if len(args) != v1Args {
+				if len(args) > maxV1Args {
 					return oktetoErrors.UserError{
-						E:    fmt.Errorf("%q requires %d arg(s), but received %d", cmd.CommandPath(), v1Args, len(args)),
+						E:    fmt.Errorf("%q accepts at most %d arg(s), but received %d", cmd.CommandPath(), maxV1Args, len(args)),
 						Hint: fmt.Sprintf("Visit %s for more information.", docsURL),
 					}
 				}


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

## Proposed changes

- when building with v1 Max Args accepted is 1, but can be none
- criteria for determining to build with v2 is manifest exists and has defined build services
