### PR TITLE
refactor: add build from compose

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -336,6 +336,13 @@ func GetInferredManifest(cwd string) (*Manifest, error) {
 			return nil, err
 		}
 		stackManifest.Deploy.Compose.Stack = s
+
+		for srv := range stackManifest.Deploy.Compose.Stack.Services {
+			s := stackManifest.Deploy.Compose.Stack.Services[srv]
+			if s.Build != nil {
+				stackManifest.Build[srv] = s.Build
+			}
+		}
 		return stackManifest, nil
 	}
 	return nil, nil


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>


## Proposed changes

- when inferring the manifest frm docker compose, add the Build section from Services
-
