### PR TITLE
Persist Bash History Between Iterations of a Dev Container

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -548,6 +548,32 @@ func (dev *Dev) SetDefaults() error {
 		}
 	}
 
+	dev.Environment = append(dev.Environment,
+		EnvVar{
+			Name:  "HISTSIZE",
+			Value: "10000000",
+		},
+		EnvVar{
+			Name:  "HISTFILESIZE",
+			Value: "10000000",
+		},
+		EnvVar{
+			Name:  "HISTCONTROL",
+			Value: "ignoreboth:erasedups",
+		},
+		EnvVar{
+			Name:  "HISTFILE",
+			Value: "bashrc",
+		},
+		EnvVar{
+			Name:  "BASHOPTS",
+			Value: "histappend",
+		},
+		EnvVar{
+			Name:  "PROMPT_COMMAND",
+			Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND",
+		})
+
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes https://github.com/okteto/app/issues/3231

## Proposed changes

Set ENVS to control the bash history inside the dev container. This solution creates the bashrc file at local repo and syncs this with the one at the dev container.

- HISTSIZE and HISTFILESIZE - set as env to make history file able to save more lines
- HISTCONTROL set to ignoreboth:erasedups - do not save the duplicated commands 
- HISTFILE - bashrc ; save history on this file which is sync with the app being developed
- BASHOPTS - histppend - the history is append to the file and not overwritten
- PROMPT_COMMAND - "history -a ; history -c ; history -r ; $PROMPT_COMMAND" - file is loaded to history at init and reloaded & saved with each command
