### PR TITLE
fix: stop other okteto for the same app

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -122,7 +122,7 @@ func runDown(ctx context.Context, dev *model.Dev, rm bool) error {
 		}
 		spinner.Start()
 
-		trMap, err := apps.GetTranslations(ctx, dev, app, false, c)
+		trMap, err := apps.GetTranslations(ctx, dev, app, false, "", c)
 		if err != nil {
 			exit <- err
 			return

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/google/uuid"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -177,8 +178,11 @@ func runPush(ctx context.Context, dev *model.Dev, oktetoRegistryURL string, push
 			pushOpts.ImageTag = registry.GetImageTag("", dev.Name, dev.Namespace, oktetoRegistryURL)
 		}
 	}
-
-	trMap, err := apps.GetTranslations(ctx, dev, app, false, c)
+	id := uuid.New().String()
+	if value, ok := app.ObjectMeta().Annotations[model.OktetoDevIDAnnotation]; ok {
+		id = value
+	}
+	trMap, err := apps.GetTranslations(ctx, dev, app, false, id, c)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -247,7 +247,7 @@ func (up *upContext) createDevContainer(ctx context.Context, app apps.App, creat
 	}
 
 	resetOnDevContainerStart := up.resetSyncthing || !up.Dev.PersistentVolumeEnabled()
-	trMap, err := apps.GetTranslations(ctx, up.Dev, app, resetOnDevContainerStart, up.Client)
+	trMap, err := apps.GetTranslations(ctx, up.Dev, app, resetOnDevContainerStart, up.ID, up.Client)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/forwards.go
+++ b/cmd/up/forwards.go
@@ -16,8 +16,10 @@ package up
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/okteto/okteto/cmd/utils"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/forward"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -89,6 +91,12 @@ func (up *upContext) sshForwards(ctx context.Context) error {
 			up.Dev.Forward[idx] = forwardWithServiceName
 			f = forwardWithServiceName
 		}
+
+		err := waitUntilPortIsAvailable(up.Dev.Interface, f.Local, up.Dev.Timeout.Default)
+		if err != nil {
+			return err
+		}
+
 		if err := up.Forwarder.Add(f); err != nil {
 			return err
 		}
@@ -106,4 +114,23 @@ func (up *upContext) sshForwards(ctx context.Context) error {
 	}
 
 	return up.Forwarder.Start(up.Pod.Name, up.Dev.Namespace)
+}
+
+func waitUntilPortIsAvailable(iface string, port int, timeout time.Duration) error {
+	ticker := time.NewTicker(5 * time.Second)
+	timeoutTicker := time.NewTicker(timeout)
+
+	for {
+		select {
+		case <-ticker.C:
+			if model.IsPortAvailable(iface, port) {
+				return nil
+			}
+		case <-timeoutTicker.C:
+			return oktetoErrors.UserError{
+				E:    fmt.Errorf("local port %d is already in-use in your local machine", port),
+				Hint: "Please release the port and try again",
+			}
+		}
+	}
 }

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -53,6 +53,7 @@ type upContext struct {
 	spinner           *utils.Spinner
 	StartTime         time.Time
 	Options           *UpOptions
+	ID                string
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -359,3 +359,16 @@ func doesAutocreateAppExist(ctx context.Context, dev *model.Dev, c kubernetes.In
 	}
 	return err == nil
 }
+
+// GetDevApp returns the cloned app if exists, error otherwise
+func GetDevApp(ctx context.Context, dev *model.Dev, c kubernetes.Interface) (apps.App, error) {
+	devAppDev := *dev
+	devAppDev.Name = model.DevCloneName(dev.Name)
+	app, err := apps.Get(ctx, &devAppDev, dev.Namespace, c)
+	if err != nil && !oktetoErrors.IsNotFound(err) {
+		oktetoLog.Infof("getApp autocreate k8s error, retrying...")
+		_, err := apps.Get(ctx, &devAppDev, dev.Namespace, c)
+		return nil, err
+	}
+	return app, nil
+}

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -101,12 +101,13 @@ func GetRunningPodInLoop(ctx context.Context, dev *model.Dev, app App, c kuberne
 }
 
 //GetTranslations fills all the deployments pointed by a development container
-func GetTranslations(ctx context.Context, dev *model.Dev, app App, reset bool, c kubernetes.Interface) (map[string]*Translation, error) {
+func GetTranslations(ctx context.Context, dev *model.Dev, app App, reset bool, uid string, c kubernetes.Interface) (map[string]*Translation, error) {
 	mainTr := &Translation{
 		MainDev: dev,
 		Dev:     dev,
 		App:     app,
 		Rules:   []*model.TranslationRule{dev.ToTranslationRule(dev, reset)},
+		ID:      uid,
 	}
 	result := map[string]*Translation{app.ObjectMeta().Name: mainTr}
 

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -47,6 +47,7 @@ type Translation struct {
 	App     App
 	DevApp  App
 	Rules   []*model.TranslationRule
+	ID      string
 }
 
 func (tr *Translation) translate() error {
@@ -78,6 +79,8 @@ func (tr *Translation) translate() error {
 		tr.DevApp.SetReplicas(1)
 		tr.DevApp.TemplateObjectMeta().Labels[model.InteractiveDevLabel] = tr.Dev.Name
 		TranslateOktetoSyncSecret(tr.DevApp.PodSpec(), tr.Dev.Name)
+		tr.DevApp.ObjectMeta().Annotations[model.OktetoDevIDAnnotation] = tr.ID
+		tr.DevApp.TemplateObjectMeta().Annotations[model.OktetoDevIDAnnotation] = tr.ID
 	} else {
 		tr.DevApp.TemplateObjectMeta().Labels[model.DetachedDevLabel] = tr.Dev.Name
 		TranslatePodAffinity(tr.DevApp.PodSpec(), tr.MainDev.Name)

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -34,6 +34,9 @@ const (
 	// OktetoSampleAnnotation indicates that the repo is a okteto sample
 	OktetoSampleAnnotation = "dev.okteto.com/sample"
 
+	// OktetoDevIDAnnotation indicates that the dev uid
+	OktetoDevIDAnnotation = "dev.okteto.com/dev-id"
+
 	// DetachedDevLabel indicates the detached dev pods
 	DetachedDevLabel = "detached.dev.okteto.com"
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2294

## Proposed changes
- Creates an uuid for every up execution 
- Inject that uuid as an annotation to dev deployment/statefulset
- If it's a retry and the uuid of the app has changed stop the application
- Forward will wait for the other okteto execution to stop to get the port
- If another program (not okteto) has taken the port. It will throw an error telling the user to free the port up
