### PR TITLE
fix: okteto down cause nil pointer exception

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -401,7 +401,7 @@ func (up *upContext) activateLoop() {
 
 func (up *upContext) hasDevIDChanged(ctx context.Context) bool {
 	app, err := utils.GetDevApp(ctx, up.Dev, up.Client)
-	if err != nil {
+	if err != nil || app == nil {
 		return false
 	}
 	if value, ok := app.ObjectMeta().Annotations[model.OktetoSessionIDAnnotation]; ok {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -369,7 +369,7 @@ func (up *upContext) activateLoop() {
 				<-t.C
 			}
 		}
-		if up.isRetry && up.hasDevIDChanged(ctx) {
+		if up.isRetry && up.hasSessionIDChanged(ctx) {
 			up.Exit <- oktetoErrors.UserError{
 				E:    fmt.Errorf("session disconnected: there is another `okteto up` session on this container"),
 				Hint: "Try running 'okteto exec' to get another session on this container",
@@ -399,7 +399,7 @@ func (up *upContext) activateLoop() {
 	}
 }
 
-func (up *upContext) hasDevIDChanged(ctx context.Context) bool {
+func (up *upContext) hasSessionIDChanged(ctx context.Context) bool {
 	app, err := utils.GetDevApp(ctx, up.Dev, up.Client)
 	if err != nil || app == nil {
 		return false


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes okteto down was causing a nil pointer exception on retrying autocreate devs

## Proposed changes
- If we can not find any app we should retry activate loop
-
