### PR TITLE
Discard reverse port if collision detected

### DIFF
--- a/pkg/cmd/init/run_test.go
+++ b/pkg/cmd/init/run_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package init
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+)
+
+func TestDiscardReverseIfCollision(t *testing.T) {
+	tests := []struct {
+		name      string
+		devInput  *model.Dev
+		devOutput *model.Dev
+	}{
+		{
+			name: "no collision",
+			devInput: &model.Dev{
+				Forward: []model.Forward{
+					{
+						Local:  8000,
+						Remote: 8000,
+					},
+				},
+				Reverse: []model.Reverse{
+					{
+						Local:  8001,
+						Remote: 8001,
+					},
+				},
+			},
+			devOutput: &model.Dev{
+				Forward: []model.Forward{
+					{
+						Local:  8000,
+						Remote: 8000,
+					},
+				},
+				Reverse: []model.Reverse{
+					{
+						Local:  8001,
+						Remote: 8001,
+					},
+				},
+			},
+		},
+		{
+			name: "collision",
+			devInput: &model.Dev{
+				Forward: []model.Forward{
+					{
+						Local:  8000,
+						Remote: 8000,
+					},
+				},
+				Reverse: []model.Reverse{
+					{
+						Local:  8000,
+						Remote: 8000,
+					},
+				},
+			},
+			devOutput: &model.Dev{
+				Forward: []model.Forward{
+					{
+						Local:  8000,
+						Remote: 8000,
+					},
+				},
+				Reverse: []model.Reverse{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			discardReverseIfCollision(test.devInput)
+			if !reflect.DeepEqual(test.devInput, test.devOutput) {
+				t.Errorf("expected %v got %v", test.devOutput, test.devInput)
+			}
+		})
+	}
+}

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -1,3 +1,16 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package okteto
 
 import (


### PR DESCRIPTION
Fixes #1902

## Proposed changes

- Discard reverse forwarded ports when collision is detected with forwarded ports
