### PR TITLE
fix compose build integration

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -100,7 +100,7 @@ func Build(ctx context.Context) *cobra.Command {
 			}
 
 			if isBuildV2 {
-				return buildV2(ctx, manifest, options, args)
+				return buildV2(manifest, options, args)
 			}
 
 			return buildV1(options, args)
@@ -143,7 +143,7 @@ func isSelectedService(service string, selected []string) bool {
 	return false
 }
 
-func buildV2(ctx context.Context, manifest *model.Manifest, cmdOptions build.BuildOptions, args []string) error {
+func buildV2(manifest *model.Manifest, cmdOptions build.BuildOptions, args []string) error {
 	buildManifest := manifest.Build
 	selectedArgs := []string{}
 	if len(args) != 0 {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -100,7 +100,7 @@ func Build(ctx context.Context) *cobra.Command {
 			}
 
 			if isBuildV2 {
-				return buildV2(manifest.Build, options, args)
+				return buildV2(ctx, manifest, options, args)
 			}
 
 			return buildV1(options, args)
@@ -143,8 +143,8 @@ func isSelectedService(service string, selected []string) bool {
 	return false
 }
 
-func buildV2(buildManifest model.ManifestBuild, cmdOptions build.BuildOptions, args []string) error {
-
+func buildV2(ctx context.Context, manifest *model.Manifest, cmdOptions build.BuildOptions, args []string) error {
+	buildManifest := manifest.Build
 	selectedArgs := []string{}
 	if len(args) != 0 {
 		selectedArgs = args
@@ -164,7 +164,7 @@ func buildV2(buildManifest model.ManifestBuild, cmdOptions build.BuildOptions, a
 		}
 	}
 
-	for service, manifestOpts := range buildManifest {
+	for service, buildInfo := range buildManifest {
 
 		if buildSelected && !isSelectedService(service, selectedArgs) {
 			continue
@@ -172,23 +172,27 @@ func buildV2(buildManifest model.ManifestBuild, cmdOptions build.BuildOptions, a
 
 		if isSingleService {
 			if cmdOptions.Target != "" {
-				manifestOpts.Target = cmdOptions.Target
+				buildInfo.Target = cmdOptions.Target
 			}
 			if len(cmdOptions.CacheFrom) != 0 {
-				manifestOpts.CacheFrom = cmdOptions.CacheFrom
+				buildInfo.CacheFrom = cmdOptions.CacheFrom
 			}
 			if cmdOptions.Tag != "" {
-				manifestOpts.Image = cmdOptions.Tag
+				buildInfo.Image = cmdOptions.Tag
 			}
 		}
-		if !okteto.Context().IsOkteto && manifestOpts.Image == "" {
+		if !okteto.Context().IsOkteto && buildInfo.Image == "" {
 			return fmt.Errorf("'build.%s.image' is required if your context is not managed by Okteto", service)
 		}
-		if cwd, err := os.Getwd(); err == nil && manifestOpts.Name == "" {
-			manifestOpts.Name = utils.InferName(cwd)
+		if cwd, err := os.Getwd(); err == nil && buildInfo.Name == "" {
+			buildInfo.Name = utils.InferName(cwd)
 		}
 
-		cmdOptsFromManifest := build.OptsFromManifest(service, manifestOpts, cmdOptions)
+		volumesToInclude := buildInfo.VolumesToInclude
+		if len(buildInfo.VolumesToInclude) > 0 {
+			buildInfo.VolumesToInclude = nil
+		}
+		cmdOptsFromManifest := build.OptsFromManifest(service, buildInfo, cmdOptions)
 
 		// check if image is at registry and skip
 		if build.ShouldOptimizeBuild(cmdOptsFromManifest.Tag) && !cmdOptions.BuildToGlobal {
@@ -213,6 +217,20 @@ func buildV2(buildManifest model.ManifestBuild, cmdOptions build.BuildOptions, a
 
 		if err := buildV1(cmdOptsFromManifest, []string{cmdOptsFromManifest.Path}); err != nil {
 			return err
+		}
+		if len(volumesToInclude) > 0 {
+			oktetoLog.Information("Including volume hosts for service '%s'", service)
+			svcBuild, err := registry.CreateDockerfileWithVolumeMounts(cmdOptsFromManifest.Tag, volumesToInclude)
+			if err != nil {
+				return err
+			}
+			svcBuild.VolumesToInclude = volumesToInclude
+			svcBuild.Name = buildInfo.Name
+			options := build.OptsFromManifest(service, svcBuild, build.BuildOptions{})
+			if err := buildV1(options, []string{options.Path}); err != nil {
+				return err
+			}
+
 		}
 	}
 	return nil

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -535,7 +535,7 @@ func runBuildAndSetEnvs(ctx context.Context, service string, manifest *model.Man
 	if manifest.Deploy != nil && manifest.Deploy.Compose != nil && manifest.Deploy.Compose.Stack != nil {
 		stack := manifest.Deploy.Compose.Stack
 		if stack.Services[service].Image == "" {
-			stack.Services[service].Image = options.Tag
+			stack.Services[service].Image = fmt.Sprintf("$OKTETO_BUILD_%s_IMAGE", strings.ToUpper(service))
 		}
 	}
 	return nil

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -227,8 +227,11 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 		if o.BuildToGlobal {
 			targetRegistry = okteto.GlobalRegistry
 		}
-
 		b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, b.Name, service, tag)
+		if len(b.VolumesToInclude) > 0 {
+			b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, b.Name, service, model.OktetoImageTagWithVolumes)
+		}
+
 	}
 
 	file := b.Dockerfile

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -150,7 +150,7 @@ func buildServices(ctx context.Context, s *model.Stack, options *StackDeployOpti
 			return hasBuiltSomething, fmt.Errorf("'build' and 'image' fields of service '%s' cannot be empty", name)
 		}
 		if okteto.IsOkteto() && !registry.IsOktetoRegistry(svc.Image) {
-			svc.Image = fmt.Sprintf("okteto.dev/%s-%s:okteto", s.Name, name)
+			svc.Image = fmt.Sprintf("okteto.dev/%s-%s:%s", s.Name, name, model.OktetoDefaultImageTag)
 		}
 		if !options.ForceBuild {
 			if _, err := registry.GetImageTagWithDigest(svc.Image); err != oktetoErrors.ErrNotFound {
@@ -207,7 +207,7 @@ func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, options *S
 			}
 			svc.Build = svcBuild
 			if okteto.IsOkteto() {
-				svc.Image = fmt.Sprintf("okteto.dev/%s-%s:okteto-with-volume-mounts", s.Name, name)
+				svc.Image = fmt.Sprintf("okteto.dev/%s-%s:%s", s.Name, name, model.OktetoImageTagWithVolumes)
 			}
 			if !options.ForceBuild {
 				if _, err := registry.GetImageTagWithDigest(svc.Image); err != oktetoErrors.ErrNotFound {

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -149,15 +149,16 @@ func buildServices(ctx context.Context, s *model.Stack, options *StackDeployOpti
 		if !okteto.IsOkteto() && svc.Image == "" {
 			return hasBuiltSomething, fmt.Errorf("'build' and 'image' fields of service '%s' cannot be empty", name)
 		}
+		image := svc.Image
 		if okteto.IsOkteto() && !registry.IsOktetoRegistry(svc.Image) {
-			svc.Image = fmt.Sprintf("okteto.dev/%s-%s:%s", s.Name, name, model.OktetoDefaultImageTag)
+			image = fmt.Sprintf("okteto.dev/%s-%s:%s", s.Name, name, model.OktetoDefaultImageTag)
 		}
 		if !options.ForceBuild {
-			if _, err := registry.GetImageTagWithDigest(svc.Image); err != oktetoErrors.ErrNotFound {
+			if _, err := registry.GetImageTagWithDigest(image); err != oktetoErrors.ErrNotFound {
 				s.Services[name] = svc
 				continue
 			}
-			oktetoLog.Infof("image '%s' not found, building it", svc.Image)
+			oktetoLog.Infof("image '%s' not found, building it", image)
 		}
 		if !hasBuiltSomething {
 			hasBuiltSomething = true
@@ -173,7 +174,7 @@ func buildServices(ctx context.Context, s *model.Stack, options *StackDeployOpti
 		buildOptions := build.BuildOptions{
 			Path:       svc.Build.Context,
 			File:       svc.Build.Dockerfile,
-			Tag:        svc.Image,
+			Tag:        image,
 			Target:     svc.Build.Target,
 			NoCache:    options.NoCache,
 			CacheFrom:  svc.Build.CacheFrom,
@@ -184,6 +185,7 @@ func buildServices(ctx context.Context, s *model.Stack, options *StackDeployOpti
 			return hasBuiltSomething, err
 		}
 		svc.SetLastBuiltAnnotation()
+		svc.Image = image
 		s.Services[name] = svc
 		oktetoLog.Success("Image for service '%s' successfully pushed", name)
 	}
@@ -206,15 +208,16 @@ func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, options *S
 				return hasAddedAnyVolumeMounts, err
 			}
 			svc.Build = svcBuild
+			image := svc.Image
 			if okteto.IsOkteto() {
-				svc.Image = fmt.Sprintf("okteto.dev/%s-%s:%s", s.Name, name, model.OktetoImageTagWithVolumes)
+				image = fmt.Sprintf("okteto.dev/%s-%s:%s", s.Name, name, model.OktetoImageTagWithVolumes)
 			}
 			if !options.ForceBuild {
-				if _, err := registry.GetImageTagWithDigest(svc.Image); err != oktetoErrors.ErrNotFound {
+				if _, err := registry.GetImageTagWithDigest(image); err != oktetoErrors.ErrNotFound {
 					s.Services[name] = svc
 					continue
 				}
-				oktetoLog.Infof("image '%s' not found, building it", svc.Image)
+				oktetoLog.Infof("image '%s' not found, building it", image)
 			}
 			if !hasBuiltSomething && !hasAddedAnyVolumeMounts {
 				hasAddedAnyVolumeMounts = true
@@ -226,7 +229,7 @@ func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, options *S
 			buildOptions := build.BuildOptions{
 				Path:       svc.Build.Context,
 				File:       svc.Build.Dockerfile,
-				Tag:        svc.Image,
+				Tag:        image,
 				Target:     svc.Build.Target,
 				NoCache:    options.NoCache,
 				CacheFrom:  svc.Build.CacheFrom,
@@ -237,6 +240,7 @@ func addVolumeMountsToBuiltImage(ctx context.Context, s *model.Stack, options *S
 				return hasAddedAnyVolumeMounts, err
 			}
 			svc.SetLastBuiltAnnotation()
+			svc.Image = image
 			s.Services[name] = svc
 			oktetoLog.Success("Image for service '%s' successfully pushed", name)
 		}

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -317,4 +317,7 @@ const (
 
 	// OktetoDefaultImageTag default tag assigned to image to build
 	OktetoDefaultImageTag = "okteto"
+
+	// OktetoImageTagWithVolumes is the tag assigned to an image with volume mounts
+	OktetoImageTagWithVolumes = "okteto-with-volume-mounts"
 )

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -116,13 +116,14 @@ type Args struct {
 
 // BuildInfo represents the build info to generate an image
 type BuildInfo struct {
-	Name       string      `yaml:"name,omitempty"`
-	Context    string      `yaml:"context,omitempty"`
-	Dockerfile string      `yaml:"dockerfile,omitempty"`
-	CacheFrom  []string    `yaml:"cache_from,omitempty"`
-	Target     string      `yaml:"target,omitempty"`
-	Args       Environment `yaml:"args,omitempty"`
-	Image      string      `yaml:"image,omitempty"`
+	Name             string        `yaml:"name,omitempty"`
+	Context          string        `yaml:"context,omitempty"`
+	Dockerfile       string        `yaml:"dockerfile,omitempty"`
+	CacheFrom        []string      `yaml:"cache_from,omitempty"`
+	Target           string        `yaml:"target,omitempty"`
+	Args             Environment   `yaml:"args,omitempty"`
+	Image            string        `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume `yaml:"-"`
 }
 
 // Volume represents a volume in the development container

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -545,10 +545,7 @@ func (m *Manifest) InferFromStack() (*Manifest, error) {
 		}
 		for _, v := range svcInfo.VolumeMounts {
 			if pathExistsAndDir(v.LocalPath) {
-				d.Sync.Folders = append(d.Sync.Folders, SyncFolder{
-					LocalPath:  v.LocalPath,
-					RemotePath: v.RemotePath,
-				})
+				d.Sync.Folders = append(d.Sync.Folders, SyncFolder(v))
 			}
 			toMount = append(toMount, v)
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -502,6 +502,14 @@ func (m *Manifest) ExpandEnvVars() (*Manifest, error) {
 			}
 			m.Deploy.Commands[idx] = cmd
 		}
+		if m.Deploy.Compose != nil && m.Deploy.Compose.Stack != nil {
+			for _, svc := range m.Deploy.Compose.Stack.Services {
+				svc.Image, err = ExpandEnv(svc.Image)
+				if err != nil {
+					return nil, errors.New("could not parse env vars")
+				}
+			}
+		}
 	}
 	if m.Destroy != nil {
 		for idx, cmd := range m.Destroy {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -656,7 +656,7 @@ func (m *Manifest) WriteToFile(filePath string) error {
 }
 
 // reorderDocFields orders the manifest to be: name -> build -> deploy -> dependencies -> dev
-func (m *Manifest) reorderDocFields(doc yaml3.Node) yaml3.Node {
+func (*Manifest) reorderDocFields(doc yaml3.Node) yaml3.Node {
 	contentCopy := []*yaml3.Node{}
 	nodes := []int{}
 	nameDefinitionIdx := getDocIdx(doc.Content, "name")

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -34,13 +34,14 @@ import (
 
 // BuildInfoRaw represents the build info for serialization
 type buildInfoRaw struct {
-	Name       string      `yaml:"name,omitempty"`
-	Context    string      `yaml:"context,omitempty"`
-	Dockerfile string      `yaml:"dockerfile,omitempty"`
-	CacheFrom  []string    `yaml:"cache_from,omitempty"`
-	Target     string      `yaml:"target,omitempty"`
-	Args       Environment `yaml:"args,omitempty"`
-	Image      string      `yaml:"image,omitempty"`
+	Name             string        `yaml:"name,omitempty"`
+	Context          string        `yaml:"context,omitempty"`
+	Dockerfile       string        `yaml:"dockerfile,omitempty"`
+	CacheFrom        []string      `yaml:"cache_from,omitempty"`
+	Target           string        `yaml:"target,omitempty"`
+	Args             Environment   `yaml:"args,omitempty"`
+	Image            string        `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume `yaml:"-"`
 }
 
 type syncRaw struct {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: It was rebuilding the image on the deploy if there was a stack

## Proposed changes
- If run okteto build with a compose it will run and include the host volumes on the built image
- If run okteto deploy it will build the images at the beginning and not while deploying stack
