### PR TITLE
fix: manifest v2 compose unmarshall

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -177,9 +177,12 @@ type DeployInfo struct {
 
 // ComposeInfo represents information about compose file
 type ComposeInfo struct {
-	Manifest []string `json:"manifest,omitempty" yaml:"manifest,omitempty"`
-	Stack    *Stack   `json:"-" yaml:"-"`
+	Manifest ManifestList `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+	Stack    *Stack       `json:"-" yaml:"-"`
 }
+
+// ManifestList is a list containing all the compose files
+type ManifestList []string
 
 // DeployCommand represents a command to be executed
 type DeployCommand struct {

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -856,6 +856,48 @@ func (d *DeployInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (c *ComposeInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var rawString string
+	err := unmarshal(&rawString)
+	if err == nil {
+		c.Manifest = []string{rawString}
+		return nil
+	}
+	var rawListString []string
+	err = unmarshal(&rawListString)
+	if err == nil {
+		c.Manifest = rawListString
+		return nil
+	}
+
+	type composeInfoRaw ComposeInfo
+	var compose composeInfoRaw
+	err = unmarshal(&compose)
+	if err != nil {
+		return err
+	}
+	*c = ComposeInfo(compose)
+	return nil
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (m *ManifestList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var rawString string
+	err := unmarshal(&rawString)
+	if err == nil {
+		*m = ManifestList{rawString}
+		return nil
+	}
+	var rawListString []string
+	err = unmarshal(&rawListString)
+	if err != nil {
+		return err
+	}
+	*m = ManifestList(rawListString)
+	return nil
+}
+
 type devRaw Dev
 
 func (d *devRaw) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1933,6 +1933,113 @@ func TestDeployInfoMarshalling(t *testing.T) {
 	}
 }
 
+func TestComposeInfoUnmarshalling(t *testing.T) {
+	tests := []struct {
+		name                string
+		composeInfoManifest []byte
+		expected            *ComposeInfo
+	}{
+		{
+			name: "list of compose",
+			composeInfoManifest: []byte(`
+- docker-compose.yml
+- docker-compose.dev.yml`),
+			expected: &ComposeInfo{
+				Manifest: []string{
+					"docker-compose.yml",
+					"docker-compose.dev.yml",
+				},
+			},
+		},
+		{
+			name:                "a docker compose",
+			composeInfoManifest: []byte(`docker-compose.yml`),
+			expected: &ComposeInfo{
+				Manifest: []string{
+					"docker-compose.yml",
+				},
+			},
+		},
+		{
+			name:                "extended notation one compose",
+			composeInfoManifest: []byte(`manifest: docker-compose.yml`),
+			expected: &ComposeInfo{
+				Manifest: []string{
+					"docker-compose.yml",
+				},
+			},
+		},
+		{
+			name: "extended notation one compose",
+			composeInfoManifest: []byte(`manifest:
+  - docker-compose.yml
+  - docker-compose.dev.yml`),
+			expected: &ComposeInfo{
+				Manifest: []string{
+					"docker-compose.yml",
+					"docker-compose.dev.yml",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &ComposeInfo{}
+
+			err := yaml.UnmarshalStrict(tt.composeInfoManifest, &result)
+			if err != nil {
+				t.Fatalf("Not expecting error but got %s", err)
+			}
+
+			if !assert.Equal(t, tt.expected, result) {
+				t.Fatal("Failed")
+			}
+		})
+	}
+}
+
+func TestManifestListUnmarshalling(t *testing.T) {
+	tests := []struct {
+		name                 string
+		manifestListManifest []byte
+		expected             *ManifestList
+	}{
+		{
+			name: "list of compose",
+			manifestListManifest: []byte(`
+- docker-compose.yml
+- docker-compose.dev.yml`),
+			expected: &ManifestList{
+				"docker-compose.yml",
+				"docker-compose.dev.yml",
+			},
+		},
+		{
+			name:                 "a docker compose",
+			manifestListManifest: []byte(`docker-compose.yml`),
+			expected: &ManifestList{
+				"docker-compose.yml",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &ManifestList{}
+
+			err := yaml.UnmarshalStrict(tt.manifestListManifest, &result)
+			if err != nil {
+				t.Fatalf("Not expecting error but got %s", err)
+			}
+
+			if !assert.Equal(t, tt.expected, result) {
+				t.Fatal("Failed")
+			}
+		})
+	}
+}
+
 func TestManifestBuildUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2286

## Proposed changes
- Add simple notation for unmarshalling compose on manifest v2
