### PR TITLE
fix: stack deploy is showing endpoints when fail

### DIFF
--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -116,6 +116,8 @@ func (c *DeployCommand) RunDeploy(ctx context.Context, s *model.Stack, options *
 	analytics.TrackDeployStack(err == nil, s.IsCompose, utils.IsOktetoRepo())
 	if err == nil {
 		oktetoLog.Success("Compose '%s' successfully deployed", s.Name)
+	} else {
+		return err
 	}
 
 	if !utils.LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) || !c.IsInsideDeploy {

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -114,11 +114,10 @@ func (c *DeployCommand) RunDeploy(ctx context.Context, s *model.Stack, options *
 	err := stackDeployer.Deploy(ctx, s, options)
 
 	analytics.TrackDeployStack(err == nil, s.IsCompose, utils.IsOktetoRepo())
-	if err == nil {
-		oktetoLog.Success("Compose '%s' successfully deployed", s.Name)
-	} else {
+	if err != nil {
 		return err
 	}
+	oktetoLog.Success("Compose '%s' successfully deployed", s.Name)
 
 	if !utils.LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) || !c.IsInsideDeploy {
 		if err := stack.ListEndpoints(ctx, s, ""); err != nil {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Stack deploy was showing endpoints when there was a failure on  the command

## Proposed changes
- Check if the stack deploy has an error