### PR TITLE
Check metadata if err is nil

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -131,7 +131,7 @@ func buildWithOkteto(ctx context.Context, buildOptions BuildOptions) error {
 		return err
 	}
 
-	if buildOptions.Tag != "" {
+	if err == nil && buildOptions.Tag != "" {
 		if _, err := registry.GetImageTagWithDigest(buildOptions.Tag); err != nil {
 			oktetoLog.Yellow(`Failed to push '%s' metadata to the registry:
 	  %s,


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>



## Proposed changes

- Only try to get digest if build has gone with err nil
-
