### PR TITLE
Metrics Fixes

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -314,7 +314,6 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		fmt.Sprintf("%s=%s", model.OktetoNamespaceEnvVar, okteto.Context().Namespace),
 	)
 	oktetoLog.EnableMasking()
-
 	err = dc.deploy(ctx, deployOptions)
 	oktetoLog.DisableMasking()
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -187,13 +187,14 @@ func Deploy(ctx context.Context) *cobra.Command {
 				options.Manifest.Deploy.Compose.Manifest != nil {
 				deployType = "compose"
 			}
+
 			analytics.TrackDeploy(analytics.TrackDeployMetadata{
 				Success:                err == nil,
 				IsOktetoRepo:           utils.IsOktetoRepo(),
 				Duration:               time.Since(startTime),
 				PipelineType:           c.PipelineType,
 				DeployType:             deployType,
-				IsPreview:              false, // TODO: How should we get this value?
+				IsPreview:              os.Getenv(model.OktetoCurrentDeployBelongsToPreview) == "true",
 				HasDependenciesSection: options.Manifest.IsV2 && len(options.Manifest.Dependencies) > 0,
 				HasBuildSection:        options.Manifest.IsV2 && len(options.Manifest.Build) > 0,
 			})

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -128,7 +128,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			}
 			// This is needed because the deploy command needs the original kubeconfig configuration even in the execution within another
 			// deploy command. If not, we could be proxying a proxy and we would be applying the incorrect deployed-by label
-			os.Setenv(model.OktetoWithinDeployCommandContextEnvVar, "false")
+			os.Setenv(model.OktetoSkipConfigCredentialsUpdate, "false")
 
 			if err := contextCMD.LoadManifestV2WithContext(ctx, options.Namespace, options.ManifestPath); err != nil {
 				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{Namespace: options.Namespace}); err != nil {
@@ -305,9 +305,12 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		deployOptions.Variables,
 		// Set KUBECONFIG environment variable as environment for the commands to be executed
 		fmt.Sprintf("%s=%s", model.KubeConfigEnvVar, dc.TempKubeconfigFile),
-		// Set OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT env variable, so all the Okteto commands executed within this command execution
-		// should not overwrite the server and the credentials in the kubeconfig
+		// Set OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT env variable, so all okteto commands ran inside this deploy
+		// know they are running inside another okteto deploy
 		fmt.Sprintf("%s=true", model.OktetoWithinDeployCommandContextEnvVar),
+		// Set OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE env variable, so all the Okteto commands executed within this command execution
+		// should not overwrite the server and the credentials in the kubeconfig
+		fmt.Sprintf("%s=true", model.OktetoSkipConfigCredentialsUpdate),
 		// Set OKTETO_DISABLE_SPINNER=true env variable, so all the Okteto commands disable spinner which leads to errors
 		fmt.Sprintf("%s=true", model.OktetoDisableSpinnerEnvVar),
 		// Set OKTETO_NAMESPACE=namespace-name env variable, so all the commandsruns on the same namespace

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -281,6 +281,7 @@ func TrackDeploy(m TrackDeployMetadata) {
 		"deployType":             m.DeployType,
 		"isPreview":              m.IsPreview,
 		"hasDependenciesSection": m.HasDependenciesSection,
+		"hasBuildSection":        m.HasBuildSection,
 	}
 	if m.Err != nil {
 		props["error"] = m.Err.Error()

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -339,10 +339,7 @@ func track(event string, success bool, props map[string]interface{}) {
 		mpOS = "Linux"
 	}
 
-	origin, ok := os.LookupEnv(model.OktetoOriginEnvVar)
-	if !ok {
-		origin = "cli"
-	}
+	origin := config.GetDeployOrigin()
 
 	if props == nil {
 		props = map[string]interface{}{}

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -32,7 +32,7 @@ import (
 const (
 	// skipcq GSC-G101
 	// This is mixpanel's public token, is needed to send analytics to the project
-	mixpanelToken = "db84e1636cf6489d13582457eb63dfeb"
+	mixpanelToken = "92fe782cdffa212d8f03861fbf1ea301"
 
 	upEvent                  = "Up"
 	upErrorEvent             = "Up Error"

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -49,7 +49,7 @@ const (
 	doctorEvent              = "Doctor"
 	buildEvent               = "Build"
 	buildTransientErrorEvent = "BuildTransientError"
-	deployEvent              = "OktetoDeploy"
+	deployEvent              = "UnifiedDeploy"
 	destroyEvent             = "Destroy"
 	deployStackEvent         = "Deploy Stack"
 	destroyStackEvent        = "Destroy Stack"

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -49,8 +49,7 @@ const (
 	doctorEvent              = "Doctor"
 	buildEvent               = "Build"
 	buildTransientErrorEvent = "BuildTransientError"
-	deployEvent              = "Deploy"
-	oktetoDeployEvent        = "Okteto Deploy"
+	deployEvent              = "OktetoDeploy"
 	destroyEvent             = "Destroy"
 	deployStackEvent         = "Deploy Stack"
 	destroyStackEvent        = "Destroy Stack"
@@ -286,7 +285,7 @@ func TrackDeploy(m TrackDeployMetadata) {
 	if m.Err != nil {
 		props["error"] = m.Err.Error()
 	}
-	track(oktetoDeployEvent, m.Success, props)
+	track(deployEvent, m.Success, props)
 }
 
 // TrackDestroy sends a tracking event to mixpanel when the user destroys a pipeline from local

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -49,7 +49,7 @@ const (
 	doctorEvent              = "Doctor"
 	buildEvent               = "Build"
 	buildTransientErrorEvent = "BuildTransientError"
-	deployEvent              = "UnifiedDeploy"
+	deployEvent              = "Deploy"
 	destroyEvent             = "Destroy"
 	deployStackEvent         = "Deploy Stack"
 	destroyStackEvent        = "Destroy Stack"
@@ -152,16 +152,25 @@ func TrackResetDatabase(success bool) {
 	track(syncResetDatabase, success, nil)
 }
 
+type TrackUpMetadata struct {
+	IsInteractive          bool
+	IsOktetoRepository     bool
+	HasDependenciesSection bool
+	HasBuildSection        bool
+	HasDeploySection       bool
+	Success                bool
+}
+
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
-func TrackUp(success bool, devName string, interactive, single, divert, isOktetoRepository bool) {
+func TrackUp(m TrackUpMetadata) {
 	props := map[string]interface{}{
-		"name":               devName,
-		"interactive":        interactive,
-		"singleService":      single,
-		"divert":             divert,
-		"isOktetoRepository": isOktetoRepository,
+		"isInteractive":          m.IsInteractive,
+		"isOktetoRepository":     m.IsOktetoRepository,
+		"hasDependenciesSection": m.HasDependenciesSection,
+		"hasBuildSection":        m.HasBuildSection,
+		"hasDeploySection":       m.HasDeploySection,
 	}
-	track(upEvent, success, props)
+	track(upEvent, m.Success, props)
 }
 
 // TrackUpError sends a tracking event to mixpanel when the okteto up command fails

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -261,3 +261,18 @@ func GetOktetoContextsStorePath() string {
 func GetCertificatePath() string {
 	return filepath.Join(GetOktetoHome(), ".ca.crt")
 }
+
+// GetDeployOrigin gets the pipeline deploy origin. This is the initiator of the
+// deploy action: web, cli, github-action, etc
+func GetDeployOrigin() (src string) {
+	src = os.Getenv(model.OktetoOriginEnvVar)
+	if src == "" {
+		src = "cli"
+	}
+	// deploys within another okteto deploy take precedence as a deploy origin.
+	// This is running okteto pipeline deploy as a step of another okteto deploy
+	if os.Getenv(model.OktetoWithinDeployCommandContextEnvVar) == "true" {
+		src = "okteto-deploy"
+	}
+	return
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -276,3 +276,7 @@ func GetDeployOrigin() (src string) {
 	}
 	return
 }
+
+func RunningInInstaller() bool {
+	return os.Getenv(model.OktetoInInstaller) == "true"
+}

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -277,6 +277,10 @@ const (
 	// with the okteto credentials
 	OktetoSkipConfigCredentialsUpdate = "OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE"
 
+	// OktetoCurrentDeployBelongsToPreview if set the current okteto deploy belongs
+	// to a preview environment
+	OktetoCurrentDeployBelongsToPreview = "OKTETO_CURRENT_DEPLOY_BELONGS_TO_PREVIEW"
+
 	// OktetoTimeoutEnvVar defines the timeout for okteto commands
 	OktetoTimeoutEnvVar = "OKTETO_TIMEOUT"
 

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -273,6 +273,10 @@ const (
 	// OktetoWithinDeployCommandContextEnvVar defines if an okteto command is executed by deploy command
 	OktetoWithinDeployCommandContextEnvVar = "OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT"
 
+	// OktetoSkipConfigCredentialsUpdate prevents the kubernetes config from being updated
+	// with the okteto credentials
+	OktetoSkipConfigCredentialsUpdate = "OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE"
+
 	// OktetoTimeoutEnvVar defines the timeout for okteto commands
 	OktetoTimeoutEnvVar = "OKTETO_TIMEOUT"
 

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -273,6 +273,9 @@ const (
 	// OktetoWithinDeployCommandContextEnvVar defines if an okteto command is executed by deploy command
 	OktetoWithinDeployCommandContextEnvVar = "OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT"
 
+	// OktetoInInstaller if set to true okteto is running inside the pipeline installer
+	OktetoInInstaller = "OKTETO_IN_INSTALLER"
+
 	// OktetoSkipConfigCredentialsUpdate prevents the kubernetes config from being updated
 	// with the okteto credentials
 	OktetoSkipConfigCredentialsUpdate = "OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE"

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -311,7 +311,7 @@ func (*ContextConfigWriter) Write() error {
 func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential, namespace, userName, oktetoURL string) {
 	// If the context is being initialized within the execution of `okteto deploy` deploy command it should not
 	// write the Okteto credentials into the kubeconfig. It would overwrite the proxy settings
-	if os.Getenv(model.OktetoWithinDeployCommandContextEnvVar) == "true" {
+	if os.Getenv(model.OktetoSkipConfigCredentialsUpdate) == "true" {
 		return
 	}
 

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -115,7 +115,7 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 					Status     graphql.String
 					Repository graphql.String
 				}
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename, variables: $variables)"`
 		}
 
 		queryVariables := map[string]interface{}{

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -31,6 +31,10 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 	origin := config.GetDeployOrigin()
 
 	gitDeployResponse := &types.GitDeployResponse{}
+
+	variablesArg := []InputVariable{
+		{Name: graphql.String("OKTETO_ORIGIN"), Value: graphql.String(origin)},
+	}
 	if len(variables) > 0 {
 		var mutation struct {
 			GitDeployResponse struct {
@@ -45,11 +49,11 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 					Status     graphql.String
 					Repository graphql.String
 				}
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename, source: $source)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename)"`
 		}
-		variablesVariable := make([]InputVariable, 0)
+
 		for _, v := range variables {
-			variablesVariable = append(variablesVariable, InputVariable{
+			variablesArg = append(variablesArg, InputVariable{
 				Name:  graphql.String(v.Name),
 				Value: graphql.String(v.Value),
 			})
@@ -59,9 +63,8 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 			"repository": graphql.String(repository),
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
-			"variables":  variablesVariable,
+			"variables":  variablesArg,
 			"filename":   graphql.String(filename),
-			"source":     graphql.String(origin),
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -101,15 +104,16 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 					Status     graphql.String
 					Repository graphql.String
 				}
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename, source: $source)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename)"`
 		}
+
 		queryVariables := map[string]interface{}{
 			"name":       graphql.String(name),
 			"repository": graphql.String(repository),
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
 			"filename":   graphql.String(filename),
-			"source":     graphql.String(origin),
+			"variables":  variablesArg,
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -141,14 +145,13 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 
 //TODO: remove when all users are in Okteto Enterprise >= 0.10.0
 func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repository, branch, filename string, variables []types.Variable) (*types.GitDeployResponse, error) {
-	origin := config.GetDeployOrigin()
 	gitDeployResponse := &types.GitDeployResponse{}
 	if len(variables) > 0 {
 		var mutation struct {
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename, source: $source)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename)"`
 		}
 		variablesVariable := make([]InputVariable, 0)
 		for _, v := range variables {
@@ -164,7 +167,6 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 			"branch":     graphql.String(branch),
 			"variables":  variablesVariable,
 			"filename":   graphql.String(filename),
-			"source":     graphql.String(origin),
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -182,7 +184,7 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename, source: $source)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename)"`
 		}
 		queryVariables := map[string]interface{}{
 			"name":       graphql.String(name),
@@ -190,7 +192,6 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
 			"filename":   graphql.String(filename),
-			"source":     graphql.String(origin),
 		}
 		err := mutate(ctx, &mutation, queryVariables, c.client)
 		if err != nil {
@@ -207,14 +208,13 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 
 //TODO: remove when all users are in Okteto Enterprise >= 0.10.0
 func (c *OktetoClient) deployPipelineWithoutFilename(ctx context.Context, name, repository, branch string, variables []types.Variable) (*types.GitDeployResponse, error) {
-	origin := config.GetDeployOrigin()
 	gitDeployResponse := &types.GitDeployResponse{}
 	if len(variables) > 0 {
 		var mutation struct {
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, source: $source)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables)"`
 		}
 		variablesVariable := make([]InputVariable, 0)
 		for _, v := range variables {
@@ -229,7 +229,6 @@ func (c *OktetoClient) deployPipelineWithoutFilename(ctx context.Context, name, 
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
 			"variables":  variablesVariable,
-			"source":     graphql.String(origin),
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -247,14 +246,13 @@ func (c *OktetoClient) deployPipelineWithoutFilename(ctx context.Context, name, 
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, source: $source)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch)"`
 		}
 		queryVariables := map[string]interface{}{
 			"name":       graphql.String(name),
 			"repository": graphql.String(repository),
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
-			"source":     graphql.String(origin),
 		}
 		err := mutate(ctx, &mutation, queryVariables, c.client)
 		if err != nil {

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/okteto/okteto/pkg/config"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/types"
@@ -27,6 +28,8 @@ import (
 
 // DeployPipeline creates a pipeline
 func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, branch, filename string, variables []types.Variable) (*types.GitDeployResponse, error) {
+	origin := config.GetDeployOrigin()
+
 	gitDeployResponse := &types.GitDeployResponse{}
 	if len(variables) > 0 {
 		var mutation struct {
@@ -42,7 +45,7 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 					Status     graphql.String
 					Repository graphql.String
 				}
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename, source: $source)"`
 		}
 		variablesVariable := make([]InputVariable, 0)
 		for _, v := range variables {
@@ -58,6 +61,7 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 			"branch":     graphql.String(branch),
 			"variables":  variablesVariable,
 			"filename":   graphql.String(filename),
+			"source":     graphql.String(origin),
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -97,7 +101,7 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 					Status     graphql.String
 					Repository graphql.String
 				}
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename, source: $source)"`
 		}
 		queryVariables := map[string]interface{}{
 			"name":       graphql.String(name),
@@ -105,6 +109,7 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
 			"filename":   graphql.String(filename),
+			"source":     graphql.String(origin),
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -136,14 +141,14 @@ func (c *OktetoClient) DeployPipeline(ctx context.Context, name, repository, bra
 
 //TODO: remove when all users are in Okteto Enterprise >= 0.10.0
 func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repository, branch, filename string, variables []types.Variable) (*types.GitDeployResponse, error) {
-
+	origin := config.GetDeployOrigin()
 	gitDeployResponse := &types.GitDeployResponse{}
 	if len(variables) > 0 {
 		var mutation struct {
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename, source: $source)"`
 		}
 		variablesVariable := make([]InputVariable, 0)
 		for _, v := range variables {
@@ -159,6 +164,7 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 			"branch":     graphql.String(branch),
 			"variables":  variablesVariable,
 			"filename":   graphql.String(filename),
+			"source":     graphql.String(origin),
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -176,7 +182,7 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, filename: $filename, source: $source)"`
 		}
 		queryVariables := map[string]interface{}{
 			"name":       graphql.String(name),
@@ -184,6 +190,7 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
 			"filename":   graphql.String(filename),
+			"source":     graphql.String(origin),
 		}
 		err := mutate(ctx, &mutation, queryVariables, c.client)
 		if err != nil {
@@ -200,14 +207,14 @@ func (c *OktetoClient) deprecatedDeployPipeline(ctx context.Context, name, repos
 
 //TODO: remove when all users are in Okteto Enterprise >= 0.10.0
 func (c *OktetoClient) deployPipelineWithoutFilename(ctx context.Context, name, repository, branch string, variables []types.Variable) (*types.GitDeployResponse, error) {
-
+	origin := config.GetDeployOrigin()
 	gitDeployResponse := &types.GitDeployResponse{}
 	if len(variables) > 0 {
 		var mutation struct {
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, source: $source)"`
 		}
 		variablesVariable := make([]InputVariable, 0)
 		for _, v := range variables {
@@ -222,6 +229,7 @@ func (c *OktetoClient) deployPipelineWithoutFilename(ctx context.Context, name, 
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
 			"variables":  variablesVariable,
+			"source":     graphql.String(origin),
 		}
 
 		err := mutate(ctx, &mutation, queryVariables, c.client)
@@ -239,13 +247,14 @@ func (c *OktetoClient) deployPipelineWithoutFilename(ctx context.Context, name, 
 			GitDeployResponse struct {
 				Id     graphql.String
 				Status graphql.String
-			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch)"`
+			} `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, source: $source)"`
 		}
 		queryVariables := map[string]interface{}{
 			"name":       graphql.String(name),
 			"repository": graphql.String(repository),
 			"space":      graphql.String(Context().Namespace),
 			"branch":     graphql.String(branch),
+			"source":     graphql.String(origin),
 		}
 		err := mutate(ctx, &mutation, queryVariables, c.client)
 		if err != nil {


### PR DESCRIPTION
Send the deploy origin in the deploy mutation. Adding a special source: `okteto-deploy` used for deploy commands ran from within another okteto deploy