### PR TITLE
fix: infer stack was overriding dev and build

### DIFF
--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -16,8 +16,11 @@ package model
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestManifestExpandEnvs(t *testing.T) {
@@ -75,6 +78,293 @@ devs:
 				assert.Equal(t, tt.expectedCommand, m.Deploy.Commands[0].Command)
 			}
 
+		})
+	}
+}
+
+func TestInferFromStack(t *testing.T) {
+	stack := &Stack{
+		Services: map[string]*Service{
+			"test": {
+				Build: &BuildInfo{
+					Name:       "test",
+					Context:    "test",
+					Dockerfile: "test/Dockerfile",
+				},
+				Ports: []Port{
+					{
+						HostPort:      8080,
+						ContainerPort: 8080,
+					},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		name             string
+		currentManifest  *Manifest
+		expectedManifest *Manifest
+	}{
+		{
+			name: "infer from stack empty dev",
+			currentManifest: &Manifest{
+				Dev:   ManifestDevs{},
+				Build: ManifestBuild{},
+				Deploy: &DeployInfo{
+					Compose: &ComposeInfo{
+						Stack: stack,
+					},
+				},
+			},
+			expectedManifest: &Manifest{
+				Build: ManifestBuild{
+					"test": &BuildInfo{
+						Context:          "test",
+						Dockerfile:       "test/Dockerfile",
+						VolumesToInclude: []StackVolume{},
+					},
+				},
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Name: "test",
+						Metadata: &Metadata{
+							Labels:      Labels{},
+							Annotations: Annotations{},
+						},
+						Selector: Selector{},
+						Forward: []Forward{
+							{
+								Local:  8080,
+								Remote: 8080,
+							},
+						},
+						EmptyImage: true,
+						Image: &DevBuildInfo{
+							Context:    ".",
+							Dockerfile: "Dockerfile",
+						},
+						Push: &DevBuildInfo{
+							Context:    ".",
+							Dockerfile: "Dockerfile",
+						},
+						ImagePullPolicy: apiv1.PullAlways,
+						Probes:          &Probes{},
+						Lifecycle:       &Lifecycle{},
+						Workdir:         "/okteto",
+						SecurityContext: &SecurityContext{
+							RunAsUser:  pointer.Int64(0),
+							RunAsGroup: pointer.Int64(0),
+							FSGroup:    pointer.Int64(0),
+						},
+						SSHServerPort: 2222,
+						Volumes:       []Volume{},
+						Timeout: Timeout{
+							Default:   60 * time.Second,
+							Resources: 120 * time.Second,
+						},
+						InitContainer: InitContainer{
+							Image: OktetoBinImageTag,
+						},
+						PersistentVolumeInfo: &PersistentVolumeInfo{
+							Enabled: true,
+						},
+						Secrets: []Secret{},
+						Command: Command{
+							Values: []string{"sh"},
+						},
+						Interface: "0.0.0.0",
+						Services:  []*Dev{},
+						Sync: Sync{
+							RescanInterval: 300,
+							Folders: []SyncFolder{
+								{
+									LocalPath:  ".",
+									RemotePath: "/okteto",
+								},
+							},
+						},
+					},
+				},
+				Deploy: &DeployInfo{
+					Compose: &ComposeInfo{
+						Stack: stack,
+					},
+				},
+			},
+		},
+		{
+			name: "infer from stack not overriding build",
+			currentManifest: &Manifest{
+				Dev: ManifestDevs{},
+				Build: ManifestBuild{
+					"test": &BuildInfo{
+						Context:    "test-1",
+						Dockerfile: "test-1/Dockerfile",
+					},
+				},
+				Deploy: &DeployInfo{
+					Compose: &ComposeInfo{
+						Stack: stack,
+					},
+				},
+			},
+			expectedManifest: &Manifest{
+				Build: ManifestBuild{
+					"test": &BuildInfo{
+						Context:    "test-1",
+						Dockerfile: "test-1/Dockerfile",
+					},
+				},
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Name: "test",
+						Metadata: &Metadata{
+							Labels:      Labels{},
+							Annotations: Annotations{},
+						},
+						Selector: Selector{},
+						Forward: []Forward{
+							{
+								Local:  8080,
+								Remote: 8080,
+							},
+						},
+						EmptyImage: true,
+						Image: &DevBuildInfo{
+							Context:    ".",
+							Dockerfile: "Dockerfile",
+						},
+						Push: &DevBuildInfo{
+							Context:    ".",
+							Dockerfile: "Dockerfile",
+						},
+						ImagePullPolicy: apiv1.PullAlways,
+						Probes:          &Probes{},
+						Lifecycle:       &Lifecycle{},
+						Workdir:         "/okteto",
+						SecurityContext: &SecurityContext{
+							RunAsUser:  pointer.Int64(0),
+							RunAsGroup: pointer.Int64(0),
+							FSGroup:    pointer.Int64(0),
+						},
+						SSHServerPort: 2222,
+						Volumes:       []Volume{},
+						Timeout: Timeout{
+							Default:   60 * time.Second,
+							Resources: 120 * time.Second,
+						},
+						InitContainer: InitContainer{
+							Image: OktetoBinImageTag,
+						},
+						PersistentVolumeInfo: &PersistentVolumeInfo{
+							Enabled: true,
+						},
+						Secrets: []Secret{},
+						Command: Command{
+							Values: []string{"sh"},
+						},
+						Interface: "0.0.0.0",
+						Services:  []*Dev{},
+						Sync: Sync{
+							RescanInterval: 300,
+							Folders: []SyncFolder{
+								{
+									LocalPath:  ".",
+									RemotePath: "/okteto",
+								},
+							},
+						},
+					},
+				},
+				Deploy: &DeployInfo{
+					Compose: &ComposeInfo{
+						Stack: stack,
+					},
+				},
+			},
+		},
+		{
+			name: "infer from stack not overriding dev",
+			currentManifest: &Manifest{
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Name:      "one",
+						Namespace: "test",
+					},
+				},
+				Build: ManifestBuild{},
+				Deploy: &DeployInfo{
+					Compose: &ComposeInfo{
+						Stack: stack,
+					},
+				},
+			},
+			expectedManifest: &Manifest{
+				Build: ManifestBuild{
+					"test": &BuildInfo{
+						Context:          "test",
+						Dockerfile:       "test/Dockerfile",
+						VolumesToInclude: []StackVolume{},
+					},
+				},
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Name:      "one",
+						Namespace: "test",
+						Metadata: &Metadata{
+							Labels:      Labels{},
+							Annotations: Annotations{},
+						},
+						Selector:   Selector{},
+						EmptyImage: true,
+						Image: &DevBuildInfo{
+							Context:    ".",
+							Dockerfile: "Dockerfile",
+						},
+						ImagePullPolicy: apiv1.PullAlways,
+						Probes:          &Probes{},
+						Lifecycle:       &Lifecycle{},
+						Workdir:         "/okteto",
+						SecurityContext: &SecurityContext{
+							RunAsUser:  pointer.Int64(0),
+							RunAsGroup: pointer.Int64(0),
+							FSGroup:    pointer.Int64(0),
+						},
+						SSHServerPort: 2222,
+						Volumes:       []Volume{},
+						Timeout: Timeout{
+							Default:   60 * time.Second,
+							Resources: 120 * time.Second,
+						},
+						Command: Command{
+							Values: []string{"sh"},
+						},
+						Interface: "0.0.0.0",
+						Sync: Sync{
+							RescanInterval: 300,
+							Folders: []SyncFolder{
+								{
+									LocalPath:  ".",
+									RemotePath: "/okteto",
+								},
+							},
+						},
+					},
+				},
+				Deploy: &DeployInfo{
+					Compose: &ComposeInfo{
+						Stack: stack,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.currentManifest.InferFromStack()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedManifest, result)
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes stack overrides dev and build from manifest v2

## Proposed changes
- Checks if the current manifest has dev[svcName] before setting it

