### PR TITLE
fix: deploy fails without reason

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -206,7 +206,7 @@ func LoadStackWithContext(ctx context.Context, name, namespace string, stackPath
 }
 
 //LoadManifestV2WithContext initializes the okteto context taking into account command flags and manifest namespace/context fields
-func LoadManifestV2WithContext(ctx context.Context, namespace, path string) error {
+func LoadManifestV2WithContext(ctx context.Context, namespace, k8sContext, path string) error {
 	ctxOptions := &ContextOptions{
 		Namespace: namespace,
 		Show:      true,
@@ -218,9 +218,23 @@ func LoadManifestV2WithContext(ctx context.Context, namespace, path string) erro
 			return err
 		}
 	} else {
-		ctxOptions.Context = manifest.Context
-		if ctxOptions.Namespace == "" {
-			ctxOptions.Namespace = manifest.Namespace
+		ctxResource, err := utils.LoadManifestContext(manifest.Filename)
+		if err != nil {
+			return err
+		}
+
+		if err := ctxResource.UpdateNamespace(namespace); err != nil {
+			return err
+		}
+
+		if err := ctxResource.UpdateContext(k8sContext); err != nil {
+			return err
+		}
+
+		ctxOptions = &ContextOptions{
+			Context:   ctxResource.Context,
+			Namespace: ctxResource.Namespace,
+			Show:      true,
 		}
 	}
 

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -94,8 +94,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 		Long:  `Destroy everything created by the 'okteto deploy' command. You can also include a 'destroy' section in your okteto manifest with a list of custom commands to be executed on destroy`,
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			if err := contextCMD.LoadManifestV2WithContext(ctx, options.Namespace, options.ManifestPath); err != nil {
+			if err := contextCMD.LoadManifestV2WithContext(ctx, options.Namespace, options.K8sContext, options.ManifestPath); err != nil {
 				return err
 			}
 
@@ -154,6 +153,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.DestroyVolumes, "volumes", "v", false, "remove persistent volumes")
 	cmd.Flags().BoolVar(&options.ForceDestroy, "force-destroy", false, "forces the development environment to be destroyed even if there is an error executing the custom destroy commands defined in the manifest")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment was deployed")
+	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the up command is executed")
 
 	return cmd
 }

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -183,12 +183,11 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 			Enable: true,
 		})
 	}
-	// devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
-	// if err != nil {
-	// 	return nil, err
-	// }
+	devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
+	if err != nil {
+		return nil, err
+	}
 
-	devKey := "api"
 	return manifest.Dev[devKey], nil
 }
 

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -183,11 +183,12 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 			Enable: true,
 		})
 	}
-	devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
-	if err != nil {
-		return nil, err
-	}
+	// devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
+	// if err != nil {
+	// 	return nil, err
+	// }
 
+	devKey := "api"
 	return manifest.Dev[devKey], nil
 }
 

--- a/cmd/utils/displayer/tty.go
+++ b/cmd/utils/displayer/tty.go
@@ -155,7 +155,7 @@ func (d *TTYDisplayer) displayStdout(wg *sync.WaitGroup) {
 				sanitizedLine = strings.ReplaceAll(sanitizedLine, resetLine, "")
 				d.linesToDisplay = append(d.linesToDisplay[:d.buildingpreviousLines-1], sanitizedLine)
 			} else {
-				if len(d.linesToDisplay) == d.numberOfLines {
+				if len(d.linesToDisplay) >= d.numberOfLines {
 					d.linesToDisplay = d.linesToDisplay[1:]
 				}
 				d.linesToDisplay = append(d.linesToDisplay, line)
@@ -187,7 +187,7 @@ func (d *TTYDisplayer) displayStderr(wg *sync.WaitGroup) {
 		default:
 			line := strings.TrimSpace(d.stderrScanner.Text())
 			d.err = errors.New(line)
-			if len(d.linesToDisplay) == d.numberOfLines {
+			if len(d.linesToDisplay) >= d.numberOfLines {
 				d.linesToDisplay = d.linesToDisplay[1:]
 			}
 			d.linesToDisplay = append(d.linesToDisplay, line)
@@ -271,13 +271,10 @@ func renderCommand(spinnerChar, command string, charsPerLine int) [][]byte {
 		result = append(result, render(firstLineTpl, command))
 		return result
 	}
-	iterations := (len(command) + 3) / charsPerLine
+	iterations := (len(command) + 4) / charsPerLine
+	start := 0
+	end := charsPerLine - 5
 	for i := 0; i < iterations+1; i++ {
-		start := i*charsPerLine - 3
-		if start < 0 {
-			start = 0
-		}
-		end := i*charsPerLine + charsPerLine - 3
 		if i == iterations {
 			end = len(command) - 1
 		}
@@ -289,6 +286,8 @@ func renderCommand(spinnerChar, command string, charsPerLine int) [][]byte {
 		} else {
 			result = append(result, render(lastLineTpl, currentLine))
 		}
+		start = end
+		end += charsPerLine - 5
 	}
 	return result
 }

--- a/pkg/cmd/pipeline/crud.go
+++ b/pkg/cmd/pipeline/crud.go
@@ -29,7 +29,7 @@ import (
 // IsDeployed checks if a pipeline has been
 func IsDeployed(ctx context.Context, name, namespace string, c kubernetes.Interface) bool {
 	cmap, err := configmaps.Get(ctx, TranslatePipelineName(name), namespace, c)
-	if err != nil && k8sErrors.IsNotFound(err) {
+	if (err != nil && k8sErrors.IsNotFound(err)) || cmap == nil {
 		return false
 	}
 	return cmap.Data[statusField] != ErrorStatus


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2292

## Proposed changes
- fix: running command output on tty was displaced
- fix: Deploy will throw a warning instead of an error if it does't deploy anything
- feat: Add context flag to deploy command
