### PR TITLE
fix: check if image extended after serialisation

### DIFF
--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -46,7 +46,7 @@ func Test_LoadManifestOrDefault(t *testing.T) {
 			expectErr:  false,
 			dev: &model.Dev{
 				Name: "loaded",
-				Image: &model.DevBuildInfo{
+				Image: &model.BuildInfo{
 					Name: "okteto/test:1.0",
 				},
 				Sync: model.Sync{

--- a/pkg/cmd/doctor/run.go
+++ b/pkg/cmd/doctor/run.go
@@ -161,8 +161,8 @@ func generateManifestFile(devPath string) (string, error) {
 	}
 
 	dev := &model.Dev{
-		Image:       &model.DevBuildInfo{},
-		Push:        &model.DevBuildInfo{},
+		Image:       &model.BuildInfo{},
+		Push:        &model.BuildInfo{},
 		Environment: make([]model.EnvVar, 0),
 		Secrets:     make([]model.Secret, 0),
 		Forward:     make([]model.Forward, 0),

--- a/pkg/cmd/doctor/run_test.go
+++ b/pkg/cmd/doctor/run_test.go
@@ -34,7 +34,7 @@ func Test_generateManifestFile(t *testing.T) {
 			name: "basic",
 			dev: &model.Dev{
 				Name:    "dev",
-				Image:   &model.DevBuildInfo{Name: "okteto/dev"},
+				Image:   &model.BuildInfo{Name: "okteto/dev"},
 				Command: model.Command{Values: []string{"bash"}},
 			},
 		},
@@ -42,11 +42,11 @@ func Test_generateManifestFile(t *testing.T) {
 			name: "with-services",
 			dev: &model.Dev{
 				Name:    "dev",
-				Image:   &model.DevBuildInfo{Name: "okteto/dev"},
+				Image:   &model.BuildInfo{Name: "okteto/dev"},
 				Command: model.Command{Values: []string{"bash"}},
 				Services: []*model.Dev{{
 					Name:    "svc",
-					Image:   &model.DevBuildInfo{Name: "okteto/svc"},
+					Image:   &model.BuildInfo{Name: "okteto/svc"},
 					Command: model.Command{Values: []string{"bash"}},
 				}, {
 					Name:        "svc2",

--- a/pkg/k8s/apps/crud_test.go
+++ b/pkg/k8s/apps/crud_test.go
@@ -69,7 +69,7 @@ func TestGetStatefulset(t *testing.T) {
 	dev := &model.Dev{
 		Name:      "test",
 		Namespace: "test",
-		Image: &model.DevBuildInfo{
+		Image: &model.BuildInfo{
 			Name: "image",
 		},
 		PersistentVolumeInfo: &model.PersistentVolumeInfo{
@@ -114,7 +114,7 @@ func TestGetDeployment(t *testing.T) {
 	dev := &model.Dev{
 		Name:      "test",
 		Namespace: "test",
-		Image: &model.DevBuildInfo{
+		Image: &model.BuildInfo{
 			Name: "image",
 		},
 		PersistentVolumeInfo: &model.PersistentVolumeInfo{

--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -304,7 +304,7 @@ func GetDevDefaults(language, workdir string) (*model.Dev, error) {
 	vals := languageDefaults[language]
 
 	dev := &model.Dev{
-		Image: &model.DevBuildInfo{
+		Image: &model.BuildInfo{
 			Name: vals.image,
 		},
 		Command: model.Command{

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -506,8 +506,8 @@ func TestDev_validateName(t *testing.T) {
 			dev := &Dev{
 				Name:            tt.devName,
 				ImagePullPolicy: apiv1.PullAlways,
-				Image:           &DevBuildInfo{},
-				Push:            &DevBuildInfo{},
+				Image:           &BuildInfo{},
+				Push:            &BuildInfo{},
 				Sync: Sync{
 					Folders: []SyncFolder{
 						{
@@ -533,7 +533,7 @@ func TestDev_readImageContext(t *testing.T) {
 	tests := []struct {
 		name     string
 		manifest []byte
-		expected *DevBuildInfo
+		expected *BuildInfo
 	}{
 		{
 			name: "context pointing to url",
@@ -541,7 +541,7 @@ func TestDev_readImageContext(t *testing.T) {
 image:
   context: https://github.com/okteto/okteto.git
 `),
-			expected: &DevBuildInfo{
+			expected: &BuildInfo{
 				Context: "https://github.com/okteto/okteto.git",
 			},
 		},
@@ -551,7 +551,7 @@ image:
 image:
   context: .
 `),
-			expected: &DevBuildInfo{
+			expected: &BuildInfo{
 				Context:    ".",
 				Dockerfile: "Dockerfile",
 			},

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -287,24 +287,6 @@ func (sync Sync) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
-func (buildInfo *DevBuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var rawString string
-	err := unmarshal(&rawString)
-	if err == nil {
-		buildInfo.Name = rawString
-		return nil
-	}
-	var rawBuildInfo BuildInfo
-	err = unmarshal(&rawBuildInfo)
-	if err != nil {
-		return err
-	}
-	oktetoLog.Yellow("The `image` extended syntax is deprecated. Define the images you want to build in the 'build' section of your manifest. More info at https://www.okteto.com/docs/reference/manifest/#build")
-	*buildInfo = DevBuildInfo(rawBuildInfo)
-	return nil
-}
-
-// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
 func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var rawString string
 	err := unmarshal(&rawString)

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1114,7 +1114,7 @@ dev:
 						Selector:        Selector{},
 						EmptyImage:      true,
 						ImagePullPolicy: v1.PullAlways,
-						Image: &DevBuildInfo{
+						Image: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1124,7 +1124,7 @@ dev:
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
-						Push: &DevBuildInfo{
+						Push: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1179,7 +1179,7 @@ dev:
 						Selector:        Selector{},
 						EmptyImage:      true,
 						ImagePullPolicy: v1.PullAlways,
-						Image: &DevBuildInfo{
+						Image: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1189,7 +1189,7 @@ dev:
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
-						Push: &DevBuildInfo{
+						Push: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1259,7 +1259,7 @@ sync:
 						Selector:        Selector{},
 						EmptyImage:      true,
 						ImagePullPolicy: v1.PullAlways,
-						Image: &DevBuildInfo{
+						Image: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1269,7 +1269,7 @@ sync:
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
-						Push: &DevBuildInfo{
+						Push: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1340,7 +1340,7 @@ services:
 						Selector:        Selector{},
 						EmptyImage:      true,
 						ImagePullPolicy: v1.PullAlways,
-						Image: &DevBuildInfo{
+						Image: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1350,7 +1350,7 @@ services:
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
-						Push: &DevBuildInfo{
+						Push: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1380,7 +1380,7 @@ services:
 								Annotations:     Annotations{},
 								Selector:        Selector{},
 								EmptyImage:      true,
-								Image:           &DevBuildInfo{},
+								Image:           &BuildInfo{},
 								ImagePullPolicy: v1.PullAlways,
 								Secrets:         []Secret{},
 								Probes: &Probes{
@@ -1469,7 +1469,7 @@ dev:
 						Selector:        Selector{},
 						EmptyImage:      true,
 						ImagePullPolicy: v1.PullAlways,
-						Image: &DevBuildInfo{
+						Image: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1480,7 +1480,7 @@ dev:
 							Enabled: true,
 						},
 						Secrets: make([]Secret, 0),
-						Push: &DevBuildInfo{
+						Push: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1554,7 +1554,7 @@ dev:
 						Selector:        Selector{},
 						EmptyImage:      true,
 						ImagePullPolicy: v1.PullAlways,
-						Image: &DevBuildInfo{
+						Image: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1564,7 +1564,7 @@ dev:
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
-						Push: &DevBuildInfo{
+						Push: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1619,7 +1619,7 @@ dev:
 						Selector:        Selector{},
 						EmptyImage:      true,
 						ImagePullPolicy: v1.PullAlways,
-						Image: &DevBuildInfo{
+						Image: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",
@@ -1629,7 +1629,7 @@ dev:
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
-						Push: &DevBuildInfo{
+						Push: &BuildInfo{
 							Name:       "",
 							Context:    ".",
 							Dockerfile: "Dockerfile",

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -468,7 +468,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 		{
 			name: "default",
 			manifest: &Dev{
-				Image:         &DevBuildInfo{},
+				Image:         &BuildInfo{},
 				SSHServerPort: oktetoDefaultSSHServerPort,
 			},
 			expected: Environment{
@@ -479,7 +479,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 		{
 			name: "custom port",
 			manifest: &Dev{
-				Image:         &DevBuildInfo{},
+				Image:         &BuildInfo{},
 				SSHServerPort: 22220,
 			},
 			expected: Environment{


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes images from build section was throwing the warning because both were serialised with the same code

## Proposed changes
- Move the check for image extended to the dev initialization
-
