### PR TITLE
deprecating okteto update and adding okteto version

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -29,12 +29,13 @@ const (
 	INSTALL_PATH = "/usr/local/bin/okteto"
 )
 
-//Update check if there is a new version available and updates it
-func Update() *cobra.Command {
+//Update checks if there is a new version available and updates it
+func UpdateDeprecated() *cobra.Command {
 	return &cobra.Command{
 		Use:   "update",
-		Short: "Update okteto version",
+		Short: "Update Okteto CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			oktetoLog.Warning("'okteto update' is deprecated in favor of 'okteto version update', and will be removed in a future version")
 			currentVersion, err := semver.NewVersion(config.VersionString)
 			if err != nil {
 				return fmt.Errorf("could not retrieve version")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,6 +14,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -22,10 +25,44 @@ import (
 
 //Version returns information about the binary
 func Version() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "View the version of the okteto binary",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#version"),
+		RunE:  Show().RunE,
+	}
+	cmd.AddCommand(Update())
+	cmd.AddCommand(Show())
+	return cmd
+}
+
+//Update checks if there is a new version available and updates it
+func Update() *cobra.Command {
+	return &cobra.Command{
+		Use:   "update",
+		Short: "Update Okteto CLI version",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			currentVersion, err := semver.NewVersion(config.VersionString)
+			if err != nil {
+				return fmt.Errorf("could not retrieve version")
+			}
+
+			if isUpdateAvailable(currentVersion) {
+				displayUpdateSteps()
+			} else {
+				oktetoLog.Success("The latest okteto version is already installed")
+			}
+
+			return nil
+		},
+	}
+}
+
+//Show shows the current Okteto CLI version
+func Show() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show Okteto CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Printf("okteto version %s \n", config.VersionString)
 			return nil

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 	root.AddCommand(cmd.Exec())
 	root.AddCommand(preview.Preview(ctx))
 	root.AddCommand(cmd.Restart())
-	root.AddCommand(cmd.Update())
+	root.AddCommand(cmd.UpdateDeprecated())
 	root.AddCommand(deploy.Deploy(ctx))
 	root.AddCommand(destroy.Destroy(ctx))
 	root.AddCommand(generateFigSpec.NewCmdGenFigSpec())


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

Fixes (partially) #2177 - we still need to keep the issue open until we remove the code for `okteto update`

## Proposed changes

- Added a deprecation warning for the older Update method
- Added a new Update method as a subcommand for `okteto version`
- Added `okteto version show` 

https://user-images.githubusercontent.com/56963264/157271121-dc41fe9f-510a-40aa-aca6-501b8d8f8f56.mov


