### PR TITLE
removing duplicate code for okteto ns and ctx

### DIFF
--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -14,10 +14,7 @@
 package context
 
 import (
-	"context"
-
 	"github.com/okteto/okteto/cmd/utils"
-	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/spf13/cobra"
 )
 
@@ -40,20 +37,7 @@ To set your default context, run the ` + "`okteto context`" + ` command:
 
 This will prompt you to select one of your existing contexts or to create a new one.
 `,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			if len(args) == 1 {
-				ctxOptions.Context = args[0]
-			}
-
-			ctxOptions.IsCtxCommand = true
-			ctxOptions.Save = true
-			ctxCmd := NewContextCommand()
-
-			err := ctxCmd.Run(ctx, ctxOptions)
-			analytics.TrackContext(err == nil)
-			return err
-		},
+		RunE: Use().RunE,
 	}
 	cmd.AddCommand(Show())
 	cmd.AddCommand(Use())

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -18,8 +18,6 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
-	"github.com/okteto/okteto/pkg/analytics"
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
@@ -51,31 +49,7 @@ func Namespace(ctx context.Context) *cobra.Command {
 		Short:   "Configure the current namespace of the okteto context",
 		Aliases: []string{"ns"},
 		Args:    utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#namespace"),
-		RunE: func(cmd *cobra.Command, args []string) error {
-
-			namespace := ""
-			if len(args) > 0 {
-				namespace = args[0]
-			}
-			if options.personal {
-				namespace = okteto.Context().PersonalNamespace
-			}
-			if !okteto.IsOkteto() {
-				return oktetoErrors.ErrContextIsNotOktetoCluster
-			}
-
-			nsCmd, err := NewCommand()
-			if err != nil {
-				return err
-			}
-			err = nsCmd.Use(ctx, namespace)
-			if err != nil {
-				return err
-			}
-
-			analytics.TrackNamespace(err == nil, len(args) > 0)
-			return err
-		},
+		RunE:    Use(ctx).RunE,
 	}
 	cmd.Flags().BoolVarP(&options.personal, "personal", "", false, "Load personal account")
 

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -62,9 +62,6 @@ func Use(ctx context.Context) *cobra.Command {
 				return err
 			}
 			err = nsCmd.Use(ctx, namespace)
-			if err != nil {
-				return err
-			}
 
 			analytics.TrackNamespace(err == nil, len(args) > 0)
 			return err

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -62,6 +62,10 @@ func Use(ctx context.Context) *cobra.Command {
 				return err
 			}
 			err = nsCmd.Use(ctx, namespace)
+			if err != nil {
+				return err
+			}
+
 			analytics.TrackNamespace(err == nil, len(args) > 0)
 			return err
 		},


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>


## Proposed changes

- Removed duplicated code since we do the same thing when we run `okteto ns use` and `okteto ns` (same for `okteto ctx`)

https://user-images.githubusercontent.com/56963264/157429353-439fa939-3ddb-42b4-9a57-85211b44d9cf.mov


