### PR TITLE
feat: tty without collapsing

### DIFF
--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -119,7 +119,7 @@ func (c *DeployCommand) RunDeploy(ctx context.Context, s *model.Stack, options *
 	}
 	oktetoLog.Success("Compose '%s' successfully deployed", s.Name)
 
-	if !utils.LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) || !c.IsInsideDeploy {
+	if !(!utils.LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) || !c.IsInsideDeploy) {
 		if err := stack.ListEndpoints(ctx, s, ""); err != nil {
 			return err
 		}

--- a/cmd/utils/displayer/collapse_tty.go
+++ b/cmd/utils/displayer/collapse_tty.go
@@ -1,0 +1,411 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package displayer
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/manifoldco/promptui"
+	"github.com/manifoldco/promptui/screenbuf"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"golang.org/x/term"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var (
+	spinnerChars = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+	cursorUp     = "\x1b[1A"
+	resetLine    = "\x1b[0G"
+	re           = regexp.MustCompile(ansi)
+)
+
+// TTYCollapseDisplayer displays with a screenbuff
+type TTYCollapseDisplayer struct {
+	stdoutScanner *bufio.Scanner
+	stderrScanner *bufio.Scanner
+	screenbuf     *screenbuf.ScreenBuf
+
+	command        string
+	err            error
+	linesToDisplay []string
+	numberOfLines  int
+
+	commandContext context.Context
+	cancel         context.CancelFunc
+
+	isBuilding            bool
+	buildingpreviousLines int
+}
+
+func newTTYCollapseDisplayer(stdout, stderr io.Reader) *TTYCollapseDisplayer {
+	var (
+		stdoutScanner *bufio.Scanner
+		stderrScanner *bufio.Scanner
+	)
+	if stdout != nil {
+		stdoutScanner = bufio.NewScanner(stdout)
+	}
+	if stderr != nil {
+		stderrScanner = bufio.NewScanner(stderr)
+	}
+
+	return &TTYCollapseDisplayer{
+		numberOfLines:  25,
+		linesToDisplay: []string{},
+
+		stdoutScanner: stdoutScanner,
+		stderrScanner: stderrScanner,
+		screenbuf:     screenbuf.New(os.Stdout),
+	}
+}
+
+// Display displays a
+func (d *TTYCollapseDisplayer) Display(commandName string) {
+	d.command = commandName
+
+	d.hideCursor()
+	d.commandContext, d.cancel = context.WithCancel(context.Background())
+	wg := &sync.WaitGroup{}
+	wgDelta := 0
+	if d.stdoutScanner != nil {
+		wgDelta++
+	}
+	if d.stderrScanner != nil {
+		wgDelta++
+	}
+	wg.Add(wgDelta)
+
+	commandChan := make(chan bool, 1)
+	go d.displayCommand(commandChan)
+	if d.stdoutScanner != nil {
+		go d.displayStdout(wg)
+	}
+	if d.stderrScanner != nil {
+		go d.displayStderr(wg)
+	}
+	wg.Wait()
+	d.cancel()
+	<-commandChan
+}
+
+func (d *TTYCollapseDisplayer) displayCommand(commandChan chan bool) {
+	t := time.NewTicker(50 * time.Millisecond)
+	shouldExit := false
+	for {
+		for i := 0; i < len(spinnerChars); i++ {
+			select {
+			case <-t.C:
+				width, _, _ := term.GetSize(int(os.Stdout.Fd()))
+				commandLines := renderCommand(spinnerChars[i], d.command, width)
+				for _, commandLine := range commandLines {
+					d.screenbuf.Write(commandLine)
+				}
+				lines := renderLines(d.linesToDisplay, width)
+				for _, line := range lines {
+					d.screenbuf.Write(line)
+				}
+				d.screenbuf.Flush()
+			case <-d.commandContext.Done():
+				shouldExit = true
+			}
+			if shouldExit {
+				break
+			}
+		}
+		if shouldExit {
+			break
+		}
+	}
+	commandChan <- true
+}
+
+func (d *TTYCollapseDisplayer) displayStdout(wg *sync.WaitGroup) {
+	for d.stdoutScanner.Scan() {
+		select {
+		case <-d.commandContext.Done():
+		default:
+			line := strings.TrimSpace(d.stdoutScanner.Text())
+			if isTopDisplay(line) {
+				prevState := d.isBuilding
+				d.isBuilding = checkIfIsBuildingLine(line)
+				if d.isBuilding && d.isBuilding != prevState {
+					d.buildingpreviousLines = len(d.linesToDisplay)
+				}
+				sanitizedLine := strings.ReplaceAll(line, cursorUp, "")
+				sanitizedLine = strings.ReplaceAll(sanitizedLine, resetLine, "")
+				d.linesToDisplay = append(d.linesToDisplay[:d.buildingpreviousLines-1], sanitizedLine)
+			} else {
+				if len(d.linesToDisplay) >= d.numberOfLines {
+					d.linesToDisplay = d.linesToDisplay[1:]
+				}
+				d.linesToDisplay = append(d.linesToDisplay, line)
+			}
+			if os.Stdout == oktetoLog.GetOutput() {
+				oktetoLog.AddToBuffer(oktetoLog.InfoLevel, line)
+			}
+			continue
+		}
+		break
+	}
+	if d.stdoutScanner.Err() != nil {
+		oktetoLog.Infof("Error reading command output: %s", d.stdoutScanner.Err().Error())
+	}
+	wg.Done()
+}
+
+func checkIfIsBuildingLine(line string) bool {
+	if strings.Contains(line, "Building") {
+		return !strings.Contains(line, "FINISHED")
+	}
+	return false
+}
+
+func (d *TTYCollapseDisplayer) displayStderr(wg *sync.WaitGroup) {
+	for d.stderrScanner.Scan() {
+		select {
+		case <-d.commandContext.Done():
+		default:
+			line := strings.TrimSpace(d.stderrScanner.Text())
+			d.err = errors.New(line)
+			if len(d.linesToDisplay) >= d.numberOfLines {
+				d.linesToDisplay = d.linesToDisplay[1:]
+			}
+			d.linesToDisplay = append(d.linesToDisplay, line)
+			if os.Stdout == oktetoLog.GetOutput() {
+				oktetoLog.AddToBuffer(oktetoLog.WarningLevel, line)
+			}
+			continue
+		}
+		break
+	}
+	if d.stderrScanner.Err() != nil {
+		oktetoLog.Infof("Error reading command output: %s", d.stderrScanner.Err().Error())
+	}
+	wg.Done()
+}
+
+func isTopDisplay(line string) bool {
+	return strings.Contains(line, fmt.Sprintf("%s%s", cursorUp, resetLine))
+}
+
+// CleanUp collapses and stop displaying
+func (d *TTYCollapseDisplayer) CleanUp(err error) {
+	if d.screenbuf == nil {
+		return
+	}
+	if d.command == "" {
+		return
+	}
+
+	var message []byte
+	if err == nil {
+		message = renderSuccessCommand(d.command)
+		d.screenbuf.Reset()
+		d.screenbuf.Clear()
+		d.screenbuf.Flush()
+		d.screenbuf.Write(message)
+		d.screenbuf.Flush()
+	} else {
+		message = renderFailCommand(d.command, err)
+		d.screenbuf.Reset()
+		d.screenbuf.Clear()
+		d.screenbuf.Flush()
+		d.screenbuf.Write(message)
+		width, _, _ := term.GetSize(int(os.Stdout.Fd()))
+		lines := renderLines(d.linesToDisplay, width)
+		for _, line := range lines {
+			d.screenbuf.Write([]byte(line))
+		}
+		d.screenbuf.Flush()
+	}
+	d.cancel()
+	<-d.commandContext.Done()
+	d.reset()
+	d.showCursor()
+
+}
+
+func renderCommand(spinnerChar, command string, charsPerLine int) [][]byte {
+	firstLineCommandTemplate := fmt.Sprintf(` %s {{ . | oktetoblue }}`, spinnerChar)
+	otherLineCommandTemplate := `    {{ . | oktetoblue }}`
+	lastLineCommandTemplate := `    {{ . | oktetoblue }}:`
+	funcMap := promptui.FuncMap
+	funcMap["oktetoblue"] = oktetoLog.BlueString
+	firstLineTpl, err := template.New("").Funcs(funcMap).Parse(firstLineCommandTemplate)
+	if err != nil {
+		return [][]byte{}
+	}
+
+	otherLinesTpl, err := template.New("").Funcs(funcMap).Parse(otherLineCommandTemplate)
+	if err != nil {
+		return [][]byte{}
+	}
+
+	lastLineTpl, err := template.New("").Funcs(funcMap).Parse(lastLineCommandTemplate)
+	if err != nil {
+		return [][]byte{}
+	}
+
+	command = fmt.Sprintf(" Running '%s'", command)
+	result := [][]byte{}
+	if charsPerLine == 0 || charsPerLine < 5 {
+		result = append(result, render(firstLineTpl, command))
+		return result
+	}
+	iterations := (len(command) + 4) / charsPerLine
+	start := 0
+	end := charsPerLine - 5
+	for i := 0; i < iterations+1; i++ {
+		if i == iterations {
+			end = len(command) - 1
+		}
+		currentLine := command[start:end]
+		if i == 0 {
+			result = append(result, render(firstLineTpl, currentLine))
+		} else if i < iterations {
+			result = append(result, render(otherLinesTpl, currentLine))
+		} else {
+			result = append(result, render(lastLineTpl, currentLine))
+		}
+		start = end
+		end += charsPerLine - 5
+	}
+	return result
+}
+
+func renderSuccessCommand(command string) []byte {
+	commandTemplate := `{{ " ✓ " | bgGreen | black }} {{ . | green }}`
+	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(commandTemplate)
+	if err != nil {
+		return []byte{}
+	}
+
+	return render(tpl, command)
+}
+
+func renderFailCommand(command string, err error) []byte {
+	message := fmt.Sprintf("%s: %s", command, err.Error())
+	commandTemplate := `{{ " x " | bgRed | black }} {{ . | oktetored }}`
+	funcMap := promptui.FuncMap
+	funcMap["oktetored"] = oktetoLog.RedString
+	tpl, err := template.New("").Funcs(funcMap).Parse(commandTemplate)
+	if err != nil {
+		return []byte{}
+	}
+
+	return render(tpl, message)
+}
+
+func renderLines(queue []string, charsPerLine int) [][]byte {
+	lineTemplate := "{{ . | white }} "
+	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(lineTemplate)
+	if err != nil {
+		return [][]byte{}
+	}
+
+	result := [][]byte{}
+	for _, line := range queue {
+		lineWithoutColors := re.ReplaceAllString(line, "")
+		if len(line) == len(lineWithoutColors) {
+			result = append(result, renderLogWithoutColors(tpl, line, charsPerLine)...)
+		} else {
+			result = append(result, renderLogWithColors(tpl, line, charsPerLine)...)
+			continue
+		}
+	}
+	return result
+}
+
+func renderLogWithColors(tpl *template.Template, line string, charsPerLine int) [][]byte {
+	result := [][]byte{}
+	if charsPerLine > 4 && len(line)+2 > charsPerLine {
+		result = append(result, render(tpl, fmt.Sprintf("%s...", line[:charsPerLine-1])))
+	} else if line == "" {
+		result = append(result, []byte(""))
+	} else {
+		result = append(result, render(tpl, fmt.Sprintf("%s...", line)))
+	}
+	return result
+}
+
+func renderLogWithoutColors(tpl *template.Template, line string, charsPerLine int) [][]byte {
+	result := [][]byte{}
+	if line == "" {
+		result = append(result, []byte(""))
+	} else if charsPerLine == 0 {
+		line = fmt.Sprintf("%s", strings.TrimSpace(line))
+		result = append(result, render(tpl, line))
+	} else if iterations := len(line) / charsPerLine; iterations != 0 {
+		start := 0
+		end := charsPerLine - 2
+		for i := 0; i < iterations+1; i++ {
+			if i == iterations {
+				end = len(line) - 1
+			}
+			currentLine := line[start:end]
+			currentLine = fmt.Sprintf("%s", strings.TrimSpace(currentLine))
+			result = append(result, render(tpl, currentLine))
+			start = end
+			end += charsPerLine - 2
+
+		}
+	} else {
+		line = fmt.Sprintf("%s", strings.TrimSpace(line))
+		result = append(result, render(tpl, line))
+	}
+	return result
+}
+
+func render(tpl *template.Template, data interface{}) []byte {
+	var buf bytes.Buffer
+	err := tpl.Execute(&buf, data)
+	if err != nil {
+		return []byte(fmt.Sprintf("%v", data))
+	}
+	return buf.Bytes()
+}
+
+func (*TTYCollapseDisplayer) hideCursor() {
+	if runtime.GOOS != "windows" {
+		fmt.Print("\033[?25l")
+	}
+}
+
+func (*TTYCollapseDisplayer) showCursor() {
+	if runtime.GOOS != "windows" {
+		fmt.Print("\033[?25h")
+	}
+}
+
+func (d *TTYCollapseDisplayer) reset() {
+
+	d.command = ""
+	d.err = nil
+
+	d.linesToDisplay = []string{}
+	d.screenbuf.Reset()
+}

--- a/cmd/utils/displayer/tty.go
+++ b/cmd/utils/displayer/tty.go
@@ -15,53 +15,31 @@ package displayer
 
 import (
 	"bufio"
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
 	"io"
 	"os"
-	"regexp"
-	"runtime"
 	"strings"
 	"sync"
-	"text/template"
-	"time"
 
-	"github.com/manifoldco/promptui"
 	"github.com/manifoldco/promptui/screenbuf"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"golang.org/x/term"
 )
 
-const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
-
-var (
-	spinnerChars = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-	cursorUp     = "\x1b[1A"
-	resetLine    = "\x1b[0G"
-	re           = regexp.MustCompile(ansi)
-)
-
-// TTYDisplayer displays with a screenbuff
-type TTYDisplayer struct {
+type ttyDisplayer struct {
 	stdoutScanner *bufio.Scanner
 	stderrScanner *bufio.Scanner
 	screenbuf     *screenbuf.ScreenBuf
 
-	command        string
-	err            error
-	linesToDisplay []string
-	numberOfLines  int
-
 	commandContext context.Context
 	cancel         context.CancelFunc
 
+	linesToDisplay        []string
 	isBuilding            bool
 	buildingpreviousLines int
 }
 
-func newTTYDisplayer(stdout, stderr io.Reader) *TTYDisplayer {
+func newTTYDisplayer(stdout, stderr io.Reader) *ttyDisplayer {
 	var (
 		stdoutScanner *bufio.Scanner
 		stderrScanner *bufio.Scanner
@@ -73,23 +51,18 @@ func newTTYDisplayer(stdout, stderr io.Reader) *TTYDisplayer {
 		stderrScanner = bufio.NewScanner(stderr)
 	}
 
-	return &TTYDisplayer{
-		numberOfLines:  25,
-		linesToDisplay: []string{},
-
+	return &ttyDisplayer{
 		stdoutScanner: stdoutScanner,
 		stderrScanner: stderrScanner,
 		screenbuf:     screenbuf.New(os.Stdout),
+
+		linesToDisplay: []string{},
 	}
 }
 
-// Display displays a
-func (d *TTYDisplayer) Display(commandName string) {
-	d.command = commandName
-
-	d.hideCursor()
+func (d *ttyDisplayer) Display(command string) {
 	d.commandContext, d.cancel = context.WithCancel(context.Background())
-	wg := &sync.WaitGroup{}
+	var wg sync.WaitGroup
 	wgDelta := 0
 	if d.stdoutScanner != nil {
 		wgDelta++
@@ -98,318 +71,65 @@ func (d *TTYDisplayer) Display(commandName string) {
 		wgDelta++
 	}
 	wg.Add(wgDelta)
-
-	commandChan := make(chan bool, 1)
-	go d.displayCommand(commandChan)
 	if d.stdoutScanner != nil {
-		go d.displayStdout(wg)
-	}
-	if d.stderrScanner != nil {
-		go d.displayStderr(wg)
-	}
-	wg.Wait()
-	d.cancel()
-	<-commandChan
-}
-
-func (d *TTYDisplayer) displayCommand(commandChan chan bool) {
-	t := time.NewTicker(50 * time.Millisecond)
-	shouldExit := false
-	for {
-		for i := 0; i < len(spinnerChars); i++ {
-			select {
-			case <-t.C:
-				width, _, _ := term.GetSize(int(os.Stdout.Fd()))
-				commandLines := renderCommand(spinnerChars[i], d.command, width)
-				for _, commandLine := range commandLines {
-					d.screenbuf.Write(commandLine)
+		go func() {
+			for d.stdoutScanner.Scan() {
+				select {
+				case <-d.commandContext.Done():
+				default:
+					line := d.stdoutScanner.Text()
+					if isTopDisplay(line) {
+						prevState := d.isBuilding
+						d.isBuilding = checkIfIsBuildingLine(line)
+						if d.isBuilding && d.isBuilding != prevState {
+							d.buildingpreviousLines = len(d.linesToDisplay)
+						}
+						sanitizedLine := strings.ReplaceAll(line, cursorUp, "")
+						sanitizedLine = strings.ReplaceAll(sanitizedLine, resetLine, "")
+						d.linesToDisplay = append(d.linesToDisplay[:d.buildingpreviousLines-1], sanitizedLine)
+					} else {
+						d.linesToDisplay = append(d.linesToDisplay, line)
+					}
+					if os.Stdout == oktetoLog.GetOutput() {
+						oktetoLog.AddToBuffer(oktetoLog.InfoLevel, line)
+					}
+					width, _, _ := term.GetSize(int(os.Stdout.Fd()))
+					lines := renderLines(d.linesToDisplay, width)
+					for _, line := range lines {
+						d.screenbuf.Write(line)
+					}
+					d.screenbuf.Flush()
+					continue
 				}
-				lines := renderLines(d.linesToDisplay, width)
-				for _, line := range lines {
-					d.screenbuf.Write(line)
-				}
-				d.screenbuf.Flush()
-			case <-d.commandContext.Done():
-				shouldExit = true
-			}
-			if shouldExit {
 				break
 			}
-		}
-		if shouldExit {
-			break
-		}
+			if d.stdoutScanner.Err() != nil {
+				oktetoLog.Infof("Error reading command output: %s", d.stdoutScanner.Err().Error())
+			}
+			wg.Done()
+		}()
 	}
-	commandChan <- true
-}
 
-func (d *TTYDisplayer) displayStdout(wg *sync.WaitGroup) {
-	for d.stdoutScanner.Scan() {
-		select {
-		case <-d.commandContext.Done():
-		default:
-			line := strings.TrimSpace(d.stdoutScanner.Text())
-			if isTopDisplay(line) {
-				prevState := d.isBuilding
-				d.isBuilding = checkIfIsBuildingLine(line)
-				if d.isBuilding && d.isBuilding != prevState {
-					d.buildingpreviousLines = len(d.linesToDisplay)
+	if d.stderrScanner != nil {
+		go func() {
+			for d.stderrScanner.Scan() {
+				select {
+				case <-d.commandContext.Done():
+				default:
+					line := d.stderrScanner.Text()
+					oktetoLog.FWarning(os.Stdout, line)
+					continue
 				}
-				sanitizedLine := strings.ReplaceAll(line, cursorUp, "")
-				sanitizedLine = strings.ReplaceAll(sanitizedLine, resetLine, "")
-				d.linesToDisplay = append(d.linesToDisplay[:d.buildingpreviousLines-1], sanitizedLine)
-			} else {
-				if len(d.linesToDisplay) >= d.numberOfLines {
-					d.linesToDisplay = d.linesToDisplay[1:]
-				}
-				d.linesToDisplay = append(d.linesToDisplay, line)
+				break
 			}
-			if os.Stdout == oktetoLog.GetOutput() {
-				oktetoLog.AddToBuffer(oktetoLog.InfoLevel, line)
-			}
-			continue
-		}
-		break
+			wg.Done()
+		}()
 	}
-	if d.stdoutScanner.Err() != nil {
-		oktetoLog.Infof("Error reading command output: %s", d.stdoutScanner.Err().Error())
-	}
-	wg.Done()
+	wg.Wait()
 }
 
-func checkIfIsBuildingLine(line string) bool {
-	if strings.Contains(line, "Building") {
-		return !strings.Contains(line, "FINISHED")
-	}
-	return false
-}
-
-func (d *TTYDisplayer) displayStderr(wg *sync.WaitGroup) {
-	for d.stderrScanner.Scan() {
-		select {
-		case <-d.commandContext.Done():
-		default:
-			line := strings.TrimSpace(d.stderrScanner.Text())
-			d.err = errors.New(line)
-			if len(d.linesToDisplay) >= d.numberOfLines {
-				d.linesToDisplay = d.linesToDisplay[1:]
-			}
-			d.linesToDisplay = append(d.linesToDisplay, line)
-			if os.Stdout == oktetoLog.GetOutput() {
-				oktetoLog.AddToBuffer(oktetoLog.WarningLevel, line)
-			}
-			continue
-		}
-		break
-	}
-	if d.stderrScanner.Err() != nil {
-		oktetoLog.Infof("Error reading command output: %s", d.stderrScanner.Err().Error())
-	}
-	wg.Done()
-}
-
-func isTopDisplay(line string) bool {
-	return strings.Contains(line, fmt.Sprintf("%s%s", cursorUp, resetLine))
-}
-
-// CleanUp collapses and stop displaying
-func (d *TTYDisplayer) CleanUp(err error) {
-	if d.screenbuf == nil {
-		return
-	}
-	if d.command == "" {
-		return
-	}
-
-	var message []byte
-	if err == nil {
-		message = renderSuccessCommand(d.command)
-		d.screenbuf.Reset()
-		d.screenbuf.Clear()
-		d.screenbuf.Flush()
-		d.screenbuf.Write(message)
-		d.screenbuf.Flush()
-	} else {
-		message = renderFailCommand(d.command, err)
-		d.screenbuf.Reset()
-		d.screenbuf.Clear()
-		d.screenbuf.Flush()
-		d.screenbuf.Write(message)
-		width, _, _ := term.GetSize(int(os.Stdout.Fd()))
-		lines := renderLines(d.linesToDisplay, width)
-		for _, line := range lines {
-			d.screenbuf.Write([]byte(line))
-		}
-		d.screenbuf.Flush()
-	}
+// CleanUp stops displaying
+func (d *ttyDisplayer) CleanUp(_ error) {
 	d.cancel()
 	<-d.commandContext.Done()
-	d.reset()
-	d.showCursor()
-
-}
-
-func renderCommand(spinnerChar, command string, charsPerLine int) [][]byte {
-	firstLineCommandTemplate := fmt.Sprintf(` %s {{ . | oktetoblue }}`, spinnerChar)
-	otherLineCommandTemplate := `    {{ . | oktetoblue }}`
-	lastLineCommandTemplate := `    {{ . | oktetoblue }}:`
-	funcMap := promptui.FuncMap
-	funcMap["oktetoblue"] = oktetoLog.BlueString
-	firstLineTpl, err := template.New("").Funcs(funcMap).Parse(firstLineCommandTemplate)
-	if err != nil {
-		return [][]byte{}
-	}
-
-	otherLinesTpl, err := template.New("").Funcs(funcMap).Parse(otherLineCommandTemplate)
-	if err != nil {
-		return [][]byte{}
-	}
-
-	lastLineTpl, err := template.New("").Funcs(funcMap).Parse(lastLineCommandTemplate)
-	if err != nil {
-		return [][]byte{}
-	}
-
-	command = fmt.Sprintf(" Running '%s'", command)
-	result := [][]byte{}
-	if charsPerLine == 0 || charsPerLine < 5 {
-		result = append(result, render(firstLineTpl, command))
-		return result
-	}
-	iterations := (len(command) + 4) / charsPerLine
-	start := 0
-	end := charsPerLine - 5
-	for i := 0; i < iterations+1; i++ {
-		if i == iterations {
-			end = len(command) - 1
-		}
-		currentLine := command[start:end]
-		if i == 0 {
-			result = append(result, render(firstLineTpl, currentLine))
-		} else if i < iterations {
-			result = append(result, render(otherLinesTpl, currentLine))
-		} else {
-			result = append(result, render(lastLineTpl, currentLine))
-		}
-		start = end
-		end += charsPerLine - 5
-	}
-	return result
-}
-
-func renderSuccessCommand(command string) []byte {
-	commandTemplate := `{{ " ✓ " | bgGreen | black }} {{ . | green }}`
-	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(commandTemplate)
-	if err != nil {
-		return []byte{}
-	}
-
-	return render(tpl, command)
-}
-
-func renderFailCommand(command string, err error) []byte {
-	message := fmt.Sprintf("%s: %s", command, err.Error())
-	commandTemplate := `{{ " x " | bgRed | black }} {{ . | oktetored }}`
-	funcMap := promptui.FuncMap
-	funcMap["oktetored"] = oktetoLog.RedString
-	tpl, err := template.New("").Funcs(funcMap).Parse(commandTemplate)
-	if err != nil {
-		return []byte{}
-	}
-
-	return render(tpl, message)
-}
-
-func renderLines(queue []string, charsPerLine int) [][]byte {
-	lineTemplate := "{{ . | white }} "
-	tpl, err := template.New("").Funcs(promptui.FuncMap).Parse(lineTemplate)
-	if err != nil {
-		return [][]byte{}
-	}
-
-	result := [][]byte{}
-	for _, line := range queue {
-		lineWithoutColors := re.ReplaceAllString(line, "")
-		if len(line) == len(lineWithoutColors) {
-			result = append(result, renderLogWithoutColors(tpl, line, charsPerLine)...)
-		} else {
-			result = append(result, renderLogWithColors(tpl, line, charsPerLine)...)
-			continue
-		}
-	}
-	return result
-}
-
-func renderLogWithColors(tpl *template.Template, line string, charsPerLine int) [][]byte {
-	result := [][]byte{}
-	if charsPerLine > 4 && len(line)+2 > charsPerLine {
-		result = append(result, render(tpl, fmt.Sprintf("    %s...", line[:charsPerLine-5])))
-	} else if line == "" {
-		result = append(result, []byte(""))
-	} else {
-		result = append(result, render(tpl, fmt.Sprintf("    %s...", line)))
-	}
-	return result
-}
-
-func renderLogWithoutColors(tpl *template.Template, line string, charsPerLine int) [][]byte {
-	result := [][]byte{}
-	if line == "" {
-		result = append(result, []byte(""))
-	} else if charsPerLine == 0 {
-		line = fmt.Sprintf("    %s", strings.TrimSpace(line))
-		result = append(result, render(tpl, line))
-	} else if iterations := len(line) / (charsPerLine - 4); iterations != 0 {
-		start := 0
-		end := charsPerLine - 5
-		for i := 0; i < iterations+1; i++ {
-			if i == iterations {
-				end = len(line) - 1
-			}
-			currentLine := line[start:end]
-			prevWhitespaces := len(currentLine) - len(strings.TrimSpace(currentLine))
-			if prevWhitespaces != 0 {
-				currentLine = line[start : end+prevWhitespaces]
-			}
-			currentLine = fmt.Sprintf("    %s", strings.TrimSpace(currentLine))
-			result = append(result, render(tpl, currentLine))
-			start = end + prevWhitespaces
-			end += charsPerLine - 5 - prevWhitespaces
-
-		}
-	} else {
-		line = fmt.Sprintf("    %s", strings.TrimSpace(line))
-		result = append(result, render(tpl, line))
-	}
-	return result
-}
-
-func render(tpl *template.Template, data interface{}) []byte {
-	var buf bytes.Buffer
-	err := tpl.Execute(&buf, data)
-	if err != nil {
-		return []byte(fmt.Sprintf("%v", data))
-	}
-	return buf.Bytes()
-}
-
-func (*TTYDisplayer) hideCursor() {
-	if runtime.GOOS != "windows" {
-		fmt.Print("\033[?25l")
-	}
-}
-
-func (*TTYDisplayer) showCursor() {
-	if runtime.GOOS != "windows" {
-		fmt.Print("\033[?25h")
-	}
-}
-
-func (d *TTYDisplayer) reset() {
-
-	d.command = ""
-	d.err = nil
-
-	d.linesToDisplay = []string{}
-	d.screenbuf.Reset()
 }

--- a/cmd/utils/executor/executor.go
+++ b/cmd/utils/executor/executor.go
@@ -63,7 +63,6 @@ func (e *Executor) Execute(cmdInfo model.DeployCommand, env []string) error {
 
 	cmd := exec.Command("bash", "-c", cmdInfo.Command)
 	cmd.Env = append(os.Environ(), env...)
-
 	if err := e.displayer.startCommand(cmd); err != nil {
 		return err
 	}

--- a/pkg/log/plain.go
+++ b/pkg/log/plain.go
@@ -131,7 +131,7 @@ func (w *PlainWriter) Warning(format string, args ...interface{}) {
 // FWarning prints a message with the warning symbol first, and the text in yellow into an specific writer
 func (w *PlainWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
 	log.out.Infof(format, args...)
-	w.Fprintf(writer, "%s %s\n", coloredWarningSymbol, yellowString(format, args...))
+	w.Fprintf(writer, "%s %s\n", warningSymbol, fmt.Sprintf(format, args...))
 }
 
 // Hint prints a message with the text in blue


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes TTY was despair between build section and the deploy section

## Proposed changes
- Instead of collapsing show the full output of the command for the tty output
- Stacks being deployed from deploy command now have spinner on

