### PR TITLE
feat: set vars as options as env vars

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -113,7 +113,9 @@ func Deploy(ctx context.Context) *cobra.Command {
 		Short: "Execute the list of commands specified in the 'deploy' section of your okteto manifest",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#deploy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
+			if err := validateOptionVars(options.Variables); err != nil {
+				return err
+			}
 			if shouldExecuteRemotely(options) {
 				remoteOpts := &pipelineCMD.DeployOptions{
 					Branch:     options.Branch,

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -116,6 +116,9 @@ func Deploy(ctx context.Context) *cobra.Command {
 			if err := validateOptionVars(options.Variables); err != nil {
 				return err
 			}
+			if err := setOptionVarsAsEnvs(options.Variables); err != nil {
+				return err
+			}
 			if shouldExecuteRemotely(options) {
 				remoteOpts := &pipelineCMD.DeployOptions{
 					Branch:     options.Branch,

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -31,3 +31,13 @@ func validateOptionVars(variables []string) error {
 	}
 	return nil
 }
+
+func setOptionVarsAsEnvs(variables []string) error {
+	for _, v := range variables {
+		kv := strings.SplitN(v, "=", 2)
+		if err := os.Setenv(kv[0], kv[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func validateOptionVars(variables []string) error {
+	for _, v := range variables {
+		kv := strings.SplitN(v, "=", 2)
+		if len(kv) != 2 {
+			return fmt.Errorf("invalid variable value '%s': must follow KEY=VALUE format", v)
+		}
+		if err := os.Setenv(kv[0], kv[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateVars(t *testing.T) {
+
+	var tests = []struct {
+		name        string
+		variables   []string
+		expectedErr bool
+	}{
+		{
+			name:        "correct assingnament",
+			variables:   []string{"NAME=test"},
+			expectedErr: false,
+		},
+		{
+			name:        "bas assingnament",
+			variables:   []string{"NAME:test"},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOptionVars(tt.variables)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Deploy variables was not taken in count to expand manifest commands

## Proposed changes
- Set variables at the beingining of the command so they can be expanded on the okteto manifest
-
