### PR TITLE
deploy stack should propagate same build name

### DIFF
--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -55,6 +55,15 @@ func Test_validateImage(t *testing.T) {
 }
 
 func Test_OptsFromManifest(t *testing.T) {
+	okteto.CurrentStore = &okteto.OktetoContextStore{
+		Contexts: map[string]*okteto.OktetoContext{
+			"test": {
+				Namespace: "test",
+				Registry:  "this.is.my.okteto.registry",
+			},
+		},
+		CurrentContext: "test",
+	}
 	tests := []struct {
 		name           string
 		serviceName    string

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -14,6 +14,15 @@ import (
 )
 
 func Test_validateImage(t *testing.T) {
+	okteto.CurrentStore = &okteto.OktetoContextStore{
+		Contexts: map[string]*okteto.OktetoContext{
+			"test": {
+				Namespace: "test",
+				Registry:  "this.is.my.okteto.registry",
+			},
+		},
+		CurrentContext: "test",
+	}
 	tests := []struct {
 		name  string
 		image string

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -526,12 +526,13 @@ func (m *Manifest) ExpandEnvVars() (*Manifest, error) {
 			m.Deploy.Commands[idx] = cmd
 		}
 		if m.Deploy.Compose != nil && m.Deploy.Compose.Stack != nil {
-			for _, svc := range m.Deploy.Compose.Stack.Services {
-				svc.Image, err = ExpandEnv(svc.Image)
-				if err != nil {
-					return nil, errors.New("could not parse env vars")
-				}
+			s, err := LoadStack("", m.Deploy.Compose.Manifest)
+			if err != nil {
+				return nil, err
 			}
+			m.Deploy.Compose.Stack = s
+			s.Endpoints = m.Deploy.Endpoints
+			m, err = m.InferFromStack()
 		}
 	}
 	if m.Destroy != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -533,6 +533,9 @@ func (m *Manifest) ExpandEnvVars() (*Manifest, error) {
 			m.Deploy.Compose.Stack = s
 			s.Endpoints = m.Deploy.Endpoints
 			m, err = m.InferFromStack()
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if m.Destroy != nil {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -139,7 +139,7 @@ func IsDevRegistry(tag string) bool {
 
 // IsOktetoRegistry returns if an image tag is pointing to the okteto registry
 func IsOktetoRegistry(tag string) bool {
-	return IsDevRegistry(tag) || IsGlobalRegistry(tag)
+	return IsDevRegistry(tag) || IsGlobalRegistry(tag) || strings.HasPrefix(tag, okteto.Context().Registry)
 }
 
 // replaceRegistry replaces the short registry url with the okteto registry url

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -153,6 +153,15 @@ func Test_GetRegistryAndRepo(t *testing.T) {
 }
 
 func Test_IsOktetoRegistry(t *testing.T) {
+	okteto.CurrentStore = &okteto.OktetoContextStore{
+		Contexts: map[string]*okteto.OktetoContext{
+			"test": {
+				Namespace: "test",
+				Registry:  "this.is.my.okteto.registry",
+			},
+		},
+		CurrentContext: "test",
+	}
 	var tests = []struct {
 		name string
 		tag  string
@@ -166,6 +175,11 @@ func Test_IsOktetoRegistry(t *testing.T) {
 		{
 			name: "is-not-dev-registry",
 			tag:  "okteto.global/image",
+			want: true,
+		},
+		{
+			name: "is-expanded-dev-registry",
+			tag:  "this.is.my.okteto.registry/user/image",
 			want: true,
 		},
 		{


### PR DESCRIPTION
Fixes okteto stack and okteto deploy was getting different name due to the fact of not being able to recognise our registry as our registry

## Proposed changes
- It will check if the image is from our registry checking the registry property from context
- Loads again stack for expanding env vars
