### PR TITLE
Revert "fix: stop other okteto for the same app #2299"

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -121,7 +121,7 @@ func runDown(ctx context.Context, dev *model.Dev, rm bool) error {
 		}
 		spinner.Start()
 
-		trMap, err := apps.GetTranslations(ctx, dev, app, false, "", c)
+		trMap, err := apps.GetTranslations(ctx, dev, app, false, c)
 		if err != nil {
 			exit <- err
 			return

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/google/uuid"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -180,11 +179,8 @@ func runPush(ctx context.Context, dev *model.Dev, oktetoRegistryURL string, push
 			pushOpts.ImageTag = registry.GetImageTag("", dev.Name, dev.Namespace, oktetoRegistryURL)
 		}
 	}
-	id := uuid.New().String()
-	if value, ok := app.ObjectMeta().Annotations[model.OktetoSessionIDAnnotation]; ok {
-		id = value
-	}
-	trMap, err := apps.GetTranslations(ctx, dev, app, false, id, c)
+
+	trMap, err := apps.GetTranslations(ctx, dev, app, false, c)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -247,7 +247,7 @@ func (up *upContext) createDevContainer(ctx context.Context, app apps.App, creat
 	}
 
 	resetOnDevContainerStart := up.resetSyncthing || !up.Dev.PersistentVolumeEnabled()
-	trMap, err := apps.GetTranslations(ctx, up.Dev, app, resetOnDevContainerStart, up.ID, up.Client)
+	trMap, err := apps.GetTranslations(ctx, up.Dev, app, resetOnDevContainerStart, up.Client)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/forwards.go
+++ b/cmd/up/forwards.go
@@ -16,10 +16,8 @@ package up
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/okteto/okteto/cmd/utils"
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/forward"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -91,12 +89,6 @@ func (up *upContext) sshForwards(ctx context.Context) error {
 			up.Dev.Forward[idx] = forwardWithServiceName
 			f = forwardWithServiceName
 		}
-
-		err := waitUntilPortIsAvailable(up.Dev.Interface, f.Local)
-		if err != nil {
-			return err
-		}
-
 		if err := up.Forwarder.Add(f); err != nil {
 			return err
 		}
@@ -114,23 +106,4 @@ func (up *upContext) sshForwards(ctx context.Context) error {
 	}
 
 	return up.Forwarder.Start(up.Pod.Name, up.Dev.Namespace)
-}
-
-func waitUntilPortIsAvailable(iface string, port int) error {
-	ticker := time.NewTicker(1 * time.Second)
-	timeoutTicker := time.NewTicker(30 * time.Second)
-
-	for {
-		select {
-		case <-ticker.C:
-			if model.IsPortAvailable(iface, port) {
-				return nil
-			}
-		case <-timeoutTicker.C:
-			return oktetoErrors.UserError{
-				E:    fmt.Errorf("local port %d is already in-use in your local machine", port),
-				Hint: "Please release the port and try again",
-			}
-		}
-	}
 }

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -53,7 +53,6 @@ type upContext struct {
 	spinner           *utils.Spinner
 	StartTime         time.Time
 	Options           *UpOptions
-	ID                string
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/moby/term"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
@@ -164,7 +163,6 @@ func Up() *cobra.Command {
 				resetSyncthing: upOptions.Reset,
 				StartTime:      time.Now(),
 				Options:        upOptions,
-				ID:             uuid.New().String(),
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {
@@ -219,8 +217,6 @@ func Up() *cobra.Command {
 					err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetAppHome(dev.Namespace, dev.Name))
 				case oktetoErrors.CommandError:
 					oktetoLog.Infof("CommandError: %v", err)
-				case oktetoErrors.UserError:
-					return err
 				}
 
 			}
@@ -372,7 +368,6 @@ func (up *upContext) activateLoop() {
 
 	defer config.DeleteStateFile(up.Dev)
 
-	ctx := context.Background()
 	for {
 		if up.isRetry || isTransientError {
 			oktetoLog.Infof("waiting for shutdown sequence to finish")
@@ -386,13 +381,7 @@ func (up *upContext) activateLoop() {
 				<-t.C
 			}
 		}
-		if up.isRetry && up.hasSessionIDChanged(ctx) {
-			up.Exit <- oktetoErrors.UserError{
-				E:    fmt.Errorf("session disconnected: there is another `okteto up` session on this container"),
-				Hint: "Try running 'okteto exec' to get another session on this container",
-			}
-			return
-		}
+
 		err := up.activate()
 		if err != nil {
 			oktetoLog.Infof("activate failed with: %s", err)
@@ -414,17 +403,6 @@ func (up *upContext) activateLoop() {
 		up.Exit <- nil
 		return
 	}
-}
-
-func (up *upContext) hasSessionIDChanged(ctx context.Context) bool {
-	app, err := utils.GetDevApp(ctx, up.Dev, up.Client)
-	if err != nil || app == nil {
-		return false
-	}
-	if value, ok := app.ObjectMeta().Annotations[model.OktetoSessionIDAnnotation]; ok {
-		return value != up.ID
-	}
-	return false
 }
 
 // waitUntilExitOrInterruptOrApply blocks execution until a stop signal is sent, a disconnect event or an error or the app is modify

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -376,16 +376,3 @@ func doesAutocreateAppExist(ctx context.Context, dev *model.Dev, c kubernetes.In
 	}
 	return err == nil
 }
-
-// GetDevApp returns the cloned app if exists, error otherwise
-func GetDevApp(ctx context.Context, dev *model.Dev, c kubernetes.Interface) (apps.App, error) {
-	devAppDev := *dev
-	devAppDev.Name = model.DevCloneName(dev.Name)
-	app, err := apps.Get(ctx, &devAppDev, dev.Namespace, c)
-	if err != nil && !oktetoErrors.IsNotFound(err) {
-		oktetoLog.Infof("getApp autocreate k8s error, retrying...")
-		_, err := apps.Get(ctx, &devAppDev, dev.Namespace, c)
-		return nil, err
-	}
-	return app, nil
-}

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -101,13 +101,12 @@ func GetRunningPodInLoop(ctx context.Context, dev *model.Dev, app App, c kuberne
 }
 
 //GetTranslations fills all the deployments pointed by a development container
-func GetTranslations(ctx context.Context, dev *model.Dev, app App, reset bool, uid string, c kubernetes.Interface) (map[string]*Translation, error) {
+func GetTranslations(ctx context.Context, dev *model.Dev, app App, reset bool, c kubernetes.Interface) (map[string]*Translation, error) {
 	mainTr := &Translation{
 		MainDev: dev,
 		Dev:     dev,
 		App:     app,
 		Rules:   []*model.TranslationRule{dev.ToTranslationRule(dev, reset)},
-		ID:      uid,
 	}
 	result := map[string]*Translation{app.ObjectMeta().Name: mainTr}
 

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -47,7 +47,6 @@ type Translation struct {
 	App     App
 	DevApp  App
 	Rules   []*model.TranslationRule
-	ID      string
 }
 
 func (tr *Translation) translate() error {
@@ -79,8 +78,6 @@ func (tr *Translation) translate() error {
 		tr.DevApp.SetReplicas(1)
 		tr.DevApp.TemplateObjectMeta().Labels[model.InteractiveDevLabel] = tr.Dev.Name
 		TranslateOktetoSyncSecret(tr.DevApp.PodSpec(), tr.Dev.Name)
-		tr.DevApp.ObjectMeta().Annotations[model.OktetoSessionIDAnnotation] = tr.ID
-		tr.DevApp.TemplateObjectMeta().Annotations[model.OktetoSessionIDAnnotation] = tr.ID
 	} else {
 		tr.DevApp.TemplateObjectMeta().Labels[model.DetachedDevLabel] = tr.Dev.Name
 		TranslatePodAffinity(tr.DevApp.PodSpec(), tr.MainDev.Name)

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -430,11 +430,11 @@ services:
 	if !reflect.DeepEqual(tr1.DevApp.TemplateObjectMeta().Labels, expectedPodLabels) {
 		t.Fatalf("Wrong dev d1 pod labels: '%v'", tr1.DevApp.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{model.OktetoSessionIDAnnotation: "", "key1": "value1"}
+	expectedAnnotations = map[string]string{"key1": "value1"}
 	if !reflect.DeepEqual(tr1.DevApp.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong dev d1 annotations: '%v'", tr1.DevApp.ObjectMeta().Annotations)
 	}
-	expectedPodAnnotations := map[string]string{model.OktetoSessionIDAnnotation: "", "key1": "value1"}
+	expectedPodAnnotations := map[string]string{"key1": "value1"}
 	if !reflect.DeepEqual(tr1.DevApp.TemplateObjectMeta().Annotations, expectedPodAnnotations) {
 		t.Fatalf("Wrong dev d1 pod annotations: '%v'", tr1.DevApp.TemplateObjectMeta().Annotations)
 	}
@@ -1773,11 +1773,11 @@ services:
 	if !reflect.DeepEqual(tr1.DevApp.TemplateObjectMeta().Labels, expectedPodLabels) {
 		t.Fatalf("Wrong dev sfs1 pod labels: '%v'", tr1.DevApp.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{model.OktetoSessionIDAnnotation: "", "key1": "value1"}
+	expectedAnnotations = map[string]string{"key1": "value1"}
 	if !reflect.DeepEqual(tr1.DevApp.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong dev sfs1 annotations: '%v'", tr1.DevApp.ObjectMeta().Annotations)
 	}
-	expectedPodAnnotations := map[string]string{model.OktetoSessionIDAnnotation: "", "key1": "value1"}
+	expectedPodAnnotations := map[string]string{"key1": "value1"}
 	if !reflect.DeepEqual(tr1.DevApp.TemplateObjectMeta().Annotations, expectedPodAnnotations) {
 		t.Fatalf("Wrong dev sfs1 pod annotations: '%v'", tr1.DevApp.TemplateObjectMeta().Annotations)
 	}

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -34,9 +34,6 @@ const (
 	// OktetoSampleAnnotation indicates that the repo is a okteto sample
 	OktetoSampleAnnotation = "dev.okteto.com/sample"
 
-	// OktetoSessionIDAnnotation indicates that the dev uid
-	OktetoSessionIDAnnotation = "dev.okteto.com/session-id"
-
 	// DetachedDevLabel indicates the detached dev pods
 	DetachedDevLabel = "detached.dev.okteto.com"
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

The fix for #2294 was adding a pod annotation with the session ID, forcing the dev container redeployment on each `okteto up` execution. We should fine a way to deactivate active `okteto up` sessions without redeploying the dev container on each `okteto up`, because redeploying slows down `okteto up` exectuion