### PR TITLE
Update deprecation messages to refer to 2.2.0 instead of 1.16.x

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -79,7 +79,7 @@ If you need to automate authentication or if you don't want to use browser-based
 	$ okteto context create https://cloud.okteto.com --token ${OKTETO_TOKEN}
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto context create' is deprecated in favor of 'okteto context use', and will be removed in version 1.16")
+			oktetoLog.Warning("'okteto context create' is deprecated in favor of 'okteto context use', and will be removed in version 2.2.0")
 			ctx := context.Background()
 
 			ctxOptions.Context = args[0]

--- a/cmd/context/use-namespace.go
+++ b/cmd/context/use-namespace.go
@@ -32,7 +32,7 @@ func UseNamespace() *cobra.Command {
 		Args:   utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/cli/#use-1"),
 		Short:  "Set the namespace of the okteto context",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto context use-namespace' is deprecated in favor of 'okteto namespace', and will be removed in version 1.16")
+			oktetoLog.Warning("'okteto context use-namespace' is deprecated in favor of 'okteto namespace', and will be removed in version 2.2.0")
 			ctx := context.Background()
 			ctxOptions.Namespace = args[0]
 			ctxOptions.Context = okteto.Context().Name

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -43,7 +43,7 @@ func deprecatedCreateNamespace(ctx context.Context) *cobra.Command {
 		Use:   "namespace <name>",
 		Short: "Create a namespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto create namespace' is deprecated in favor of 'okteto namespace create', and will be removed in version 1.16")
+			oktetoLog.Warning("'okteto create namespace' is deprecated in favor of 'okteto namespace create', and will be removed in version 2.2.0")
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
 				return err
 			}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -43,7 +43,7 @@ func deprecatedDeleteNamespace(ctx context.Context) *cobra.Command {
 		Use:   "namespace <name>",
 		Short: "Delete a namespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto delete namespace' is deprecated in favor of 'okteto namespace delete', and will be removed in version 1.16")
+			oktetoLog.Warning("'okteto delete namespace' is deprecated in favor of 'okteto namespace delete', and will be removed in version 2.2.0")
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
 				return err
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,7 +39,7 @@ func deprecatedListNamespace(ctx context.Context) *cobra.Command {
 		Use:   "namespace <name>",
 		Short: "List namespaces",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto list namespace' is deprecated in favor of 'okteto namespace list', and will be removed in version 1.16")
+			oktetoLog.Warning("'okteto list namespace' is deprecated in favor of 'okteto namespace list', and will be removed in version 2.2.0")
 			return cmd.RunE(namespace.List(ctx), args)
 		},
 		Args: utils.NoArgsAccepted(""),

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -47,7 +47,7 @@ By default, this will log into cloud.okteto.com. If you want to log into your Ok
 to log in to a Okteto Enterprise instance running at okteto.example.com.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning(`'okteto login' is deprecated in favor of 'okteto context', and will be removed in version 1.16.
+			oktetoLog.Warning(`'okteto login' is deprecated in favor of 'okteto context', and will be removed in version 2.2.0.
     Learn more about okteto context at https://okteto.com/docs/reference/cli/#context`)
 
 			ctxOptions := contextCMD.ContextOptions{

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -56,7 +56,7 @@ func deploy(ctx context.Context) *cobra.Command {
 		Short: "Deploy an okteto pipeline",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli-v1/#deploy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto pipeline deploy' is deprecated in favor of 'okteto deploy [--branch] [--repository]', and will be removed in a future version")
+			oktetoLog.Warning("'okteto pipeline deploy' is deprecated in favor of 'okteto deploy [--branch] [--repository]', and will be removed in version 2.2.0")
 			return ExecuteDeployPipeline(ctx, opts)
 		},
 	}
@@ -146,7 +146,7 @@ func ExecuteDeployPipeline(ctx context.Context, opts *DeployOptions) error {
 	}
 
 	if opts.Filename != "" {
-		oktetoLog.Warning("the 'filename' flag is deprecated and will be removed in a future version. Please consider using 'file' flag")
+		oktetoLog.Warning("the 'filename' flag is deprecated and will be removed in version 2.2.0. Please consider using 'file' flag")
 		if opts.File == "" {
 			opts.File = opts.Filename
 		} else {

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -47,7 +47,7 @@ func destroy(ctx context.Context) *cobra.Command {
 		Short: "Destroy an okteto pipeline",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli-v1/#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto pipeline destroy' is deprecated in favor of 'okteto destroy', and will be removed in a future version")
+			oktetoLog.Warning("'okteto pipeline destroy' is deprecated in favor of 'okteto destroy', and will be removed in version 2.2.0")
 			return ExecuteDestroyPipeline(ctx, opts)
 
 		},

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -93,7 +93,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			}
 
 			if filename != "" {
-				oktetoLog.Warning("the 'filename' flag is deprecated and will be removed in a future version. Please consider using 'file' flag'")
+				oktetoLog.Warning("the 'filename' flag is deprecated and will be removed in version 2.2.0. Please consider using 'file' flag'")
 				if file == "" {
 					file = filename
 				} else {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -58,7 +58,7 @@ func Push(ctx context.Context) *cobra.Command {
 		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli-v1/#push"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !utils.LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) {
-				oktetoLog.Warning("'okteto push' is deprecated in favor of 'okteto deploy', and will be removed in a future version")
+				oktetoLog.Warning("'okteto push' is deprecated in favor of 'okteto deploy', and will be removed in version 2.2.0")
 			}
 			ctxResource, err := utils.LoadManifestContext(pushOpts.DevPath)
 			if err != nil {
@@ -112,7 +112,7 @@ func Push(ctx context.Context) *cobra.Command {
 			oktetoRegistryURL := okteto.Context().Registry
 
 			if pushOpts.AutoDeploy {
-				oktetoLog.Warning(`The 'deploy' flag is deprecated and will be removed in a future release.
+				oktetoLog.Warning(`The 'deploy' flag is deprecated and will be removed in version 2.2.0.
     Set the 'autocreate' field in your okteto manifest to get the same behavior.
     More information is available here: https://okteto.com/docs/reference/cli#up`)
 			}

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -50,7 +50,7 @@ func deploy(ctx context.Context) *cobra.Command {
 		Use:   "deploy [service...]",
 		Short: "Deploy a compose",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto stack deploy' is deprecated in favor of 'okteto deploy', and will be removed in a future version")
+			oktetoLog.Warning("'okteto stack deploy' is deprecated in favor of 'okteto deploy', and will be removed in version 2.2.0")
 			options.ServicesToDeploy = args
 
 			options.StackPaths = loadComposePaths(options.StackPaths)

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -36,7 +36,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 		Short: "Destroy a compose",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli-v1/#destroy-2"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto stack destroy' is deprecated in favor of 'okteto destroy', and will be removed in a future version")
+			oktetoLog.Warning("'okteto stack destroy' is deprecated in favor of 'okteto destroy', and will be removed in version 2.2.0")
 			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath)
 			if err != nil {
 				return err

--- a/cmd/stack/endpoints.go
+++ b/cmd/stack/endpoints.go
@@ -37,7 +37,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 		Use:   "endpoints [service...]",
 		Short: "Show endpoints for a stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto stack endpoints' is deprecated and will be removed in a future version")
+			oktetoLog.Warning("'okteto stack endpoints' is deprecated and will be removed in version 2.2.0")
 			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath)
 			if err != nil {
 				return err

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,7 +35,7 @@ func UpdateDeprecated() *cobra.Command {
 		Use:   "update",
 		Short: "Update Okteto CLI version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oktetoLog.Warning("'okteto update' is deprecated in favor of 'okteto version update', and will be removed in a future version")
+			oktetoLog.Warning("'okteto update' is deprecated in favor of 'okteto version update', and will be removed in version 2.2.0")
 			currentVersion, err := semver.NewVersion(config.VersionString)
 			if err != nil {
 				return fmt.Errorf("could not retrieve version")

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -467,7 +467,7 @@ func (dev *Dev) SetDefaults() error {
 	}
 
 	if dev.Healthchecks {
-		oktetoLog.Yellow("The use of 'healthchecks' field is deprecated and will be removed in a future release. Please use the field 'probes' instead.")
+		oktetoLog.Yellow("The use of 'healthchecks' field is deprecated and will be removed in version 2.2.0. Please use the field 'probes' instead.")
 		if dev.Probes == nil {
 			dev.Probes = &Probes{Liveness: true, Readiness: true, Startup: true}
 		}
@@ -1164,28 +1164,28 @@ func GetTimeout() (time.Duration, error) {
 
 func (dev *Dev) translateDeprecatedMetadataFields() error {
 	if len(dev.Labels) > 0 {
-		oktetoLog.Warning("The field 'labels' is deprecated. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)")
+		oktetoLog.Warning("The field 'labels' is deprecated and will be removed in version 2.2.0. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)")
 		for k, v := range dev.Labels {
 			dev.Selector[k] = v
 		}
 	}
 
 	if len(dev.Annotations) > 0 {
-		oktetoLog.Warning("The field 'annotations' is deprecated. Use the field 'metadata.annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)")
+		oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in version 2.2.0. Use the field 'metadata.annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)")
 		for k, v := range dev.Annotations {
 			dev.Metadata.Annotations[k] = v
 		}
 	}
 	for _, s := range dev.Services {
 		if len(s.Labels) > 0 {
-			oktetoLog.Warning("The field '%s.labels' is deprecated. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)", s.Name)
+			oktetoLog.Warning("The field '%s.labels' is deprecated and will be removed in version 2.2.0. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)", s.Name)
 			for k, v := range s.Labels {
 				s.Selector[k] = v
 			}
 		}
 
 		if len(s.Annotations) > 0 {
-			oktetoLog.Warning("The field 'annotations' is deprecated. Use the field '%s.metadata.annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)", s.Name)
+			oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in version 2.2.0. Use the field '%s.metadata.annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)", s.Name)
 			for k, v := range s.Annotations {
 				s.Metadata.Annotations[k] = v
 			}

--- a/pkg/model/devrc.go
+++ b/pkg/model/devrc.go
@@ -78,7 +78,7 @@ func ReadRC(bytes []byte) (*DevRC, error) {
 
 func MergeDevWithDevRc(dev *Dev, devRc *DevRC) {
 	if len(devRc.Annotations) > 0 {
-		oktetoLog.Warning("The field 'annotations' is deprecated. Use the field 'metadata.Annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)")
+		oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in version 2.2.0. Use the field 'metadata.Annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)")
 		for annotationKey, annotationValue := range devRc.Annotations {
 			dev.Metadata.Annotations[annotationKey] = annotationValue
 		}
@@ -142,7 +142,7 @@ func MergeDevWithDevRc(dev *Dev, devRc *DevRC) {
 	}
 
 	if len(devRc.Labels) > 0 {
-		oktetoLog.Warning("The field 'labels' is deprecated. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)")
+		oktetoLog.Warning("The field 'labels' is deprecated and will be removed in version 2.2.0. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)")
 		for labelKey, labelValue := range devRc.Labels {
 			dev.Selector[labelKey] = labelValue
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -451,7 +451,7 @@ func Read(bytes []byte) (*Manifest, error) {
 	for _, d := range manifest.Dev {
 		if (d.Image.Context != "" || d.Image.Dockerfile != "") && !hasShownWarning {
 			hasShownWarning = true
-			oktetoLog.Yellow(`The 'image' extended syntax is deprecated. Define the images you want to build in the 'build' section of your manifest. More info at https://www.okteto.com/docs/reference/manifest/#build"`)
+			oktetoLog.Yellow(`The 'image' extended syntax is deprecated and will be removed in version 2.2.0. Define the images you want to build in the 'build' section of your manifest. More info at https://www.okteto.com/docs/reference/manifest/#build"`)
 		}
 	}
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -496,7 +496,7 @@ func (v *Volume) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	parts := strings.SplitN(raw, ":", 2)
 	if len(parts) == 2 {
-		oktetoLog.Yellow("The syntax '%s' is deprecated in the 'volumes' field. Use the field 'sync' instead (%s)", raw, syncFieldDocsURL)
+		oktetoLog.Yellow("The syntax '%s' is deprecated in the 'volumes' field and will be removed in version 2.2.0. Use the field 'sync' instead (%s)", raw, syncFieldDocsURL)
 		v.LocalPath, err = ExpandEnv(parts[0])
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes

Current deprecation messages refer to CLI 1.16 but they should refer to 2.2.0