### PR TITLE
fix manifest init

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -133,9 +133,12 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 	if err != nil {
 		return nil, err
 	}
-	ctxResource, err := utils.LoadManifestContext(m.Filename)
-	if err != nil {
-		return nil, err
+	ctxResource := &model.ContextResource{}
+	if m.Type != model.ChartType && m.Type != model.KubernetesType {
+		ctxResource, err = utils.LoadManifestContext(m.Filename)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if err := ctxResource.UpdateNamespace(opts.Namespace); err != nil {
@@ -218,9 +221,12 @@ func LoadManifestV2WithContext(ctx context.Context, namespace, k8sContext, path 
 			return err
 		}
 	} else {
-		ctxResource, err := utils.LoadManifestContext(manifest.Filename)
-		if err != nil {
-			return err
+		ctxResource := &model.ContextResource{}
+		if manifest.Type != model.ChartType && manifest.Type != model.KubernetesType {
+			ctxResource, err = utils.LoadManifestContext(manifest.Filename)
+			if err != nil {
+				return err
+			}
 		}
 
 		if err := ctxResource.UpdateNamespace(namespace); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -78,6 +78,6 @@ func Init() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Context, "context", "c", "", "context target for generating the okteto manifest")
 	cmd.Flags().StringVarP(&opts.DevPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
 	cmd.Flags().BoolVarP(&opts.Overwrite, "replace", "r", false, "overwrite existing manifest file")
-	cmd.Flags().BoolVarP(&opts.Version1, "v1", "", false, "execute v1")
+	cmd.Flags().BoolVarP(&opts.Version1, "v1", "", false, "create a v1 okteto manifest: www.okteto.com/docs/reference/manifest-v1/")
 	return cmd
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -79,5 +79,7 @@ func Init() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.DevPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
 	cmd.Flags().BoolVarP(&opts.Overwrite, "replace", "r", false, "overwrite existing manifest file")
 	cmd.Flags().BoolVarP(&opts.Version1, "v1", "", false, "create a v1 okteto manifest: www.okteto.com/docs/reference/manifest-v1/")
+	cmd.Flags().BoolVarP(&opts.AutoDeploy, "deploy", "", false, "deploy the application after generate the okteto manifest")
+	cmd.Flags().BoolVarP(&opts.AutoConfigureDev, "configure-devs", "", false, "configure devs after deploying the application")
 	return cmd
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -67,10 +67,8 @@ func Init() *cobra.Command {
 					return err
 				}
 			} else {
-
-				if err := mc.RunInitV2(ctx, opts); err != nil {
-					return err
-				}
+				_, err := mc.RunInitV2(ctx, opts)
+				return err
 			}
 			return nil
 		},

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"os"
+
+	contextCMD "github.com/okteto/okteto/cmd/context"
+	"github.com/okteto/okteto/cmd/manifest"
+	"github.com/okteto/okteto/cmd/utils"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/cobra"
+)
+
+// Init creates okteto manifest
+func Init() *cobra.Command {
+	opts := &manifest.InitOpts{}
+	cmd := &cobra.Command{
+		Use:   "init",
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#init"),
+		Short: "Automatically generate your okteto manifest",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			ctxResource := &model.ContextResource{}
+			if err := ctxResource.UpdateNamespace(opts.Namespace); err != nil {
+				return err
+			}
+
+			if err := ctxResource.UpdateContext(opts.Context); err != nil {
+				return err
+			}
+			ctxOptions := &contextCMD.ContextOptions{
+				Context:   ctxResource.Context,
+				Namespace: ctxResource.Namespace,
+				Show:      true,
+			}
+			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+				return err
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			opts.Workdir = cwd
+			opts.ShowCTA = oktetoLog.IsInteractive()
+			mc := &manifest.ManifestCommand{
+				K8sClientProvider: okteto.NewK8sClientProvider(),
+			}
+			if opts.Version1 {
+				if err := mc.RunInitV1(ctx, opts); err != nil {
+					return err
+				}
+			} else {
+
+				if err := mc.RunInitV2(ctx, opts); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "namespace target for generating the okteto manifest")
+	cmd.Flags().StringVarP(&opts.Context, "context", "c", "", "context target for generating the okteto manifest")
+	cmd.Flags().StringVarP(&opts.DevPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
+	cmd.Flags().BoolVarP(&opts.Overwrite, "replace", "r", false, "overwrite existing manifest file")
+	cmd.Flags().BoolVarP(&opts.Version1, "v1", "", false, "execute v1")
+	return cmd
+}

--- a/cmd/manifest/init-v1.go
+++ b/cmd/manifest/init-v1.go
@@ -85,7 +85,7 @@ func InitV1(opts *InitOpts) error {
 }
 
 // RunInitV1 runs the sequence to generate okteto.yml
-func (mc *ManifestCommand) RunInitV1(ctx context.Context, opts *InitOpts) error {
+func (*ManifestCommand) RunInitV1(ctx context.Context, opts *InitOpts) error {
 	oktetoLog.Println("This command walks you through creating an okteto manifest.")
 	oktetoLog.Println("It only covers the most common items, and tries to guess sensible defaults.")
 	oktetoLog.Println("See https://okteto.com/docs/reference/manifest/ for the official documentation about the okteto manifest.")

--- a/cmd/manifest/init-v1.go
+++ b/cmd/manifest/init-v1.go
@@ -30,6 +30,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/registry"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -104,7 +105,7 @@ func (*ManifestCommand) RunInitV1(ctx context.Context, opts *InitOpts) error {
 		return err
 	}
 
-	dev, err := linguist.GetDevDefaults(opts.Language, opts.Workdir)
+	dev, err := linguist.GetDevDefaults(opts.Language, opts.Workdir, &registry.ImageConfig{})
 	if err != nil {
 		return err
 	}

--- a/cmd/manifest/init-v1_test.go
+++ b/cmd/manifest/init-v1_test.go
@@ -55,6 +55,7 @@ func TestRun(t *testing.T) {
 	opts := &InitOpts{
 		DevPath:  p,
 		Language: "golang",
+		Workdir:  dir,
 	}
 
 	if err := mc.RunInitV1(ctx, opts); err != nil {
@@ -83,6 +84,7 @@ func TestRun(t *testing.T) {
 	opts = &InitOpts{
 		DevPath:   p,
 		Language:  "ruby",
+		Workdir:   dir,
 		Overwrite: true,
 	}
 
@@ -119,6 +121,7 @@ func TestRunJustCreateNecessaryFields(t *testing.T) {
 	opts := &InitOpts{
 		DevPath:  p,
 		Language: "golang",
+		Workdir:  dir,
 	}
 	if err := mc.RunInitV1(ctx, opts); err != nil {
 		t.Fatal(err)

--- a/cmd/manifest/init-v1_test.go
+++ b/cmd/manifest/init-v1_test.go
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package init
+package manifest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,11 +45,19 @@ func TestRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.Background()
 
 	defer os.RemoveAll(dir)
 
 	p := filepath.Join(dir, fmt.Sprintf("okteto-%s", uuid.New().String()))
-	if err := Run(p, "golang", dir, false); err != nil {
+
+	mc := &ManifestCommand{}
+	opts := &InitOpts{
+		DevPath:  p,
+		Language: "golang",
+	}
+
+	if err := mc.RunInitV1(ctx, opts); err != nil {
 		t.Fatal(err)
 	}
 
@@ -71,7 +80,13 @@ func TestRun(t *testing.T) {
 		t.Errorf("got %s, expected %s", dev.Image, "okteto/golang:1")
 	}
 
-	if err := Run(p, "ruby", dir, true); err != nil {
+	opts = &InitOpts{
+		DevPath:   p,
+		Language:  "ruby",
+		Overwrite: true,
+	}
+
+	if err := mc.RunInitV1(ctx, opts); err != nil {
 		t.Fatalf("manifest wasn't overwritten: %s", err)
 	}
 
@@ -95,11 +110,17 @@ func TestRunJustCreateNecessaryFields(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.Background()
 
 	defer os.RemoveAll(dir)
 
+	mc := &ManifestCommand{}
 	p := filepath.Join(dir, fmt.Sprintf("okteto-%s", uuid.New().String()))
-	if err := Run(p, "golang", dir, false); err != nil {
+	opts := &InitOpts{
+		DevPath:  p,
+		Language: "golang",
+	}
+	if err := mc.RunInitV1(ctx, opts); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -287,17 +287,17 @@ func createFromCompose(composePath string) (*model.Manifest, error) {
 		Filename: composePath,
 		IsV2:     true,
 	}
-	manifest, err = manifest.InferFromStack()
+	cwd, err := os.Getwd()
+	if err != nil {
+		oktetoLog.Info("could not detect working directory")
+	}
+	manifest, err = manifest.InferFromStack(cwd)
 	if err != nil {
 		return nil, err
 	}
 	manifest.Context = okteto.Context().Name
 	manifest.Namespace = okteto.Context().Namespace
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get the current working directory: %w", err)
-	}
 	for _, build := range manifest.Build {
 		build.Context, err = filepath.Rel(cwd, build.Context)
 		if err != nil {

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -143,7 +143,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 					return nil, err
 				}
 				if answer {
-					if err := mc.configureDevsByResources(ctx, opts); err != nil {
+					if err := mc.configureDevsByResources(ctx); err != nil {
 						return nil, err
 					}
 				}
@@ -158,7 +158,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 	return manifest, nil
 }
 
-func (mc *ManifestCommand) configureManifestDeployAndBuild(cwd string) (*model.Manifest, error) {
+func (*ManifestCommand) configureManifestDeployAndBuild(cwd string) (*model.Manifest, error) {
 
 	composeFiles := utils.GetStackFiles(cwd)
 	if len(composeFiles) > 0 {
@@ -224,7 +224,7 @@ func (mc *ManifestCommand) deploy(ctx context.Context, opts *InitOpts) error {
 	return nil
 }
 
-func (mc *ManifestCommand) configureDevsByResources(ctx context.Context, opts *InitOpts) error {
+func (mc *ManifestCommand) configureDevsByResources(ctx context.Context) error {
 	c, _, err := okteto.GetK8sClient()
 	if err != nil {
 		return err
@@ -326,6 +326,9 @@ func createFromKubernetes(cwd string) (*model.Manifest, error) {
 		return nil, err
 	}
 	manifest.Dev, err = inferDevsSection(cwd)
+	if err != nil {
+		return nil, err
+	}
 
 	return manifest, nil
 }
@@ -393,7 +396,7 @@ func inferDevsSection(cwd string) (model.ManifestDevs, error) {
 			oktetoLog.Debugf("could not detect any okteto manifest on %s", f.Name())
 			continue
 		}
-		if dev.IsV2 == false && len(dev.Dev) != 0 {
+		if !dev.IsV2 && len(dev.Dev) != 0 {
 			devs[f.Name()] = dev.Dev[f.Name()]
 		}
 	}

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -100,6 +100,7 @@ func Init() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Context, "context", "c", "", "context target for generating the okteto manifest")
 	cmd.Flags().StringVarP(&opts.DevPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
 	cmd.Flags().BoolVarP(&opts.Overwrite, "replace", "r", false, "overwrite existing manifest file")
+	cmd.Flags().BoolVarP(&opts.Version1, "v1", "", false, "create a v1 okteto manifest: www.okteto.com/docs/reference/manifest-v1/")
 	return cmd
 }
 
@@ -148,7 +149,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 					}
 				}
 			}
-			oktetoLog.Success("Okteto manifest (%s) configured correctly", opts.DevPath)
+			oktetoLog.Success("Okteto manifest (%s) configured successfully", opts.DevPath)
 			if !answer {
 				oktetoLog.Information("Run 'okteto init' to continue configuring your dev section")
 			}
@@ -254,7 +255,7 @@ func (mc *ManifestCommand) configureDevsByResources(ctx context.Context) error {
 			return err
 		}
 		spinner.Stop()
-		oktetoLog.Success("Development container '%s' configured correctly", app.ObjectMeta().Name)
+		oktetoLog.Success("Development container '%s' configured successfully", app.ObjectMeta().Name)
 		mc.manifest.Dev[app.ObjectMeta().Name] = dev
 	}
 	return nil

--- a/cmd/manifest/init.go
+++ b/cmd/manifest/init.go
@@ -112,7 +112,7 @@ func (mc *ManifestCommand) Init(ctx context.Context, opts *InitOpts) error {
 			return err
 		}
 		if composePath != "" {
-			answer, err := utils.AskYesNo("creating an okteto manifest is optional if you want to use a compose file. Do you want to continue? ")
+			answer, err := utils.AskYesNo("creating an okteto manifest is optional if you want to use a compose file. Do you want to continue? [y/n] ")
 			if err != nil {
 				return err
 			}

--- a/cmd/manifest/init.go
+++ b/cmd/manifest/init.go
@@ -162,7 +162,7 @@ func (mc *ManifestCommand) Init(ctx context.Context, opts *InitOpts) error {
 					}
 				}
 			}
-			oktetoLog.Success("Okteto manifest configured correctly")
+			oktetoLog.Success("Okteto manifest (%s) configured correctly", opts.DevPath)
 			oktetoLog.Information("Run 'okteto up' to activate your development container")
 		}
 	}

--- a/cmd/manifest/init.go
+++ b/cmd/manifest/init.go
@@ -107,7 +107,7 @@ func (mc *ManifestCommand) Init(ctx context.Context, opts *InitOpts) error {
 
 	var manifest *model.Manifest
 	if len(composeFiles) > 0 {
-		composePath, create, err := selectComposeFile(composeFiles)
+		composePath, err := selectComposeFile(composeFiles)
 		if err != nil {
 			return err
 		}
@@ -123,11 +123,6 @@ func (mc *ManifestCommand) Init(ctx context.Context, opts *InitOpts) error {
 			if err != nil {
 				return err
 			}
-		} else if create {
-			manifest, err = createNewCompose()
-			if err != nil {
-				return err
-			}
 		} else {
 			manifest, err = createFromKubernetes(cwd)
 			if err != nil {
@@ -135,20 +130,9 @@ func (mc *ManifestCommand) Init(ctx context.Context, opts *InitOpts) error {
 			}
 		}
 	} else {
-		selection, err := utils.AskForOptions([]string{"Docker Compose", "Kubernetes Manifest"}, "How do you want to launch your development environment?")
+		manifest, err = createFromKubernetes(cwd)
 		if err != nil {
 			return err
-		}
-		if selection == "Docker Compose" {
-			manifest, err = createNewCompose()
-			if err != nil {
-				return err
-			}
-		} else {
-			manifest, err = createFromKubernetes(cwd)
-			if err != nil {
-				return err
-			}
 		}
 	}
 
@@ -299,12 +283,6 @@ func createFromCompose(composePath string) (*model.Manifest, error) {
 		}
 	}
 	return manifest, err
-}
-
-func createNewCompose() (*model.Manifest, error) {
-	oktetoLog.Information("Docker Compose helps you define a multicontainer application")
-	oktetoLog.Information("Learn how to configure a docker compose file here: https://github.com/compose-spec/compose-spec/blob/master/spec.md")
-	return nil, nil
 }
 
 func createFromKubernetes(cwd string) (*model.Manifest, error) {

--- a/cmd/manifest/init.go
+++ b/cmd/manifest/init.go
@@ -163,6 +163,9 @@ func (mc *ManifestCommand) Init(ctx context.Context, opts *InitOpts) error {
 				}
 			}
 			oktetoLog.Success("Okteto manifest (%s) configured correctly", opts.DevPath)
+			if !answer {
+				oktetoLog.Information("Run 'okteto init' to continue configuring your dev section")
+			}
 			oktetoLog.Information("Run 'okteto up' to activate your development container")
 		}
 	}

--- a/cmd/manifest/selector.go
+++ b/cmd/manifest/selector.go
@@ -24,28 +24,23 @@ import (
 )
 
 const (
-	newComposeOption  = "New compose file"
 	noneComposeOption = "None of the above"
 
 	dockerfileName = "Dockerfile"
 )
 
-func selectComposeFile(paths []string) (string, bool, error) {
+func selectComposeFile(paths []string) (string, error) {
 	if len(paths) == 1 {
-		return paths[0], false, nil
+		return paths[0], nil
 	}
 
-	paths = append(paths, newComposeOption)
 	paths = append(paths, noneComposeOption)
 	selection, err := utils.AskForOptions(paths, "Select the compose to use:")
 	if err != nil || selection == noneComposeOption {
-		return "", false, err
-	}
-	if selection == newComposeOption {
-		return "", true, nil
+		return "", err
 	}
 
-	return selection, false, nil
+	return selection, nil
 }
 
 func selectDockerfiles(cwd string) ([]string, error) {

--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	initCMD "github.com/okteto/okteto/cmd/init"
+	"github.com/okteto/okteto/cmd/manifest"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -149,7 +149,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 		return nil
 	}
 
-	language, err := initCMD.GetLanguage("", folder)
+	language, err := manifest.GetLanguage("", folder)
 	if err != nil {
 		return fmt.Errorf("failed to get language for '%s': %s", folder, err.Error())
 	}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -89,7 +89,7 @@ func Up() *cobra.Command {
 			ctx := context.Background()
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: upOptions.DevPath, Namespace: upOptions.Namespace, K8sContext: upOptions.K8sContext}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
+			oktetoManifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
 			if err != nil {
 				if !strings.Contains(err.Error(), "okteto init") {
 					return err
@@ -98,23 +98,55 @@ func Up() *cobra.Command {
 					return err
 				}
 
-				manifest, err = LoadManifestWithInit(ctx, upOptions.K8sContext, upOptions.Namespace, upOptions.DevPath)
+				oktetoManifest, err = LoadManifestWithInit(ctx, upOptions.K8sContext, upOptions.Namespace, upOptions.DevPath)
 				if err != nil {
 					return err
 				}
 			}
-			if manifest.Name == "" {
-				wd, err := os.Getwd()
-				if err != nil {
-					return err
-				}
-				manifest.Name = utils.InferName(wd)
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			if oktetoManifest.Name == "" {
+				oktetoManifest.Name = utils.InferName(wd)
 			}
 			devName := ""
 			if len(args) == 1 {
 				devName = args[0]
 			}
-			dev, err := utils.GetDevFromManifest(manifest, devName)
+			if len(oktetoManifest.Dev) == 0 {
+				oktetoLog.Warning("okteto manifest has no 'dev' section.")
+				answer, err := utils.AskYesNo("Do you want to configure okteto manifest now? [y/n]")
+				if err != nil {
+					return err
+				}
+				if answer {
+					mc := &manifest.ManifestCommand{
+						K8sClientProvider: okteto.NewK8sClientProvider(),
+					}
+					if upOptions.DevPath == "" {
+						upOptions.DevPath = utils.DefaultManifest
+					}
+					oktetoManifest, err = mc.RunInitV2(ctx, &manifest.InitOpts{
+						DevPath:   upOptions.DevPath,
+						Namespace: upOptions.Namespace,
+						Context:   upOptions.K8sContext,
+						ShowCTA:   false,
+						Workdir:   wd,
+					})
+					if err != nil {
+						return err
+					}
+					if oktetoManifest.Namespace == "" {
+						oktetoManifest.Namespace = okteto.Context().Namespace
+					}
+					if oktetoManifest.Context == "" {
+						oktetoManifest.Context = okteto.Context().Name
+					}
+					oktetoManifest.IsV2 = true
+				}
+			}
+			dev, err := utils.GetDevFromManifest(oktetoManifest, devName)
 			if err != nil {
 				return err
 			}
@@ -158,7 +190,7 @@ func Up() *cobra.Command {
 			}
 
 			up := &upContext{
-				Manifest:       manifest,
+				Manifest:       oktetoManifest,
 				Dev:            dev,
 				Exit:           make(chan error, 1),
 				resetSyncthing: upOptions.Reset,
@@ -243,7 +275,10 @@ func Up() *cobra.Command {
 }
 
 func LoadManifestWithInit(ctx context.Context, k8sContext, namespace, devPath string) (*model.Manifest, error) {
-
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
 	ctxOptions := &contextCMD.ContextOptions{
 		Context:   k8sContext,
 		Namespace: namespace,
@@ -253,13 +288,16 @@ func LoadManifestWithInit(ctx context.Context, k8sContext, namespace, devPath st
 		return nil, err
 	}
 
-	mc := &manifest.ManifestCommand{}
-	if err := mc.RunInitV2(ctx, &manifest.InitOpts{DevPath: devPath, ShowCTA: false}); err != nil {
+	mc := &manifest.ManifestCommand{
+		K8sClientProvider: okteto.NewK8sClientProvider(),
+	}
+	manifest, err := mc.RunInitV2(ctx, &manifest.InitOpts{DevPath: devPath, ShowCTA: false, Workdir: dir})
+	if err != nil {
 		return nil, err
 	}
 
 	oktetoLog.Success(fmt.Sprintf("okteto manifest (%s) created", devPath))
-	return model.GetManifestV2(devPath)
+	return manifest, nil
 }
 
 func loadManifestOverrides(dev *model.Dev, upOptions *UpOptions) error {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -110,7 +110,7 @@ func Up() *cobra.Command {
 			if oktetoManifest.Name == "" {
 				oktetoManifest.Name = utils.InferName(wd)
 			}
-			os.Setenv(model.OktetoNameEnvVar, manifest.Name)
+			os.Setenv(model.OktetoNameEnvVar, oktetoManifest.Name)
 			devName := ""
 			if len(args) == 1 {
 				devName = args[0]
@@ -158,7 +158,7 @@ func Up() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := setBuildEnvVars(manifest, dev.Name); err != nil {
+			if err := setBuildEnvVars(oktetoManifest, dev.Name); err != nil {
 				return err
 			}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -26,7 +26,7 @@ import (
 	"github.com/moby/term"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
-	initCMD "github.com/okteto/okteto/cmd/init"
+	"github.com/okteto/okteto/cmd/manifest"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/cmd/utils/executor"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -243,10 +243,7 @@ func Up() *cobra.Command {
 }
 
 func LoadManifestWithInit(ctx context.Context, k8sContext, namespace, devPath string) (*model.Manifest, error) {
-	workDir, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("unknown current folder: %s", err)
-	}
+
 	ctxOptions := &contextCMD.ContextOptions{
 		Context:   k8sContext,
 		Namespace: namespace,
@@ -256,7 +253,8 @@ func LoadManifestWithInit(ctx context.Context, k8sContext, namespace, devPath st
 		return nil, err
 	}
 
-	if err := initCMD.Run(devPath, "", workDir, false); err != nil {
+	mc := &manifest.ManifestCommand{}
+	if err := mc.RunInitV2(ctx, &manifest.InitOpts{DevPath: devPath, ShowCTA: false}); err != nil {
 		return nil, err
 	}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -127,11 +127,13 @@ func Up() *cobra.Command {
 						upOptions.DevPath = utils.DefaultManifest
 					}
 					oktetoManifest, err = mc.RunInitV2(ctx, &manifest.InitOpts{
-						DevPath:   upOptions.DevPath,
-						Namespace: upOptions.Namespace,
-						Context:   upOptions.K8sContext,
-						ShowCTA:   false,
-						Workdir:   wd,
+						DevPath:          upOptions.DevPath,
+						Namespace:        upOptions.Namespace,
+						Context:          upOptions.K8sContext,
+						ShowCTA:          false,
+						Workdir:          wd,
+						AutoDeploy:       true,
+						AutoConfigureDev: true,
 					})
 					if err != nil {
 						return err
@@ -143,6 +145,11 @@ func Up() *cobra.Command {
 						oktetoManifest.Context = okteto.Context().Name
 					}
 					oktetoManifest.IsV2 = true
+					for _, d := range oktetoManifest.Dev {
+						if err := d.SetDefaults(); err != nil {
+							return err
+						}
+					}
 				}
 			}
 			dev, err := utils.GetDevFromManifest(oktetoManifest, devName)

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -187,8 +187,17 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 	if err != nil {
 		return nil, err
 	}
+	dev := manifest.Dev[devKey]
 
-	if err := manifest.Dev[devKey].Validate(); err != nil {
+	dev.Name = devKey
+	if dev.Namespace == "" {
+		dev.Namespace = manifest.Namespace
+	}
+
+	if dev.Context == "" {
+		dev.Context = manifest.Context
+	}
+	if err := dev.Validate(); err != nil {
 		return nil, err
 	}
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
 	"github.com/okteto/okteto/cmd/destroy"
-	initCMD "github.com/okteto/okteto/cmd/init"
 	"github.com/okteto/okteto/cmd/manifest"
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/pipeline"
@@ -113,7 +112,7 @@ func main() {
 	root.AddCommand(manifest.Manifest(ctx))
 
 	root.AddCommand(namespace.Namespace(ctx))
-	root.AddCommand(initCMD.Init())
+	root.AddCommand(cmd.Init())
 	root.AddCommand(up.Up())
 	root.AddCommand(cmd.Down())
 	root.AddCommand(cmd.Status())

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -50,7 +50,7 @@ func Get(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Int
 
 //IsDevModeOn returns if a statefulset is in devmode
 func IsDevModeOn(app App) bool {
-	return app.ObjectMeta().Labels[model.DevLabel] == "true"
+	return app.ObjectMeta().Labels[model.DevLabel] == "true" || len(app.ObjectMeta().Labels[model.DevLabel]) > 0
 }
 
 //SetLastBuiltAnnotation sets the app timestamp

--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/registry"
 	apiv1 "k8s.io/api/core/v1"
 )
 
@@ -299,10 +300,13 @@ func GetSupportedLanguages() []string {
 }
 
 // GetDevDefaults gets default values for the specified language
-func GetDevDefaults(language, workdir string) (*model.Dev, error) {
+func GetDevDefaults(language, workdir string, imageConfig *registry.ImageConfig) (*model.Dev, error) {
 	language = NormalizeLanguage(language)
 	vals := languageDefaults[language]
 
+	if imageConfig.Workdir == "" {
+		imageConfig.Workdir = vals.path
+	}
 	dev := &model.Dev{
 		Image: &model.BuildInfo{
 			Name: vals.image,
@@ -316,8 +320,8 @@ func GetDevDefaults(language, workdir string) (*model.Dev, error) {
 			RescanInterval: model.DefaultSyncthingRescanInterval,
 			Folders: []model.SyncFolder{
 				{
-					LocalPath:  ".",
-					RemotePath: vals.path,
+					LocalPath:  workdir,
+					RemotePath: imageConfig.Workdir,
 				},
 			},
 		},

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -636,6 +636,10 @@ func (dev *Dev) Validate() error {
 		return fmt.Errorf("Name cannot be empty")
 	}
 
+	if dev.Image == nil {
+		dev.Image = &BuildInfo{}
+	}
+
 	if ValidKubeNameRegex.MatchString(dev.Name) {
 		return errBadName
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -48,7 +48,7 @@ var (
 
 // Dev represents a development container
 type Dev struct {
-	Name                 string             `json:"name" yaml:"name"`
+	Name                 string             `json:"name,omitempty" yaml:"name,omitempty"`
 	Username             string             `json:"-" yaml:"-"`
 	RegistryURL          string             `json:"-" yaml:"-"`
 	Selector             Selector           `json:"selector,omitempty" yaml:"selector,omitempty"`

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -588,6 +588,10 @@ type Dependency struct {
 
 // InferFromStack infers data from a stackfile
 func (m *Manifest) InferFromStack() (*Manifest, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		oktetoLog.Info("could not detect working directory")
+	}
 	for svcName, svcInfo := range m.Deploy.Compose.Stack.Services {
 		d := NewDev()
 		for _, p := range svcInfo.Ports {
@@ -623,6 +627,14 @@ func (m *Manifest) InferFromStack() (*Manifest, error) {
 			buildInfo.Image = svcInfo.Image
 		}
 		buildInfo.VolumesToInclude = toMount
+		buildInfo.Context, err = filepath.Rel(cwd, buildInfo.Context)
+		if err != nil {
+			return nil, err
+		}
+		buildInfo.Dockerfile, err = filepath.Rel(cwd, buildInfo.Dockerfile)
+		if err != nil {
+			return nil, err
+		}
 		if _, ok := m.Build[svcName]; !ok {
 			m.Build[svcName] = buildInfo
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -652,6 +652,9 @@ func (m *Manifest) WriteToFile(filePath string) error {
 			}
 		}
 	}
+	for _, b := range m.Build {
+		b.Name = ""
+	}
 	for dName, d := range m.Dev {
 		d.Name = ""
 		if d.Image != nil && d.Image.Name != "" {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -57,8 +57,7 @@ const (
 	devHeadComment          = "The dev section defines how to activate a development container\nMore info: https://www.okteto.com/docs/reference/manifest/#dev"
 	dependenciesHeadComment = "The dependencies section defines other git repositories to be deployed as part of your development environment\nMore info: https://www.okteto.com/docs/reference/manifest/#dependencies"
 	dependenciesExample     = `dependencies:
-  - https://github.com/okteto/b
-  - frontend/okteto.yml`
+  - https://github.com/okteto/b`
 
 	// FakeCommand prints into terminal a fake command
 	FakeCommand = "echo 'Replace this line with the proper 'helm' or 'kubectl' commands to deploy your development environment'"

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -418,7 +418,7 @@ func getChartPath(cwd string) string {
 	for _, name := range chartsSubPath {
 		path := filepath.Join(cwd, name, "Chart.yaml")
 		if FileExists(path) {
-			return path
+			return filepath.Dir(path)
 		}
 	}
 	return ""

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -596,7 +596,8 @@ func (m *Manifest) InferFromStack() (*Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
-		if _, ok := m.Dev[svcName]; !ok {
+
+		if _, ok := m.Dev[svcName]; !ok && len(d.Sync.Folders) > 0 {
 			m.Dev[svcName] = d
 		}
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -56,22 +56,19 @@ const (
 	deployHeadComment = "The deploy section defines how to deploy your development environment\nMore info: https://www.okteto.com/docs/reference/manifest/#deploy"
 	devHeadComment    = "The dev section defines how to activate a development container\nMore info: https://www.okteto.com/docs/reference/manifest/#dev"
 	devExample        = `dev:
-  selector:
-    app.kubernetes.io/part-of: test
-  image: python:3
-  command: ["python", "app.py"]
-  workdir: /usr/src/app
-  sync:
-   - .:/usr/src/app
-  environment:
-    - name=$USER
-  forward:
-    - 8080:80
-  reverse:
-    - 9000:9001`
+  sample:
+    image: okteto/dev:latest
+    command: bash
+    workdir: /usr/src/app
+    sync:
+      - .:/usr/src/app
+    environment:
+      - name=$USER
+    forward:
+      - 8080:80`
 	dependenciesHeadComment = "The dependencies section defines other git repositories to be deployed as part of your development environment\nMore info: https://www.okteto.com/docs/reference/manifest/#dependencies"
 	dependenciesExample     = `dependencies:
-  - https://github.com/okteto/b`
+  - https://github.com/okteto/sample`
 
 	// FakeCommand prints into terminal a fake command
 	FakeCommand = "echo 'Replace this line with the proper 'helm' or 'kubectl' commands to deploy your development environment'"

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -634,6 +634,7 @@ func (m *Manifest) WriteToFile(filePath string) error {
 		}
 	}
 	for _, d := range m.Dev {
+		d.Name = ""
 		if d.Image.Name != "" {
 			d.Image.Context = ""
 			d.Image.Dockerfile = ""

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -292,6 +292,10 @@ func GetInferredManifest(cwd string) (*Manifest, error) {
 
 	if stackPath := getFilePath(cwd, stackFiles); stackPath != "" {
 		oktetoLog.Infof("Found okteto compose")
+		stackPath, err := filepath.Rel(cwd, stackPath)
+		if err != nil {
+			return nil, err
+		}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Found okteto compose manifest on %s", stackPath)
 		stackManifest := &Manifest{
 			Type: StackType,
@@ -320,6 +324,10 @@ func GetInferredManifest(cwd string) (*Manifest, error) {
 
 	if chartPath := getChartPath(cwd); chartPath != "" {
 		oktetoLog.Infof("Found chart")
+		chartPath, err := filepath.Rel(cwd, chartPath)
+		if err != nil {
+			return nil, err
+		}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Found helm chart on %s", chartPath)
 		chartManifest := &Manifest{
 			Type: ChartType,
@@ -340,6 +348,10 @@ func GetInferredManifest(cwd string) (*Manifest, error) {
 	}
 	if manifestPath := getManifestsPath(cwd); manifestPath != "" {
 		oktetoLog.Infof("Found kubernetes manifests")
+		manifestPath, err := filepath.Rel(cwd, manifestPath)
+		if err != nil {
+			return nil, err
+		}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Found kubernetes manifest on %s", manifestPath)
 		k8sManifest := &Manifest{
 			Type: KubernetesType,

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -652,16 +652,21 @@ func (m *Manifest) WriteToFile(filePath string) error {
 			}
 		}
 	}
-	for _, d := range m.Dev {
+	for dName, d := range m.Dev {
 		d.Name = ""
-		if d.Image.Name != "" {
+		if d.Image != nil && d.Image.Name != "" {
 			d.Image.Context = ""
 			d.Image.Dockerfile = ""
 		} else {
-			d.Image = nil
+			if v, ok := m.Build[dName]; ok {
+				d.Image = &BuildInfo{Name: v.Image}
+			} else {
+				d.Image = nil
+			}
+
 		}
 
-		if d.Push.Name != "" {
+		if d.Push != nil && d.Push.Name != "" {
 			d.Push.Context = ""
 			d.Push.Dockerfile = ""
 		} else {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -668,8 +668,6 @@ func (m *Manifest) WriteToFile(filePath string) error {
 			d.Push = nil
 		}
 	}
-	m.Context = ""
-	m.Namespace = ""
 	//Unmarshal with yamlv2 because we have the marshal with yaml v2
 	b, err := yaml.Marshal(m)
 	if err != nil {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -247,7 +247,7 @@ func TestInferFromStack(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := tt.currentManifest.InferFromStack()
+			result, err := tt.currentManifest.InferFromStack("")
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedManifest, result)
 		})

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -129,67 +129,7 @@ func TestInferFromStack(t *testing.T) {
 						VolumesToInclude: []StackVolume{},
 					},
 				},
-				Dev: ManifestDevs{
-					"test": &Dev{
-						Name: "test",
-						Metadata: &Metadata{
-							Labels:      Labels{},
-							Annotations: Annotations{},
-						},
-						Selector: Selector{},
-						Forward: []Forward{
-							{
-								Local:  8080,
-								Remote: 8080,
-							},
-						},
-						EmptyImage: true,
-						Image: &BuildInfo{
-							Context:    ".",
-							Dockerfile: "Dockerfile",
-						},
-						Push: &BuildInfo{
-							Context:    ".",
-							Dockerfile: "Dockerfile",
-						},
-						ImagePullPolicy: apiv1.PullAlways,
-						Probes:          &Probes{},
-						Lifecycle:       &Lifecycle{},
-						Workdir:         "/okteto",
-						SecurityContext: &SecurityContext{
-							RunAsUser:  pointer.Int64(0),
-							RunAsGroup: pointer.Int64(0),
-							FSGroup:    pointer.Int64(0),
-						},
-						SSHServerPort: 2222,
-						Volumes:       []Volume{},
-						Timeout: Timeout{
-							Default:   60 * time.Second,
-							Resources: 120 * time.Second,
-						},
-						InitContainer: InitContainer{
-							Image: OktetoBinImageTag,
-						},
-						PersistentVolumeInfo: &PersistentVolumeInfo{
-							Enabled: true,
-						},
-						Secrets: []Secret{},
-						Command: Command{
-							Values: []string{"sh"},
-						},
-						Interface: devInterface,
-						Services:  []*Dev{},
-						Sync: Sync{
-							RescanInterval: 300,
-							Folders: []SyncFolder{
-								{
-									LocalPath:  ".",
-									RemotePath: "/okteto",
-								},
-							},
-						},
-					},
-				},
+				Dev: ManifestDevs{},
 				Deploy: &DeployInfo{
 					Compose: &ComposeInfo{
 						Stack: stack,
@@ -220,67 +160,7 @@ func TestInferFromStack(t *testing.T) {
 						Dockerfile: "test-1/Dockerfile",
 					},
 				},
-				Dev: ManifestDevs{
-					"test": &Dev{
-						Name: "test",
-						Metadata: &Metadata{
-							Labels:      Labels{},
-							Annotations: Annotations{},
-						},
-						Selector: Selector{},
-						Forward: []Forward{
-							{
-								Local:  8080,
-								Remote: 8080,
-							},
-						},
-						EmptyImage: true,
-						Image: &BuildInfo{
-							Context:    ".",
-							Dockerfile: "Dockerfile",
-						},
-						Push: &BuildInfo{
-							Context:    ".",
-							Dockerfile: "Dockerfile",
-						},
-						ImagePullPolicy: apiv1.PullAlways,
-						Probes:          &Probes{},
-						Lifecycle:       &Lifecycle{},
-						Workdir:         "/okteto",
-						SecurityContext: &SecurityContext{
-							RunAsUser:  pointer.Int64(0),
-							RunAsGroup: pointer.Int64(0),
-							FSGroup:    pointer.Int64(0),
-						},
-						SSHServerPort: 2222,
-						Volumes:       []Volume{},
-						Timeout: Timeout{
-							Default:   60 * time.Second,
-							Resources: 120 * time.Second,
-						},
-						InitContainer: InitContainer{
-							Image: OktetoBinImageTag,
-						},
-						PersistentVolumeInfo: &PersistentVolumeInfo{
-							Enabled: true,
-						},
-						Secrets: []Secret{},
-						Command: Command{
-							Values: []string{"sh"},
-						},
-						Interface: devInterface,
-						Services:  []*Dev{},
-						Sync: Sync{
-							RescanInterval: 300,
-							Folders: []SyncFolder{
-								{
-									LocalPath:  ".",
-									RemotePath: "/okteto",
-								},
-							},
-						},
-					},
-				},
+				Dev: ManifestDevs{},
 				Deploy: &DeployInfo{
 					Compose: &ComposeInfo{
 						Stack: stack,

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -882,6 +882,16 @@ func (c *ComposeInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (c *ComposeInfo) MarshalYAML() (interface{}, error) {
+	if len(c.Manifest) == 1 {
+		return c.Manifest[0], nil
+	} else if len(c.Manifest) > 1 {
+		return c.Manifest, nil
+	}
+	return c, nil
+}
+
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
 func (m *ManifestList) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var rawString string


### PR DESCRIPTION
Fixes Manifest init

## Proposed changes
- Fixes all the bugs with okteto init
- Create flag v1 for retrocompatibility
- Show docker compose option if there is at least one compose file
- Show manifest path when created
- Show a hint to run okteto init to continue configuring the manifest
- Fix indentation (4-> 2)
- Save with relative paths
- Add a commented dev section
- Marhsal compose on simple notation
- Only set dev env when there is a volume mount
- Call to okteto init on okteto up if no manifest 
