### PR TITLE
fix: command name displayed incorrectly

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -231,8 +231,7 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
 		for _, command := range manifest.Destroy {
 			oktetoLog.Information("Running %s", command.Name)
 			if err := dc.executor.Execute(command, opts.Variables); err != nil {
-				oktetoLog.SetStage(command.Name)
-				oktetoLog.Fail("error executing command '%s': %s", command, err.Error())
+				oktetoLog.Fail("error executing command '%s': %s", command.Name, err.Error())
 				if !opts.ForceDestroy {
 					if err := setErrorStatus(ctx, cfg, data, err, c); err != nil {
 						exit <- err


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2363

## Proposed changes
- Display command name instead of command struct
-
