### PR TITLE
fix: up expand variables from build section into dev

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -500,7 +500,7 @@ func checkImageAtGlobalAndSetEnvs(service string, options build.BuildOptions) (b
 		return false, err
 	}
 
-	if err := setManifestEnvVars(service, imageWithDigest); err != nil {
+	if err := SetManifestEnvVars(service, imageWithDigest); err != nil {
 		return false, err
 	}
 	oktetoLog.Debug("image already built at global registry, running optimization for deployment")
@@ -542,7 +542,7 @@ func runBuildAndSetEnvs(ctx context.Context, service string, manifest *model.Man
 		}
 	}
 	oktetoLog.Success("Image for service '%s' pushed to registry: %s", service, options.Tag)
-	if err := setManifestEnvVars(service, imageWithDigest); err != nil {
+	if err := SetManifestEnvVars(service, imageWithDigest); err != nil {
 		return err
 	}
 	if manifest.Deploy != nil && manifest.Deploy.Compose != nil && manifest.Deploy.Compose.Stack != nil {
@@ -555,7 +555,8 @@ func runBuildAndSetEnvs(ctx context.Context, service string, manifest *model.Man
 	return nil
 }
 
-func setManifestEnvVars(service, reference string) error {
+// SetManifestEnvVars set okteto build env vars
+func SetManifestEnvVars(service, reference string) error {
 	reg, repo, tag, image := registry.GetReferecenceEnvs(reference)
 
 	oktetoLog.Debugf("envs registry=%s repository=%s image=%s tag=%s", reg, repo, image, tag)
@@ -821,7 +822,7 @@ func checkServicesToBuild(service string, manifest *model.Manifest, ch chan stri
 	}
 	oktetoLog.Debug("Skipping build for image for service")
 
-	if err := setManifestEnvVars(service, imageWithDigest); err != nil {
+	if err := SetManifestEnvVars(service, imageWithDigest); err != nil {
 		return err
 	}
 	if manifest.Deploy != nil && manifest.Deploy.Compose != nil && manifest.Deploy.Compose.Stack != nil {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -415,7 +415,7 @@ func getFakeManifest(_ string) (*model.Manifest, error) {
 	return fakeManifest, nil
 }
 
-func Test_setManifestEnvVars(t *testing.T) {
+func Test_SetManifestEnvVars(t *testing.T) {
 	tests := []struct {
 		name          string
 		service       string
@@ -464,7 +464,7 @@ func Test_setManifestEnvVars(t *testing.T) {
 				}
 			}
 
-			setManifestEnvVars(tt.service, tt.reference)
+			SetManifestEnvVars(tt.service, tt.reference)
 
 			registryEnvValue := os.Getenv(registryEnv)
 			imageEnvValue := os.Getenv(imageEnv)

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -329,7 +329,7 @@ func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.
 }
 
 func getExpandedName(name string) string {
-	expandedName, err := model.ExpandEnv(name)
+	expandedName, err := model.ExpandEnv(name, true)
 	if err != nil {
 		return name
 	}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -29,6 +29,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/cmd/utils/executor"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/cmd/build"
 	buildCMD "github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/config"
@@ -109,12 +110,16 @@ func Up() *cobra.Command {
 				}
 				manifest.Name = utils.InferName(wd)
 			}
+			os.Setenv(model.OktetoNameEnvVar, manifest.Name)
 			devName := ""
 			if len(args) == 1 {
 				devName = args[0]
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
+				return err
+			}
+			if err := setBuildEnvVars(manifest, dev.Name); err != nil {
 				return err
 			}
 
@@ -616,4 +621,28 @@ func printDisplayContext(dev *model.Dev, divertURL string) {
 		oktetoLog.Println(fmt.Sprintf("    %s       %s", oktetoLog.BlueString("URL:"), divertURL))
 	}
 	oktetoLog.Println()
+}
+
+func setBuildEnvVars(m *model.Manifest, devName string) error {
+	sp := utils.NewSpinner("Loading build env vars...")
+	sp.Start()
+	defer sp.Stop()
+
+	for buildName, buildInfo := range m.Build {
+		opts := build.OptsFromManifest(buildName, buildInfo, build.BuildOptions{})
+		imageWithDigest, err := registry.GetImageTagWithDigest(opts.Tag)
+		if err == oktetoErrors.ErrNotFound {
+			os.Setenv(fmt.Sprintf("OKTETO_BUILD_%s_IMAGE", strings.ToUpper(buildName)), opts.Tag)
+		} else if err != nil {
+			return fmt.Errorf("error checking image at registry %s: %v", opts.Tag, err)
+		} else {
+			if err := deploy.SetManifestEnvVars(devName, imageWithDigest); err != nil {
+				return err
+			}
+		}
+	}
+
+	var err error
+	m.Dev[devName].Image.Name, err = model.ExpandEnv(m.Dev[devName].Image.Name)
+	return err
 }

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -643,6 +643,6 @@ func setBuildEnvVars(m *model.Manifest, devName string) error {
 	}
 
 	var err error
-	m.Dev[devName].Image.Name, err = model.ExpandEnv(m.Dev[devName].Image.Name)
+	m.Dev[devName].Image.Name, err = model.ExpandEnv(m.Dev[devName].Image.Name, false)
 	return err
 }

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -183,12 +183,11 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 			Enable: true,
 		})
 	}
-	// devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
-	// if err != nil {
-	// 	return nil, err
-	// }
+	devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
+	if err != nil {
+		return nil, err
+	}
 
-	devKey := "frontend"
 	if err := manifest.Dev[devKey].Validate(); err != nil {
 		return nil, err
 	}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -183,11 +183,12 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 			Enable: true,
 		})
 	}
-	devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
-	if err != nil {
-		return nil, err
-	}
+	// devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
+	// if err != nil {
+	// 	return nil, err
+	// }
 
+	devKey := "frontend"
 	if err := manifest.Dev[devKey].Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -88,7 +88,7 @@ func translateStackEnvVars(ctx context.Context, s *model.Stack) error {
 
 func translateServiceEnvFile(ctx context.Context, svc *model.Service, svcName, filename string) error {
 	var err error
-	filename, err = model.ExpandEnv(filename)
+	filename, err = model.ExpandEnv(filename, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -381,7 +381,7 @@ func (dev *Dev) expandEnvVars() error {
 func (dev *Dev) loadName() error {
 	var err error
 	if len(dev.Name) > 0 {
-		dev.Name, err = ExpandEnv(dev.Name)
+		dev.Name, err = ExpandEnv(dev.Name, true)
 		if err != nil {
 			return err
 		}
@@ -392,7 +392,7 @@ func (dev *Dev) loadName() error {
 func (dev *Dev) loadNamespace() error {
 	var err error
 	if len(dev.Namespace) > 0 {
-		dev.Namespace, err = ExpandEnv(dev.Namespace)
+		dev.Namespace, err = ExpandEnv(dev.Namespace, true)
 		if err != nil {
 			return err
 		}
@@ -403,7 +403,7 @@ func (dev *Dev) loadNamespace() error {
 func (dev *Dev) loadContext() error {
 	var err error
 	if len(dev.Context) > 0 {
-		dev.Context, err = ExpandEnv(dev.Context)
+		dev.Context, err = ExpandEnv(dev.Context, true)
 		if err != nil {
 			return err
 		}
@@ -414,7 +414,7 @@ func (dev *Dev) loadContext() error {
 func (dev *Dev) loadSelector() error {
 	var err error
 	for i := range dev.Selector {
-		dev.Selector[i], err = ExpandEnv(dev.Selector[i])
+		dev.Selector[i], err = ExpandEnv(dev.Selector[i], true)
 		if err != nil {
 			return err
 		}
@@ -428,7 +428,7 @@ func (dev *Dev) loadImage() error {
 		dev.Image = &BuildInfo{}
 	}
 	if len(dev.Image.Name) > 0 {
-		dev.Image.Name, err = ExpandEnv(dev.Image.Name)
+		dev.Image.Name, err = ExpandEnv(dev.Image.Name, false)
 		if err != nil {
 			return err
 		}
@@ -600,7 +600,7 @@ func (dev *Dev) setTimeout() error {
 
 func (dev *Dev) expandEnvFiles() error {
 	for _, envFile := range dev.EnvFiles {
-		filename, err := ExpandEnv(envFile)
+		filename, err := ExpandEnv(envFile, true)
 		if err != nil {
 			return err
 		}
@@ -1137,12 +1137,12 @@ func (s *Secret) GetFileName() string {
 }
 
 //ExpandEnv expands the environments supporting the notation "${var:-$DEFAULT}"
-func ExpandEnv(value string) (string, error) {
+func ExpandEnv(value string, expandIfEmpty bool) (string, error) {
 	result, err := envsubst.String(value)
 	if err != nil {
 		return "", fmt.Errorf("error expanding environment on '%s': %s", value, err.Error())
 	}
-	if result == "" {
+	if result == "" && !expandIfEmpty {
 		return value, nil
 	}
 	return result, nil

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1142,6 +1142,9 @@ func ExpandEnv(value string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error expanding environment on '%s': %s", value, err.Error())
 	}
+	if result == "" {
+		return value, nil
+	}
 	return result, nil
 }
 

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1078,7 +1078,7 @@ func Test_ExpandEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := ExpandEnv(tt.value)
+			result, err := ExpandEnv(tt.value, true)
 			if err != nil {
 				t.Errorf("error in test '%s': %s", tt.name, err.Error())
 			}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -159,7 +159,7 @@ func NewManifest() *Manifest {
 // NewManifestFromDev creates a manifest from a dev
 func NewManifestFromDev(dev *Dev) *Manifest {
 	manifest := NewManifest()
-	name, err := ExpandEnv(dev.Name)
+	name, err := ExpandEnv(dev.Name, true)
 	if err != nil {
 		oktetoLog.Infof("could not expand dev name '%s'", dev.Name)
 		name = dev.Name
@@ -519,7 +519,7 @@ func (m *Manifest) ExpandEnvVars() (*Manifest, error) {
 	var err error
 	if m.Deploy != nil {
 		for idx, cmd := range m.Deploy.Commands {
-			cmd.Command, err = ExpandEnv(cmd.Command)
+			cmd.Command, err = ExpandEnv(cmd.Command, true)
 			if err != nil {
 				return nil, errors.New("could not parse env vars")
 			}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -149,14 +149,14 @@ func (e *EnvVar) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	parts := strings.SplitN(raw, "=", 2)
 	e.Name = parts[0]
 	if len(parts) == 2 {
-		e.Value, err = ExpandEnv(parts[1])
+		e.Value, err = ExpandEnv(parts[1], true)
 		if err != nil {
 			return err
 		}
 		return nil
 	}
 
-	e.Name, err = ExpandEnv(parts[0])
+	e.Name, err = ExpandEnv(parts[0], true)
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	rawExpanded, err := ExpandEnv(raw)
+	rawExpanded, err := ExpandEnv(raw, true)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (v *Volume) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	parts := strings.SplitN(raw, ":", 2)
 	if len(parts) == 2 {
 		oktetoLog.Yellow("The syntax '%s' is deprecated in the 'volumes' field and will be removed in version 2.2.0. Use the field 'sync' instead (%s)", raw, syncFieldDocsURL)
-		v.LocalPath, err = ExpandEnv(parts[0])
+		v.LocalPath, err = ExpandEnv(parts[0], true)
 		if err != nil {
 			return err
 		}
@@ -523,22 +523,22 @@ func (s *SyncFolder) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	parts := strings.Split(raw, ":")
 	if len(parts) == 2 {
-		s.LocalPath, err = ExpandEnv(parts[0])
+		s.LocalPath, err = ExpandEnv(parts[0], true)
 		if err != nil {
 			return err
 		}
-		s.RemotePath, err = ExpandEnv(parts[1])
+		s.RemotePath, err = ExpandEnv(parts[1], true)
 		if err != nil {
 			return err
 		}
 		return nil
 	} else if len(parts) == 3 {
 		windowsPath := fmt.Sprintf("%s:%s", parts[0], parts[1])
-		s.LocalPath, err = ExpandEnv(windowsPath)
+		s.LocalPath, err = ExpandEnv(windowsPath, true)
 		if err != nil {
 			return err
 		}
-		s.RemotePath, err = ExpandEnv(parts[2])
+		s.RemotePath, err = ExpandEnv(parts[2], true)
 		if err != nil {
 			return err
 		}
@@ -1111,7 +1111,7 @@ func getKeyValue(unmarshal func(interface{}) error) (map[string]string, error) {
 		return nil, err
 	}
 	for key, value := range rawMap {
-		value, err = ExpandEnv(value)
+		value, err = ExpandEnv(value, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -214,7 +214,7 @@ func GetStack(name, stackPath string, isCompose bool) (*Stack, error) {
 		return nil, err
 	}
 
-	expandedManifest, err := ExpandEnv(string(b))
+	expandedManifest, err := ExpandEnv(string(b), true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Up was not able to get expanded env vars

## Proposed changes
- Check if image is already built and set env var, then expand env var
-
