### PR TITLE
fix: update not existing image error message

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -16,6 +16,7 @@ package up
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -85,6 +86,12 @@ func (up *upContext) activate() error {
 
 	if _, err := registry.GetImageTagWithDigest(up.Dev.Image.Name); err == oktetoErrors.ErrNotFound {
 		oktetoLog.Infof("image '%s' not found, building it: %s", up.Dev.Image.Name, err.Error())
+		if _, err := os.Stat(up.Dev.Image.Dockerfile); err != nil {
+			return oktetoErrors.UserError{
+				E:    fmt.Errorf("The image '%s' doesn't exist and can't be build", up.Dev.Image.Name),
+				Hint: "Please update your build section and try again",
+			}
+		}
 		up.Options.Build = true
 	}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -218,6 +218,8 @@ func Up() *cobra.Command {
 					err = fmt.Errorf("%w\n    Find additional logs at: %s/okteto.log", err, config.GetAppHome(dev.Namespace, dev.Name))
 				case oktetoErrors.CommandError:
 					oktetoLog.Infof("CommandError: %v", err)
+				case oktetoErrors.UserError:
+					return err
 				}
 
 			}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2366

## Proposed changes
- Update message if the image can not be built with the information given in build section
<img width="753" alt="Captura de pantalla 2022-03-16 a las 18 16 48" src="https://user-images.githubusercontent.com/25170843/158649174-6a7f598d-71e9-45ba-9c53-7b79008ef668.png">

