### PR TITLE
fix: ignore image if build exists and is okteto registry

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -124,18 +124,19 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 		if svcInfo.Build == nil && len(svcInfo.VolumeMounts) == 0 {
 			continue
 		}
-		if !okteto.IsOkteto() && svcInfo.Image == "" {
+		buildInfo := svcInfo.Build
+		if !okteto.IsOkteto() && buildInfo.Image == "" {
 			return fmt.Errorf("'build' and 'image' fields of service '%s' cannot be empty", svcName)
 		}
 
+		if okteto.IsOkteto() && !registry.IsOktetoRegistry(buildInfo.Image) {
+			buildInfo.Image = fmt.Sprintf("okteto.dev/%s-%s:okteto", s.Name, svcName)
+		}
 		if !options.ForceBuild {
-			buildInfo := svcInfo.Build
 			if buildInfo != nil {
 				opts := build.OptsFromManifest(svcName, buildInfo, build.BuildOptions{})
 				if _, err := registry.GetImageTagWithDigest(opts.Tag); err != oktetoErrors.ErrNotFound {
-					if svcInfo.Image == "" {
-						svcInfo.Image = opts.Tag
-					}
+					svcInfo.Image = opts.Tag
 					continue
 				}
 				oktetoLog.Infof("image '%s' not found, building it", opts.Tag)
@@ -153,7 +154,6 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 			}
 		}
 
-		buildInfo := svcInfo.Build
 		volumesToInclude := svcInfo.VolumeMounts
 		var options build.BuildOptions
 		if buildInfo != nil {

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -128,13 +128,13 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 		if !okteto.IsOkteto() && buildInfo.Image == "" {
 			return fmt.Errorf("'build' and 'image' fields of service '%s' cannot be empty", svcName)
 		}
+		opts := build.OptsFromManifest(svcName, buildInfo, build.BuildOptions{})
 
 		if okteto.IsOkteto() && !registry.IsOktetoRegistry(buildInfo.Image) {
-			buildInfo.Image = fmt.Sprintf("okteto.dev/%s-%s:okteto", s.Name, svcName)
+			buildInfo.Image = opts.Tag
 		}
 		if !options.ForceBuild {
 			if buildInfo != nil {
-				opts := build.OptsFromManifest(svcName, buildInfo, build.BuildOptions{})
 				if _, err := registry.GetImageTagWithDigest(opts.Tag); err != oktetoErrors.ErrNotFound {
 					svcInfo.Image = opts.Tag
 					continue


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2359

This was a regression because of the changes that we needed to introduce to have the build working with stack 
## Proposed changes
- Add the if statement missing
