### PR TITLE
Don't bypass "not-found-error" when destroying preview environment

### DIFF
--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -227,9 +227,6 @@ func (c *OktetoClient) DestroyPreview(ctx context.Context, name string) error {
 	}
 
 	err := mutate(ctx, &mutation, variables, c.client)
-	if oktetoErrors.IsNotFound(err) {
-		return nil
-	}
 	return err
 }
 


### PR DESCRIPTION
Fixes #
Helps with [Issue 2343](https://github.com/okteto/okteto/issues/2343)
More explicit error to the user when destroying preview environments

## Proposed changes

- Send the error through the error chain
