### PR TITLE
fix: set proxy name label after start

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -258,8 +258,16 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		} else {
 			deployOptions.Name = utils.InferName(cwd)
 		}
-		dc.Proxy.SetName(deployOptions.Name)
+
+	} else {
+		if deployOptions.Manifest != nil {
+			deployOptions.Manifest.Name = deployOptions.Name
+		}
+		if deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.Compose != nil && deployOptions.Manifest.Deploy.Compose.Stack != nil {
+			deployOptions.Manifest.Deploy.Compose.Stack.Name = deployOptions.Name
+		}
 	}
+	dc.Proxy.SetName(deployOptions.Name)
 	oktetoLog.SetStage("")
 
 	dc.PipelineType = deployOptions.Manifest.Type

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -84,6 +84,8 @@ func (fk *fakeProxy) Start() {
 	fk.started = true
 }
 
+func (fk *fakeProxy) SetName(_ string) {}
+
 func (fk *fakeProxy) Shutdown(_ context.Context) error {
 	if fk.errOnShutdown != nil {
 		return fk.errOnShutdown

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -245,11 +245,12 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 			if err != nil {
 				return nil, err
 			}
-
 			if devManifest != nil && devManifest.Deploy != nil && devManifest.Deploy.Endpoints != nil {
 				inferredManifest.Deploy.Compose.Stack.Endpoints = devManifest.Deploy.Endpoints
 			}
-
+			if inferredManifest.Deploy.Compose.Stack.Name != "" {
+				inferredManifest.Name = inferredManifest.Deploy.Compose.Stack.Name
+			}
 		}
 		if devManifest != nil {
 			inferredManifest.mergeWithOktetoManifest(devManifest)
@@ -297,6 +298,9 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 			return nil, err
 		}
 		stackManifest.Deploy.Compose.Stack = s
+		if stackManifest.Deploy.Compose.Stack.Name != "" {
+			stackManifest.Name = stackManifest.Deploy.Compose.Stack.Name
+		}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Okteto compose unmarshalled successfully")
 		return stackManifest, nil
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes an error occurring if the name of the stack was different to the name of the folder/repo

## Proposed changes
- Start the proxy and then check the name of the label (It can be different to the one used by the user)
- Set the compose/manifest v2 according to the inferred name/options.Name/manifest.name 
