### PR TITLE
add json/yaml outputs for okteto ctx list

### DIFF
--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -81,7 +81,7 @@ func executeListContext(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		fmt.Print(string(ctxRaw))
+		fmt.Println(string(ctxRaw))
 	} else if output == "yaml" {
 		ctxRaw, err := yaml.Marshal(&ctxs)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -100,8 +100,8 @@ func main() {
 		},
 	}
 
-	root.PersistentFlags().StringVarP(&logLevel, "loglevel", "l", "warn", "amount of information outputted (debug, info, warn, error)")
-	root.PersistentFlags().StringVarP(&outputMode, "output", "o", oktetoLog.TTYFormat, "output format (tty, plain, json)")
+	root.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "warn", "amount of information outputted (debug, info, warn, error)")
+	root.PersistentFlags().StringVar(&outputMode, "log-output", oktetoLog.TTYFormat, "output format for logs (tty, plain, json)")
 
 	root.AddCommand(cmd.Analytics())
 	root.AddCommand(cmd.Version())

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -60,15 +60,15 @@ type OktetoContext struct {
 	Username          string               `json:"username,omitempty" yaml:"username,omitempty"`
 	Token             string               `json:"token,omitempty" yaml:"token,omitempty"`
 	Namespace         string               `json:"namespace" yaml:"namespace,omitempty"`
-	Cfg               *clientcmdapi.Config `json:"-"`
+	Cfg               *clientcmdapi.Config `json:"-" yaml:"-"`
 	Builder           string               `json:"builder,omitempty" yaml:"builder,omitempty"`
 	Registry          string               `json:"registry,omitempty" yaml:"registry,omitempty"`
 	Certificate       string               `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	PersonalNamespace string               `json:"personalNamespace,omitempty" yaml:"personalNamespace,omitempty"`
-	GlobalNamespace   string               `json:"-"`
-	Analytics         bool                 `json:"-"`
-	ClusterType       string               `json:"-"`
-	IsOkteto          bool                 `json:"isOkteto"`
+	GlobalNamespace   string               `json:"-" yaml:"-"`
+	Analytics         bool                 `json:"-" yaml:"-"`
+	ClusterType       string               `json:"-" yaml:"-"`
+	IsOkteto          bool                 `json:"isOkteto,omitempty" yaml:"isOkteto,omitempty"`
 }
 
 // InitContextWithDeprecatedToken initializes the okteto context if an old fashion exists and it matches the current kubernetes context


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

Fixes #2204 

## Proposed changes

https://user-images.githubusercontent.com/56963264/159427525-6d9b1055-a38c-43c8-991a-a994c7ff9d88.mov

I had to change the `output` persistent flag in `main.go` to a different name because otherwise, the new `output` flag for `ctx list` wasn't showing up in the command help. 

The older `output` flag was anyways confusing since it referred to the output format for logs and not a particular command. Also, does that even need to be a persistent flag?
