### PR TITLE
fix: stack ctx pointing to kubecfg

### DIFF
--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -25,8 +25,6 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/stack"
-	"github.com/okteto/okteto/pkg/config"
-	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -58,7 +56,7 @@ func deploy(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			c, config, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get(config.GetKubeconfigPath()))
+			c, config, err := okteto.NewK8sClientProvider().Provide(okteto.Context().Cfg)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- Stack was pointing to kubeconfig instead of okteto context
