### PR TITLE
Tag image with manifest name

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -184,7 +184,10 @@ func buildV2(manifest *model.Manifest, cmdOptions build.BuildOptions, args []str
 		if !okteto.Context().IsOkteto && buildInfo.Image == "" {
 			return fmt.Errorf("'build.%s.image' is required if your context is not managed by Okteto", service)
 		}
-		if cwd, err := os.Getwd(); err == nil && buildInfo.Name == "" {
+
+		if manifest.Name != "" {
+			buildInfo.Name = manifest.Name
+		} else if cwd, err := os.Getwd(); err == nil && manifest.Name == "" {
 			buildInfo.Name = utils.InferName(cwd)
 		}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -100,10 +100,10 @@ func Build(ctx context.Context) *cobra.Command {
 			}
 
 			if isBuildV2 {
-				return buildV2(manifest, options, args)
+				return buildV2(manifest, &options, args)
 			}
 
-			return buildV1(options, args)
+			return buildV1(&options, args)
 		},
 	}
 
@@ -143,7 +143,7 @@ func isSelectedService(service string, selected []string) bool {
 	return false
 }
 
-func buildV2(manifest *model.Manifest, cmdOptions build.BuildOptions, args []string) error {
+func buildV2(manifest *model.Manifest, cmdOptions *build.BuildOptions, args []string) error {
 	buildManifest := manifest.Build
 	selectedArgs := []string{}
 	if len(args) != 0 {
@@ -229,7 +229,7 @@ func buildV2(manifest *model.Manifest, cmdOptions build.BuildOptions, args []str
 			}
 			svcBuild.VolumesToInclude = volumesToInclude
 			svcBuild.Name = buildInfo.Name
-			options := build.OptsFromManifest(service, svcBuild, build.BuildOptions{})
+			options := build.OptsFromManifest(service, svcBuild, &build.BuildOptions{})
 			if err := buildV1(options, []string{options.Path}); err != nil {
 				return err
 			}
@@ -239,7 +239,7 @@ func buildV2(manifest *model.Manifest, cmdOptions build.BuildOptions, args []str
 	return nil
 }
 
-func buildV1(options build.BuildOptions, args []string) error {
+func buildV1(options *build.BuildOptions, args []string) error {
 	path := "."
 	if len(args) == 1 {
 		path = args[0]

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -511,7 +511,7 @@ func (dc *DeployCommand) deployStack(ctx context.Context, opts *Options) error {
 	return stackCommand.RunDeploy(ctx, composeInfo.Stack, stackOpts)
 }
 
-func checkImageAtGlobalAndSetEnvs(service string, options build.BuildOptions) (bool, error) {
+func checkImageAtGlobalAndSetEnvs(service string, options *build.BuildOptions) (bool, error) {
 	globalReference := strings.Replace(options.Tag, okteto.DevRegistry, okteto.GlobalRegistry, 1)
 
 	imageWithDigest, err := registry.GetImageTagWithDigest(globalReference)
@@ -539,7 +539,7 @@ func runBuildAndSetEnvs(ctx context.Context, service string, manifest *model.Man
 	if len(buildInfo.VolumesToInclude) > 0 {
 		buildInfo.VolumesToInclude = nil
 	}
-	options := build.OptsFromManifest(service, buildInfo, build.BuildOptions{})
+	options := build.OptsFromManifest(service, buildInfo, &build.BuildOptions{})
 	if err := build.Run(ctx, options); err != nil {
 		return err
 	}
@@ -555,7 +555,7 @@ func runBuildAndSetEnvs(ctx context.Context, service string, manifest *model.Man
 			return err
 		}
 		svcBuild.VolumesToInclude = volumesToInclude
-		options = build.OptsFromManifest(service, svcBuild, build.BuildOptions{})
+		options = build.OptsFromManifest(service, svcBuild, &build.BuildOptions{})
 		if err := build.Run(ctx, options); err != nil {
 			return err
 		}
@@ -719,7 +719,7 @@ func shouldExecuteRemotely(options *Options) bool {
 
 func checkServicesToBuild(service string, manifest *model.Manifest, ch chan string) error {
 	buildInfo := manifest.Build[service]
-	opts := build.OptsFromManifest(service, buildInfo, build.BuildOptions{})
+	opts := build.OptsFromManifest(service, buildInfo, &build.BuildOptions{})
 
 	if build.ShouldOptimizeBuild(opts.Tag) {
 		oktetoLog.Debug("found OKTETO_GIT_COMMIT, optimizing the build flow")

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -468,7 +468,7 @@ func inferBuildSectionFromDockerfiles(cwd string, dockerfiles []string) (model.M
 			}
 			buildInfo.Image = imageName
 		} else {
-			_ = build.OptsFromManifest(name, buildInfo, build.BuildOptions{})
+			_ = build.OptsFromManifest(name, buildInfo, &build.BuildOptions{})
 		}
 		manifestBuild[name] = buildInfo
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -279,7 +279,7 @@ func buildImage(ctx context.Context, dev *model.Dev, imageFromApp, oktetoRegistr
 	oktetoLog.Infof("pushing with image tag %s", buildTag)
 
 	buildArgs := model.SerializeBuildArgs(dev.Push.Args)
-	buildOptions := build.BuildOptions{
+	buildOptions := &build.BuildOptions{
 		Path:       dev.Push.Context,
 		File:       dev.Push.Dockerfile,
 		Tag:        buildTag,

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -525,7 +525,7 @@ func (up *upContext) buildDevImage(ctx context.Context, app apps.App) error {
 
 	buildArgs := model.SerializeBuildArgs(up.Dev.Image.Args)
 
-	buildOptions := buildCMD.BuildOptions{
+	buildOptions := &buildCMD.BuildOptions{
 		Path:       up.Dev.Image.Context,
 		File:       up.Dev.Image.Dockerfile,
 		Tag:        imageTag,
@@ -675,7 +675,7 @@ func setBuildEnvVars(m *model.Manifest, devName string) error {
 	defer sp.Stop()
 
 	for buildName, buildInfo := range m.Build {
-		opts := build.OptsFromManifest(buildName, buildInfo, build.BuildOptions{})
+		opts := build.OptsFromManifest(buildName, buildInfo, &build.BuildOptions{})
 		imageWithDigest, err := registry.GetImageTagWithDigest(opts.Tag)
 		if err == oktetoErrors.ErrNotFound {
 			os.Setenv(fmt.Sprintf("OKTETO_BUILD_%s_IMAGE", strings.ToUpper(buildName)), opts.Tag)

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -48,7 +48,7 @@ type BuildOptions struct {
 }
 
 // Run runs the build sequence
-func Run(ctx context.Context, buildOptions BuildOptions) error {
+func Run(ctx context.Context, buildOptions *BuildOptions) error {
 	buildOptions.OutputMode = setOutputMode(buildOptions.OutputMode)
 	if okteto.Context().Builder == "" {
 		if err := buildWithDocker(ctx, buildOptions); err != nil {
@@ -77,7 +77,7 @@ func setOutputMode(outputMode string) string {
 
 }
 
-func buildWithOkteto(ctx context.Context, buildOptions BuildOptions) error {
+func buildWithOkteto(ctx context.Context, buildOptions *BuildOptions) error {
 	oktetoLog.Infof("building your image on %s", okteto.Context().Builder)
 	buildkitClient, err := getBuildkitClient(ctx)
 	if err != nil {
@@ -153,7 +153,7 @@ func buildWithOkteto(ctx context.Context, buildOptions BuildOptions) error {
 }
 
 // https://github.com/docker/cli/blob/56e5910181d8ac038a634a203a4f3550bb64991f/cli/command/image/build.go#L209
-func buildWithDocker(ctx context.Context, buildOptions BuildOptions) error {
+func buildWithDocker(ctx context.Context, buildOptions *BuildOptions) error {
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -207,7 +207,7 @@ func translateDockerErr(err error) error {
 }
 
 // OptsFromManifest returns the parsed options for the build from the manifest
-func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildOptions {
+func OptsFromManifest(service string, b *model.BuildInfo, o *BuildOptions) *BuildOptions {
 	if b.Name == "" {
 		b.Name = os.Getenv(model.OktetoNameEnvVar)
 	}
@@ -241,7 +241,7 @@ func OptsFromManifest(service string, b *model.BuildInfo, o BuildOptions) BuildO
 	if !filepath.IsAbs(b.Dockerfile) && !model.FileExistsAndNotDir(file) {
 		file = filepath.Join(b.Context, b.Dockerfile)
 	}
-	opts := BuildOptions{
+	opts := &BuildOptions{
 		CacheFrom: b.CacheFrom,
 		Target:    b.Target,
 		Path:      b.Context,

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -227,7 +227,7 @@ func OptsFromManifest(service string, b *model.BuildInfo, o *BuildOptions) *Buil
 
 		// if flag --global, point to global registry
 		targetRegistry := okteto.DevRegistry
-		if o.BuildToGlobal {
+		if o != nil && o.BuildToGlobal {
 			targetRegistry = okteto.GlobalRegistry
 		}
 		b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, b.Name, service, tag)
@@ -250,10 +250,12 @@ func OptsFromManifest(service string, b *model.BuildInfo, o *BuildOptions) *Buil
 		BuildArgs: args,
 	}
 
-	if o.OutputMode == "" {
-		o.OutputMode = oktetoLog.GetOutputFormat()
+	outputMode := oktetoLog.GetOutputFormat()
+	if o != nil && o.OutputMode != "" {
+		outputMode = o.OutputMode
 	}
-	opts.OutputMode = setOutputMode(o.OutputMode)
+	opts.OutputMode = setOutputMode(outputMode)
+
 	return opts
 }
 

--- a/pkg/cmd/build/build_docker.go
+++ b/pkg/cmd/build/build_docker.go
@@ -54,7 +54,7 @@ import (
 )
 
 // https://github.com/docker/cli/blob/56e5910181d8ac038a634a203a4f3550bb64991f/cli/command/image/build_buildkit.go#L48
-func buildWithDockerDaemonBuildkit(ctx context.Context, buildOptions BuildOptions, cli *client.Client) error {
+func buildWithDockerDaemonBuildkit(ctx context.Context, buildOptions *BuildOptions, cli *client.Client) error {
 	oktetoLog.Infof("building your image with docker client v%s", cli.ClientVersion())
 	s, err := session.NewSession(context.Background(), buildOptions.Path, "")
 	if err != nil {
@@ -164,7 +164,7 @@ func buildWithDockerDaemonBuildkit(ctx context.Context, buildOptions BuildOption
 }
 
 // https://github.com/docker/cli/blob/56e5910181d8ac038a634a203a4f3550bb64991f/cli/command/image/build.go#L209
-func buildWithDockerDaemon(ctx context.Context, buildOptions BuildOptions, cli *client.Client) error {
+func buildWithDockerDaemon(ctx context.Context, buildOptions *BuildOptions, cli *client.Client) error {
 	oktetoLog.Infof("building your image with docker client v%s", cli.ClientVersion())
 
 	dockerBuildContext, err := getBuildContext(buildOptions.Path, buildOptions.File)
@@ -377,7 +377,7 @@ func readDockerignore(contextDir string) ([]string, error) {
 }
 
 // getDockerOptions returns the docker build options
-func getDockerOptions(buildOptions BuildOptions) (types.ImageBuildOptions, error) {
+func getDockerOptions(buildOptions *BuildOptions) (types.ImageBuildOptions, error) {
 	opts := types.ImageBuildOptions{
 		SuppressOutput: false,
 		Remove:         true,

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -79,15 +79,15 @@ func Test_OptsFromManifest(t *testing.T) {
 		buildInfo      *model.BuildInfo
 		okGitCommitEnv string
 		isOkteto       bool
-		initialOpts    BuildOptions
-		expected       BuildOptions
+		initialOpts    *BuildOptions
+		expected       *BuildOptions
 	}{
 		{
 			name:        "empty-values-is-okteto",
 			serviceName: "service",
 			buildInfo:   &model.BuildInfo{Name: "movies"},
 			isOkteto:    true,
-			expected: BuildOptions{
+			expected: &BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
 				BuildArgs:  []string{},
@@ -99,7 +99,7 @@ func Test_OptsFromManifest(t *testing.T) {
 			buildInfo:      &model.BuildInfo{Name: "movies"},
 			okGitCommitEnv: "dev1235466",
 			isOkteto:       true,
-			expected: BuildOptions{
+			expected: &BuildOptions{
 				Tag:        "okteto.dev/movies-service:okteto",
 				OutputMode: oktetoLog.TTYFormat,
 				BuildArgs:  []string{},
@@ -111,7 +111,7 @@ func Test_OptsFromManifest(t *testing.T) {
 			buildInfo:      &model.BuildInfo{Name: "movies"},
 			okGitCommitEnv: "1235466",
 			isOkteto:       true,
-			expected: BuildOptions{
+			expected: &BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:114921fe985b5f874c8d312b0a098959da6d119209c9d1e42a89c4309569692d",
 				BuildArgs:  []string{},
@@ -130,7 +130,7 @@ func Test_OptsFromManifest(t *testing.T) {
 				}},
 			okGitCommitEnv: "1235466",
 			isOkteto:       true,
-			expected: BuildOptions{
+			expected: &BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:c0776074a88fa37835b1dfa67365b6a6b08b11c4cf49a9d42524ea9797959e58",
 				BuildArgs:  []string{"arg1=value1"},
@@ -141,7 +141,7 @@ func Test_OptsFromManifest(t *testing.T) {
 			serviceName: "service",
 			buildInfo:   &model.BuildInfo{Name: "movies"},
 			isOkteto:    false,
-			expected: BuildOptions{
+			expected: &BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
 				BuildArgs:  []string{},
 			},
@@ -162,11 +162,11 @@ func Test_OptsFromManifest(t *testing.T) {
 					},
 				},
 			},
-			initialOpts: BuildOptions{
+			initialOpts: &BuildOptions{
 				OutputMode: "tty",
 			},
 			isOkteto: true,
-			expected: BuildOptions{
+			expected: &BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
 				File:       filepath.Join("service", "CustomDockerfile"),

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -44,7 +44,7 @@ const (
 type buildWriter struct{}
 
 // getSolveOpt returns the buildkit solve options
-func getSolveOpt(buildOptions BuildOptions) (*client.SolveOpt, error) {
+func getSolveOpt(buildOptions *BuildOptions) (*client.SolveOpt, error) {
 	var localDirs map[string]string
 	var frontendAttrs map[string]string
 

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -133,7 +133,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 				VolumesToInclude: svcInfo.VolumeMounts,
 			}
 		}
-		opts := build.OptsFromManifest(svcName, buildInfo, build.BuildOptions{})
+		opts := build.OptsFromManifest(svcName, buildInfo, &build.BuildOptions{})
 
 		if okteto.IsOkteto() && !registry.IsOktetoRegistry(buildInfo.Image) {
 			buildInfo.Image = opts.Tag
@@ -158,7 +158,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 		}
 
 		volumesToInclude := svcInfo.VolumeMounts
-		var options build.BuildOptions
+		var options *build.BuildOptions
 		var imageTagWithDigest string
 		var err error
 		if buildInfo != nil && buildInfo.Dockerfile != "" {
@@ -168,7 +168,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 				buildInfo.VolumesToInclude = nil
 			}
 
-			options = build.OptsFromManifest(svcName, buildInfo, build.BuildOptions{})
+			options = build.OptsFromManifest(svcName, buildInfo, &build.BuildOptions{})
 			if err := build.Run(ctx, options); err != nil {
 				return err
 			}
@@ -189,7 +189,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 				return err
 			}
 			svcBuild.VolumesToInclude = volumesToInclude
-			options = build.OptsFromManifest(svcName, svcBuild, build.BuildOptions{})
+			options = build.OptsFromManifest(svcName, svcBuild, &build.BuildOptions{})
 			if err := build.Run(ctx, options); err != nil {
 				return err
 			}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -785,6 +785,7 @@ func (d *Manifest) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	d.Context = manifest.Context
 	d.IsV2 = true
 	d.Dependencies = manifest.Dependencies
+	d.Name = manifest.Name
 	return nil
 }
 


### PR DESCRIPTION


## Proposed changes

- when using new manifest, if name is defined for the manifest, this should be part of the image tag and not the infered repository name
-
