### PR TITLE
fix: skip non existant folder on volume mounts

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -191,8 +191,8 @@ func buildV2(manifest *model.Manifest, cmdOptions *build.BuildOptions, args []st
 			buildInfo.Name = utils.InferName(cwd)
 		}
 
-		volumesToInclude := buildInfo.VolumesToInclude
-		if len(buildInfo.VolumesToInclude) > 0 {
+		volumesToInclude := build.GetVolumesToInclude(buildInfo.VolumesToInclude)
+		if len(volumesToInclude) > 0 {
 			buildInfo.VolumesToInclude = nil
 		}
 		cmdOptsFromManifest := build.OptsFromManifest(service, buildInfo, cmdOptions)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -536,8 +536,8 @@ func runBuildAndSetEnvs(ctx context.Context, service string, manifest *model.Man
 	oktetoLog.SetStage(fmt.Sprintf("Building service %s", service))
 	buildInfo := manifest.Build[service]
 	oktetoLog.Information("Building image for service '%s'", service)
-	volumesToInclude := buildInfo.VolumesToInclude
-	if len(buildInfo.VolumesToInclude) > 0 {
+	volumesToInclude := build.GetVolumesToInclude(buildInfo.VolumesToInclude)
+	if len(volumesToInclude) > 0 {
 		buildInfo.VolumesToInclude = nil
 	}
 	options := build.OptsFromManifest(service, buildInfo, &build.BuildOptions{})

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -267,3 +267,16 @@ func ShouldOptimizeBuild(image string) bool {
 		envGitCommit != "" &&
 		!isLocalEnvGitCommit
 }
+
+// GetVolumesToInclude checks if the path exists, if it doesn't it skip it
+func GetVolumesToInclude(volumesToInclude []model.StackVolume) []model.StackVolume {
+	result := []model.StackVolume{}
+	for _, p := range volumesToInclude {
+		if _, err := os.Stat(p.LocalPath); err == nil {
+			result = append(result, p)
+		} else {
+
+		}
+	}
+	return result
+}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -274,8 +274,6 @@ func GetVolumesToInclude(volumesToInclude []model.StackVolume) []model.StackVolu
 	for _, p := range volumesToInclude {
 		if _, err := os.Stat(p.LocalPath); err == nil {
 			result = append(result, p)
-		} else {
-
 		}
 	}
 	return result

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -148,6 +148,10 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 			}
 		}
 
+		volumesToInclude := build.GetVolumesToInclude(svcInfo.VolumeMounts)
+		if buildInfo == nil || buildInfo.Dockerfile == "" && len(volumesToInclude) == 0 {
+			continue
+		}
 		if !hasBuiltSomething {
 			hasBuiltSomething = true
 			if okteto.Context().Builder != "" {
@@ -157,14 +161,13 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 			}
 		}
 
-		volumesToInclude := svcInfo.VolumeMounts
 		options := &build.BuildOptions{}
 		var imageTagWithDigest string
 		var err error
 		if buildInfo != nil && buildInfo.Dockerfile != "" {
 			oktetoLog.Information("Building image for service '%s'", svcName)
 
-			if len(buildInfo.VolumesToInclude) > 0 {
+			if len(volumesToInclude) > 0 {
 				buildInfo.VolumesToInclude = nil
 			}
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes If a volume mount is not found locally skip it

## Proposed changes
- It could lead to a build error
-
