### PR TITLE
Allow to update an existing configmap even if it is managed by an installer

### DIFF
--- a/pkg/k8s/configmaps/crud.go
+++ b/pkg/k8s/configmaps/crud.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/model"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -51,15 +50,12 @@ func List(ctx context.Context, namespace, labelSelector string, c kubernetes.Int
 
 // Deploy creates or updates a configmap
 func Deploy(ctx context.Context, cf *apiv1.ConfigMap, namespace string, c kubernetes.Interface) error {
-	old, err := Get(ctx, cf.Name, namespace, c)
+	_, err := Get(ctx, cf.Name, namespace, c)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return Create(ctx, cf, namespace, c)
 		}
 		return err
-	}
-	if old.Labels[model.OktetoInstallerRunningLabel] == "true" {
-		return nil
 	}
 	return update(ctx, cf, namespace, c)
 }


### PR DESCRIPTION
Signed-off-by: Nacho Fuertes <nacho@okteto.com>

## Proposed changes

- Allow to update an existing configmap even when it is managed by the installer. In this way, `okteto deploy` command updates the configmap to include things like the manifest given that we are removing that logic from the installer

Conflicts with ongoing deploys are being managed in another level

<img width="1131" alt="Captura de pantalla 2022-03-24 a las 13 20 15" src="https://user-images.githubusercontent.com/3510171/159973573-2ac66c0f-8dad-487f-a603-0d586f78a532.png">
