### PR TITLE
Remove warning if "deploy" doesn't deploy anything

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -410,9 +410,6 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			if err := pipeline.AddDevAnnotations(ctx, deployOptions.Manifest, c); err != nil {
 				oktetoLog.Warning("could not add dev annotations due to: %s", err.Error())
 			}
-		} else {
-			oktetoLog.Warning(`%s
-    Update the 'deploy' section of your manifest and try again`, oktetoErrors.ErrDeployHasNotDeployAnyResource.Error())
 		}
 		data.Status = pipeline.DeployedStatus
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -141,9 +141,6 @@ var (
 	// ErrUserAnsweredNoToCreateFromCompose raised when the user has selected a compose file but is trying to deploy without it
 	ErrUserAnsweredNoToCreateFromCompose = fmt.Errorf("user does not want to create from compose")
 
-	// ErrDeployHasNotDeployAnyResource raised when a deploy command has not created any resource
-	ErrDeployHasNotDeployAnyResource = errors.New("it seems that you haven't deployed anything")
-
 	// ErrDeployHasFailedCommand raised when a deploy command is executed and fails
 	ErrDeployHasFailedCommand = errors.New("one of the commands in the 'deploy' section of your okteto manifests failed")
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

There are several valid use cases where `deploy` doesn't create any resources, we shouldn't warn the user in this case:
- I want a dev container with `autocreate`
- My okteto manifest is just to deploy other git repos
- My manifest only deploy resources external to Kubernetes