### PR TITLE
Include the filename in the configmap for destroy command

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -201,7 +201,9 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
 	data := &pipeline.CfgData{
 		Name:      opts.Name,
 		Namespace: namespace,
-		Status:    pipeline.DestroyingStatus}
+		Status:    pipeline.DestroyingStatus,
+		Filename:  manifest.Filename,
+	}
 	cfg, err := pipeline.TranslateConfigMapAndDeploy(ctx, data, c)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Nacho Fuertes <nacho@okteto.com>

## Proposed changes

- Include the filename specified in the configmap for destroy operations. If not, when a custom command fails and it is retried, it is not taking the right file
