### PR TITLE
Partially restore #2427. Update only the configmap for a running installer if it is a git deploy

### DIFF
--- a/pkg/k8s/configmaps/crud.go
+++ b/pkg/k8s/configmaps/crud.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/model"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -50,12 +51,15 @@ func List(ctx context.Context, namespace, labelSelector string, c kubernetes.Int
 
 // Deploy creates or updates a configmap
 func Deploy(ctx context.Context, cf *apiv1.ConfigMap, namespace string, c kubernetes.Interface) error {
-	_, err := Get(ctx, cf.Name, namespace, c)
+	old, err := Get(ctx, cf.Name, namespace, c)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return Create(ctx, cf, namespace, c)
 		}
 		return err
+	}
+	if old.Labels[model.OktetoInstallerRunningLabel] == "true" && old.Labels[model.GitDeployLabel] != "true" {
+		return nil
 	}
 	return update(ctx, cf, namespace, c)
 }


### PR DESCRIPTION
Signed-off-by: Nacho Fuertes <nacho@okteto.com>

## Proposed changes

- Partially reverted this PR https://github.com/okteto/okteto/pull/2427. Update the configmap for a running installer only if it is a git deploy. In the case of any other installer, it won't do anything. According to the originally issue, this was added for stacks because CLI and installer could be modifying the same configmap at the same time. 
