### PR TITLE
fix: init image on default

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -472,6 +472,9 @@ func (dev *Dev) SetDefaults() error {
 		dev.Selector = make(Selector)
 	}
 
+	if dev.InitContainer.Image == "" {
+		dev.InitContainer.Image = OktetoBinImageTag
+	}
 	if dev.Healthchecks {
 		oktetoLog.Yellow("The use of 'healthchecks' field is deprecated and will be removed in version 2.2.0. Please use the field 'probes' instead.")
 		if dev.Probes == nil {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -212,6 +212,7 @@ func TestInferFromStack(t *testing.T) {
 							Dockerfile: "Dockerfile",
 						},
 						ImagePullPolicy: apiv1.PullAlways,
+						InitContainer:   InitContainer{Image: OktetoBinImageTag},
 						Probes:          &Probes{},
 						Lifecycle:       &Lifecycle{},
 						Workdir:         "/okteto",


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- if init image is empty set it to the default
- If we don't load again the image we are not setting any init image and it fails
