### PR TITLE
Jlopezbarb/fix destroy different name

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -152,6 +152,18 @@ func Deploy(ctx context.Context) *cobra.Command {
 				}
 			}
 
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("failed to get the current working directory: %w", err)
+			}
+			name := ""
+			if options.Name == "" {
+				name = utils.InferName(cwd)
+				if err != nil {
+					return fmt.Errorf("could not infer environment name")
+				}
+			}
+
 			options.ShowCTA = oktetoLog.IsInteractive()
 			options.servicesToDeploy = args
 
@@ -168,7 +180,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				Kubeconfig:         kubeconfig,
 				Executor:           executor.NewExecutor(oktetoLog.GetOutputFormat()),
 				Proxy:              proxy,
-				TempKubeconfigFile: GetTempKubeConfigFile(options.Name),
+				TempKubeconfigFile: GetTempKubeConfigFile(name),
 				K8sClientProvider:  okteto.NewK8sClientProvider(),
 			}
 			startTime := time.Now()

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -174,6 +174,18 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
 			Destroy: []model.DeployCommand{},
 		}
 	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %w", err)
+	}
+	if opts.Name == "" {
+		if manifest.Name != "" {
+			opts.Name = manifest.Name
+		} else {
+			opts.Name = utils.InferName(cwd)
+		}
+
+	}
 	manifest, err = manifest.ExpandEnvVars()
 	if err != nil {
 		return err

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -103,9 +103,9 @@ func Destroy(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get the current working directory: %w", err)
 			}
-
+			name := ""
 			if options.Name == "" {
-				options.Name = utils.InferName(cwd)
+				name = utils.InferName(cwd)
 				if err != nil {
 					return fmt.Errorf("could not infer environment name")
 				}
@@ -137,7 +137,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 				k8sClientProvider: okteto.NewK8sClientProvider(),
 			}
 
-			kubeconfigPath := deploy.GetTempKubeConfigFile(options.Name)
+			kubeconfigPath := deploy.GetTempKubeConfigFile(name)
 			if err := kubeconfig.Write(okteto.Context().Cfg, kubeconfigPath); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes destroy with manifest name was not destroying the right configmap

## Proposed changes
- If the destroy command has no name flag, it should remove the one in the manifest instead of the folder one
-
