### PR TITLE
fix: destroy spinner

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -350,13 +350,13 @@ func (dc *destroyCommand) destroyHelmReleasesIfPresent(ctx context.Context, opts
 		cmdInfo := model.DeployCommand{Command: cmd, Name: cmd}
 		spinner.Stop()
 		oktetoLog.Information("Running %s", cmdInfo.Name)
-		spinner.Start()
 		if err := dc.executor.Execute(cmdInfo, opts.Variables); err != nil {
 			oktetoLog.Infof("could not uninstall helm release '%s': %s", releaseName, err)
 			if !opts.ForceDestroy {
 				return err
 			}
 		}
+		spinner.Start()
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes destroy spinner race condition with helm

## Proposed changes
- Wait until the destroy command output to continue displaying spinner
-
