### PR TITLE
fix: inject secrets on manifest

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -159,6 +159,11 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 		return nil, err
 	}
 
+	// We need to read it again to propagate secrets env vars
+	m, err = model.GetManifestV2(opts.Filename)
+	if err != nil {
+		return nil, err
+	}
 	m.Namespace = okteto.Context().Namespace
 	m.Context = okteto.Context().Name
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes a bug on okteto up where it reads the manifest before injecting the 

## Proposed changes
- ReLoad manifest after injecting secrets
-
