### PR TITLE
fix: ca-data-override

### DIFF
--- a/cmd/deploy/config.go
+++ b/cmd/deploy/config.go
@@ -56,6 +56,9 @@ func (k *KubeConfig) Modify(port int, sessionToken, destKubeconfigFile string) e
 	// Change server to our proxy
 	clusterInfo.Server = fmt.Sprintf("https://localhost:%d", port)
 	// Set the certificate authority to talk with the proxy
+	if clusterInfo.CertificateAuthority != "" {
+		clusterInfo.CertificateAuthority = ""
+	}
 	clusterInfo.CertificateAuthorityData = cert
 
 	// Save on disk the config changes


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Minikube proxy was failing to deploy because it had a `ca-authority-data` and a `ca-authority` 

## Proposed changes
- If the kubeconfig had `ca-authority` we need to remove it and  set only `ca-authority-data`



fixes #2459 