### PR TITLE
fix: selector label length larger than width

### DIFF
--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -133,7 +133,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 	}
 
 	if manifest == nil || len(manifest.Build) == 0 || manifest.Deploy == nil {
-		manifest, err = mc.configureManifestDeployAndBuild(opts.Workdir)
+		manifest, err = mc.configureManifestDeployAndBuild(ctx, opts.Workdir)
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +206,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 	return manifest, nil
 }
 
-func (*ManifestCommand) configureManifestDeployAndBuild(cwd string) (*model.Manifest, error) {
+func (*ManifestCommand) configureManifestDeployAndBuild(ctx context.Context, cwd string) (*model.Manifest, error) {
 
 	composeFiles := utils.GetStackFiles(cwd)
 	if len(composeFiles) > 0 {
@@ -228,14 +228,14 @@ func (*ManifestCommand) configureManifestDeployAndBuild(cwd string) (*model.Mani
 			}
 			return manifest, nil
 		}
-		manifest, err := createFromKubernetes(cwd)
+		manifest, err := createFromKubernetes(ctx, cwd)
 		if err != nil {
 			return nil, err
 		}
 		return manifest, nil
 
 	}
-	manifest, err := createFromKubernetes(cwd)
+	manifest, err := createFromKubernetes(ctx, cwd)
 	if err != nil {
 		return nil, err
 	}
@@ -432,9 +432,9 @@ func createFromCompose(composePath string) (*model.Manifest, error) {
 	return manifest, err
 }
 
-func createFromKubernetes(cwd string) (*model.Manifest, error) {
+func createFromKubernetes(ctx context.Context, cwd string) (*model.Manifest, error) {
 	manifest := model.NewManifest()
-	dockerfiles, err := selectDockerfiles(cwd)
+	dockerfiles, err := selectDockerfiles(ctx, cwd)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/utils/selector.go
+++ b/cmd/utils/selector.go
@@ -30,6 +30,7 @@ import (
 	"github.com/manifoldco/promptui/screenbuf"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
+	"golang.org/x/term"
 )
 
 const (
@@ -411,9 +412,27 @@ func (s *OktetoSelector) renderDetails(item interface{}) [][]byte {
 }
 
 func (s *OktetoSelector) renderLabel(sb *screenbuf.ScreenBuf) {
+	width, _, _ := term.GetSize(int(os.Stdout.Fd()))
 	for _, labelLine := range strings.Split(s.Label, "\n") {
-		labelLineBytes := render(s.OktetoTemplates.label, labelLine)
-		sb.Write(labelLineBytes)
+		if width == 0 {
+			labelLineBytes := render(s.OktetoTemplates.label, labelLine)
+			sb.Write(labelLineBytes)
+		} else {
+			lines := len(labelLine) / width
+			lastChar := 0
+			for i := 0; i < lines+1; i++ {
+				if lines == i {
+					midLine := labelLine[lastChar:]
+					labelLineBytes := render(s.OktetoTemplates.label, midLine)
+					sb.Write(labelLineBytes)
+					break
+				}
+				midLine := labelLine[lastChar : lastChar+width]
+				labelLineBytes := render(s.OktetoTemplates.label, midLine)
+				sb.Write(labelLineBytes)
+				lastChar += width
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes selector if length larger that terminal width

## Proposed changes
- Use our selector implementation and get the correct output
- This change uses a new selectedTemplate which is the okteto one

## Screenshots:
<img width="605" alt="Captura de pantalla 2022-03-30 a las 18 03 06" src="https://user-images.githubusercontent.com/25170843/160880338-678d6d1e-9b8a-4d5d-a56f-9348f7ca80bd.png">
<img width="609" alt="Captura de pantalla 2022-03-30 a las 18 06 27" src="https://user-images.githubusercontent.com/25170843/160880541-6743f6e3-63dc-44ec-97da-fca575343f67.png">


