### PR TITLE
fix: skip ingress with no rule.host defined

### DIFF
--- a/pkg/k8s/ingresses/crud.go
+++ b/pkg/k8s/ingresses/crud.go
@@ -144,6 +144,9 @@ func (iClient *Client) GetEndpointsBySelector(ctx context.Context, namespace, la
 		}
 		for i := range iList.Items {
 			for _, rule := range iList.Items[i].Spec.Rules {
+				if rule.Host == "" {
+					continue
+				}
 				for _, path := range rule.IngressRuleValue.HTTP.Paths {
 					result = append(result, fmt.Sprintf("https://%s%s", rule.Host, path.Path))
 				}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes: When you run on Minikube a deploy command and don't have any rule.host this happens:

<img width="711" alt="Captura de pantalla 2022-03-30 a las 16 52 28" src="https://user-images.githubusercontent.com/25170843/161016072-b8044203-3ae0-4782-8a79-6bb41c61d88c.png">

## Proposed changes
- If the Ingres doesn't have rule.Host defined skip
-
