### PR TITLE
docs: fix grammar in `how-to-install-okteto-cli.md`

### DIFF
--- a/docs/how-to-install-okteto-cli.md
+++ b/docs/how-to-install-okteto-cli.md
@@ -30,7 +30,7 @@ Alternatively, you can directly download the binary [from GitHub](https://github
 
 #### Which binary should I download?
 
-First of all you need to check your OS and architecture to download the correct binary. You can check your OS by running:
+First you need to check your OS and architecture to download the correct binary. You can check your OS by running:
 
 ```console
 uname


### PR DESCRIPTION
Often, this adverbial phrase is redundant. Consider using first.

Signed-off-by: John Bampton <jbampton@gmail.com>
