### PR TITLE
fix: windows tests failing because of paths

### DIFF
--- a/cmd/utils/manifest_test.go
+++ b/cmd/utils/manifest_test.go
@@ -14,6 +14,7 @@
 package utils
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,12 +28,12 @@ func TestGetWorkdirFromManifest(t *testing.T) {
 	}{
 		{
 			name:         "inside .okteto folder",
-			path:         ".okteto/okteto.yml",
+			path:         filepath.Join(".okteto", "okteto.yml"),
 			expectedPath: ".",
 		},
 		{
 			name:         "one path ahead",
-			path:         "test/okteto.yml",
+			path:         filepath.Join("test", "okteto.yml"),
 			expectedPath: "test",
 		},
 		{
@@ -42,17 +43,17 @@ func TestGetWorkdirFromManifest(t *testing.T) {
 		},
 		{
 			name:         "full path",
-			path:         "/usr/okteto.yml",
+			path:         filepath.Join("/usr", "okteto.yml"),
 			expectedPath: "/usr",
 		},
 		{
 			name:         "full path on .okteto",
-			path:         "/usr/.okteto/okteto.yml",
+			path:         filepath.Join("/usr", ".okteto", "okteto.yml"),
 			expectedPath: "/usr",
 		},
 		{
 			name:         "relative path with more than two paths ahead",
-			path:         "~/app/.okteto/okteto.yml",
+			path:         filepath.Join("~", "app", ".okteto", "okteto.yml"),
 			expectedPath: "~/app",
 		},
 	}

--- a/cmd/utils/manifest_test.go
+++ b/cmd/utils/manifest_test.go
@@ -44,17 +44,17 @@ func TestGetWorkdirFromManifest(t *testing.T) {
 		{
 			name:         "full path",
 			path:         filepath.Join("/usr", "okteto.yml"),
-			expectedPath: "/usr",
+			expectedPath: filepath.Clean("/usr"),
 		},
 		{
 			name:         "full path on .okteto",
 			path:         filepath.Join("/usr", ".okteto", "okteto.yml"),
-			expectedPath: "/usr",
+			expectedPath: filepath.Clean("/usr"),
 		},
 		{
 			name:         "relative path with more than two paths ahead",
 			path:         filepath.Join("~", "app", ".okteto", "okteto.yml"),
-			expectedPath: "~/app",
+			expectedPath: filepath.Join("~", "app"),
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes windows tests 

## Proposed changes
- Changed paths to file path on tests
-
