### PR TITLE
Add env value when empty

### DIFF
--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -16,6 +16,7 @@ package model
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -430,6 +431,9 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 
 	svc.Environment = Environment{}
 	for _, env := range serviceRaw.Environment {
+		if env.Value == "" {
+			env.Value = os.Getenv(env.Name)
+		}
 		if env.Value != "" {
 			svc.Environment = append(svc.Environment, env)
 		}

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1602,7 +1602,9 @@ func Test_Environment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			if tt.setEnvar {
-				os.Setenv("OKTETO_ENVTEST", "myvalue")
+				if err := os.Setenv("OKTETO_ENVTEST", "myvalue"); err != nil {
+					t.Fatal(err)
+				}
 				defer os.Unsetenv("OKTETO_ENVTEST")
 			}
 

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1567,7 +1567,6 @@ func Test_Environment(t *testing.T) {
 	tests := []struct {
 		name        string
 		manifest    []byte
-		setEnvar    bool
 		environment Environment
 	}{
 		{
@@ -1583,13 +1582,11 @@ func Test_Environment(t *testing.T) {
 		{
 			name:        "empty envs - exists envar",
 			manifest:    []byte("services:\n  app:\n    environment:\n        OKTETO_ENVTEST:\n    image: okteto/vote:1"),
-			setEnvar:    true,
 			environment: Environment{EnvVar{Name: "OKTETO_ENVTEST", Value: "myvalue"}},
 		},
 		{
 			name:        "empty list envs - exists envar",
 			manifest:    []byte("services:\n  app:\n    environment:\n      - OKTETO_ENVTEST\n    image: okteto/vote:1"),
-			setEnvar:    true,
 			environment: Environment{EnvVar{Name: "OKTETO_ENVTEST", Value: "myvalue"}},
 		},
 		{
@@ -1601,11 +1598,8 @@ func Test_Environment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			if tt.setEnvar {
-				if err := os.Setenv("OKTETO_ENVTEST", "myvalue"); err != nil {
-					t.Fatal(err)
-				}
-				defer os.Unsetenv("OKTETO_ENVTEST")
+			if err := os.Setenv("OKTETO_ENVTEST", "myvalue"); err != nil {
+				t.Fatal(err)
 			}
 
 			s, err := ReadStack(tt.manifest, false)

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1567,6 +1567,7 @@ func Test_Environment(t *testing.T) {
 	tests := []struct {
 		name        string
 		manifest    []byte
+		setEnvar    bool
 		environment Environment
 	}{
 		{
@@ -1580,6 +1581,18 @@ func Test_Environment(t *testing.T) {
 			environment: Environment{},
 		},
 		{
+			name:        "empty envs - exists envar",
+			manifest:    []byte("services:\n  app:\n    environment:\n        OKTETO_ENVTEST:\n    image: okteto/vote:1"),
+			setEnvar:    true,
+			environment: Environment{EnvVar{Name: "OKTETO_ENVTEST", Value: "myvalue"}},
+		},
+		{
+			name:        "empty list envs - exists envar",
+			manifest:    []byte("services:\n  app:\n    environment:\n      - OKTETO_ENVTEST\n    image: okteto/vote:1"),
+			setEnvar:    true,
+			environment: Environment{EnvVar{Name: "OKTETO_ENVTEST", Value: "myvalue"}},
+		},
+		{
 			name:        "noenvs",
 			manifest:    []byte("services:\n  app:\n    image: okteto/vote:1"),
 			environment: Environment{},
@@ -1587,6 +1600,11 @@ func Test_Environment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.setEnvar {
+				os.Setenv("OKTETO_ENVTEST", "myvalue")
+				defer os.Unsetenv("OKTETO_ENVTEST")
+			}
 
 			s, err := ReadStack(tt.manifest, false)
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2239 

## Proposed changes

- when a service environment var is empty value, get env by name and assign the value
