### PR TITLE
Support for export cache when build

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -112,6 +112,7 @@ func Build(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Target, "target", "", "", "set the target build stage to build")
 	cmd.Flags().BoolVarP(&options.NoCache, "no-cache", "", false, "do not use cache when building the image")
 	cmd.Flags().StringArrayVar(&options.CacheFrom, "cache-from", nil, "cache source images")
+	cmd.Flags().StringVarP(&options.ExportCache, "export-cache", "", "", "export cache image")
 	cmd.Flags().StringVarP(&options.OutputMode, "progress", "", oktetoLog.TTYFormat, "show plain/tty build output")
 	cmd.Flags().StringArrayVar(&options.BuildArgs, "build-arg", nil, "set build-time variables")
 	cmd.Flags().StringArrayVar(&options.Secrets, "secret", nil, "secret files exposed to the build. Format: id=mysecret,src=/local/secret")
@@ -153,7 +154,11 @@ func buildV2(manifest *model.Manifest, cmdOptions *build.BuildOptions, args []st
 	isSingleService := len(selectedArgs) == 1
 
 	// cmd flags only allowed when single service build
-	if !isSingleService && (cmdOptions.Tag != "" || cmdOptions.Target != "" || cmdOptions.CacheFrom != nil || cmdOptions.Secrets != nil) {
+	if !isSingleService && (cmdOptions.Tag != "" ||
+		cmdOptions.Target != "" ||
+		cmdOptions.CacheFrom != nil ||
+		cmdOptions.Secrets != nil ||
+		cmdOptions.ExportCache != "") {
 		return fmt.Errorf("flags only allowed when building a single image with `okteto build [NAME]`")
 	}
 
@@ -178,6 +183,9 @@ func buildV2(manifest *model.Manifest, cmdOptions *build.BuildOptions, args []st
 			}
 			if cmdOptions.Tag != "" {
 				buildInfo.Image = cmdOptions.Tag
+			}
+			if cmdOptions.ExportCache != "" {
+				buildInfo.ExportCache = cmdOptions.ExportCache
 			}
 		}
 		if !okteto.Context().IsOkteto && buildInfo.Image == "" {

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -107,6 +107,8 @@ func buildWithOkteto(ctx context.Context, buildOptions *BuildOptions) error {
 			buildOptions.CacheFrom[i] = registry.ExpandOktetoDevRegistry(buildOptions.CacheFrom[i])
 			buildOptions.CacheFrom[i] = registry.ExpandOktetoGlobalRegistry(buildOptions.CacheFrom[i])
 		}
+		buildOptions.ExportCache = registry.ExpandOktetoDevRegistry(buildOptions.ExportCache)
+		buildOptions.ExportCache = registry.ExpandOktetoGlobalRegistry(buildOptions.ExportCache)
 	}
 	opt, err := getSolveOpt(buildOptions)
 	if err != nil {
@@ -243,12 +245,13 @@ func OptsFromManifest(service string, b *model.BuildInfo, o *BuildOptions) *Buil
 		file = filepath.Join(b.Context, b.Dockerfile)
 	}
 	opts := &BuildOptions{
-		CacheFrom: b.CacheFrom,
-		Target:    b.Target,
-		Path:      b.Context,
-		Tag:       b.Image,
-		File:      file,
-		BuildArgs: args,
+		CacheFrom:   b.CacheFrom,
+		Target:      b.Target,
+		Path:        b.Context,
+		Tag:         b.Image,
+		File:        file,
+		BuildArgs:   args,
+		ExportCache: b.ExportCache,
 	}
 
 	outputMode := oktetoLog.GetOutputFormat()

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -107,8 +107,10 @@ func buildWithOkteto(ctx context.Context, buildOptions *BuildOptions) error {
 			buildOptions.CacheFrom[i] = registry.ExpandOktetoDevRegistry(buildOptions.CacheFrom[i])
 			buildOptions.CacheFrom[i] = registry.ExpandOktetoGlobalRegistry(buildOptions.CacheFrom[i])
 		}
-		buildOptions.ExportCache = registry.ExpandOktetoDevRegistry(buildOptions.ExportCache)
-		buildOptions.ExportCache = registry.ExpandOktetoGlobalRegistry(buildOptions.ExportCache)
+		if buildOptions.ExportCache != "" {
+			buildOptions.ExportCache = registry.ExpandOktetoDevRegistry(buildOptions.ExportCache)
+			buildOptions.ExportCache = registry.ExpandOktetoGlobalRegistry(buildOptions.ExportCache)
+		}
 	}
 	opt, err := getSolveOpt(buildOptions)
 	if err != nil {

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -45,6 +45,7 @@ type BuildOptions struct {
 	Target        string
 	Namespace     string
 	BuildToGlobal bool
+	ExportCache   string
 }
 
 // Run runs the build sequence

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -102,6 +102,7 @@ func getSolveOpt(buildOptions *BuildOptions) (*client.SolveOpt, error) {
 		FrontendAttrs: frontendAttrs,
 		Session:       attachable,
 		CacheImports:  []client.CacheOptionsEntry{},
+		CacheExports:  []client.CacheOptionsEntry{},
 	}
 
 	if buildOptions.Tag != "" {
@@ -125,6 +126,22 @@ func getSolveOpt(buildOptions *BuildOptions) (*client.SolveOpt, error) {
 		)
 	}
 
+	if buildOptions.ExportCache != "" {
+		mode := "min"
+		if buildOptions.ExportCache != buildOptions.Tag {
+			mode = "max"
+		}
+		opt.CacheExports = append(
+			opt.CacheExports,
+			client.CacheOptionsEntry{
+				Type: "registry",
+				Attrs: map[string]string{
+					"ref":  buildOptions.ExportCache,
+					"mode": mode,
+				},
+			},
+		)
+	}
 	return opt, nil
 }
 

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -123,6 +123,7 @@ type BuildInfo struct {
 	Args             Environment   `yaml:"args,omitempty"`
 	Image            string        `yaml:"image,omitempty"`
 	VolumesToInclude []StackVolume `yaml:"-"`
+	ExportCache      string        `yaml:"export_cache,omitempty"`
 }
 
 // Volume represents a volume in the development container

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -314,18 +314,18 @@ func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) err
 }
 
 // MarshalYAML Implements the marshaler interface of the yaml pkg.
-func (buildInfo BuildInfo) MarshalYAML() (interface{}, error) {
+func (buildInfo *BuildInfo) MarshalYAML() (interface{}, error) {
 	if buildInfo.Context != "" && buildInfo.Context != "." {
-		return buildInfoRaw(buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	if buildInfo.Dockerfile != "" && buildInfo.Dockerfile != "./Dockerfile" {
-		return buildInfoRaw(buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	if buildInfo.Target != "" {
-		return buildInfoRaw(buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	if buildInfo.Args != nil && len(buildInfo.Args) != 0 {
-		return buildInfoRaw(buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	return buildInfo.Name, nil
 }

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -42,6 +42,7 @@ type buildInfoRaw struct {
 	Args             Environment   `yaml:"args,omitempty"`
 	Image            string        `yaml:"image,omitempty"`
 	VolumesToInclude []StackVolume `yaml:"-"`
+	ExportCache      string        `yaml:"export_cache,omitempty"`
 }
 
 type syncRaw struct {
@@ -308,6 +309,7 @@ func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) err
 	buildInfo.Args = rawBuildInfo.Args
 	buildInfo.Image = rawBuildInfo.Image
 	buildInfo.CacheFrom = rawBuildInfo.CacheFrom
+	buildInfo.ExportCache = rawBuildInfo.ExportCache
 	return nil
 }
 

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -251,22 +251,22 @@ func TestCommandMashalling(t *testing.T) {
 func TestImageMashalling(t *testing.T) {
 	tests := []struct {
 		name     string
-		image    BuildInfo
+		image    *BuildInfo
 		expected string
 	}{
 		{
 			name:     "single-name",
-			image:    BuildInfo{Name: "image-name"},
+			image:    &BuildInfo{Name: "image-name"},
 			expected: "image-name\n",
 		},
 		{
 			name:     "single-name-and-defaults",
-			image:    BuildInfo{Name: "image-name", Context: "."},
+			image:    &BuildInfo{Name: "image-name", Context: "."},
 			expected: "image-name\n",
 		},
 		{
 			name:     "build",
-			image:    BuildInfo{Name: "image-name", Context: "path"},
+			image:    &BuildInfo{Name: "image-name", Context: "path"},
 			expected: "name: image-name\ncontext: path\n",
 		},
 	}


### PR DESCRIPTION
Fixes #2126 

## Proposed changes

- add flag to build cmd, add option at build manifest
- cache export mode min when tag is the same as cache export tag, max when they are different
- setup buildkit opts to use ExportCache when applicable
