### PR TITLE
fix: remote e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           name: Integration tests
           environment:
             OKTETO_SKIP_CLEANUP: 'true'
-          command: go test -run ^TestUpCompose$ github.com/okteto/okteto/integration -tags='actions common integration' -v
+          command: make integration
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: Prepare env
           command: |
-            new-item $HOME\.okteto -itemtype "directory" -force
+            new-item $HOME\.okteto -itemtype "directory" -force\n\r
             new-item $HOME\.okteto\.noanalytics -itemtype "file" -value "noanalytics" -force
             & 'C:\Users\circleci\project\artifacts\bin\okteto.exe' login --token $env:API_TOKEN
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           name: Integration tests
           environment:
             OKTETO_SKIP_CLEANUP: 'true'
-          command: make integration
+          command: go test -run ^TestUpCompose$ github.com/okteto/okteto/integration -tags='actions common integration' -v
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
       - run:
           name: Prepare env
           command: |
-            new-item $HOME\.okteto -itemtype "directory" -force\n\r
+            new-item $HOME\.okteto -itemtype "directory" -force
             new-item $HOME\.okteto\.noanalytics -itemtype "file" -value "noanalytics" -force
             & 'C:\Users\circleci\project\artifacts\bin\okteto.exe' login --token $env:API_TOKEN
       - run:

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -814,7 +814,7 @@ func TestUpCompose(t *testing.T) {
 		t.Fatalf("Expected to have only one endpoint for svc 'vote' but got %d", len(svc.Spec.Ports))
 	}
 
-	if !model.IsPortAvailable("localhost", 5005) {
+	if !model.IsPortAvailable("0.0.0.0", 5005) {
 		t.Fatal("Expected to have 5005 as port on localhost taken but it was not")
 	}
 

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -814,8 +815,12 @@ func TestUpCompose(t *testing.T) {
 		t.Fatalf("Expected to have only one endpoint for svc 'vote' but got %d", len(svc.Spec.Ports))
 	}
 
-	if !model.IsPortAvailable("0.0.0.0", 5005) {
-		t.Fatal("Expected to have 5005 as port on localhost taken but it was not")
+	port := "5005"
+	ln, err := net.Listen("tcp", ":"+port)
+
+	if err == nil {
+		_ = ln.Close()
+		t.Fatalf("port 5005 is available locally")
 	}
 
 	if err := downSvc(ctx, "vote", microservicesComposeFolder, oktetoPath); err != nil {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes compose up e2e test

## Proposed changes
- Check interface `0.0.0.0` instead of localhost to check if the port is open
- WIP: Docker in windows is returning a failure while building vote image
