### PR TITLE
Only deploy endpoints and volumes specified in servicesToDeploy

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -688,8 +688,11 @@ func (manifest *Manifest) ExpandEnvVars() (*Manifest, error) {
 				}
 			}
 			manifest.Deploy.ComposeSection.Stack = s
-			if manifest.Deploy.Endpoints != nil {
-				s.Endpoints = manifest.Deploy.Endpoints
+			if len(manifest.Deploy.Endpoints) > 0 {
+				if len(manifest.Deploy.ComposeSection.Stack.Endpoints) > 0 {
+					oktetoLog.Warning("Endpoints are defined in the stack and in the manifest. The endpoints defined in the manifest will be used")
+				}
+				manifest.Deploy.ComposeSection.Stack.Endpoints = manifest.Deploy.Endpoints
 			}
 			cwd, err := os.Getwd()
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Agustin Ramiro Diaz <agustin.ramiro.diaz@gmail.com>

Fixes #2519

## Proposed changes

- Filter out endpoints and volumes at the deploy options level
