### PR TITLE
Check okteto name env when manifest is compose

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -255,6 +255,10 @@ func GetStack(name, stackPath string, isCompose bool) (*Stack, error) {
 }
 
 func getStackName(name, stackPath, actualStackName string) (string, error) {
+	nameEnvVar := os.Getenv(OktetoNameEnvVar)
+	if nameEnvVar != "" {
+		return nameEnvVar, nil
+	}
 	if name != "" {
 		if err := os.Setenv(OktetoNameEnvVar, name); err != nil {
 			return "", err

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -207,8 +207,8 @@ const (
 	DependsOnServiceCompleted DependsOnCondition = "service_completed_successfully"
 )
 
-// GetStack returns an okteto stack object from a given file
-func GetStack(name, stackPath string, isCompose bool) (*Stack, error) {
+// GetStackFromPath returns an okteto stack object from a given file
+func GetStackFromPath(name, stackPath string, isCompose bool) (*Stack, error) {
 	b, err := os.ReadFile(stackPath)
 	if err != nil {
 		return nil, err
@@ -389,11 +389,7 @@ func (s *Stack) Validate() error {
 		}
 		svc.IgnoreSyncVolumes(s)
 	}
-	if err := validateDependsOn(s); err != nil {
-		return err
-	}
-
-	return nil
+	return validateDependsOn(s)
 }
 
 func validateStackName(name string) error {
@@ -631,7 +627,7 @@ func (r *StackResources) IsDefaultValue() bool {
 	return false
 }
 
-func (svcResources ServiceResources) IsDefaultValue() bool {
+func (svcResources *ServiceResources) IsDefaultValue() bool {
 	return svcResources.CPU.Value.IsZero() && svcResources.Memory.Value.IsZero() && svcResources.Storage.Size.Value.IsZero() && svcResources.Storage.Class == ""
 }
 
@@ -699,7 +695,7 @@ func getStack(name, manifestPath string) (*Stack, error) {
 	if isPathAComposeFile(manifestPath) {
 		isCompose = true
 	}
-	stack, err := GetStack(name, manifestPath, isCompose)
+	stack, err := GetStackFromPath(name, manifestPath, isCompose)
 	if err != nil {
 		return nil, err
 	}
@@ -730,7 +726,7 @@ func getOverrideFile(stackPath string) (*Stack, error) {
 		if isPathAComposeFile(stackPath) {
 			isCompose = true
 		}
-		stack, err := GetStack("", overridePath, isCompose)
+		stack, err := GetStackFromPath("", overridePath, isCompose)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -255,15 +255,15 @@ func GetStack(name, stackPath string, isCompose bool) (*Stack, error) {
 }
 
 func getStackName(name, stackPath, actualStackName string) (string, error) {
-	nameEnvVar := os.Getenv(OktetoNameEnvVar)
-	if nameEnvVar != "" {
-		return nameEnvVar, nil
-	}
 	if name != "" {
 		if err := os.Setenv(OktetoNameEnvVar, name); err != nil {
 			return "", err
 		}
 		return name, nil
+	}
+	nameEnvVar := os.Getenv(OktetoNameEnvVar)
+	if nameEnvVar != "" {
+		return nameEnvVar, nil
 	}
 	if actualStackName == "" {
 		name, err := GetValidNameFromGitRepo(filepath.Dir(stackPath))

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -261,11 +261,11 @@ func getStackName(name, stackPath, actualStackName string) (string, error) {
 		}
 		return name, nil
 	}
-	nameEnvVar := os.Getenv(OktetoNameEnvVar)
-	if nameEnvVar != "" {
-		return nameEnvVar, nil
-	}
 	if actualStackName == "" {
+		nameEnvVar := os.Getenv(OktetoNameEnvVar)
+		if nameEnvVar != "" {
+			return nameEnvVar, nil
+		}
 		name, err := GetValidNameFromGitRepo(filepath.Dir(stackPath))
 		if err != nil {
 			name, err = GetValidNameFromFolder(filepath.Dir(stackPath))

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -952,7 +952,7 @@ func TestStack_ExpandEnvsAtFileLevel(t *testing.T) {
 				os.Setenv(key, value)
 			}
 
-			stack, err := GetStack("test", tmpFile.Name(), false)
+			stack, err := GetStackFromPath("test", tmpFile.Name(), false)
 			if err != nil {
 				t.Fatalf("Error detected: %s", err.Error())
 			}

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -1059,3 +1059,76 @@ func Test_validateDependsOn(t *testing.T) {
 		})
 	}
 }
+
+func Test_getStackName(t *testing.T) {
+	tests := []struct {
+		testName        string
+		name            string
+		stackPath       string
+		actualStackName string
+		nameEnv         string
+		expected        string
+		expectedErr     bool
+	}{
+		{
+			testName: "name is not empty",
+			name:     "stack1",
+			expected: "stack1",
+		},
+		{
+			testName:        "actualStackName is not empty",
+			actualStackName: "stack2",
+			expected:        "stack2",
+		},
+		{
+			testName: "name and actualName and stackPath are empty - name env var not empty",
+			nameEnv:  "stack3",
+			expected: "stack3",
+		},
+		{
+			testName:  "name and actualName are empty - name env var and stackPath not empty",
+			nameEnv:   "stack3",
+			stackPath: "path/to/stack4/compose.yaml",
+			expected:  "stack3",
+		},
+		{
+			testName:  "name and actualName are empty - infer from folder",
+			stackPath: "path/to/stack4/compose.yaml",
+			expected:  "stack4",
+		},
+		{
+			testName:        "(name and actualStackName) are not empty",
+			name:            "stack1",
+			actualStackName: "stack2",
+			expected:        "stack1",
+		},
+		{
+			testName:        "name is empty and (nameEnv and actualStackName) are not empty",
+			actualStackName: "stack1",
+			nameEnv:         "stack2",
+			expected:        "stack1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			os.Setenv(OktetoNameEnvVar, tt.nameEnv)
+			res, err := getStackName(tt.name, tt.stackPath, tt.actualStackName)
+			resEnv := os.Getenv(OktetoNameEnvVar)
+
+			if err == nil && tt.expectedErr {
+				t.Fatal("expected error but not thrown")
+			}
+			if err != nil && !tt.expectedErr {
+				t.Fatal(err)
+			}
+			if res != tt.expected {
+				t.Fatalf("expected %s, got %s", tt.expected, res)
+			}
+			if resEnv != tt.expected {
+				t.Fatalf("expected env OKTETO_NAME %s, got %s", tt.expected, resEnv)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2501 

## Proposed changes

- check the Okteto name EnvVar when unmarshalling a compose manifest. 

Repo to test extended dependencies : https://github.com/teresaromero/movies-catalog/tree/tere/extended-dependencies

## Context
After investigating this, the problem was not the name at the dependencies section, but the name assigned to an okteto compose manifest, when this is part of a deploy command inside an okteto manifest.

So, for dependencies at the okteto manifest, this can be defined short or extended:

Short:
````
name: catalog

dependencies:
  - https://github.com/okteto/movies-frontend-with-divert
  - https://github.com/okteto/movies-rentals
````

Extended:
````
name: catalog

dependencies:
    frontend:
        repository: https://github.com/okteto/movies-frontend-with-divert
    rentals:
        repository: https://github.com/okteto/movies-rentals
````
When using extended, the name for the dependency (dev environment for that dependency) should be taken from the name assigned at the manifest, in this case frontend and rentals. Also, a manifest can have a name informed, so the dev environment for that manifest should be name, in this case, catalog.

When a manifest has a deployment of a compose file, like so:
````
name: catalog

dependencies:
    frontend:
        repository: https://github.com/okteto/movies-frontend-with-divert
    rentals:
        repository: https://github.com/okteto/movies-rentals

deploy:
    - okteto deploy -f mongodb-compose.yml
````

When transforming the compose into manifest v2, the name for the manifest was inferred from repo, or from the name flag, so, even though name is defined for okteto.yaml, name for the first command of deploy of this manifest, was not being transmitted to the compose. This also affected the dependencies which had a compose deployment, so 2 dev environments where created when deploying this manifests: 1 called catalog and other called movies-catalog which is the name of the repository.

Fixing this will require updating the cli version at the installer component, as the pipelines from dependencies are done by it. Also, there is an issue at the installer, which needs to be solved prior to include this fix into it.
https://github.com/okteto/app/issues/3632