### PR TITLE
fix: dettached paths on windows

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -239,6 +239,9 @@ func GetDevDetachMode(manifest *model.Manifest, devs []string) (*model.Dev, erro
 			}
 			for _, f := range d.Sync.Folders {
 				mountValue := filepath.Join("/", d.Name, f.RemotePath)
+				if runtime.GOOS == "windows" {
+					mountValue = filepath.ToSlash(mountValue)
+				}
 				dev.Sync.Folders = append(dev.Sync.Folders, model.SyncFolder{
 					LocalPath:  f.LocalPath,
 					RemotePath: mountValue,
@@ -271,6 +274,9 @@ func GetDevDetachMode(manifest *model.Manifest, devs []string) (*model.Dev, erro
 			dev.Services = append(dev.Services, d)
 			for _, f := range d.Sync.Folders {
 				mountValue := filepath.Join("/", d.Name, f.RemotePath)
+				if runtime.GOOS == "windows" {
+					mountValue = filepath.ToSlash(mountValue)
+				}
 				dev.Sync.Folders = append(dev.Sync.Folders, model.SyncFolder{
 					LocalPath:  f.LocalPath,
 					RemotePath: mountValue,

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -742,7 +742,7 @@ func Test_GetDevDetach(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.want.SetDefaults()
+			tt.want.SetDefaults()
 			for _, d := range tt.want.Services {
 				d.SetDefaults()
 			}
@@ -752,7 +752,18 @@ func Test_GetDevDetach(t *testing.T) {
 
 			d, err := GetDevDetachMode(tt.input, tt.devs)
 			assert.NoError(t, err)
-			assert.Equal(t, tt.want, d)
+
+			assert.Len(t, d.Services, len(tt.want.Services))
+			assert.Len(t, d.Sync.Folders, len(tt.want.Sync.Folders))
+			assert.Len(t, d.Forward, len(tt.want.Forward))
+
+			for _, testDev := range d.Services {
+				if d.Name != "test" {
+					continue
+				}
+				assert.Equal(t, tt.want.Services[0].Sync.Folders, testDev.Sync.Folders)
+				assert.Equal(t, tt.want.Services[0].Forward, testDev.Forward)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes path in sync with windows was creating path in windows style

## Proposed changes
- If the OS is windows translate it to unix style
-
