### PR TITLE
feat: if its docker extension enable detach mode

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
@@ -144,9 +145,10 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 	}
 
 	ctxOptions := &ContextOptions{
-		Context:   ctxResource.Context,
-		Namespace: ctxResource.Namespace,
-		Show:      true,
+		Context:       ctxResource.Context,
+		Namespace:     ctxResource.Namespace,
+		Show:          true,
+		DockerDesktop: os.Getenv(model.OktetoOriginEnvVar) == model.OktetoDockerDesktopOrigin,
 	}
 
 	if err := NewContextCommand().Run(ctx, ctxOptions); err != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -51,17 +51,18 @@ const ReconnectingMessage = "Trying to reconnect to your cluster. File synchroni
 
 // UpOptions represents the options available on up command
 type UpOptions struct {
-	DevPath    string
-	Namespace  string
-	K8sContext string
-	DevName    string
-	Devs       []string
-	Remote     int
-	Deploy     bool
-	Build      bool
-	ForcePull  bool
-	Reset      bool
-	Detach     bool
+	DevPath       string
+	Namespace     string
+	K8sContext    string
+	DevName       string
+	Devs          []string
+	Remote        int
+	Deploy        bool
+	Build         bool
+	ForcePull     bool
+	Reset         bool
+	Detach        bool
+	DockerDesktop bool
 }
 
 // Up starts a development container
@@ -79,7 +80,9 @@ func Up() *cobra.Command {
 			if err := upOptions.AddArgs(cmd, args); err != nil {
 				return err
 			}
-
+			if upOptions.DockerDesktop {
+				upOptions.Detach = true
+			}
 			u := utils.UpgradeAvailable()
 			if len(u) > 0 {
 				warningFolder := filepath.Join(config.GetOktetoHome(), ".warnings")
@@ -305,6 +308,8 @@ func Up() *cobra.Command {
 	cmd.Flags().MarkHidden("pull")
 	cmd.Flags().BoolVarP(&upOptions.Reset, "reset", "", false, "reset the file synchronization database")
 	cmd.Flags().BoolVarP(&upOptions.Detach, "detach", "", false, "activate one more development containers in detached mode")
+	cmd.Flags().BoolVarP(&upOptions.DockerDesktop, "docker-desktop", "", false, "if the command is executed from the Docker Desktop extension")
+	cmd.Flags().MarkHidden("docker-desktop")
 	return cmd
 }
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -82,6 +82,7 @@ func Up() *cobra.Command {
 			}
 			if upOptions.DockerDesktop {
 				upOptions.Detach = true
+				os.Setenv(model.OktetoOriginEnvVar, model.OktetoDockerDesktopOrigin)
 			}
 			u := utils.UpgradeAvailable()
 			if len(u) > 0 {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- Adds docker desktop flag to enable always the detach mode and load context with docker desktop origin
-
