### PR TITLE
fix: check build section

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -833,7 +833,7 @@ func checkServicesToBuild(service string, manifest *model.Manifest, ch chan stri
 	}
 	if manifest.Deploy != nil && manifest.Deploy.ComposeSection != nil && manifest.Deploy.ComposeSection.Stack != nil {
 		stack := manifest.Deploy.ComposeSection.Stack
-		if stack.Services[service].Image == "" {
+		if svc, ok := stack.Services[service]; ok && svc.Image == "" {
 			stack.Services[service].Image = fmt.Sprintf("${OKTETO_BUILD_%s_IMAGE}", strings.ToUpper(strings.ReplaceAll(service, "-", "_")))
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2548

## Proposed changes
The error was caused when there was a manifest v2 with a docker compose and the build section was trying to build a custom svc.
- The solution was to check if the compose had the svc that was trying to build
