### PR TITLE
fix: use busybox as dev image

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -295,6 +295,7 @@ func GetDevDetachMode(manifest *model.Manifest, devs []string) (*model.Dev, erro
 		}
 	}
 	dev.Name = detachModePodName
+	dev.Image = &model.BuildInfo{Name: "busybox"}
 	dev.Namespace = okteto.Context().Namespace
 	dev.Context = okteto.Context().Name
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2551

## Proposed changes
- Use busy box as the dev image for okteto detached mode
-
