### PR TITLE
fix: stream logs after up

### DIFF
--- a/cmd/up/logs.go
+++ b/cmd/up/logs.go
@@ -134,6 +134,7 @@ func getSternConfig(kubeconfigPath string) (*stern.Config, error) {
 		LabelSelector:       labelSelector,
 		FieldSelector:       fields.Everything(),
 		AllNamespaces:       false,
+		Follow:              true,
 		ErrOut:              os.Stderr,
 		Out:                 os.Stdout,
 		ContainerStates:     []stern.ContainerState{"running"},


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2550

## Proposed changes
- Stream the logs generated after running the up sequence
-
