### PR TITLE
fix: fix e2e flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
             OKTETO_PATH: 'C:\Users\circleci\project\artifacts\bin\okteto.exe'
             OKTETO_SKIP_CLEANUP: 'true'
           command: |
-            go test github.com/okteto/okteto/integration -tags="common integration actions" --count=1 -v -timeout 45m
+            go test github.com/okteto/okteto/integration -tags="common integration actions" --count=1 -v -timeout 1h
       - save_cache:
           key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 
 .PHONY: integration
 integration:
-	go test github.com/okteto/okteto/integration -tags="common integration actions" --count=1 -v -timeout 45m
+	go test github.com/okteto/okteto/integration -tags="common integration actions" --count=1 -v -timeout 1h
 
 .PHONY: integration-actions
 integration-actions:

--- a/integration/auto-wake_test.go
+++ b/integration/auto-wake_test.go
@@ -102,7 +102,7 @@ func TestAutoWake(t *testing.T) {
 	}
 
 	endpoint := fmt.Sprintf("https://%s-%s.%s", name, namespace, appsSubdomain)
-	content, err := getContent(endpoint, 150, nil)
+	content, err := getContent(endpoint, 300, nil)
 	if err != nil {
 		t.Fatalf("failed to get content: %s", err)
 	}
@@ -115,11 +115,11 @@ func TestAutoWake(t *testing.T) {
 	}
 
 	time.Sleep(5 * time.Second)
-	if err := checkIfSleeping(ctx, name, namespace, 150); err != nil {
+	if err := checkIfSleeping(ctx, name, namespace, 300); err != nil {
 		t.Fatal(err)
 	}
 
-	content, err = getContent(endpoint, 150, nil)
+	content, err = getContent(endpoint, 300, nil)
 	if err != nil {
 		t.Fatalf("failed to get content: %s", err)
 	}
@@ -127,7 +127,7 @@ func TestAutoWake(t *testing.T) {
 		t.Fatalf("failed to get content")
 	}
 
-	if err := checkIfAwake(ctx, name, namespace, false, 150); err != nil {
+	if err := checkIfAwake(ctx, name, namespace, false, 300); err != nil {
 		t.Fatal(err)
 	}
 
@@ -135,7 +135,7 @@ func TestAutoWake(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := checkIfSleeping(ctx, name, namespace, 150); err != nil {
+	if err := checkIfSleeping(ctx, name, namespace, 300); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,7 +146,7 @@ func TestAutoWake(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := checkIfAwake(ctx, name, namespace, true, 150); err != nil {
+	if err := checkIfAwake(ctx, name, namespace, true, 300); err != nil {
 		t.Fatal(err)
 	}
 

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -72,7 +72,7 @@ func TestDeployDestroy(t *testing.T) {
 		log.Printf("deployed \n")
 
 		endpoint := fmt.Sprintf("https://movies-%s.%s", namespace, appsSubdomain)
-		content, err := getContent(endpoint, 150, nil)
+		content, err := getContent(endpoint, 300, nil)
 		if err != nil {
 			t.Fatalf("failed to get app content: %s", err)
 		}

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -69,7 +69,7 @@ func TestPush(t *testing.T) {
 		log.Printf("pushed using %s \n", pushManifest)
 
 		endpoint := fmt.Sprintf("https://react-getting-started-%s.%s", namespace, appsSubdomain)
-		content, err := getContent(endpoint, 150, nil)
+		content, err := getContent(endpoint, 300, nil)
 		if err != nil {
 			t.Fatalf("failed to get app content: %s", err)
 		}

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -387,9 +387,8 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = getContent(indexEndpoint, 300, newUpErrorChannel)
-	if err != nil {
-		t.Fatalf("failed to get index content: %s", err)
+	if err := testUpdateContent(fmt.Sprintf("%s-reconnect", name), contentPath, 300, upErrorChannel); err != nil {
+		t.Fatal(err)
 	}
 
 	if err := checkIfUpFinished(ctx, p.Pid); err != nil {

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -387,7 +387,7 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testUpdateContent(fmt.Sprintf("%s-reconnect", name), contentPath, 300, upErrorChannel); err != nil {
+	if err := testUpdateContent(fmt.Sprintf("%s-reconnect", name), contentPath, 300, newUpErrorChannel); err != nil {
 		t.Fatal(err)
 	}
 

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -306,13 +306,13 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	waitForDeployment(ctx, namespace, name, 2, 120)
+	waitForDeployment(ctx, namespace, name, 2, 300)
 
 	defer showUpLogs(name, namespace, t)
 
 	log.Println("getting synchronized content")
 
-	content, err := getContent(indexEndpoint, 150, upErrorChannel)
+	content, err := getContent(indexEndpoint, 300, upErrorChannel)
 	if err != nil {
 		t.Fatalf("failed to get index content: %s", err)
 	}
@@ -323,7 +323,7 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatalf("expected synchronized index content to be '%s', got '%s'", name, content)
 	}
 
-	content, err = getContent(varEndpoint, 150, upErrorChannel)
+	content, err = getContent(varEndpoint, 300, upErrorChannel)
 	if err != nil {
 		t.Fatalf("failed to get var content: %s", err)
 	}
@@ -352,7 +352,7 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testUpdateContent(fmt.Sprintf("%s-updated", name), contentPath, 150, upErrorChannel); err != nil {
+	if err := testUpdateContent(fmt.Sprintf("%s-updated", name), contentPath, 300, upErrorChannel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -360,7 +360,7 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testUpdateContent(fmt.Sprintf("%s-kill-syncthing", name), contentPath, 150, upErrorChannel); err != nil {
+	if err := testUpdateContent(fmt.Sprintf("%s-kill-syncthing", name), contentPath, 300, upErrorChannel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -368,7 +368,7 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testUpdateContent(fmt.Sprintf("%s-destroy-pod", name), contentPath, 150, upErrorChannel); err != nil {
+	if err := testUpdateContent(fmt.Sprintf("%s-destroy-pod", name), contentPath, 300, upErrorChannel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -387,7 +387,7 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = getContent(indexEndpoint, 150, newUpErrorChannel)
+	_, err = getContent(indexEndpoint, 300, newUpErrorChannel)
 	if err != nil {
 		t.Fatalf("failed to get index content: %s", err)
 	}
@@ -481,13 +481,13 @@ func TestUpStatefulset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	waitForStatefulset(ctx, namespace, name, 120)
+	waitForStatefulset(ctx, namespace, name, 300)
 
 	defer showUpLogs(name, namespace, t)
 
 	log.Println("getting synchronized content")
 
-	content, err := getContent(indexEndpoint, 120, upErrorChannel)
+	content, err := getContent(indexEndpoint, 300, upErrorChannel)
 	if err != nil {
 		t.Fatalf("failed to get content: %s", err)
 	}
@@ -497,7 +497,7 @@ func TestUpStatefulset(t *testing.T) {
 		t.Fatalf("expected synchronized content to be %s, got %s", name, content)
 	}
 
-	content, err = getContent(varEndpoint, 150, upErrorChannel)
+	content, err = getContent(varEndpoint, 300, upErrorChannel)
 	if err != nil {
 		t.Fatalf("failed to get var content: %s", err)
 	}
@@ -609,7 +609,7 @@ func TestDivert(t *testing.T) {
 
 	log.Printf("pipeline using %s \n", divertGitRepo)
 
-	waitForDeployment(ctx, namespace, "health-checker", 1, 120)
+	waitForDeployment(ctx, namespace, "health-checker", 1, 300)
 
 	if err := modifyDivertApp(); err != nil {
 		t.Fatal(err)
@@ -623,17 +623,17 @@ func TestDivert(t *testing.T) {
 	}
 
 	divertedSvcName := fmt.Sprintf("health-checker-%s-okteto", user)
-	waitForDeployment(ctx, namespace, divertedSvcName, 2, 120)
+	waitForDeployment(ctx, namespace, divertedSvcName, 2, 300)
 
 	defer showUpLogs(name, namespace, t)
 
 	apiSvc := "catalog-chart"
-	originalContent, err := getContent(fmt.Sprintf("https://%s-%s.%s/data", apiSvc, namespace, appsSubdomain), 150, upErrorChannel)
+	originalContent, err := getContent(fmt.Sprintf("https://%s-%s.%s/data", apiSvc, namespace, appsSubdomain), 300, upErrorChannel)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := waitForDivertedContent(originalContent, namespace, apiSvc, upErrorChannel, 150); err != nil {
+	if err := waitForDivertedContent(originalContent, namespace, apiSvc, upErrorChannel, 300); err != nil {
 
 		t.Fatal("Contents are the same")
 	}
@@ -707,13 +707,13 @@ func TestUpAutocreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	waitForDeployment(ctx, namespace, fmt.Sprintf("%s-okteto", name), 1, 120)
+	waitForDeployment(ctx, namespace, fmt.Sprintf("%s-okteto", name), 1, 300)
 
 	defer showUpLogs(name, namespace, t)
 
 	log.Println("getting synchronized content")
 
-	content, err := getContent(indexEndpoint, 150, upErrorChannel)
+	content, err := getContent(indexEndpoint, 300, upErrorChannel)
 	if err != nil {
 		t.Fatalf("failed to get index content: %s", err)
 	}
@@ -732,7 +732,7 @@ func TestUpAutocreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testUpdateContent(fmt.Sprintf("%s-kill-syncthing", name), contentPath, 150, upErrorChannel); err != nil {
+	if err := testUpdateContent(fmt.Sprintf("%s-kill-syncthing", name), contentPath, 300, upErrorChannel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -740,7 +740,7 @@ func TestUpAutocreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testUpdateContent(fmt.Sprintf("%s-destroy-pod", name), contentPath, 150, upErrorChannel); err != nil {
+	if err := testUpdateContent(fmt.Sprintf("%s-destroy-pod", name), contentPath, 300, upErrorChannel); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes e2e tests are failing because of slow connectivity on CI

## Proposed changes
- Increase timeout to 1h
- Increase timeouts on e2e tests
