### PR TITLE
Fix #2505. Fix okteto deploy command within other okteto deploy execution

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -53,7 +53,7 @@ const (
 	succesfullyDeployedmsg = "Development environment '%s' successfully deployed"
 )
 
-var tempKubeConfigTemplate = "%s/.okteto/kubeconfig-%s"
+var tempKubeConfigTemplate = "%s/.okteto/kubeconfig-%s-%d"
 
 // Options options for deploy command
 type Options struct {
@@ -148,7 +148,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get the current working directory: %w", err)
 			}
-			name := ""
+			name := options.Name
 			if options.Name == "" {
 				name = utils.InferName(cwd)
 				if err != nil {
@@ -161,7 +161,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 
 			kubeconfig := NewKubeConfig()
 
-			proxy, err := NewProxy(options.Name, kubeconfig)
+			proxy, err := NewProxy(kubeconfig)
 			if err != nil {
 				oktetoLog.Infof("could not configure local proxy: %s", err)
 				return err
@@ -730,7 +730,7 @@ func isSPDY(r *http.Request) bool {
 
 //GetTempKubeConfigFile returns a where the temp kubeConfigFile should be stored
 func GetTempKubeConfigFile(name string) string {
-	return fmt.Sprintf(tempKubeConfigTemplate, config.GetUserHomeDir(), name)
+	return fmt.Sprintf(tempKubeConfigTemplate, config.GetUserHomeDir(), name, time.Now().UnixMilli())
 }
 
 func addEnvVars(ctx context.Context, cwd string) error {

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -51,7 +51,7 @@ type proxyHandler struct {
 }
 
 //NewProxy creates a new proxy
-func NewProxy(name string, kubeconfig *KubeConfig) (*Proxy, error) {
+func NewProxy(kubeconfig *KubeConfig) (*Proxy, error) {
 	// Look for a free local port to start the proxy
 	port, err := model.GetAvailablePort("localhost")
 	if err != nil {

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -107,7 +107,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get the current working directory: %w", err)
 			}
-			name := ""
+			name := options.Name
 			if options.Name == "" {
 				name = utils.InferName(cwd)
 				if err != nil {

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -245,7 +245,7 @@ func (*ManifestCommand) configureManifestDeployAndBuild(ctx context.Context, cwd
 
 func (mc *ManifestCommand) deploy(ctx context.Context, opts *InitOpts) error {
 	kubeconfig := deploy.NewKubeConfig()
-	proxy, err := deploy.NewProxy(mc.manifest.Name, kubeconfig)
+	proxy, err := deploy.NewProxy(kubeconfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -379,7 +379,7 @@ func loadManifestOverrides(dev *model.Dev, upOptions *UpOptions) error {
 
 func (up *upContext) deployApp(ctx context.Context) error {
 	kubeconfig := deploy.NewKubeConfig()
-	proxy, err := deploy.NewProxy(up.Manifest.Name, kubeconfig)
+	proxy, err := deploy.NewProxy(kubeconfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Nacho Fuertes <nacho@okteto.com>

Fixes #2505 

## Proposed changes

- In some cases, the deploy name is the same for the parent and child commands, so the temporal Kubernetes config used was exactly the same. That was provoking that the child command was removing the Kubeconfig, so next commands executed by the parent deploy would not have the right Kubeconfig. Now, I include the current timestamp in milliseconds to create different files if needed
