### PR TITLE
fix: fail if port is already in use in local machine

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -219,10 +219,7 @@ func GetDevDetachMode(manifest *model.Manifest, devs []string) (*model.Dev, erro
 			for _, forward := range d.Forward {
 				localPort := forward.Local
 				if !model.IsPortAvailable(dev.Interface, forward.Local) {
-					localPort, err = model.GetAvailablePort(dev.Interface)
-					if err != nil {
-						return nil, err
-					}
+					return nil, fmt.Errorf("local port %d is already in-use in your local machine", forward.Local)
 				}
 				dev.Forward = append(dev.Forward, model.Forward{
 					Local:       localPort,
@@ -251,15 +248,11 @@ func GetDevDetachMode(manifest *model.Manifest, devs []string) (*model.Dev, erro
 			dev.Services = append(dev.Services, d)
 		}
 	} else {
-		var err error
 		for dName, d := range manifest.Dev {
 			for _, forward := range d.Forward {
 				localPort := forward.Local
 				if !model.IsPortAvailable(dev.Interface, forward.Local) {
-					localPort, err = model.GetAvailablePort(dev.Interface)
-					if err != nil {
-						return nil, err
-					}
+					return nil, fmt.Errorf("local port %d is already in-use in your local machine", forward.Local)
 				}
 				dev.Forward = append(dev.Forward, model.Forward{
 					Local:       localPort,


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- If a `okteto up --detach` had any port taken the cli was taking a random port to create the forward. This PR returns a clear error instead of setting a random port

