### PR TITLE
fix: use 'okteto.dev' registry when image tagging to avoid authorizat…

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -144,7 +144,7 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 		opts := build.OptsFromManifest(svcName, buildInfo, &build.BuildOptions{})
 
 		if okteto.IsOkteto() && !registry.IsOktetoRegistry(buildInfo.Image) {
-			buildInfo.Image = opts.Tag
+			buildInfo.Image = ""
 		}
 		if !options.ForceBuild {
 			if buildInfo != nil {


### PR DESCRIPTION
…ion error

Signed-off-by: Adrian Pedriza Herrero <adripedriza@gmail.com>

Fixes #2532

## Proposed changes

- it was an error with `okteto stack deploy --build`.
- solution: change image tag name using `okteto.dev`registry to avoid authorization issues.
