### PR TITLE
fix: deploy from file not found error

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -120,9 +120,11 @@ func Deploy(ctx context.Context) *cobra.Command {
 			// deploy command. If not, we could be proxying a proxy and we would be applying the incorrect deployed-by label
 			os.Setenv(model.OktetoSkipConfigCredentialsUpdate, "false")
 			if options.ManifestPath != "" {
-				if err := os.Chdir(utils.GetWorkdirFromManifestPath(options.ManifestPath)); err != nil {
+				workdir := utils.GetWorkdirFromManifestPath(options.ManifestPath)
+				if err := os.Chdir(workdir); err != nil {
 					return err
 				}
+				options.ManifestPath = utils.GetManifestPathFromWorkdir(options.ManifestPath, workdir)
 			}
 			if err := contextCMD.LoadManifestV2WithContext(ctx, options.Namespace, options.K8sContext, options.ManifestPath); err != nil {
 				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{Namespace: options.Namespace}); err != nil {

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -47,9 +47,11 @@ func Endpoints(ctx context.Context) *cobra.Command {
 		Short: "Show endpoints for an environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.ManifestPath != "" {
-				if err := os.Chdir(utils.GetWorkdirFromManifestPath(options.ManifestPath)); err != nil {
+				workdir := utils.GetWorkdirFromManifestPath(options.ManifestPath)
+				if err := os.Chdir(workdir); err != nil {
 					return err
 				}
+				options.ManifestPath = utils.GetManifestPathFromWorkdir(options.ManifestPath, workdir)
 			}
 
 			ctxResource, err := utils.LoadManifestContext(options.ManifestPath)

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -95,9 +95,11 @@ func Destroy(ctx context.Context) *cobra.Command {
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.ManifestPath != "" {
-				if err := os.Chdir(utils.GetWorkdirFromManifestPath(options.ManifestPath)); err != nil {
+				workdir := utils.GetWorkdirFromManifestPath(options.ManifestPath)
+				if err := os.Chdir(workdir); err != nil {
 					return err
 				}
+				options.ManifestPath = utils.GetManifestPathFromWorkdir(options.ManifestPath, workdir)
 			}
 			if err := contextCMD.LoadManifestV2WithContext(ctx, options.Namespace, options.K8sContext, options.ManifestPath); err != nil {
 				return err

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -52,9 +52,11 @@ func Down() *cobra.Command {
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: devPath, Namespace: namespace, K8sContext: k8sContext}
 			if devPath != "" {
-				if err := os.Chdir(utils.GetWorkdirFromManifestPath(devPath)); err != nil {
+				workdir := utils.GetWorkdirFromManifestPath(devPath)
+				if err := os.Chdir(workdir); err != nil {
 					return err
 				}
+				devPath = utils.GetManifestPathFromWorkdir(devPath, workdir)
 			}
 			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
 			if err != nil {

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -53,9 +53,11 @@ func deploy(ctx context.Context) *cobra.Command {
 
 			options.StackPaths = loadComposePaths(options.StackPaths)
 			if len(options.StackPaths) == 1 {
-				if err := os.Chdir(utils.GetWorkdirFromManifestPath(options.StackPaths[0])); err != nil {
+				workdir := utils.GetWorkdirFromManifestPath(options.StackPaths[0])
+				if err := os.Chdir(workdir); err != nil {
 					return err
 				}
+				options.StackPaths[0] = utils.GetManifestPathFromWorkdir(options.StackPaths[0], workdir)
 			}
 			s, err := contextCMD.LoadStackWithContext(ctx, options.Name, options.Namespace, options.StackPaths)
 			if err != nil {

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -39,9 +39,11 @@ func Destroy(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto stack destroy' is deprecated in favor of 'okteto destroy', and will be removed in version 2.2.0")
 			if len(stackPath) == 1 {
-				if err := os.Chdir(utils.GetWorkdirFromManifestPath(stackPath[0])); err != nil {
+				workdir := utils.GetWorkdirFromManifestPath(stackPath[0])
+				if err := os.Chdir(workdir); err != nil {
 					return err
 				}
+				stackPath[0] = utils.GetManifestPathFromWorkdir(stackPath[0], workdir)
 			}
 			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath)
 			if err != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -97,9 +97,11 @@ func Up() *cobra.Command {
 			ctx := context.Background()
 
 			if upOptions.DevPath != "" {
-				if err := os.Chdir(utils.GetWorkdirFromManifestPath(upOptions.DevPath)); err != nil {
+				workdir := utils.GetWorkdirFromManifestPath(upOptions.DevPath)
+				if err := os.Chdir(workdir); err != nil {
 					return err
 				}
+				upOptions.DevPath = utils.GetManifestPathFromWorkdir(upOptions.DevPath, workdir)
 			}
 			manifestOpts := contextCMD.ManifestOptions{Filename: upOptions.DevPath, Namespace: upOptions.Namespace, K8sContext: upOptions.K8sContext}
 			oktetoManifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)

--- a/cmd/utils/manifest.go
+++ b/cmd/utils/manifest.go
@@ -40,3 +40,12 @@ func GetWorkdirFromManifestPath(manifestPath string) string {
 	}
 	return dir
 }
+
+// GetManifestPathFromWorkdir returns the path from a workdir
+func GetManifestPathFromWorkdir(manifestPath, workdir string) string {
+	mPath, err := filepath.Rel(workdir, manifestPath)
+	if err != nil {
+		return ""
+	}
+	return mPath
+}

--- a/cmd/utils/manifest_test.go
+++ b/cmd/utils/manifest_test.go
@@ -15,6 +15,7 @@ package utils
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,13 @@ func TestGetWorkdirFromManifest(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GetWorkdirFromManifestPath(tt.path)
 			assert.Equal(t, tt.expectedPath, result)
+			newManifestPath := GetManifestPathFromWorkdir(tt.path, result)
+			if strings.Contains(tt.path, ".okteto") {
+				assert.Equal(t, ".okteto/okteto.yml", newManifestPath)
+			} else {
+				assert.Equal(t, "okteto.yml", newManifestPath)
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
Fixes #2573

## Proposed changes
- Get the actual path of the file after changing workdir
- 
