### PR TITLE
fix: paths on windows test

### DIFF
--- a/cmd/utils/manifest_test.go
+++ b/cmd/utils/manifest_test.go
@@ -65,7 +65,7 @@ func TestGetWorkdirFromManifest(t *testing.T) {
 			assert.Equal(t, tt.expectedPath, result)
 			newManifestPath := GetManifestPathFromWorkdir(tt.path, result)
 			if strings.Contains(tt.path, ".okteto") {
-				assert.Equal(t, ".okteto/okteto.yml", newManifestPath)
+				assert.Equal(t, filepath.Join(".okteto", "okteto.yml"), newManifestPath)
 			} else {
 				assert.Equal(t, "okteto.yml", newManifestPath)
 			}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes paths on windows

## Proposed changes
- Set paths independently of the OS on tests
-
