### PR TITLE
fix: check gh releases e2e test

### DIFF
--- a/cmd/utils/upgrade.go
+++ b/cmd/utils/upgrade.go
@@ -56,7 +56,7 @@ func UpgradeAvailable() string {
 func GetLatestVersionFromGithub() (string, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
-	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 5})
+	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 10})
 	if err != nil {
 		return "", fmt.Errorf("fail to get releases from github: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes get release from github

## Proposed changes
- We had 5 releases candidates without having an official release which is causing e2e tests to fail
