### PR TITLE
fix: manifestv1 was not passing ctx and ns to v2

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -293,6 +293,8 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 		if devManifest.IsV2 {
 			return devManifest, nil
 		}
+		devManifest.SetManifestDefaultsFromDev()
+
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Okteto manifest unmarshalled successfully")
 	}
 
@@ -1056,4 +1058,16 @@ func (m *Manifest) IsDeployDefault() bool {
 		return true
 	}
 	return false
+}
+
+// SetManifestDefaultsFromDev sets context and namespace from the dev
+func (m *Manifest) SetManifestDefaultsFromDev() {
+	if len(m.Dev) == 1 {
+		for _, devInfo := range m.Dev {
+			m.Context = devInfo.Context
+			m.Namespace = devInfo.Namespace
+		}
+	} else {
+		oktetoLog.Infof("could not set context and manifest from dev section due to being '%d' devs declared", len(m.Dev))
+	}
 }

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -262,3 +262,75 @@ func TestInferFromStack(t *testing.T) {
 		})
 	}
 }
+
+func TestSetManifestDefaultsFromDev(t *testing.T) {
+	os.Setenv("my_key", "my_value")
+	tests := []struct {
+		name              string
+		currentManifest   *Manifest
+		expectedContext   string
+		expectedNamespace string
+	}{
+		{
+			name: "setting only manifest.Namespace",
+			currentManifest: &Manifest{
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Namespace: "other-ns",
+					},
+				},
+			},
+			expectedContext:   "",
+			expectedNamespace: "other-ns",
+		},
+		{
+			name: "setting only manifest.Context",
+			currentManifest: &Manifest{
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Context: "other-ctx",
+					},
+				},
+			},
+			expectedContext:   "other-ctx",
+			expectedNamespace: "",
+		},
+		{
+			name: "setting manifest.Context & manifest.Namespace",
+			currentManifest: &Manifest{
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Context:   "other-ctx",
+						Namespace: "other-ns",
+					},
+				},
+			},
+			expectedContext:   "other-ctx",
+			expectedNamespace: "other-ns",
+		},
+		{
+			name: "not overwrite if manifest has more than one dev",
+			currentManifest: &Manifest{
+				Namespace: "test",
+				Context:   "test",
+				Dev: ManifestDevs{
+					"test": &Dev{
+						Context: "other-ctx",
+					},
+					"test-2": &Dev{
+						Context: "other-ctx",
+					},
+				},
+			},
+			expectedContext:   "test",
+			expectedNamespace: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.currentManifest.SetManifestDefaultsFromDev()
+			assert.Equal(t, tt.expectedContext, tt.currentManifest.Context)
+			assert.Equal(t, tt.expectedNamespace, tt.currentManifest.Namespace)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2582

## Proposed changes
- When loading a manifest v1 okteto was transforming it to a manifest v2 not taking in count the ctx and ns provided from the manifest v1
