### PR TITLE
feat: show options to the user if failure

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -151,19 +151,27 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 	} else if len(manifest.Dev) == 1 {
 		for name, dev := range manifest.Dev {
 			if devName != "" && devName != name {
-				return nil, fmt.Errorf("dev '%s' doesn't exist", devName)
+				return nil, oktetoErrors.UserError{
+					E:    fmt.Errorf("development container '%s' doesn't exist", devName),
+					Hint: fmt.Sprintf("Available options are: [%s]", name),
+				}
 			}
 			return dev, nil
 		}
 	}
 
 	if devName != "" {
+		options := []string{}
 		for k := range manifest.Dev {
 			if k == devName {
 				return manifest.Dev[devName], nil
 			}
+			options = append(options, k)
 		}
-		return nil, fmt.Errorf("development container '%s' doesn't exist", devName)
+		return nil, oktetoErrors.UserError{
+			E:    fmt.Errorf("development container '%s' doesn't exist", devName),
+			Hint: fmt.Sprintf("Available options are: [%s]", strings.Join(options, ", ")),
+		}
 	}
 	devs := []string{}
 	for k := range manifest.Dev {

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -145,14 +145,15 @@ func LoadManifestOrDefault(devPath, name string) (*model.Manifest, error) {
 	return nil, err
 }
 
+// GetDevFromManifest gets a dev from a manifest by
 func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, error) {
 	if len(manifest.Dev) == 0 {
-		return nil, fmt.Errorf("okteto manifest has no 'dev' section. Configure it with 'okteto init'")
+		return nil, oktetoErrors.ErrManifestNoDevSection
 	} else if len(manifest.Dev) == 1 {
 		for name, dev := range manifest.Dev {
 			if devName != "" && devName != name {
 				return nil, oktetoErrors.UserError{
-					E:    fmt.Errorf("development container '%s' doesn't exist", devName),
+					E:    fmt.Errorf(oktetoErrors.ErrDevContainerNotExists, devName),
 					Hint: fmt.Sprintf("Available options are: [%s]", name),
 				}
 			}
@@ -169,7 +170,7 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 			options = append(options, k)
 		}
 		return nil, oktetoErrors.UserError{
-			E:    fmt.Errorf("development container '%s' doesn't exist", devName),
+			E:    fmt.Errorf(oktetoErrors.ErrDevContainerNotExists, devName),
 			Hint: fmt.Sprintf("Available options are: [%s]", strings.Join(options, ", ")),
 		}
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -155,6 +155,12 @@ var (
 
 	// ErrNoFlagAllowedOnSingleImageBuild is raised when the user tries to build a single image with flags
 	ErrNoFlagAllowedOnSingleImageBuild = errors.New("flags only allowed when building a single image with `okteto build [NAME]`")
+
+	// ErrManifestNoDevSection is raised when the manifest doesn't have a dev section and the user tries to access it
+	ErrManifestNoDevSection = errors.New("okteto manifest has no 'dev' section. Configure it with 'okteto init'")
+
+	// ErrDevContainerNotExists is raised when the dev container doesn't exist on dev section
+	ErrDevContainerNotExists = "development container '%s' doesn't exist"
 )
 
 // IsForbidden raised if the Okteto API returns 401


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2547

## Proposed changes
- If the user introduce a wrong dev okteto will show the same error as before but now CLI will display a hint with the options that the user has.

## Screenshoot
<img width="819" alt="Captura de pantalla 2022-04-27 a las 18 07 39" src="https://user-images.githubusercontent.com/25170843/165563381-c1b88e70-a571-4787-84a2-47cc9e0768f8.png">

