### PR TITLE
fix: deploy a subset of svcs was building everything

### DIFF
--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -118,3 +118,24 @@ func (bc *OktetoBuilder) checkImageAtGlobalAndSetEnvs(service string, options *t
 	return true, nil
 
 }
+
+// GetServicesToBuildFromSubset returns the services it has to built because they are not already built from a subset of services
+func (bc *OktetoBuilder) GetServicesToBuildFromSubset(ctx context.Context, manifest *model.Manifest, subset []string) ([]string, error) {
+	for name := range manifest.Build {
+		needsBuild := false
+		for _, toBuildName := range subset {
+			if name == toBuildName {
+				needsBuild = true
+				break
+			}
+		}
+		if !needsBuild {
+			delete(manifest.Build, name)
+		}
+	}
+	svcsToBuild, err := bc.GetServicesToBuild(ctx, manifest)
+	if err != nil {
+		return []string{}, err
+	}
+	return svcsToBuild, err
+}

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -86,3 +86,45 @@ func TestServicesNotInStack(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(fakeManifest.Build)-len(alreadyBuilt), len(toBuild))
 }
+
+func TestAllServicesAlreadyBuiltWithSubset(t *testing.T) {
+	fakeReg := test.NewFakeOktetoRegistry(nil)
+	bc := &OktetoBuilder{
+		Registry: fakeReg,
+	}
+	alreadyBuilt := []string{}
+	fakeReg.AddImageByName(alreadyBuilt...)
+	ctx := context.Background()
+	toBuild, err := bc.GetServicesToBuildFromSubset(ctx, fakeManifest, []string{"test-1"})
+	//should not throw error
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(toBuild))
+}
+
+func TestServicesNotAreAlreadyBuiltWithSubset(t *testing.T) {
+	fakeReg := test.NewFakeOktetoRegistry(nil)
+	bc := &OktetoBuilder{
+		Registry: fakeReg,
+	}
+	alreadyBuilt := []string{"test/test-1"}
+	fakeReg.AddImageByName(alreadyBuilt...)
+	ctx := context.Background()
+	toBuild, err := bc.GetServicesToBuildFromSubset(ctx, fakeManifest, []string{"test-1"})
+	//should not throw error
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(toBuild))
+}
+
+func TestNoServiceBuiltWithSubset(t *testing.T) {
+	fakeReg := test.NewFakeOktetoRegistry(nil)
+	bc := &OktetoBuilder{
+		Registry: fakeReg,
+	}
+	alreadyBuilt := []string{"test/test-1", "test/test-2"}
+	fakeReg.AddImageByName(alreadyBuilt...)
+	ctx := context.Background()
+	toBuild, err := bc.GetServicesToBuildFromSubset(ctx, fakeManifest, []string{"test-1"})
+	//should not throw error
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(toBuild))
+}

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -30,7 +30,7 @@ func TestAllServicesAlreadyBuilt(t *testing.T) {
 	alreadyBuilt := []string{}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest)
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1", "test-2"})
 	//should not throw error
 	assert.NoError(t, err)
 	assert.Equal(t, len(fakeManifest.Build)-len(alreadyBuilt), len(toBuild))
@@ -44,7 +44,7 @@ func TestServicesNotAreAlreadyBuilt(t *testing.T) {
 	alreadyBuilt := []string{"test/test-1"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest)
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1", "test-2"})
 	//should not throw error
 	assert.NoError(t, err)
 	assert.Equal(t, len(fakeManifest.Build)-len(alreadyBuilt), len(toBuild))
@@ -58,7 +58,7 @@ func TestNoServiceBuilt(t *testing.T) {
 	alreadyBuilt := []string{"test/test-1", "test/test-2"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest)
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1", "test-2"})
 	//should not throw error
 	assert.NoError(t, err)
 	assert.Equal(t, len(fakeManifest.Build)-len(alreadyBuilt), len(toBuild))
@@ -81,7 +81,7 @@ func TestServicesNotInStack(t *testing.T) {
 	fakeManifest.Deploy = &model.DeployInfo{ComposeSection: &model.ComposeSectionInfo{
 		Stack: stack,
 	}}
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest)
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1", "test-2"})
 	//should not throw error
 	assert.NoError(t, err)
 	assert.Equal(t, len(fakeManifest.Build)-len(alreadyBuilt), len(toBuild))
@@ -95,7 +95,7 @@ func TestAllServicesAlreadyBuiltWithSubset(t *testing.T) {
 	alreadyBuilt := []string{}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuildFromSubset(ctx, fakeManifest, []string{"test-1"})
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1"})
 	//should not throw error
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(toBuild))
@@ -109,7 +109,7 @@ func TestServicesNotAreAlreadyBuiltWithSubset(t *testing.T) {
 	alreadyBuilt := []string{"test/test-1"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuildFromSubset(ctx, fakeManifest, []string{"test-1"})
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1"})
 	//should not throw error
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(toBuild))
@@ -123,7 +123,7 @@ func TestNoServiceBuiltWithSubset(t *testing.T) {
 	alreadyBuilt := []string{"test/test-1", "test/test-2"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuildFromSubset(ctx, fakeManifest, []string{"test-1"})
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1"})
 	//should not throw error
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(toBuild))

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -286,18 +286,9 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			return err
 		}
 	} else {
-
-		var svcsToBuild []string
-		if len(deployOptions.servicesToDeploy) == 0 {
-			svcsToBuild, err = dc.Builder.GetServicesToBuild(ctx, deployOptions.Manifest)
-			if err != nil {
-				return err
-			}
-		} else {
-			svcsToBuild, err = dc.Builder.GetServicesToBuildFromSubset(ctx, deployOptions.Manifest, deployOptions.servicesToDeploy)
-			if err != nil {
-				return err
-			}
+		svcsToBuild, err := dc.Builder.GetServicesToBuild(ctx, deployOptions.Manifest, deployOptions.servicesToDeploy)
+		if err != nil {
+			return err
 		}
 		if len(svcsToBuild) != 0 {
 			buildOptions := &types.BuildOptions{

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -464,7 +464,9 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 				deployOptions.servicesToDeploy = append(deployOptions.servicesToDeploy, service)
 			}
 		}
-		deployOptions.servicesToDeploy = stack.AddDependentServicesIfNotPresent(ctx, deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.servicesToDeploy, c)
+		if len(deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo) > 0 {
+			deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo[0].ServicesToDeploy = stack.AddDependentServicesIfNotPresent(ctx, deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.servicesToDeploy, c)
+		}
 	}
 
 	if len(deployOptions.servicesToDeploy) == 0 {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -465,7 +465,8 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 			}
 		}
 		if len(deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo) > 0 {
-			deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo[0].ServicesToDeploy = stack.AddDependentServicesIfNotPresent(ctx, deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.servicesToDeploy, c)
+			deployOptions.servicesToDeploy = stack.AddDependentServicesIfNotPresent(ctx, deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.servicesToDeploy, c)
+			deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo[0].ServicesToDeploy = deployOptions.servicesToDeploy
 		}
 	}
 

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -724,7 +724,7 @@ func addDependentServices(ctx context.Context, s *model.Stack, svcsToDeploy []st
 			if _, ok := svcsToDeploySet[dependentSvc]; ok {
 				continue
 			}
-			if !isSvcToBeDeployed(svcsToDeploy, dependentSvc) && !isSvcRunning(ctx, s.Services[dependentSvc], s.Namespace, dependentSvc, c) {
+			if !isSvcRunning(ctx, s.Services[dependentSvc], s.Namespace, dependentSvc, c) {
 				svcsToDeploy = append(svcsToDeploy, dependentSvc)
 				svcsToDeploySet[dependentSvc] = true
 			}
@@ -748,13 +748,4 @@ func getAddedSvcs(initialSvcsToDeploy, svcsToDeployWithDependencies []string) []
 		}
 	}
 	return added
-}
-
-func isSvcToBeDeployed(servicesToDeploy []string, svcName string) bool {
-	for _, svcToBeDeployedName := range servicesToDeploy {
-		if svcName == svcToBeDeployedName {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/cmd/stack/deploy_test.go
+++ b/pkg/cmd/stack/deploy_test.go
@@ -497,7 +497,7 @@ func Test_AddSomeServices(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			options := &StackDeployOptions{ServicesToDeploy: tt.svcsToBeDeployed}
-			addDependentServicesIfNotPresent(ctx, tt.stack, options, fakeClient)
+			options.ServicesToDeploy = AddDependentServicesIfNotPresent(ctx, tt.stack, options.ServicesToDeploy, fakeClient)
 
 			if !reflect.DeepEqual(tt.expectedSvcsToBeDeployed, options.ServicesToDeploy) {
 				t.Errorf("Expected %v but got %v", tt.expectedSvcsToBeDeployed, options.ServicesToDeploy)

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -134,20 +134,9 @@ func translateBuildImages(ctx context.Context, s *model.Stack, options *StackDep
 			return err
 		}
 	} else {
-		var (
-			svcsToBuild []string
-			err         error
-		)
-		if len(options.ServicesToDeploy) == 0 {
-			svcsToBuild, err = builder.GetServicesToBuild(ctx, manifest)
-			if err != nil {
-				return err
-			}
-		} else {
-			svcsToBuild, err = builder.GetServicesToBuildFromSubset(ctx, manifest, options.ServicesToDeploy)
-			if err != nil {
-				return err
-			}
+		svcsToBuild, err := builder.GetServicesToBuild(ctx, manifest, options.ServicesToDeploy)
+		if err != nil {
+			return err
 		}
 
 		if len(svcsToBuild) != 0 {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Deploying a subset of services was building everything

## Proposed changes
- Fix: getting dependant services was only getting the first dependant service and not going deeper
- It was not checking the services to build given a list of services
- It was showing twice some messages because okteto stack and okteto deploy was sharing some logic
