### PR TITLE
fix: avoid nil pointer when cannot load manifest

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -130,6 +130,8 @@ func Up() *cobra.Command {
 					if err != nil {
 						return err
 					}
+				} else {
+					return err
 				}
 			}
 			wd, err := os.Getwd()

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -118,19 +118,20 @@ func Up() *cobra.Command {
 				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.CloudURL).Error() {
 					return err
 				}
-				if errors.Is(err, oktetoErrors.ErrManifestNotFound) {
-					if !utils.AskIfOktetoInit(upOptions.DevPath) {
-						return err
-					}
 
-					if upOptions.DevPath == "" {
-						upOptions.DevPath = utils.DefaultManifest
-					}
-					oktetoManifest, err = LoadManifestWithInit(ctx, upOptions.K8sContext, upOptions.Namespace, upOptions.DevPath)
-					if err != nil {
-						return err
-					}
-				} else {
+				if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+					return err
+				}
+
+				if !utils.AskIfOktetoInit(upOptions.DevPath) {
+					return err
+				}
+
+				if upOptions.DevPath == "" {
+					upOptions.DevPath = utils.DefaultManifest
+				}
+				oktetoManifest, err = LoadManifestWithInit(ctx, upOptions.K8sContext, upOptions.Namespace, upOptions.DevPath)
+				if err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Adrian Pedriza Herrero <adripedriza@gmail.com>

## Proposed changes

- Control error when cannot load manifest but is found
