### PR TITLE
fix: load env files from stack directory

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -75,8 +75,10 @@ func (sd *Stack) Deploy(ctx context.Context, s *model.Stack, options *StackDeplo
 		return err
 	}
 
-	if err := translate(ctx, s, options); err != nil {
-		return err
+	if !options.InsidePipeline {
+		if err := buildStackImages(ctx, s, options); err != nil {
+			return err
+		}
 	}
 
 	cfg := translateConfigMap(s)

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -14,10 +14,8 @@
 package stack
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -33,107 +31,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 )
-
-const (
-	env = `A=hello
-# comment
-OKTETO_TEST=
-
-B=$B
-
-C=3
-
-D="4
-5 $B
-\"6\"
-'7'"
-E=word -notword`
-	envOverride = "A=1"
-)
-
-func Test_translate(t *testing.T) {
-	ctx := context.Background()
-	stack := &model.Stack{
-		Name: "name",
-		Services: map[string]*model.Service{
-			"1": {
-				Image:    "image",
-				EnvFiles: []string{"/non-existing"},
-			},
-		},
-	}
-	if err := translate(ctx, stack, &StackDeployOptions{ForceBuild: false, Wait: false}); err == nil {
-		t.Fatalf("An error should be returned")
-	}
-}
-
-func Test_translateEnvVars(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", ".env")
-	if err != nil {
-		t.Fatalf("failed to create dynamic env file: %s", err.Error())
-	}
-	if err := os.WriteFile(tmpFile.Name(), []byte(env), 0600); err != nil {
-		t.Fatalf("failed to write env file: %s", err.Error())
-	}
-	defer os.RemoveAll(tmpFile.Name())
-
-	tmpFile2, err := os.CreateTemp("", ".env")
-	if err != nil {
-		t.Fatalf("failed to create dynamic env file: %s", err.Error())
-	}
-	if err := os.WriteFile(tmpFile2.Name(), []byte(envOverride), 0600); err != nil {
-		t.Fatalf("failed to write env file: %s", err.Error())
-	}
-	defer os.RemoveAll(tmpFile2.Name())
-
-	os.Setenv("B", "2")
-	os.Setenv("ENV_PATH", tmpFile.Name())
-	os.Setenv("ENV_PATH2", tmpFile2.Name())
-	os.Setenv("OKTETO_TEST", "myvalue")
-	stack := &model.Stack{
-		Name: "name",
-		Services: map[string]*model.Service{
-			"1": {
-				Image:    "image",
-				EnvFiles: []string{"${ENV_PATH}", "${ENV_PATH2}"},
-				Environment: []model.EnvVar{
-					{
-						Name:  "C",
-						Value: "original",
-					},
-				},
-			},
-		},
-	}
-	ctx := context.Background()
-	translateStackEnvVars(ctx, stack)
-	if stack.Services["1"].Image != "image" {
-		t.Errorf("Wrong image: %s", stack.Services["1"].Image)
-	}
-	if len(stack.Services["1"].Environment) != 6 {
-		t.Errorf("Wrong environment: %v", stack.Services["1"].Environment)
-	}
-	for _, e := range stack.Services["1"].Environment {
-		if e.Name == "A" && e.Value != "1" {
-			t.Errorf("Wrong environment variable A: %s", e.Value)
-		}
-		if e.Name == "B" && e.Value != "2" {
-			t.Errorf("Wrong environment variable B: %s", e.Value)
-		}
-		if e.Name == "C" && e.Value != "original" {
-			t.Errorf("Wrong environment variable C: %s", e.Value)
-		}
-		if e.Name == "D" && e.Value != "4\n5 2\n\"6\"\n'7'" {
-			t.Errorf("Wrong environment variable D: %s", e.Value)
-		}
-		if e.Name == "E" && e.Value != "word -notword" {
-			t.Errorf("Wrong environment variable E: %s", e.Value)
-		}
-		if e.Name == "OKTETO_TEST" && e.Value != "myvalue" {
-			t.Errorf("Wrong environment variable OKTETO_TEST: %s", e.Value)
-		}
-	}
-}
 
 func Test_translateConfigMap(t *testing.T) {
 	s := &model.Stack{

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -809,11 +809,14 @@ func (m *Manifest) InferFromStack(cwd string) (*Manifest, error) {
 		}
 
 		for idx, volume := range buildInfo.VolumesToInclude {
-			volume.LocalPath, err = filepath.Rel(buildInfo.Context, volume.LocalPath)
-			if err != nil {
-				volume.LocalPath, err = filepath.Rel(cwd, volume.LocalPath)
+			localPath := volume.LocalPath
+			if filepath.IsAbs(localPath) {
+				localPath, err = filepath.Rel(buildInfo.Context, volume.LocalPath)
 				if err != nil {
-					oktetoLog.Info("can not find svc[%s].build.volumes to include relative to svc[%s].build.context", svcName, svcName)
+					localPath, err = filepath.Rel(cwd, volume.LocalPath)
+					if err != nil {
+						oktetoLog.Info("can not find svc[%s].build.volumes to include relative to svc[%s].build.context", svcName, svcName)
+					}
 				}
 			}
 			buildInfo.VolumesToInclude[idx] = volume


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- Load stack env files when unmarshaling the compose file. Env files could be from on another folder
- Load stack files with a relative path to the compose file instead of the command execution dir
