### PR TITLE
fix: remove warning symbols on stderr

### DIFF
--- a/cmd/utils/displayer/tty.go
+++ b/cmd/utils/displayer/tty.go
@@ -93,7 +93,7 @@ func (d *ttyDisplayer) Display(command string) {
 				case <-d.commandContext.Done():
 				default:
 					line := d.stderrScanner.Text()
-					oktetoLog.FWarning(os.Stdout, line)
+					oktetoLog.Println(line)
 					continue
 				}
 				break


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2533

## Proposed changes
- Show stderr without modifying it

