### PR TITLE
fix: only skip ports if svc is public

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -866,7 +866,10 @@ func translateContainerPorts(svc *model.Service) []apiv1.ContainerPort {
 
 func translateServicePorts(svc model.Service) []apiv1.ServicePort {
 	result := []apiv1.ServicePort{}
-	ports := getPortsToAddToSvc(svc.Ports)
+	ports := svc.Ports
+	if svc.Public {
+		ports = getPortsToAddToSvc(svc.Ports)
+	}
 	for _, p := range ports {
 		if !isServicePortAdded(p.ContainerPort, result) {
 			result = append(


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes Database ports were skipped and services created didn't have public ports 

