### PR TITLE
fix: nil pointer when okteto manifest is created

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -132,8 +132,6 @@ func Up() *cobra.Command {
 				if err != nil {
 					return err
 				}
-			} else if err != nil {
-				return err
 			}
 			wd, err := os.Getwd()
 			if err != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -376,6 +376,23 @@ func LoadManifestWithInit(ctx context.Context, k8sContext, namespace, devPath st
 	if err != nil {
 		return nil, err
 	}
+
+	if manifest.Namespace == "" {
+		manifest.Namespace = okteto.Context().Namespace
+	}
+	if manifest.Context == "" {
+		manifest.Context = okteto.Context().Name
+	}
+	manifest.IsV2 = true
+	for devName, d := range manifest.Dev {
+		if err := d.SetDefaults(); err != nil {
+			return nil, err
+		}
+		d.Name = devName
+		d.Namespace = manifest.Namespace
+		d.Context = manifest.Context
+	}
+
 	return manifest, nil
 }
 

--- a/pkg/linguist/dev.go
+++ b/pkg/linguist/dev.go
@@ -14,6 +14,8 @@
 package linguist
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -307,6 +309,18 @@ func GetDevDefaults(language, workdir string, imageConfig *registry.ImageConfig)
 	if imageConfig.Workdir == "" || imageConfig.Workdir == "/" {
 		imageConfig.Workdir = vals.path
 	}
+
+	if filepath.IsAbs(workdir) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		workdir, err = filepath.Rel(wd, workdir)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	dev := &model.Dev{
 		Image: &model.BuildInfo{
 			Name: vals.image,


### PR DESCRIPTION
Fixes #2628

## Proposed changes

- Set default values in manifest.dev to avoid nil pointer
- update local folder path to use a rel path if an abs path is given
