### PR TITLE
Support multile envs at stack

### DIFF
--- a/pkg/model/stack_expander.go
+++ b/pkg/model/stack_expander.go
@@ -1,0 +1,73 @@
+package model
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	yaml3 "gopkg.in/yaml.v3"
+)
+
+func expandEnvScalarNode(node *yaml3.Node) (*yaml3.Node, error) {
+	switch node.Kind {
+	case yaml3.ScalarNode:
+		expandValue, err := ExpandEnv(node.Value, true)
+		if err != nil {
+			return node, err
+		}
+		node.Value = expandValue
+		return node, nil
+	case yaml3.SequenceNode:
+		for indx, subNode := range node.Content {
+			if strings.HasPrefix(subNode.Value, "$") {
+				value := subNode.Value
+				key := strings.TrimSuffix(strings.TrimPrefix(value, "$"), "=")
+				node.Content[indx].Value = fmt.Sprintf("%s=%s", key, value)
+			}
+		}
+	case yaml3.MappingNode:
+		for indx, subNode := range node.Content {
+			value := subNode.Value
+			if indx%2 == 0 && strings.HasPrefix(value, "$") && node.Content[indx+1] != nil && node.Content[indx+1].Value == "" {
+				node.Content[indx].Value = strings.TrimPrefix(value, "$")
+				node.Content[indx+1] = &yaml3.Node{
+					Kind:  yaml3.ScalarNode,
+					Value: value,
+				}
+			}
+		}
+	}
+
+	for indx, subNode := range node.Content {
+		expandedNode, err := expandEnvScalarNode(subNode)
+		if err != nil {
+			return node, err
+		}
+		node.Content[indx] = expandedNode
+	}
+	return node, nil
+}
+
+// ExpandStackEnvs returns the stack manifest with expanded envs
+func ExpandStackEnvs(file []byte) ([]byte, error) {
+	doc := yaml3.Node{}
+	if err := yaml3.Unmarshal(file, &doc); err != nil {
+		return nil, err
+	}
+
+	expandedDoc, err := expandEnvScalarNode(doc.Content[0])
+	if err != nil {
+		return nil, err
+	}
+
+	buffer := bytes.NewBuffer(nil)
+	encoder := yaml3.NewEncoder(buffer)
+	encoder.SetIndent(2)
+
+	err = encoder.Encode(expandedDoc)
+	if err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+
+}

--- a/pkg/model/stack_expander.go
+++ b/pkg/model/stack_expander.go
@@ -9,7 +9,9 @@ import (
 )
 
 func expandEnvScalarNode(node *yaml3.Node) (*yaml3.Node, error) {
+	// depeding on the kind of node
 	switch node.Kind {
+	// when is a ScalarNode, replace its value with the ENV replaced
 	case yaml3.ScalarNode:
 		expandValue, err := ExpandEnv(node.Value, true)
 		if err != nil {
@@ -17,6 +19,7 @@ func expandEnvScalarNode(node *yaml3.Node) (*yaml3.Node, error) {
 		}
 		node.Value = expandValue
 		return node, nil
+	// when is a Sequence and starts with $ can be a list of envs, so transform the list to key=value format
 	case yaml3.SequenceNode:
 		for indx, subNode := range node.Content {
 			if strings.HasPrefix(subNode.Value, "$") {
@@ -25,6 +28,7 @@ func expandEnvScalarNode(node *yaml3.Node) (*yaml3.Node, error) {
 				node.Content[indx].Value = fmt.Sprintf("%s=%s", key, value)
 			}
 		}
+	// when MappingNode and only the ENV, transform the node by adding a ScalarNode so there is key and value nodes for the map
 	case yaml3.MappingNode:
 		for indx, subNode := range node.Content {
 			value := subNode.Value

--- a/pkg/model/stack_expander.go
+++ b/pkg/model/stack_expander.go
@@ -9,7 +9,6 @@ import (
 )
 
 func expandEnvScalarNode(node *yaml3.Node) (*yaml3.Node, error) {
-	// depeding on the kind of node
 	switch node.Kind {
 	// when is a ScalarNode, replace its value with the ENV replaced
 	case yaml3.ScalarNode:

--- a/pkg/model/stack_expander_test.go
+++ b/pkg/model/stack_expander_test.go
@@ -25,12 +25,14 @@ services:
         args:
             - $CUSTOM_ENV
             - CUSTOM2_ENV=$CUSTOM_ENV
+            - EMPTY
         ports:
             - 8080:8080
         environment:
             FLASK_ENV: development
             CUSTOM_ENV: $CUSTOM_ENV
             $CUSTOM2_ENV:
+            EMPTY:
         volumes:
             - ./vote:/src
 
@@ -51,12 +53,14 @@ volumes:
     args:
       - CUSTOM_ENV=MYVALUE
       - CUSTOM2_ENV=MYVALUE
+      - EMPTY
     ports:
       - 8080:8080
     environment:
       FLASK_ENV: development
       CUSTOM_ENV: MYVALUE
       CUSTOM2_ENV:
+      EMPTY:
     volumes:
       - ./vote:/src
   redis:

--- a/pkg/model/stack_expander_test.go
+++ b/pkg/model/stack_expander_test.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ExpandStackEnvs(t *testing.T) {
+	tests := []struct {
+		name          string
+		file          []byte
+		envValue      string
+		expectedStack string
+		expectedError bool
+	}{
+		{
+			name: "oneline envs",
+			file: []byte(`
+services:
+    myservice:
+        build:
+            context: vote
+        args:
+            - $CUSTOM_ENV
+            - CUSTOM2_ENV=$CUSTOM_ENV
+        ports:
+            - 8080:8080
+        environment:
+            FLASK_ENV: development
+            CUSTOM_ENV: $CUSTOM_ENV
+            $CUSTOM2_ENV:
+        volumes:
+            - ./vote:/src
+
+    redis:
+        image: redis
+        ports:
+            - 6379
+        volumes:
+            - redis:/data
+
+volumes:
+    redis:`),
+			envValue: "MYVALUE",
+			expectedStack: `services:
+  myservice:
+    build:
+      context: vote
+    args:
+      - CUSTOM_ENV=MYVALUE
+      - CUSTOM2_ENV=MYVALUE
+    ports:
+      - 8080:8080
+    environment:
+      FLASK_ENV: development
+      CUSTOM_ENV: MYVALUE
+      CUSTOM2_ENV:
+    volumes:
+      - ./vote:/src
+  redis:
+    image: redis
+    ports:
+      - 6379
+    volumes:
+      - redis:/data
+volumes:
+  redis:
+`,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			if err := os.Setenv("CUSTOM_ENV", tt.envValue); err != nil {
+				t.Fatal(err)
+			}
+			result, err := ExpandStackEnvs(tt.file)
+			if err != nil && !tt.expectedError {
+				t.Fatalf("expected no error, but got error: %v", err)
+			} else if err == nil && tt.expectedError {
+				t.Fatalf("expected error, but got nil")
+			}
+
+			assert.Equal(t, tt.expectedStack, string(result))
+
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes https://github.com/okteto/app/issues/3781

## Proposed changes

- when expanding multiline envs, the string resulting of that for a stack manifest was breaking the yaml stucture and so the stack was not unmarshalled
- replace the ExpandEnv method for supporting multiline ENVs
- new method will transform into yaml3 nodes, check if there is a node with env and expand the value, then marshal again into a string so it can be unmarshalled to a stack
- tested multiple line vars with okteto manifest, and these are parsed ok - no changes to apply into okteto manifest