### PR TITLE
fix: avoid expand env if are created on a deployment pipeline

### DIFF
--- a/cmd/build/v2/environment_test.go
+++ b/cmd/build/v2/environment_test.go
@@ -108,58 +108,6 @@ func Test_SetServiceEnvVars(t *testing.T) {
 	}
 }
 
-func TestExpandCommandVariables(t *testing.T) {
-	ctx := context.Background()
-	okteto.CurrentStore = &okteto.OktetoContextStore{
-		Contexts: map[string]*okteto.OktetoContext{
-			"test": {
-				Namespace: "test",
-				IsOkteto:  true,
-			},
-		},
-		CurrentContext: "test",
-	}
-
-	registry := test.NewFakeOktetoRegistry(nil)
-	builder := test.NewFakeOktetoBuilder(registry)
-	bc := &OktetoBuilder{
-		Builder:   builder,
-		Registry:  registry,
-		V1Builder: buildv1.NewBuilder(builder, registry),
-	}
-	manifest := &model.Manifest{
-		Name: "test",
-		Build: model.ManifestBuild{
-			"test": &model.BuildInfo{
-				Image: "nginx",
-				VolumesToInclude: []model.StackVolume{
-					{
-						LocalPath:  "test",
-						RemotePath: "test",
-					},
-				},
-			},
-		},
-		Deploy: &model.DeployInfo{
-			Commands: []model.DeployCommand{
-				{
-					Command: "${OKTETO_BUILD_TEST_IMAGE}",
-				},
-			},
-		},
-	}
-	err := bc.Build(ctx, &types.BuildOptions{
-		Manifest: manifest,
-	})
-
-	// error from the build
-	assert.NoError(t, err)
-
-	// Not substituted by empty string
-	assert.NotEmpty(t, manifest.Deploy.Commands[0].Command)
-	assert.NotEqual(t, manifest.Deploy.Commands[0].Command, "${OKTETO_BUILD_TEST_IMAGE}")
-}
-
 func TestExpandStackVariables(t *testing.T) {
 	ctx := context.Background()
 	okteto.CurrentStore = &okteto.OktetoContextStore{

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -739,13 +739,6 @@ func (m *Manifest) mergeWithOktetoManifest(other *Manifest) {
 func (manifest *Manifest) ExpandEnvVars() error {
 	var err error
 	if manifest.Deploy != nil {
-		for idx, cmd := range manifest.Deploy.Commands {
-			cmd.Command, err = ExpandEnv(cmd.Command, true)
-			if err != nil {
-				return errors.New("could not parse env vars")
-			}
-			manifest.Deploy.Commands[idx] = cmd
-		}
 		if manifest.Deploy.ComposeSection != nil && manifest.Deploy.ComposeSection.Stack != nil {
 			var stackFiles []string
 			for _, composeInfo := range manifest.Deploy.ComposeSection.ComposesInfo {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -47,7 +47,7 @@ deploy:
 devs:
   - api/okteto.yml
   - frontend/okteto.yml`),
-			expectedCommand: "okteto build -t okteto.dev/api:dev api",
+			expectedCommand: "okteto build -t okteto.dev/api:${OKTETO_GIT_COMMIT} api",
 		},
 		{
 			name: "expand envs on command without env var set",
@@ -60,7 +60,7 @@ deploy:
 devs:
   - api/okteto.yml
   - frontend/okteto.yml`),
-			expectedCommand: "okteto build -t okteto.dev/api:dev api",
+			expectedCommand: "okteto build -t okteto.dev/api:${OKTETO_GIT_COMMIT:=dev} api",
 		},
 	}
 


### PR DESCRIPTION
Fixes #3738

## Proposed changes

- avoid substitution of environment variables from `deploy` section in manifest, they will be substituted when executing the command
- adapt test to this new approach
