### PR TITLE
fix: avoid use compose files if manifest is v1

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -15,6 +15,7 @@ package context
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -130,12 +131,20 @@ func addKubernetesContext(cfg *clientcmdapi.Config, ctxResource *model.ContextRe
 }
 
 func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.Manifest, error) {
-	m, err := model.GetManifestV2(opts.Filename)
+
+	var manifest *model.Manifest
+	manifest, err := model.GetManifestV1(opts.Filename)
 	if err != nil {
+		if errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+			manifest, err = model.GetManifestV2(opts.Filename)
+			if err != nil {
+				return nil, err
+			}
+		}
 		return nil, err
 	}
 
-	ctxResource := model.GetContextResourceFromManifest(m)
+	ctxResource := model.GetContextResourceFromManifest(manifest)
 	if err := ctxResource.UpdateNamespace(opts.Namespace); err != nil {
 		return nil, err
 	}
@@ -156,14 +165,22 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 	}
 
 	// We need to read it again to propagate secrets env vars
-	m, err = model.GetManifestV2(opts.Filename)
-	if err != nil {
-		return nil, err
+	if manifest.IsV2 {
+		manifest, err = model.GetManifestV2(opts.Filename)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		manifest, err = model.GetManifestV1(opts.Filename)
+		if err != nil {
+			return nil, err
+		}
 	}
-	m.Namespace = okteto.Context().Namespace
-	m.Context = okteto.Context().Name
 
-	for _, dev := range m.Dev {
+	manifest.Namespace = okteto.Context().Namespace
+	manifest.Context = okteto.Context().Name
+
+	for _, dev := range manifest.Dev {
 		if err := utils.LoadManifestRc(dev); err != nil {
 			return nil, err
 		}
@@ -172,7 +189,7 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 		dev.Context = okteto.Context().Name
 	}
 
-	return m, nil
+	return manifest, nil
 }
 
 func LoadStackWithContext(ctx context.Context, name, namespace string, stackPaths []string) (*model.Stack, error) {

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -135,13 +135,13 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 	var manifest *model.Manifest
 	manifest, err := model.GetManifestV1(opts.Filename)
 	if err != nil {
-		if errors.Is(err, oktetoErrors.ErrManifestNotFound) {
-			manifest, err = model.GetManifestV2(opts.Filename)
-			if err != nil {
-				return nil, err
-			}
+		if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+			return nil, err
 		}
-		return nil, err
+		manifest, err = model.GetManifestV2(opts.Filename)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ctxResource := model.GetContextResourceFromManifest(manifest)

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -360,7 +360,7 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 	}
 
 	if manifest != nil && manifest.IsV2 {
-		return nil, nil
+		return manifest, nil
 	}
 
 	inferredManifest, err := GetInferredManifest(cwd)

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1013,7 +1013,7 @@ func (m *Manifest) WriteToFile(filePath string) error {
 		}
 	}
 
-	doc = m.reorderDocFields(doc)
+	m.reorderDocFields(&doc)
 
 	buffer := bytes.NewBuffer(nil)
 	encoder := yaml3.NewEncoder(buffer)
@@ -1032,7 +1032,7 @@ func (m *Manifest) WriteToFile(filePath string) error {
 }
 
 // reorderDocFields orders the manifest to be: name -> build -> deploy -> dependencies -> dev
-func (*Manifest) reorderDocFields(doc yaml3.Node) yaml3.Node {
+func (*Manifest) reorderDocFields(doc *yaml3.Node) {
 	contentCopy := []*yaml3.Node{}
 	nodes := []int{}
 	nameDefinitionIdx := getDocIdx(doc.Content, "name")
@@ -1118,7 +1118,6 @@ func (*Manifest) reorderDocFields(doc yaml3.Node) yaml3.Node {
 		}
 	}
 	doc.Content = contentCopy
-	return doc
 }
 
 func getDocIdxWithPrior(contents []*yaml3.Node, value string) int {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -301,7 +301,7 @@ func getManifestFromDevFilePath(cwd, manifestPath string) (*Manifest, error) {
 		return manifest, nil
 	}
 
-	return nil, nil
+	return nil, oktetoErrors.ErrManifestNotFound
 }
 
 //GetManifestV1 gets a manifest from a path or search for the files to generate it
@@ -313,7 +313,9 @@ func GetManifestV1(manifestPath string) (*Manifest, error) {
 
 	manifest, err := getManifestFromDevFilePath(cwd, manifestPath)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+			return nil, err
+		}
 	}
 
 	if manifest != nil {
@@ -341,7 +343,9 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 
 	manifest, err := getManifestFromDevFilePath(cwd, manifestPath)
 	if err != nil {
-		return nil, err
+		if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+			return nil, err
+		}
 	}
 
 	if manifest != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -281,7 +281,7 @@ func getManifestFromOktetoFile(cwd string) (*Manifest, error) {
 	return nil, oktetoErrors.ErrManifestNotFound
 }
 
-func getManifestFromDevFilePath(cwd string, manifestPath string) (*Manifest, error) {
+func getManifestFromDevFilePath(cwd, manifestPath string) (*Manifest, error) {
 	if manifestPath != "" && !filepath.IsAbs(manifestPath) {
 		manifestPath = filepath.Join(cwd, manifestPath)
 	}


### PR DESCRIPTION
Signed-off-by: adripedriza <adripedriza@gmail.com>

Fixes #2575

## Proposed changes

- create new method to manage manifest v1 that will not merge data from docker-compose files if present
