### PR TITLE
fix: kill other okteto instance

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -230,9 +230,6 @@ func GetDevDetachMode(manifest *model.Manifest, devs []string) (*model.Dev, erro
 			}
 			for _, forward := range d.Forward {
 				localPort := forward.Local
-				if !model.IsPortAvailable(dev.Interface, forward.Local) {
-					return nil, fmt.Errorf("local port %d is already in-use in your local machine", forward.Local)
-				}
 				dev.Forward = append(dev.Forward, model.Forward{
 					Local:       localPort,
 					Remote:      forward.Remote,


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- Dont check if the port is taken when creating the autoenv
- If the port is already taken and the syncthing folder is the same, other okteto process is killed
