### PR TITLE
Jlopezbarb/fix env vars not getting inyected into stack

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -254,6 +254,9 @@ func GetStackFromPath(name, stackPath string, isCompose bool) (*Stack, error) {
 	}
 
 	for svcName, svc := range s.Services {
+		if err := loadEnvFiles(svc, svcName); err != nil {
+			return nil, err
+		}
 		if svc.Build == nil {
 			continue
 		}
@@ -263,9 +266,6 @@ func GetStackFromPath(name, stackPath string, isCompose bool) (*Stack, error) {
 		} else {
 			svc.Build.Context = loadAbsPath(stackDir, svc.Build.Context)
 			svc.Build.Dockerfile = loadAbsPath(svc.Build.Context, svc.Build.Dockerfile)
-		}
-		if err := loadEnvFiles(svc, svcName); err != nil {
-			return nil, err
 		}
 		copy(svc.Build.VolumesToInclude, svc.Volumes)
 	}
@@ -846,12 +846,10 @@ func setEnvironmentFromFile(svc *Service, filename string) error {
 		if value == "" {
 			value = os.Getenv(name)
 		}
-		if value != "" {
-			svc.Environment = append(
-				svc.Environment,
-				EnvVar{Name: name, Value: value},
-			)
-		}
+		svc.Environment = append(
+			svc.Environment,
+			EnvVar{Name: name, Value: value},
+		)
 	}
 
 	return nil

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -26,6 +26,7 @@ const (
 	env = `A=hello
 # comment
 OKTETO_TEST=
+EMPTY_VAR=
 
 B=$B
 
@@ -190,6 +191,7 @@ services:
     environment:
       - OPTION_A=Cats
       - OPTION_B=Dogs
+      - EMPTY_VAR=
     ports:
       - 80
     replicas: 2
@@ -1194,7 +1196,7 @@ func Test_translateEnvVars(t *testing.T) {
 	if stack.Services["1"].Image != "image" {
 		t.Errorf("Wrong image: %s", stack.Services["1"].Image)
 	}
-	if len(stack.Services["1"].Environment) != 6 {
+	if len(stack.Services["1"].Environment) != 7 {
 		t.Errorf("Wrong environment: %v", stack.Services["1"].Environment)
 	}
 	for _, e := range stack.Services["1"].Environment {
@@ -1215,6 +1217,9 @@ func Test_translateEnvVars(t *testing.T) {
 		}
 		if e.Name == "OKTETO_TEST" && e.Value != "myvalue" {
 			t.Errorf("Wrong environment variable OKTETO_TEST: %s", e.Value)
+		}
+		if e.Name == "EMPTY_VAR" && e.Value != "" {
+			t.Errorf("Wrong environment variable EMPTY_VAR: %s", e.Value)
 		}
 	}
 }


### PR DESCRIPTION
Fixes env vars were not getting infected into environment

## Proposed changes
- Load always the env files from all the services
- If the environment comes from env files and they are empty they should be inyected
- If the environment comes from environment and they are empty they should be skipped
