### PR TITLE
Added new Build Option to check if image is autogen or not

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -227,6 +227,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 	args := model.SerializeBuildArgs(b.Args)
 
 	if okteto.Context().IsOkteto && b.Image == "" {
+		o.AutogenTag = true
 		tag := model.OktetoDefaultImageTag
 
 		envGitCommit := os.Getenv(model.OktetoGitCommitEnvVar)
@@ -252,13 +253,14 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		file = filepath.Join(b.Context, b.Dockerfile)
 	}
 	opts := &types.BuildOptions{
-		CacheFrom: b.CacheFrom,
-		Target:    b.Target,
-		Path:      b.Context,
-		Tag:       b.Image,
-		File:      file,
-		BuildArgs: args,
-		NoCache:   o.NoCache,
+		CacheFrom:  b.CacheFrom,
+		Target:     b.Target,
+		Path:       b.Context,
+		Tag:        b.Image,
+		File:       file,
+		BuildArgs:  args,
+		NoCache:    o.NoCache,
+		AutogenTag: o.AutogenTag,
 	}
 
 	outputMode := oktetoLog.GetOutputFormat()
@@ -272,7 +274,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 
 // ShouldOptimizeBuild returns if optimization should be applied
 func ShouldOptimizeBuild(options *types.BuildOptions) bool {
-	return okteto.IsPipeline() && registry.IsOktetoRegistry(options.Tag) && !options.NoCache && !options.BuildToGlobal
+	return options.AutogenTag && okteto.IsPipeline() && registry.IsOktetoRegistry(options.Tag) && !options.NoCache && !options.BuildToGlobal
 }
 
 // GetVolumesToInclude checks if the path exists, if it doesn't it skip it

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -92,6 +92,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
 				BuildArgs:  []string{},
+				AutogenTag: true,
 			},
 		},
 		{
@@ -104,6 +105,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Tag:        "okteto.dev/movies-service:okteto",
 				OutputMode: oktetoLog.TTYFormat,
 				BuildArgs:  []string{},
+				AutogenTag: true,
 			},
 		},
 		{
@@ -116,6 +118,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:114921fe985b5f874c8d312b0a098959da6d119209c9d1e42a89c4309569692d",
 				BuildArgs:  []string{},
+				AutogenTag: true,
 			},
 		},
 		{
@@ -134,6 +137,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:c0776074a88fa37835b1dfa67365b6a6b08b11c4cf49a9d42524ea9797959e58",
 				BuildArgs:  []string{"arg1=value1"},
+				AutogenTag: true,
 			},
 		},
 		{
@@ -173,6 +177,38 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Path:       "service",
 				CacheFrom:  []string{"cache-image"},
 				BuildArgs:  []string{"arg1=value1"},
+				AutogenTag: true,
+			},
+		},
+		{
+			name:        "all-values-image",
+			serviceName: "service",
+			buildInfo: &model.BuildInfo{
+				Image:      "okteto.dev/mycustomimage:dev",
+				Context:    "service",
+				Dockerfile: "CustomDockerfile",
+				Target:     "build",
+				CacheFrom:  []string{"cache-image"},
+				Args: model.Environment{
+					{
+						Name:  "arg1",
+						Value: "value1",
+					},
+				},
+			},
+			initialOpts: &types.BuildOptions{
+				OutputMode: "tty",
+			},
+			isOkteto: true,
+			expected: &types.BuildOptions{
+				OutputMode: oktetoLog.TTYFormat,
+				Tag:        "okteto.dev/mycustomimage:dev",
+				File:       filepath.Join("service", "CustomDockerfile"),
+				Target:     "build",
+				Path:       "service",
+				CacheFrom:  []string{"cache-image"},
+				BuildArgs:  []string{"arg1=value1"},
+				AutogenTag: false,
 			},
 		},
 	}

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -30,6 +30,7 @@ type BuildOptions struct {
 	BuildToGlobal bool
 	K8sContext    string
 	ExportCache   string
+	AutogenTag    bool
 	// CommandArgs comes from the user input on the command
 	CommandArgs  []string
 	EnableStages bool


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2666 

## Proposed changes

- When pipeline and image is set at the manifest, the optimization was running so the image was not being built, this changes adds new option which informs if the image tag has been autogenerated or informed by the manifest, only autogenerated tags would be applied the optimization
-
