### PR TITLE
update error message. Use devPath in '-f' arg only if present

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -443,7 +443,7 @@ func CheckIfRegularFile(path string) error {
 
 func GetDownCommand(devPath string) string {
 	okDownCommandHint := "okteto down -v"
-	if DefaultManifest != devPath {
+	if DefaultManifest != devPath && devPath != "" {
 		okDownCommandHint = fmt.Sprintf("okteto down -v -f %s", devPath)
 	}
 	return okDownCommandHint


### PR DESCRIPTION
Fixes #2642

## Proposed changes

- use `-f [devFile]` suggestion only if devmanifest does not have default name and it has a valid value 
