### PR TITLE
fix: check if has access to namespace when working with vanilla cluster

### DIFF
--- a/cmd/utils/okteto_test.go
+++ b/cmd/utils/okteto_test.go
@@ -83,7 +83,7 @@ func Test_createContext(t *testing.T) {
 			fakeClient := client.NewFakeOktetoClient()
 			fakeClient.Namespace = client.NewFakeNamespaceClient(tt.namespaces, tt.err)
 			fakeClient.Preview = client.NewFakePreviewClient(tt.previews, tt.err)
-			hasAccess, err := HasAccessToNamespace(ctx, "test", fakeClient)
+			hasAccess, err := HasAccessToOktetoClusterNamespace(ctx, "test", fakeClient)
 
 			assert.Equal(t, tt.expectedErr, err != nil)
 			assert.Equal(t, tt.expectedAccess, hasAccess)


### PR DESCRIPTION
Signed-off-by: adripedriza <adripedriza@gmail.com>

Fixes #2634

## Proposed changes

- Added check that the namespace exists when the user runs `okteto context use [vanilla cluster] --namespace [nsName]`. 