### PR TITLE
fix: omit init volume initialization logs

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/model"
 
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	apiv1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -512,7 +513,7 @@ func TranslateOktetoInitFromImageContainer(spec *apiv1.PodSpec, rule *model.Tran
 		ImagePullPolicy: apiv1.PullIfNotPresent,
 		VolumeMounts:    []apiv1.VolumeMount{},
 	}
-	command := "echo initializing"
+	command := "echo initializing..."
 	iVolume := 1
 	for _, v := range rule.Volumes {
 		if !strings.HasPrefix(v.SubPath, model.SourceCodeSubPath) && !strings.HasPrefix(v.SubPath, model.DataSubPath) {
@@ -527,11 +528,16 @@ func TranslateOktetoInitFromImageContainer(spec *apiv1.PodSpec, rule *model.Tran
 			},
 		)
 		mounPath := path.Join(v.MountPath, ".")
-		command = fmt.Sprintf("%s && ( [ \"$(ls -A /init-volume/%d)\" ] || cp -R %s/. /init-volume/%d || true)", command, iVolume, mounPath, iVolume)
+		completedCommand := "echo initialization completed."
+		command = fmt.Sprintf("%s && ( [ \"$(ls -A /init-volume/%d)\" ] || cp -R %s/. /init-volume/%d || true) && %s", command, iVolume, mounPath, iVolume, completedCommand)
 		iVolume++
 	}
 
-	c.Command = []string{"sh", "-cx", command}
+	shOpts := "-c"
+	if oktetoLog.GetLevel() == oktetoLog.DebugLevel {
+		shOpts = shOpts + "x"
+	}
+	c.Command = []string{"sh", shOpts, command}
 	translateInitResources(c, rule.InitContainer.Resources)
 	TranslateContainerSecurityContext(c, rule.SecurityContext)
 	spec.InitContainers = append(spec.InitContainers, *c)

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -528,10 +528,10 @@ func TranslateOktetoInitFromImageContainer(spec *apiv1.PodSpec, rule *model.Tran
 			},
 		)
 		mounPath := path.Join(v.MountPath, ".")
-		completedCommand := "echo initialization completed."
-		command = fmt.Sprintf("%s && ( [ \"$(ls -A /init-volume/%d)\" ] || cp -R %s/. /init-volume/%d || true) && %s", command, iVolume, mounPath, iVolume, completedCommand)
+		command = fmt.Sprintf("%s && ( [ \"$(ls -A /init-volume/%d)\" ] || cp -R %s/. /init-volume/%d || true)", command, iVolume, mounPath, iVolume)
 		iVolume++
 	}
+	command = fmt.Sprintf("%s && echo initialization completed.", command)
 
 	shOpts := "-c"
 	if oktetoLog.GetLevel() == oktetoLog.DebugLevel {

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -244,7 +244,7 @@ services:
 				Name:            OktetoInitVolumeContainerName,
 				Image:           "web:latest",
 				ImagePullPolicy: apiv1.PullIfNotPresent,
-				Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /go/pkg/. /init-volume/1 || true) && ( [ \"$(ls -A /init-volume/2)\" ] || cp -R /root/.cache/go-build/. /init-volume/2 || true) && ( [ \"$(ls -A /init-volume/3)\" ] || cp -R /app/. /init-volume/3 || true) && ( [ \"$(ls -A /init-volume/4)\" ] || cp -R /path/. /init-volume/4 || true)"},
+				Command:         []string{"sh", "-c", "echo initializing... && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /go/pkg/. /init-volume/1 || true) && ( [ \"$(ls -A /init-volume/2)\" ] || cp -R /root/.cache/go-build/. /init-volume/2 || true) && ( [ \"$(ls -A /init-volume/3)\" ] || cp -R /app/. /init-volume/3 || true) && ( [ \"$(ls -A /init-volume/4)\" ] || cp -R /path/. /init-volume/4 || true) && echo initialization completed."},
 				SecurityContext: &apiv1.SecurityContext{
 					RunAsUser:  &runAsUser,
 					RunAsGroup: &runAsGroup,
@@ -1338,7 +1338,7 @@ services:
 				Name:            OktetoInitVolumeContainerName,
 				Image:           "web:latest",
 				ImagePullPolicy: apiv1.PullIfNotPresent,
-				Command:         []string{"sh", "-cx", "echo initializing && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /go/pkg/. /init-volume/1 || true) && ( [ \"$(ls -A /init-volume/2)\" ] || cp -R /root/.cache/go-build/. /init-volume/2 || true) && ( [ \"$(ls -A /init-volume/3)\" ] || cp -R /app/. /init-volume/3 || true) && ( [ \"$(ls -A /init-volume/4)\" ] || cp -R /path/. /init-volume/4 || true)"},
+				Command:         []string{"sh", "-c", "echo initializing... && ( [ \"$(ls -A /init-volume/1)\" ] || cp -R /go/pkg/. /init-volume/1 || true) && ( [ \"$(ls -A /init-volume/2)\" ] || cp -R /root/.cache/go-build/. /init-volume/2 || true) && ( [ \"$(ls -A /init-volume/3)\" ] || cp -R /app/. /init-volume/3 || true) && ( [ \"$(ls -A /init-volume/4)\" ] || cp -R /path/. /init-volume/4 || true) && echo initialization completed."},
 				SecurityContext: &apiv1.SecurityContext{
 					RunAsUser:  &runAsUser,
 					RunAsGroup: &runAsGroup,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -59,6 +59,8 @@ var (
 	WarningLevel = "warn"
 	// ErrorLevel is the json level for error
 	ErrorLevel = "error"
+
+	DebugLevel = "debug"
 )
 
 type logger struct {
@@ -129,6 +131,12 @@ func SetLevel(level string) {
 	if err == nil {
 		log.out.SetLevel(l)
 	}
+}
+
+// GetLevel gets the level of the main logger
+func GetLevel() string {
+	l := log.out.Level
+	return l.String()
 }
 
 // GetOutputFormat returns the output format of the command


### PR DESCRIPTION
Fixes #2411

## Proposed changes

- update init container command to only display comands executed within it if we are working with `--log-level=debug`
