### PR TITLE
fix: not fallback buildv1 if error unmarshalling manifest

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -88,8 +88,7 @@ func (bc *Command) getBuilder(options *types.BuildOptions) (Builder, error) {
 
 	manifest, err := bc.GetManifest(options.File)
 	if err != nil {
-		var invalidManifestErr *oktetoErrors.InvalidManifestError
-		if errors.As(err, &invalidManifestErr) {
+		if errors.Is(err, oktetoErrors.ErrInvalidManifest) {
 			return nil, err
 		}
 

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -93,7 +93,7 @@ func (bc *Command) getBuilder(options *types.BuildOptions) (Builder, error) {
 			return nil, err
 		}
 
-		oktetoLog.Info("The manifest %s is not v2 compatible, falling back to building as a v1 manifest: %v", options.File, err)
+		oktetoLog.Infof("The manifest %s is not v2 compatible, falling back to building as a v1 manifest: %v", options.File, err)
 		builder = buildv1.NewBuilder(bc.Builder, bc.Registry)
 	} else {
 		if isBuildV2(manifest) {

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -92,7 +92,7 @@ func (bc *Command) getBuilder(options *types.BuildOptions) (Builder, error) {
 			return nil, err
 		}
 
-		oktetoLog.Warning("error getting manifest v2 from file %s: %v. Fallback to build v1", options.File, err)
+		oktetoLog.Info("The manifest %s is not v2 compatible, falling back to building as a v1 manifest: %v", options.File, err)
 		builder = buildv1.NewBuilder(bc.Builder, bc.Registry)
 	} else {
 		if isBuildV2(manifest) {

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -88,7 +88,8 @@ func (bc *Command) getBuilder(options *types.BuildOptions) (Builder, error) {
 
 	manifest, err := bc.GetManifest(options.File)
 	if err != nil {
-		if errors.Is(err, oktetoErrors.ErrInvalidManifest) {
+		var invalidManifestErr *oktetoErrors.InvalidManifestError
+		if errors.As(err, &invalidManifestErr) {
 			return nil, err
 		}
 

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -120,6 +120,7 @@ func TestIsBuildV2(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			answer := isBuildV2(tt.manifest)
 			assert.Equal(t, answer, tt.expectedAnswer)
 		})

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -41,7 +41,9 @@ func getManifestWithError(_ string) (*model.Manifest, error) {
 }
 
 func getManifestWithInvalidManifestError(_ string) (*model.Manifest, error) {
-	return nil, oktetoErrors.ErrInvalidManifest
+	return nil, &oktetoErrors.InvalidManifestError{
+		Msg: oktetoErrors.ErrInvalidManifest.Error(),
+	}
 }
 
 func getFakeManifestV1(_ string) (*model.Manifest, error) {
@@ -204,10 +206,14 @@ func TestBuilderIsProperlyGenerated(t *testing.T) {
 	options := &types.BuildOptions{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			builder, err := tt.buildCommand.getBuilder(options)
 			if err != nil && !tt.expectedError {
 				t.Errorf("getBuilder() fail on '%s'. Expected nil error, got %s", tt.name, err.Error())
+			}
+
+			if err == nil && tt.expectedError {
+				t.Errorf("getBuilder() fail on '%s'. Expected error, got nil", tt.name)
 			}
 
 			if builder == nil {

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -42,7 +42,7 @@ func getManifestWithError(_ string) (*model.Manifest, error) {
 
 func getManifestWithInvalidManifestError(_ string) (*model.Manifest, error) {
 	return nil, &oktetoErrors.InvalidManifestError{
-		Msg: oktetoErrors.ErrInvalidManifest.Error(),
+		Msg: oktetoErrors.ErrInvalidManifest,
 	}
 }
 

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -41,9 +41,7 @@ func getManifestWithError(_ string) (*model.Manifest, error) {
 }
 
 func getManifestWithInvalidManifestError(_ string) (*model.Manifest, error) {
-	return nil, &oktetoErrors.InvalidManifestError{
-		Msg: oktetoErrors.ErrInvalidManifest,
-	}
+	return nil, oktetoErrors.ErrInvalidManifest
 }
 
 func getFakeManifestV1(_ string) (*model.Manifest, error) {

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -124,6 +124,7 @@ func TestIsBuildV2(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			answer := isBuildV2(tt.manifest)
@@ -205,8 +206,9 @@ func TestBuilderIsProperlyGenerated(t *testing.T) {
 
 	options := &types.BuildOptions{}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			//t.Parallel()
+			t.Parallel()
 			builder, err := tt.buildCommand.getBuilder(options)
 			if err != nil && !tt.expectedError {
 				t.Errorf("getBuilder() fail on '%s'. Expected nil error, got %s", tt.name, err.Error())

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -14,9 +14,10 @@
 package build
 
 import (
-	"reflect"
 	"testing"
 
+	buildV1 "github.com/okteto/okteto/cmd/build/v1"
+	buildV2 "github.com/okteto/okteto/cmd/build/v2"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/types"
@@ -214,15 +215,15 @@ func TestBuilderIsProperlyGenerated(t *testing.T) {
 					t.Errorf("getBuilder() fail on '%s'. Expected builder, got nil", tt.name)
 				}
 			} else {
-				metaBuildValue := reflect.ValueOf(builder).Elem()
-				field := metaBuildValue.FieldByName("V1Builder")
-				if tt.isBuildV2Expected {
-					if field == (reflect.Value{}) {
-						t.Errorf("getBuilder() fail on '%s'. Expected builder v2, got builder v1", tt.name)
+				switch builder.(type) {
+				case *buildV1.OktetoBuilder:
+					if tt.isBuildV2Expected {
+						t.Errorf("getBuilder() fail on '%s'. Expected builderv2, got builderv1", tt.name)
 					}
-				} else {
-					if field != (reflect.Value{}) {
-						t.Errorf("getBuilder() fail on '%s'. Expected builder v1, got builder v2", tt.name)
+				case *buildV2.OktetoBuilder:
+					if !tt.isBuildV2Expected {
+						t.Errorf("getBuilder() fail on '%s'. Expected builderv1, got builderv2", tt.name)
+
 					}
 				}
 			}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -38,7 +38,7 @@ type CommandError struct {
 
 // Error returns the error message
 func (e UserError) Is(target error) bool {
-	return strings.HasPrefix(e.Error(), target.Error())
+	return e.E == target
 }
 
 // Error returns the error message

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -30,15 +30,19 @@ func (u UserError) Error() string {
 	return u.E.Error()
 }
 
+// InvalidManifestError is meant for errors caused by an invalid manifest
+type InvalidManifestError struct {
+	Msg string
+}
+
+func (e *InvalidManifestError) Error() string {
+	return e.Msg
+}
+
 // CommandError is meant for errors displayed to the user. It can include a message and a hint
 type CommandError struct {
 	E      error
 	Reason error
-}
-
-// Error returns the error message
-func (e UserError) Is(target error) bool {
-	return e.E == target
 }
 
 // Error returns the error message

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -172,7 +172,7 @@ var (
 	ErrDevContainerNotExists = "development container '%s' doesn't exist"
 
 	//ErrInvalidManifest is raised when cannot unmarshal manifest properly
-	ErrInvalidManifest = "invalid manifest"
+	ErrInvalidManifest = errors.New("invalid manifest")
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -172,7 +172,7 @@ var (
 	ErrDevContainerNotExists = "development container '%s' doesn't exist"
 
 	//ErrInvalidManifest is raised when cannot unmarshal manifest properly
-	ErrInvalidManifest = fmt.Errorf("invalid manifest")
+	ErrInvalidManifest = "invalid manifest"
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -164,6 +164,9 @@ var (
 
 	//ErrInvalidManifest is raised when cannot unmarshal manifest properly
 	ErrInvalidManifest = errors.New("invalid manifest")
+
+	//ErrEmptyManifest is raised when cannot detected content to read in manifest
+	ErrEmptyManifest = errors.New("no content detected for okteto.yml file")
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -37,6 +37,11 @@ type CommandError struct {
 }
 
 // Error returns the error message
+func (e UserError) Is(target error) bool {
+	return strings.HasPrefix(e.Error(), target.Error())
+}
+
+// Error returns the error message
 func (u CommandError) Error() string {
 	return fmt.Sprintf("%s: %s", u.E.Error(), strings.ToLower(u.Reason.Error()))
 }
@@ -161,6 +166,9 @@ var (
 
 	// ErrDevContainerNotExists is raised when the dev container doesn't exist on dev section
 	ErrDevContainerNotExists = "development container '%s' doesn't exist"
+
+	//ErrInvalidManifest is raised when cannot unmarshal manifest properly
+	ErrInvalidManifest = fmt.Errorf("invalid manifest")
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -30,15 +30,6 @@ func (u UserError) Error() string {
 	return u.E.Error()
 }
 
-// InvalidManifestError is meant for errors caused by an invalid manifest
-type InvalidManifestError struct {
-	Msg string
-}
-
-func (e *InvalidManifestError) Error() string {
-	return e.Msg
-}
-
 // CommandError is meant for errors displayed to the user. It can include a message and a hint
 type CommandError struct {
 	E      error

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -684,7 +684,7 @@ func Read(bytes []byte) (*Manifest, error) {
 		if err := yaml.UnmarshalStrict(bytes, manifest); err != nil {
 			if strings.HasPrefix(err.Error(), "yaml: unmarshal errors:") {
 				var sb strings.Builder
-				_, _ = sb.WriteString("Invalid manifest:\n")
+				_, _ = sb.WriteString("invalid manifest:\n")
 				l := strings.Split(err.Error(), "\n")
 				for i := 1; i < len(l); i++ {
 					e := strings.TrimSuffix(l[i], "in type model.Manifest")

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -626,7 +626,9 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 
 	manifest, err := Read(b)
 	if err != nil {
-		return nil, err
+		return nil, &oktetoErrors.InvalidManifestError{
+			Msg: fmt.Sprintf("%s:\n%s", oktetoErrors.ErrInvalidManifest.Error(), err.Error()),
+		}
 	}
 
 	for _, dev := range manifest.Dev {
@@ -684,20 +686,21 @@ func Read(bytes []byte) (*Manifest, error) {
 		if err := yaml.UnmarshalStrict(bytes, manifest); err != nil {
 			if strings.HasPrefix(err.Error(), "yaml: unmarshal errors:") {
 				var sb strings.Builder
+				//_, _ = sb.WriteString("Invalid manifest:\n")
 				l := strings.Split(err.Error(), "\n")
 				for i := 1; i < len(l); i++ {
 					e := strings.TrimSuffix(l[i], "in type model.Manifest")
 					e = strings.TrimSpace(e)
-					_, _ = sb.WriteString(fmt.Sprintf("- %s\n", e))
+					_, _ = sb.WriteString(fmt.Sprintf("    - %s\n", e))
 				}
 
 				_, _ = sb.WriteString(fmt.Sprintf("    See %s for details", "https://okteto.com/docs/reference/manifest/"))
-				return nil, oktetoErrors.UserError{E: oktetoErrors.ErrInvalidManifest, Hint: sb.String()}
+				return nil, errors.New(sb.String())
 			}
 
-			msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", fmt.Sprintf("%s:", oktetoErrors.ErrInvalidManifest.Error()), 1)
-			msg = strings.TrimSuffix(msg, "in type model.Manifest")
-			return nil, oktetoErrors.UserError{E: oktetoErrors.ErrInvalidManifest, Hint: msg}
+			//msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", fmt.Sprintf("%s:", oktetoErrors.ErrInvalidManifest.Error()), 1)
+			msg := strings.TrimSuffix(err.Error(), "in type model.Manifest")
+			return nil, errors.New(msg)
 		}
 	}
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -686,7 +686,6 @@ func Read(bytes []byte) (*Manifest, error) {
 		if err := yaml.UnmarshalStrict(bytes, manifest); err != nil {
 			if strings.HasPrefix(err.Error(), "yaml: unmarshal errors:") {
 				var sb strings.Builder
-				//_, _ = sb.WriteString("Invalid manifest:\n")
 				l := strings.Split(err.Error(), "\n")
 				for i := 1; i < len(l); i++ {
 					e := strings.TrimSuffix(l[i], "in type model.Manifest")
@@ -698,7 +697,6 @@ func Read(bytes []byte) (*Manifest, error) {
 				return nil, errors.New(sb.String())
 			}
 
-			//msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", fmt.Sprintf("%s:", oktetoErrors.ErrInvalidManifest.Error()), 1)
 			msg := strings.TrimSuffix(err.Error(), "in type model.Manifest")
 			return nil, errors.New(msg)
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -627,7 +627,7 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 	manifest, err := Read(b)
 	if err != nil {
 		return nil, &oktetoErrors.InvalidManifestError{
-			Msg: fmt.Sprintf("%s:\n%s", oktetoErrors.ErrInvalidManifest.Error(), err.Error()),
+			Msg: fmt.Sprintf("%s:\n%s", oktetoErrors.ErrInvalidManifest, err.Error()),
 		}
 	}
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -684,21 +684,20 @@ func Read(bytes []byte) (*Manifest, error) {
 		if err := yaml.UnmarshalStrict(bytes, manifest); err != nil {
 			if strings.HasPrefix(err.Error(), "yaml: unmarshal errors:") {
 				var sb strings.Builder
-				_, _ = sb.WriteString("invalid manifest:\n")
 				l := strings.Split(err.Error(), "\n")
 				for i := 1; i < len(l); i++ {
 					e := strings.TrimSuffix(l[i], "in type model.Manifest")
 					e = strings.TrimSpace(e)
-					_, _ = sb.WriteString(fmt.Sprintf("    - %s\n", e))
+					_, _ = sb.WriteString(fmt.Sprintf("- %s\n", e))
 				}
 
 				_, _ = sb.WriteString(fmt.Sprintf("    See %s for details", "https://okteto.com/docs/reference/manifest/"))
-				return nil, oktetoErrors.UserError{E: errors.New(sb.String())}
+				return nil, oktetoErrors.UserError{E: oktetoErrors.ErrInvalidManifest, Hint: sb.String()}
 			}
 
-			msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", "invalid manifest:", 1)
+			msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", fmt.Sprintf("%s:", oktetoErrors.ErrInvalidManifest.Error()), 1)
 			msg = strings.TrimSuffix(msg, "in type model.Manifest")
-			return nil, oktetoErrors.UserError{E: errors.New(msg)}
+			return nil, oktetoErrors.UserError{E: oktetoErrors.ErrInvalidManifest, Hint: msg}
 		}
 	}
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -416,6 +416,10 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 	devManifest, err := getOktetoManifest(manifestPath)
 	if err != nil {
+		if errors.Is(err, oktetoErrors.ErrInvalidManifest) {
+			return nil, err
+		}
+
 		oktetoLog.Info("devManifest err, fallback to stack unmarshall")
 		stackManifest := &Manifest{
 			Type: StackType,
@@ -621,12 +625,19 @@ func inferHelmTags(path string) string {
 func getOktetoManifest(devPath string) (*Manifest, error) {
 	b, err := os.ReadFile(devPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, oktetoErrors.ErrManifestNotFound
+		}
 		return nil, err
+	}
+
+	if isEmptyManifestFile(b) {
+		return nil, fmt.Errorf("%w: %s", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrEmptyManifest)
 	}
 
 	manifest, err := Read(b)
 	if err != nil {
-		return nil, fmt.Errorf("%w:\n %s", oktetoErrors.ErrInvalidManifest, err.Error())
+		return nil, fmt.Errorf("%w: %s", oktetoErrors.ErrInvalidManifest, err.Error())
 	}
 
 	for _, dev := range manifest.Dev {
@@ -643,6 +654,13 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 	}
 
 	return manifest, nil
+}
+
+func isEmptyManifestFile(bytes []byte) bool {
+	if bytes == nil || strings.TrimSpace(string(bytes)) == "" {
+		return true
+	}
+	return false
 }
 
 func getFilePath(cwd string, files []string) string {
@@ -692,11 +710,11 @@ func Read(bytes []byte) (*Manifest, error) {
 				}
 
 				_, _ = sb.WriteString(fmt.Sprintf("    See %s for details", "https://okteto.com/docs/reference/manifest/"))
-				return nil, errors.New(sb.String())
+				return nil, fmt.Errorf("\n%s", sb.String())
 			}
 
 			msg := strings.TrimSuffix(err.Error(), "in type model.Manifest")
-			return nil, errors.New(msg)
+			return nil, fmt.Errorf("\n%s", msg)
 		}
 	}
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -626,9 +626,7 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 
 	manifest, err := Read(b)
 	if err != nil {
-		return nil, &oktetoErrors.InvalidManifestError{
-			Msg: fmt.Sprintf("%s:\n%s", oktetoErrors.ErrInvalidManifest, err.Error()),
-		}
+		return nil, fmt.Errorf("%w:\n %s", oktetoErrors.ErrInvalidManifest, err.Error())
 	}
 
 	for _, dev := range manifest.Dev {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -693,14 +693,15 @@ func Read(bytes []byte) (*Manifest, error) {
 				}
 
 				_, _ = sb.WriteString(fmt.Sprintf("    See %s for details", "https://okteto.com/docs/reference/manifest/"))
-				return nil, errors.New(sb.String())
+				return nil, oktetoErrors.UserError{E: errors.New(sb.String())}
 			}
 
 			msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", "invalid manifest:", 1)
 			msg = strings.TrimSuffix(msg, "in type model.Manifest")
-			return nil, errors.New(msg)
+			return nil, oktetoErrors.UserError{E: errors.New(msg)}
 		}
 	}
+
 	hasShownWarning := false
 	for _, d := range manifest.Dev {
 		if (d.Image.Context != "" || d.Image.Dockerfile != "") && !hasShownWarning {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -404,3 +404,45 @@ func TestSetManifestDefaultsFromDev(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEmptyManifestFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		rawContent     []byte
+		expectedAnswer bool
+	}{
+		{
+			name:           "empty manifest with only blank space",
+			rawContent:     []byte("  "),
+			expectedAnswer: true,
+		},
+		{
+			name:           "empty manifest with only escape character",
+			rawContent:     []byte("  \n"),
+			expectedAnswer: true,
+		},
+		{
+			name:           "empty manifest with only tab character",
+			rawContent:     []byte("  \t"),
+			expectedAnswer: true,
+		},
+		{
+			name:           "no empty manifest",
+			rawContent:     []byte("  a"),
+			expectedAnswer: false,
+		},
+		{
+			name:           "nil manifest content",
+			rawContent:     []byte(nil),
+			expectedAnswer: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isEmptyManifestFile := isEmptyManifestFile(tt.rawContent)
+			if isEmptyManifestFile != tt.expectedAnswer {
+				t.Fatalf("isEmptyManifestFile() fail '%s': expected result %t, got %t", tt.name, tt.expectedAnswer, isEmptyManifestFile)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2689

## Proposed changes

- instead of try to build using a Dockerfile when user runs `okteto build` and there is an invalid manifest we should return an error because the user's initial goal is to use the manifest to build the necessary images.
