### PR TITLE
Jlopezbarb/refactor unit test folders and envs

### DIFF
--- a/cmd/build/v1/build_test.go
+++ b/cmd/build/v1/build_test.go
@@ -44,7 +44,7 @@ func TestBuildWithErrorFromDockerfile(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
 
 	tag := "okteto.dev/test"
@@ -78,9 +78,8 @@ func TestBuildWithNoErrorFromDockerfile(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	tag := "okteto.dev/test"
 	options := &types.BuildOptions{
@@ -113,9 +112,8 @@ func TestBuildWithNoErrorFromDockerfileAndNoTag(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	options := &types.BuildOptions{
 		CommandArgs: []string{dir},
@@ -129,13 +127,10 @@ func TestBuildWithNoErrorFromDockerfileAndNoTag(t *testing.T) {
 	assert.Empty(t, image)
 }
 
-func createDockerfile() (string, error) {
-	dir, err := os.MkdirTemp("", "build")
-	if err != nil {
-		return "", err
-	}
+func createDockerfile(t *testing.T) (string, error) {
+	dir := t.TempDir()
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
-	err = os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
+	err := os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -119,11 +119,7 @@ func TestOnlyInjectVolumeMountsInOkteto(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	dir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -169,14 +165,8 @@ func TestTwoStepsBuild(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	dir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	dir, err = createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -227,9 +217,8 @@ func TestBuildWithoutVolumeMountWithoutImage(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -271,9 +260,8 @@ func TestBuildWithoutVolumeMountWithImage(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -317,9 +305,8 @@ func TestBuildWithStack(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -370,13 +357,10 @@ func Test_getAccessibleVolumeMounts(t *testing.T) {
 	assert.Len(t, volumes, 1)
 }
 
-func createDockerfile() (string, error) {
-	dir, err := os.MkdirTemp("", "build")
-	if err != nil {
-		return "", err
-	}
+func createDockerfile(t *testing.T) (string, error) {
+	dir := t.TempDir()
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
-	err = os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
+	err := os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/context/context_test.go
+++ b/cmd/context/context_test.go
@@ -75,6 +75,7 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 
 func createDeprecatedToken(t *testing.T, url string) (string, error) {
 	dir := t.TempDir()
+	t.Setenv(model.OktetoFolderEnvVar, dir)
 	token := &okteto.Token{
 		URL:       url,
 		Buildkit:  "buildkit",

--- a/cmd/context/context_test.go
+++ b/cmd/context/context_test.go
@@ -54,7 +54,7 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tokenPath, err := createDeprecatedToken(tt.tokenUrl)
+			tokenPath, err := createDeprecatedToken(t, tt.tokenUrl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,12 +73,8 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 	}
 }
 
-func createDeprecatedToken(url string) (string, error) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return "", err
-	}
-	os.Setenv(model.OktetoFolderEnvVar, dir)
+func createDeprecatedToken(t *testing.T, url string) (string, error) {
+	dir := t.TempDir()
 	token := &okteto.Token{
 		URL:       url,
 		Buildkit:  "buildkit",

--- a/cmd/context/options_test.go
+++ b/cmd/context/options_test.go
@@ -246,7 +246,7 @@ func Test_initFromEnvVars(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			tt.in.initFromEnvVars()
 			if !reflect.DeepEqual(tt.in, tt.want) {

--- a/cmd/context/use_test.go
+++ b/cmd/context/use_test.go
@@ -56,8 +56,7 @@ func Test_setSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				err := os.Setenv(k, v)
-				assert.NoError(t, err)
+				t.Setenv(k, v)
 			}
 			setSecrets(tt.secrets)
 			assert.Equal(t, expectedValue, os.Getenv(key))

--- a/cmd/manifest/init-v1_test.go
+++ b/cmd/manifest/init-v1_test.go
@@ -41,13 +41,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestRun(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	ctx := context.Background()
-
-	defer os.RemoveAll(dir)
 
 	p := filepath.Join(dir, fmt.Sprintf("okteto-%s", uuid.New().String()))
 
@@ -108,10 +103,7 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunJustCreateNecessaryFields(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	ctx := context.Background()
 
 	defer os.RemoveAll(dir)

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -14,7 +14,6 @@
 package pipeline
 
 import (
-	"os"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -69,11 +68,7 @@ func Test_getRepositoryURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			if _, err := model.GetRepositoryURL(dir); err == nil {
 

--- a/cmd/stack/deploy_test.go
+++ b/cmd/stack/deploy_test.go
@@ -15,7 +15,6 @@ package stack
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 	"testing"
 
@@ -93,7 +92,7 @@ func Test_loadPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(model.ComposeFileEnvVar, tt.composeEnvVar)
+			t.Setenv(model.ComposeFileEnvVar, tt.composeEnvVar)
 			result := loadComposePaths(tt.stackPath)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/cmd/utils/git_test.go
+++ b/cmd/utils/git_test.go
@@ -27,11 +27,7 @@ import (
 )
 
 func Test_getBranch(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	r, err := git.PlainInit(dir, false)
 	if err != nil {

--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -39,10 +39,7 @@ const (
 )
 
 func Test_multipleStack(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 
 	path, err := createFile(dir, "docker-compose.yml", firstStack)
@@ -107,10 +104,7 @@ func Test_multipleStack(t *testing.T) {
 }
 
 func Test_overrideFileStack(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 
 	path, err := createFile(dir, "docker-compose.yml", firstStack)

--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -82,7 +82,7 @@ func Test_multipleStack(t *testing.T) {
 		t.Fatalf("Expected %v but got %v", svcResult.Image, svc.Image)
 	}
 
-	os.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
+	t.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
 	svcResult.Image = "test"
 
 	stack, err = model.LoadStack("", paths, true)
@@ -105,6 +105,7 @@ func Test_multipleStack(t *testing.T) {
 
 func Test_overrideFileStack(t *testing.T) {
 	dir := t.TempDir()
+	t.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
 	log.Printf("created tempdir: %s", dir)
 
 	path, err := createFile(dir, "docker-compose.yml", firstStack)

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -134,10 +134,7 @@ func TestBuildActionPipeline(t *testing.T) {
 		t.Fatalf("Create namespace action failed: %s", err.Error())
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine")
@@ -330,10 +327,7 @@ func TestStacksActions(t *testing.T) {
 		t.Fatalf("Create namespace action failed: %s", err.Error())
 	}
 
-	dir, err := os.MkdirTemp("", namespace)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 	filePath := filepath.Join(dir, "okteto-stack.yaml")
 	if err := os.WriteFile(filePath, []byte(stackFile), 0644); err != nil {

--- a/integration/auto-wake_test.go
+++ b/integration/auto-wake_test.go
@@ -49,10 +49,7 @@ func TestAutoWake(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir, err := os.MkdirTemp("", tName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 
 	dPath := filepath.Join(dir, "deployment.yaml")

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -253,10 +253,7 @@ func TestUpDeployments(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir, err := os.MkdirTemp("", tName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	defer os.RemoveAll(dir)
 
 	log.Printf("created tempdir: %s", dir)
@@ -440,10 +437,7 @@ func TestUpStatefulset(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir, err := os.MkdirTemp("", tName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 
 	sfsPath := filepath.Join(dir, "statefulset.yaml")
@@ -597,10 +591,7 @@ func TestUpAutocreate(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir, err := os.MkdirTemp("", tName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 
 	contentPath := filepath.Join(dir, "index.html")

--- a/pkg/analytics/config_test.go
+++ b/pkg/analytics/config_test.go
@@ -1,7 +1,6 @@
 package analytics
 
 import (
-	"os"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -50,7 +49,7 @@ func Test_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			os.Setenv(model.OktetoFolderEnvVar, dir)
+			t.Setenv(model.OktetoFolderEnvVar, dir)
 
 			if !tt.currentAnalytics {
 				currentAnalytics = nil

--- a/pkg/analytics/config_test.go
+++ b/pkg/analytics/config_test.go
@@ -48,13 +48,7 @@ func Test_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				os.RemoveAll(dir)
-			}()
+			dir := t.TempDir()
 
 			os.Setenv(model.OktetoFolderEnvVar, dir)
 

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -68,7 +68,7 @@ func Test_getTrackID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			os.Setenv(model.OktetoHomeEnvVar, dir)
+			t.Setenv(model.OktetoHomeEnvVar, dir)
 
 			a := get()
 			a.MachineID = tt.machineID

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -66,11 +66,7 @@ func Test_getTrackID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			os.Setenv(model.OktetoHomeEnvVar, dir)
 

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -1,7 +1,6 @@
 package build
 
 import (
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -251,7 +250,6 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Unsetenv(model.OktetoGitCommitEnvVar)
 			okteto.CurrentStore = &okteto.OktetoContextStore{
 				Contexts: map[string]*okteto.OktetoContext{
 					"test": {
@@ -267,7 +265,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 					tt.serviceName: tt.buildInfo,
 				},
 			}
-			os.Setenv(model.OktetoGitCommitEnvVar, tt.okGitCommitEnv)
+			t.Setenv(model.OktetoGitCommitEnvVar, tt.okGitCommitEnv)
 			result := OptsFromBuildInfo(manifest.Name, tt.serviceName, manifest.Build[tt.serviceName], tt.initialOpts)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,7 +14,6 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestGetUserHomeDir(t *testing.T) {
 
 	dir := t.TempDir()
 
-	os.Setenv(model.OktetoHomeEnvVar, dir)
+	t.Setenv(model.OktetoHomeEnvVar, dir)
 	home = GetUserHomeDir()
 	if home != dir {
 		t.Fatalf("OKTETO_HOME override failed, got %s instead of %s", home, dir)
@@ -74,25 +73,8 @@ func Test_homedirWindows(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			home := os.Getenv(model.HomeEnvVar)
-			up := os.Getenv(model.UserProfileEnvVar)
-			hp := os.Getenv(model.HomePathEnvVar)
-			hd := os.Getenv(model.HomeDriveEnvVar)
-
-			os.Unsetenv(model.HomeEnvVar)
-			os.Unsetenv(model.UserProfileEnvVar)
-			os.Unsetenv(model.HomePathEnvVar)
-			os.Unsetenv(model.HomeDriveEnvVar)
-
-			defer func() {
-				os.Setenv(model.HomeEnvVar, home)
-				os.Setenv(model.UserProfileEnvVar, up)
-				os.Setenv(model.HomePathEnvVar, hp)
-				os.Setenv(model.HomeDriveEnvVar, hd)
-			}()
-
 			for k, v := range tt.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 
 			got, err := homedirWindows()
@@ -110,7 +92,7 @@ func Test_homedirWindows(t *testing.T) {
 func TestGetOktetoHome(t *testing.T) {
 	dir := t.TempDir()
 
-	os.Setenv(model.OktetoFolderEnvVar, dir)
+	t.Setenv(model.OktetoFolderEnvVar, dir)
 
 	got := GetOktetoHome()
 	if got != dir {
@@ -121,7 +103,7 @@ func TestGetOktetoHome(t *testing.T) {
 func TestGetAppHome(t *testing.T) {
 	dir := t.TempDir()
 
-	os.Setenv(model.OktetoFolderEnvVar, dir)
+	t.Setenv(model.OktetoFolderEnvVar, dir)
 
 	got := GetAppHome("ns", "dp")
 	expected := filepath.Join(dir, "ns", "dp")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,14 +27,7 @@ func TestGetUserHomeDir(t *testing.T) {
 		t.Fatal("got an empty home value")
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.RemoveAll(dir)
-		os.Unsetenv(model.OktetoHomeEnvVar)
-	}()
+	dir := t.TempDir()
 
 	os.Setenv(model.OktetoHomeEnvVar, dir)
 	home = GetUserHomeDir()
@@ -115,14 +108,7 @@ func Test_homedirWindows(t *testing.T) {
 }
 
 func TestGetOktetoHome(t *testing.T) {
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.RemoveAll(dir)
-		os.Unsetenv(model.OktetoFolderEnvVar)
-	}()
+	dir := t.TempDir()
 
 	os.Setenv(model.OktetoFolderEnvVar, dir)
 
@@ -133,11 +119,7 @@ func TestGetOktetoHome(t *testing.T) {
 }
 
 func TestGetAppHome(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.Setenv(model.OktetoFolderEnvVar, dir)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestGetUserHomeDir(t *testing.T) {
 
 	dir := t.TempDir()
 
-	t.Setenv(model.OktetoHomeEnvVar, dir)
+	os.Setenv(model.OktetoHomeEnvVar, dir)
 	home = GetUserHomeDir()
 	if home != dir {
 		t.Fatalf("OKTETO_HOME override failed, got %s instead of %s", home, dir)
@@ -73,6 +74,11 @@ func Test_homedirWindows(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(model.HomeEnvVar, "")
+			t.Setenv(model.UserProfileEnvVar, "")
+			t.Setenv(model.HomePathEnvVar, "")
+			t.Setenv(model.HomeDriveEnvVar, "")
+
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
@@ -92,7 +98,7 @@ func Test_homedirWindows(t *testing.T) {
 func TestGetOktetoHome(t *testing.T) {
 	dir := t.TempDir()
 
-	t.Setenv(model.OktetoFolderEnvVar, dir)
+	os.Setenv(model.OktetoFolderEnvVar, dir)
 
 	got := GetOktetoHome()
 	if got != dir {
@@ -103,7 +109,7 @@ func TestGetOktetoHome(t *testing.T) {
 func TestGetAppHome(t *testing.T) {
 	dir := t.TempDir()
 
-	t.Setenv(model.OktetoFolderEnvVar, dir)
+	os.Setenv(model.OktetoFolderEnvVar, dir)
 
 	got := GetAppHome("ns", "dp")
 	expected := filepath.Join(dir, "ns", "dp")

--- a/pkg/linguist/linguist_test.go
+++ b/pkg/linguist/linguist_test.go
@@ -69,20 +69,15 @@ func TestProcessDirectory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmp, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			defer os.RemoveAll(tmp)
+			dir := t.TempDir()
 
 			for _, f := range tt.files {
-				if _, err := os.Create(filepath.Join(tmp, f)); err != nil {
+				if _, err := os.Create(filepath.Join(dir, f)); err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			got, err := ProcessDirectory(tmp)
+			got, err := ProcessDirectory(dir)
 
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/model/context_test.go
+++ b/pkg/model/context_test.go
@@ -43,7 +43,7 @@ func Test_GetContextResource(t *testing.T) {
 			defer os.RemoveAll(tmpFile.Name())
 
 			for k, v := range tt.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			result, err := GetContextResource(tmpFile.Name())
 			if err != nil {

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -715,11 +715,7 @@ func Test_validate(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	dir, err := os.MkdirTemp("/tmp", "okteto-secret-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(dir)
+	dir := t.TempDir()
 
 	tests := []struct {
 		name      string

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -325,7 +325,7 @@ services:
 				devName = "n1"
 			}
 
-			os.Setenv("value", tt.value)
+			t.Setenv("value", tt.value)
 			manifest, err := Read(manifestBytes)
 			if err != nil {
 				t.Fatal(err)
@@ -375,7 +375,7 @@ func Test_loadSelector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dev := &Dev{Selector: tt.selector}
-			os.Setenv("value", tt.value)
+			t.Setenv("value", tt.value)
 			if err := dev.loadSelector(); err != nil {
 				t.Fatalf("couldn't load selector")
 			}
@@ -468,7 +468,7 @@ services:
 `, tt.image))
 			}
 
-			os.Setenv("tag", tt.tagValue)
+			t.Setenv("tag", tt.tagValue)
 			manifest, err := Read(manifestBytes)
 			if err != nil {
 				t.Fatal(err)
@@ -1027,7 +1027,7 @@ func TestPersistentVolumeEnabled(t *testing.T) {
 }
 
 func Test_ExpandEnv(t *testing.T) {
-	os.Setenv("BAR", "bar")
+	t.Setenv("BAR", "bar")
 	tests := []struct {
 		name   string
 		value  string
@@ -1075,13 +1075,10 @@ func TestGetTimeout(t *testing.T) {
 		{name: "bad env var", wantErr: true, env: "bad value"},
 	}
 
-	original := os.Getenv(OktetoTimeoutEnvVar)
-	defer os.Setenv(OktetoTimeoutEnvVar, original)
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != "" {
-				os.Setenv(OktetoTimeoutEnvVar, tt.env)
+				t.Setenv(OktetoTimeoutEnvVar, tt.env)
 			}
 			got, err := GetTimeout()
 			if (err != nil) != tt.wantErr {
@@ -1135,7 +1132,7 @@ func Test_loadEnvFile(t *testing.T) {
 			}
 
 			for k, v := range tt.existing {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 
 			if err := godotenv.Load(); err != nil {
@@ -1502,7 +1499,7 @@ func Test_expandEnvFiles(t *testing.T) {
 
 			tt.dev.EnvFiles = EnvFiles{file.Name()}
 
-			os.Setenv("OKTETO_TEST", "myvalue")
+			t.Setenv("OKTETO_TEST", "myvalue")
 
 			if _, err = file.Write(tt.envs); err != nil {
 				t.Fatal("Failed to write to temporary file", err)

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -15,7 +15,6 @@ package model
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -67,7 +66,7 @@ devs:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			m, err := Read(tt.manifest)
 			assert.NoError(t, err)
@@ -334,7 +333,7 @@ func TestInferFromStack(t *testing.T) {
 }
 
 func TestSetManifestDefaultsFromDev(t *testing.T) {
-	os.Setenv("my_key", "my_value")
+	t.Setenv("my_key", "my_value")
 	tests := []struct {
 		name              string
 		currentManifest   *Manifest

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -149,13 +149,8 @@ func TestEnvVarMashalling(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			var result EnvVar
-			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
-				t.Fatal(err)
-			}
-
-			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("DEV_ENV", "test_environment")
+			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
 
 			if err := yaml.Unmarshal(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -356,9 +351,7 @@ func TestSecretMarshalling(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	if err := os.Setenv("TEST_HOME", file.Name()); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("TEST_HOME", file.Name())
 
 	tests := []struct {
 		name          string
@@ -680,13 +673,8 @@ func TestLabelsUnmashalling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := make(Labels)
-			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
-				t.Fatal(err)
-			}
-
-			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("DEV_ENV", "test_environment")
+			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
 
 			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -785,13 +773,8 @@ func TestAnnotationsUnmashalling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := make(Annotations)
-			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
-				t.Fatal(err)
-			}
-
-			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("DEV_ENV", "test_environment")
+			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
 
 			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -981,7 +964,7 @@ rescanInterval: 10`),
 }
 
 func TestSyncFoldersUnmashalling(t *testing.T) {
-	os.Setenv("REMOTE_PATH", "/usr/src/app")
+	t.Setenv("REMOTE_PATH", "/usr/src/app")
 	tests := []struct {
 		name     string
 		data     []byte

--- a/pkg/model/stack_expander_test.go
+++ b/pkg/model/stack_expander_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -140,9 +139,8 @@ volumes:
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			if err := os.Setenv("CUSTOM_ENV", tt.envValue); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("CUSTOM_ENV", tt.envValue)
+
 			result, err := ExpandStackEnvs(tt.file)
 			if err != nil && !tt.expectedError {
 				t.Fatalf("expected no error, but got error: %v", err)
@@ -152,7 +150,6 @@ volumes:
 
 			assert.Equal(t, tt.expectedStack, string(result))
 
-			os.Unsetenv("CUSTOM_ENV")
 		})
 	}
 }

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1587,10 +1587,7 @@ func Test_Environment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			if err := os.Setenv("OKTETO_ENVTEST", "myvalue"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("OKTETO_ENVTEST", "myvalue")
 
 			s, err := ReadStack(tt.manifest, false)
 			if err != nil {

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -979,7 +979,7 @@ func TestStack_ExpandEnvsAtFileLevel(t *testing.T) {
 			defer os.RemoveAll(tmpFile.Name())
 
 			for key, value := range tt.envs {
-				os.Setenv(key, value)
+				t.Setenv(key, value)
 			}
 
 			stack, err := GetStackFromPath("test", tmpFile.Name(), false)
@@ -1142,7 +1142,7 @@ func Test_getStackName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			os.Setenv(OktetoNameEnvVar, tt.nameEnv)
+			t.Setenv(OktetoNameEnvVar, tt.nameEnv)
 			res, err := getStackName(tt.name, tt.stackPath, tt.actualStackName)
 			resEnv := os.Getenv(OktetoNameEnvVar)
 
@@ -1182,10 +1182,10 @@ func Test_translateEnvVars(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpFile2.Name())
 
-	os.Setenv("B", "2")
-	os.Setenv("ENV_PATH", tmpFile.Name())
-	os.Setenv("ENV_PATH2", tmpFile2.Name())
-	os.Setenv("OKTETO_TEST", "myvalue")
+	t.Setenv("B", "2")
+	t.Setenv("ENV_PATH", tmpFile.Name())
+	t.Setenv("ENV_PATH2", tmpFile2.Name())
+	t.Setenv("OKTETO_TEST", "myvalue")
 	stack := &Stack{
 		Name: "name",
 		Services: map[string]*Service{

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -20,12 +20,7 @@ import (
 )
 
 func TestCopyFile(t *testing.T) {
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	from := filepath.Join(dir, "from")
 	to := filepath.Join(dir, "to")
@@ -59,12 +54,7 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	p := filepath.Join(dir, "exists")
 	if FileExists(p) {

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -14,31 +14,26 @@
 package okteto
 
 import (
-	"os"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
 )
 
 func TestInDevContainer(t *testing.T) {
-	v := os.Getenv(model.OktetoNameEnvVar)
-	os.Setenv(model.OktetoNameEnvVar, "")
-	defer func() {
-		os.Setenv(model.OktetoNameEnvVar, v)
-	}()
+	t.Setenv(model.OktetoNameEnvVar, "")
 
 	in := InDevContainer()
 	if in {
 		t.Errorf("in dev container when there was no marker env var")
 	}
 
-	os.Setenv(model.OktetoNameEnvVar, "")
+	t.Setenv(model.OktetoNameEnvVar, "")
 	in = InDevContainer()
 	if in {
 		t.Errorf("in dev container when there was an empty marker env var")
 	}
 
-	os.Setenv(model.OktetoNameEnvVar, "1")
+	t.Setenv(model.OktetoNameEnvVar, "1")
 	in = InDevContainer()
 	if !in {
 		t.Errorf("not in dev container when there was a marker env var")

--- a/pkg/ssh/config_test.go
+++ b/pkg/ssh/config_test.go
@@ -41,13 +41,9 @@ func TestWriteToNewFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
-	defer os.RemoveAll(d)
-	path := filepath.Join(d, "config")
+	path := filepath.Join(dir, "config")
 
 	if err := config.writeToFilepath(path); err != nil {
 		t.Fatal(err)

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestKeyExists(t *testing.T) {
 	dir := t.TempDir()
+	t.Setenv(model.OktetoFolderEnvVar, dir)
 
 	if KeyExists() {
 		t.Error("keys shouldn't exist in an empty directory")
@@ -48,8 +49,8 @@ func TestKeyExists(t *testing.T) {
 
 func TestGenerateKeys(t *testing.T) {
 	dir := t.TempDir()
+	t.Setenv(model.OktetoFolderEnvVar, dir)
 
-	os.Setenv(model.OktetoFolderEnvVar, dir)
 	public, private := getKeyPaths()
 	if err := generateKeys(public, private, 128); err != nil {
 		t.Error(err)

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -22,18 +22,7 @@ import (
 )
 
 func TestKeyExists(t *testing.T) {
-
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		os.RemoveAll(dir)
-		os.Unsetenv(model.OktetoFolderEnvVar)
-	}()
-
-	os.Setenv(model.OktetoFolderEnvVar, dir)
+	dir := t.TempDir()
 
 	if KeyExists() {
 		t.Error("keys shouldn't exist in an empty directory")
@@ -58,15 +47,7 @@ func TestKeyExists(t *testing.T) {
 }
 
 func TestGenerateKeys(t *testing.T) {
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		os.RemoveAll(dir)
-		os.Unsetenv(model.OktetoFolderEnvVar)
-	}()
+	dir := t.TempDir()
 
 	os.Setenv(model.OktetoFolderEnvVar, dir)
 	public, private := getKeyPaths()

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -29,8 +29,6 @@ func Test_addOnEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer os.RemoveAll(dir)
-
 	sshConfig := filepath.Join(dir, "config")
 
 	if err := add(sshConfig, "test.okteto", model.Localhost, 8080); err != nil {
@@ -52,12 +50,8 @@ func Test_addOnEmpty(t *testing.T) {
 	}
 }
 func Test_add(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
-	defer os.RemoveAll(dir)
 	sshConfig := filepath.Join(dir, "config")
 
 	if err := add(sshConfig, "test.okteto", model.Localhost, 8080); err != nil {
@@ -224,7 +218,7 @@ func Test_removeHost(t *testing.T) {
 func TestGetPort(t *testing.T) {
 	dir := t.TempDir()
 
-	defer os.Unsetenv(model.OktetoHomeEnvVar)
+	t.Setenv(model.OktetoHomeEnvVar, dir)
 
 	if _, err := GetPort(t.Name()); err == nil {
 		t.Fatal("expected error on non existing host")

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -23,10 +23,7 @@ import (
 )
 
 func Test_addOnEmpty(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	if err := os.RemoveAll(dir); err != nil {
 		t.Fatal(err)
@@ -225,16 +222,7 @@ func Test_removeHost(t *testing.T) {
 }
 
 func TestGetPort(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)
-
-	if err := os.Setenv(model.OktetoHomeEnvVar, dir); err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	defer os.Unsetenv(model.OktetoHomeEnvVar)
 

--- a/pkg/syncthing/install_test.go
+++ b/pkg/syncthing/install_test.go
@@ -15,7 +15,6 @@ package syncthing
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -191,22 +190,9 @@ func TestGetMinimumVersion(t *testing.T) {
 		},
 	}
 
-	env := os.Getenv(model.SyncthingVersionEnvVar)
-	if err := os.Setenv(model.SyncthingVersionEnvVar, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	defer func() {
-		if err := os.Setenv(model.SyncthingVersionEnvVar, env); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			if err := os.Setenv(model.SyncthingVersionEnvVar, tt.version); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv(model.SyncthingVersionEnvVar, tt.version)
 			got := GetMinimumVersion()
 			if got.String() != tt.expected {
 				t.Errorf("got %s, expected %s", got.String(), tt.expected)

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -14,7 +14,6 @@
 package syncthing
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +23,7 @@ import (
 func TestGetFiles(t *testing.T) {
 
 	dir := t.TempDir()
+	t.Setenv(model.OktetoFolderEnvVar, dir)
 	log := GetLogFile("test", "application")
 	expected := filepath.Join(dir, "test", "application", "syncthing.log")
 

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -23,16 +23,7 @@ import (
 
 func TestGetFiles(t *testing.T) {
 
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		os.RemoveAll(dir)
-		os.Unsetenv(model.OktetoFolderEnvVar)
-	}()
-
-	os.Setenv(model.OktetoFolderEnvVar, dir)
+	dir := t.TempDir()
 	log := GetLogFile("test", "application")
 	expected := filepath.Join(dir, "test", "application", "syncthing.log")
 


### PR DESCRIPTION
Fixes #2677

## Proposed changes
- Use `t.TempDir` to create temporary dirs that gets removed when a test finish
- Use `t.SetEnv` to set the env vars for a test that returns back to previous state when the test finishes
- While doing this refactor detected a test which was passing because of setting an env var on a previous test. Fixed
