### PR TITLE
Remove dead code handling old Okteto API < 0.10

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -260,54 +260,11 @@ func waitUntilRunning(ctx context.Context, name string, action *types.Action, ti
 }
 
 func waitToBeDeployed(ctx context.Context, name string, action *types.Action, timeout time.Duration) error {
-	if action == nil {
-		return deprecatedWaitToBeDeployed(ctx, name, timeout)
-	}
 	oktetoClient, err := okteto.NewOktetoClient()
 	if err != nil {
 		return err
 	}
 	return oktetoClient.WaitForActionToFinish(ctx, name, action.Name, timeout)
-}
-
-//TODO: remove when all users are in Okteto Enterprise >= 0.10.0
-func deprecatedWaitToBeDeployed(ctx context.Context, name string, timeout time.Duration) error {
-
-	t := time.NewTicker(1 * time.Second)
-	to := time.NewTicker(timeout)
-	attempts := 0
-	oktetoClient, err := okteto.NewOktetoClient()
-	if err != nil {
-		return err
-	}
-
-	for {
-		select {
-		case <-to.C:
-			return fmt.Errorf("'%s' deploy didn't finish after %s", name, timeout.String())
-		case <-t.C:
-			p, err := oktetoClient.GetPipelineByName(ctx, name)
-			if err != nil {
-				if oktetoErrors.IsNotFound(err) || oktetoErrors.IsNotExist(err) {
-					return nil
-				}
-
-				return fmt.Errorf("failed to get repository '%s': %s", name, err)
-			}
-
-			switch p.Status {
-			case "deployed", "running":
-				return nil
-			case "error":
-				attempts++
-				if attempts > 30 {
-					return fmt.Errorf("repository '%s' failed", name)
-				}
-			default:
-				oktetoLog.Infof("repository '%s' is '%s'", name, p.Status)
-			}
-		}
-	}
 }
 
 func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.Duration) error {

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -182,42 +182,9 @@ func waitUntilDestroyed(ctx context.Context, name string, action *types.Action, 
 }
 
 func waitToBeDestroyed(ctx context.Context, name string, action *types.Action, timeout time.Duration) error {
-	if action == nil {
-		return deprecatedWaitToBeDestroyed(ctx, name, timeout)
-	}
 	oktetoClient, err := okteto.NewOktetoClient()
 	if err != nil {
 		return err
 	}
 	return oktetoClient.WaitForActionToFinish(ctx, name, action.Name, timeout)
-}
-
-//TODO: remove when all users are in Okteto Enterprise >= 0.10.0
-func deprecatedWaitToBeDestroyed(ctx context.Context, name string, timeout time.Duration) error {
-
-	t := time.NewTicker(1 * time.Second)
-	to := time.NewTicker(timeout)
-	oktetoClient, err := okteto.NewOktetoClient()
-	if err != nil {
-		return err
-	}
-
-	for {
-		select {
-		case <-to.C:
-			return fmt.Errorf("'%s' destroy didn't finish after %s", name, timeout.String())
-		case <-t.C:
-			p, err := oktetoClient.GetPipelineByName(ctx, name)
-			if err != nil {
-				if oktetoErrors.IsNotFound(err) || oktetoErrors.IsNotExist(err) {
-					return nil
-				}
-				return fmt.Errorf("failed to get repository '%s': %s", name, err)
-			}
-
-			if p.Status == "error" {
-				return fmt.Errorf("repository '%s' failed", name)
-			}
-		}
-	}
 }

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -239,53 +239,11 @@ func waitUntilRunning(ctx context.Context, name string, a *types.Action, timeout
 	return nil
 }
 func waitToBeDeployed(ctx context.Context, name string, a *types.Action, timeout time.Duration) error {
-	if a == nil {
-		return deprecatedWaitToBeDeployed(ctx, name, timeout)
-	}
 	oktetoClient, err := okteto.NewOktetoClient()
 	if err != nil {
 		return err
 	}
 	return oktetoClient.WaitForActionToFinish(ctx, name, a.Name, timeout)
-}
-
-//TODO: remove when all users are in Okteto Enterprise >= 0.10.0
-func deprecatedWaitToBeDeployed(ctx context.Context, name string, timeout time.Duration) error {
-	t := time.NewTicker(1 * time.Second)
-	to := time.NewTicker(timeout)
-	attempts := 0
-	oktetoClient, err := okteto.NewOktetoClient()
-	if err != nil {
-		return err
-	}
-	for {
-		select {
-		case <-to.C:
-			return fmt.Errorf("preview environment '%s' didn't finish after %s", name, timeout.String())
-		case <-t.C:
-
-			p, err := oktetoClient.GetPreviewEnvByName(ctx, name)
-			if err != nil {
-				if oktetoErrors.IsNotFound(err) || oktetoErrors.IsNotExist(err) {
-					return nil
-				}
-
-				return fmt.Errorf("failed to get preview environment '%s': %s", name, err)
-			}
-
-			switch p.Status {
-			case "deployed", "running":
-				return nil
-			case "error":
-				attempts++
-				if attempts > 30 {
-					return fmt.Errorf("preview environment '%s' failed", name)
-				}
-			default:
-				oktetoLog.Infof("preview environment '%s' is '%s'", name, p.Status)
-			}
-		}
-	}
 }
 
 func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.Duration) error {

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/types"
@@ -66,9 +65,6 @@ func (c *namespaceClient) List(ctx context.Context) ([]types.Namespace, error) {
 
 	err := query(ctx, &queryStruct, nil, c.client)
 	if err != nil {
-		if strings.Contains(err.Error(), "Cannot query field \"status\" on type \"Space\"") {
-			return c.deprecatedListNamespaces(ctx)
-		}
 		return nil, err
 	}
 
@@ -77,35 +73,6 @@ func (c *namespaceClient) List(ctx context.Context) ([]types.Namespace, error) {
 		result = append(result, types.Namespace{
 			ID:     string(space.Id),
 			Status: string(space.Status),
-		})
-	}
-
-	return result, nil
-}
-
-// TODO: remove when all users are in OktetoEnterprise >= 10.6
-func (c *namespaceClient) deprecatedListNamespaces(ctx context.Context) ([]types.Namespace, error) {
-	var queryStruct struct {
-		Spaces []struct {
-			Id       graphql.String
-			Sleeping graphql.Boolean
-		} `graphql:"spaces"`
-	}
-
-	err := query(ctx, &queryStruct, nil, c.client)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]types.Namespace, 0)
-	for _, space := range queryStruct.Spaces {
-		status := "Active"
-		if space.Sleeping {
-			status = "Sleeping"
-		}
-		result = append(result, types.Namespace{
-			ID:     string(space.Id),
-			Status: status,
 		})
 	}
 

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -100,9 +100,6 @@ func (c *OktetoClient) DeployPreview(ctx context.Context, name, scope, repositor
 		}
 		err := mutate(ctx, &mutation, queryVariables, c.client)
 		if err != nil {
-			if strings.Contains(err.Error(), "Cannot query field \"action\" on type \"Preview\"") {
-				return c.deprecatedDeployPreview(ctx, name, scope, repository, branch, sourceUrl, filename, variables)
-			}
 			return nil, translatePreviewAPIErr(err, name)
 		}
 		previewResponse.Action = &types.Action{
@@ -140,9 +137,6 @@ func (c *OktetoClient) DeployPreview(ctx context.Context, name, scope, repositor
 		}
 		err := mutate(ctx, &mutation, queryVariables, c.client)
 		if err != nil {
-			if strings.Contains(err.Error(), "Cannot query field \"job\" on type \"Preview\"") {
-				return c.deprecatedDeployPreview(ctx, name, scope, repository, branch, sourceUrl, filename, variables)
-			}
 			return nil, translatePreviewAPIErr(err, name)
 		}
 		previewResponse.Action = &types.Action{
@@ -155,64 +149,6 @@ func (c *OktetoClient) DeployPreview(ctx context.Context, name, scope, repositor
 		}
 	}
 	return previewResponse, nil
-}
-
-//TODO: remove when all users are in Okteto Enterprise >= 0.10.0
-func (c *OktetoClient) deprecatedDeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []types.Variable) (*types.PreviewResponse, error) {
-
-	previewEnv := &types.PreviewResponse{}
-
-	if len(variables) > 0 {
-		var mutation struct {
-			Preview struct {
-				Id graphql.String
-			} `graphql:"deployPreview(name: $name, scope: $scope, repository: $repository, branch: $branch, sourceUrl: $sourceURL, variables: $variables, filename: $filename)"`
-		}
-
-		variablesVariable := make([]InputVariable, 0)
-		for _, v := range variables {
-			variablesVariable = append(variablesVariable, InputVariable{
-				Name:  graphql.String(v.Name),
-				Value: graphql.String(v.Value),
-			})
-		}
-		variables := map[string]interface{}{
-			"name":       graphql.String(name),
-			"scope":      PreviewScope(scope),
-			"repository": graphql.String(repository),
-			"branch":     graphql.String(branch),
-			"sourceURL":  graphql.String(sourceUrl),
-			"variables":  variablesVariable,
-			"filename":   graphql.String(filename),
-		}
-		err := mutate(ctx, &mutation, variables, c.client)
-		if err != nil {
-			return nil, translatePreviewAPIErr(err, name)
-		}
-		previewEnv.Preview = &types.Preview{ID: string(mutation.Preview.Id)}
-	} else {
-		var mutation struct {
-			Preview struct {
-				Id graphql.String
-			} `graphql:"deployPreview(name: $name, scope: $scope, repository: $repository, branch: $branch, sourceUrl: $sourceURL, filename: $filename)"`
-		}
-
-		variables := map[string]interface{}{
-			"name":       graphql.String(name),
-			"scope":      PreviewScope(scope),
-			"repository": graphql.String(repository),
-			"branch":     graphql.String(branch),
-			"sourceURL":  graphql.String(sourceUrl),
-			"filename":   graphql.String(filename),
-		}
-		err := mutate(ctx, &mutation, variables, c.client)
-		if err != nil {
-			return nil, translatePreviewAPIErr(err, name)
-		}
-		previewEnv.Preview = &types.Preview{ID: string(mutation.Preview.Id)}
-	}
-
-	return previewEnv, nil
 }
 
 // DestroyPreview destroy a preview environment


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

I checked our metrics and all our customers are in OE >= 0.10.6, so it's safe to remove the logic to handle those old APIs