### PR TITLE
Fix "okteto up" metrics for vanilla clusters

### DIFF
--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -59,7 +59,7 @@ func Test_addKubernetesContext(t *testing.T) {
 			wantStore: &okteto.OktetoContextStore{
 				CurrentContext: "context",
 				Contexts: map[string]*okteto.OktetoContext{
-					"context": {Name: "context", Namespace: "n-ctx"},
+					"context": {Name: "context", Namespace: "n-ctx", Analytics: true},
 				},
 			},
 			wantError: false,
@@ -77,7 +77,7 @@ func Test_addKubernetesContext(t *testing.T) {
 			wantStore: &okteto.OktetoContextStore{
 				CurrentContext: "context",
 				Contexts: map[string]*okteto.OktetoContext{
-					"context": {Name: "context", Namespace: "n-cfg"},
+					"context": {Name: "context", Namespace: "n-cfg", Analytics: true},
 				},
 			},
 			wantError: false,
@@ -95,7 +95,7 @@ func Test_addKubernetesContext(t *testing.T) {
 			wantStore: &okteto.OktetoContextStore{
 				CurrentContext: "context",
 				Contexts: map[string]*okteto.OktetoContext{
-					"context": {Name: "context", Namespace: "default"},
+					"context": {Name: "context", Namespace: "default", Analytics: true},
 				},
 			},
 			wantError: false,

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -359,9 +359,15 @@ func track(event string, success bool, props map[string]interface{}) {
 		return
 	}
 
-	if !okteto.IsContextInitialized() || (!okteto.Context().Analytics && !okteto.IsOktetoCloud()) {
+	if !okteto.IsContextInitialized() {
+		oktetoLog.Info("failed to send analytics: okteto context not initialized")
 		return
 	}
+
+	if disabledByOktetoAdmin() {
+		return
+	}
+
 	// skip events from nested okteto deploys and manifest dependencies
 	origin := config.GetDeployOrigin()
 	if origin == "okteto-deploy" {
@@ -406,4 +412,11 @@ func track(event string, success bool, props map[string]interface{}) {
 	if err := mixpanelClient.Track(getTrackID(), event, e); err != nil {
 		oktetoLog.Infof("Failed to send analytics: %s", err)
 	}
+}
+
+func disabledByOktetoAdmin() bool {
+	if okteto.IsOktetoCloud() {
+		return false
+	}
+	return !okteto.Context().Analytics
 }

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -94,3 +94,54 @@ func Test_getTrackID(t *testing.T) {
 		})
 	}
 }
+
+func Test_disabledInOktetoCluster(t *testing.T) {
+	var tests = []struct {
+		name         string
+		contextStore *okteto.OktetoContextStore
+		expected     bool
+	}{
+		{
+			name: "cloud-always-enabled",
+			contextStore: &okteto.OktetoContextStore{
+				Contexts:       map[string]*okteto.OktetoContext{okteto.CloudURL: {Name: okteto.CloudURL, IsOkteto: true, Analytics: false}},
+				CurrentContext: okteto.CloudURL,
+			},
+			expected: false,
+		},
+		{
+			name: "vanilla-always-enabled",
+			contextStore: &okteto.OktetoContextStore{
+				Contexts:       map[string]*okteto.OktetoContext{"minikube": {Name: "minikube", IsOkteto: false, Analytics: true}},
+				CurrentContext: "minikube",
+			},
+			expected: false,
+		},
+		{
+			name: "admin-enabled",
+			contextStore: &okteto.OktetoContextStore{
+				Contexts:       map[string]*okteto.OktetoContext{"oe": {Name: "oe", IsOkteto: true, Analytics: true}},
+				CurrentContext: "oe",
+			},
+			expected: false,
+		},
+		{
+			name: "admin-disabled",
+			contextStore: &okteto.OktetoContextStore{
+				Contexts:       map[string]*okteto.OktetoContext{"oe": {Name: "oe", IsOkteto: true, Analytics: false}},
+				CurrentContext: "oe",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			okteto.CurrentStore = tt.contextStore
+			result := disabledByOktetoAdmin()
+			if result != tt.expected {
+				t.Fatalf("test %s, expected %t result %t", tt.name, tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -275,6 +275,7 @@ func AddKubernetesContext(name, namespace, buildkitURL string) {
 		Name:      name,
 		Namespace: namespace,
 		Builder:   buildkitURL,
+		Analytics: true,
 	}
 	CurrentStore.CurrentContext = name
 }


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Since CLI 1.14.2 (04 Nov 2021) we were ignoring `okteto up` metrics 