### PR TITLE
Revert refactor unit test folders and envs (#2713)

### DIFF
--- a/cmd/build/v1/build_test.go
+++ b/cmd/build/v1/build_test.go
@@ -44,7 +44,7 @@ func TestBuildWithErrorFromDockerfile(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile(t)
+	dir, err := createDockerfile()
 	assert.NoError(t, err)
 
 	tag := "okteto.dev/test"
@@ -78,8 +78,9 @@ func TestBuildWithNoErrorFromDockerfile(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile(t)
+	dir, err := createDockerfile()
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 
 	tag := "okteto.dev/test"
 	options := &types.BuildOptions{
@@ -112,8 +113,9 @@ func TestBuildWithNoErrorFromDockerfileAndNoTag(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile(t)
+	dir, err := createDockerfile()
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 
 	options := &types.BuildOptions{
 		CommandArgs: []string{dir},
@@ -127,10 +129,13 @@ func TestBuildWithNoErrorFromDockerfileAndNoTag(t *testing.T) {
 	assert.Empty(t, image)
 }
 
-func createDockerfile(t *testing.T) (string, error) {
-	dir := t.TempDir()
+func createDockerfile() (string, error) {
+	dir, err := os.MkdirTemp("", "build")
+	if err != nil {
+		return "", err
+	}
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
-	err := os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
+	err = os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -119,7 +119,11 @@ func TestOnlyInjectVolumeMountsInOkteto(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -165,8 +169,14 @@ func TestTwoStepsBuild(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	dir, err := createDockerfile(t)
+	dir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	dir, err = createDockerfile()
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -217,8 +227,9 @@ func TestBuildWithoutVolumeMountWithoutImage(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile(t)
+	dir, err := createDockerfile()
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -260,8 +271,9 @@ func TestBuildWithoutVolumeMountWithImage(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile(t)
+	dir, err := createDockerfile()
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -305,8 +317,9 @@ func TestBuildWithStack(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile(t)
+	dir, err := createDockerfile()
 	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -357,10 +370,13 @@ func Test_getAccessibleVolumeMounts(t *testing.T) {
 	assert.Len(t, volumes, 1)
 }
 
-func createDockerfile(t *testing.T) (string, error) {
-	dir := t.TempDir()
+func createDockerfile() (string, error) {
+	dir, err := os.MkdirTemp("", "build")
+	if err != nil {
+		return "", err
+	}
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
-	err := os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
+	err = os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/context/context_test.go
+++ b/cmd/context/context_test.go
@@ -54,7 +54,7 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tokenPath, err := createDeprecatedToken(t, tt.tokenUrl)
+			tokenPath, err := createDeprecatedToken(tt.tokenUrl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,9 +73,12 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 	}
 }
 
-func createDeprecatedToken(t *testing.T, url string) (string, error) {
-	dir := t.TempDir()
-	t.Setenv(model.OktetoFolderEnvVar, dir)
+func createDeprecatedToken(url string) (string, error) {
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	os.Setenv(model.OktetoFolderEnvVar, dir)
 	token := &okteto.Token{
 		URL:       url,
 		Buildkit:  "buildkit",

--- a/cmd/context/options_test.go
+++ b/cmd/context/options_test.go
@@ -246,7 +246,7 @@ func Test_initFromEnvVars(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.env {
-				t.Setenv(k, v)
+				os.Setenv(k, v)
 			}
 			tt.in.initFromEnvVars()
 			if !reflect.DeepEqual(tt.in, tt.want) {

--- a/cmd/context/use_test.go
+++ b/cmd/context/use_test.go
@@ -56,7 +56,8 @@ func Test_setSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				t.Setenv(k, v)
+				err := os.Setenv(k, v)
+				assert.NoError(t, err)
 			}
 			setSecrets(tt.secrets)
 			assert.Equal(t, expectedValue, os.Getenv(key))

--- a/cmd/manifest/init-v1_test.go
+++ b/cmd/manifest/init-v1_test.go
@@ -41,8 +41,13 @@ func TestMain(m *testing.M) {
 }
 
 func TestRun(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := context.Background()
+
+	defer os.RemoveAll(dir)
 
 	p := filepath.Join(dir, fmt.Sprintf("okteto-%s", uuid.New().String()))
 
@@ -103,7 +108,10 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunJustCreateNecessaryFields(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx := context.Background()
 
 	defer os.RemoveAll(dir)

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -14,6 +14,7 @@
 package pipeline
 
 import (
+	"os"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -68,7 +69,11 @@ func Test_getRepositoryURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
+			dir, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
 
 			if _, err := model.GetRepositoryURL(dir); err == nil {
 

--- a/cmd/stack/deploy_test.go
+++ b/cmd/stack/deploy_test.go
@@ -15,6 +15,7 @@ package stack
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"testing"
 
@@ -92,7 +93,7 @@ func Test_loadPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(model.ComposeFileEnvVar, tt.composeEnvVar)
+			os.Setenv(model.ComposeFileEnvVar, tt.composeEnvVar)
 			result := loadComposePaths(tt.stackPath)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/cmd/utils/git_test.go
+++ b/cmd/utils/git_test.go
@@ -27,7 +27,11 @@ import (
 )
 
 func Test_getBranch(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
 
 	r, err := git.PlainInit(dir, false)
 	if err != nil {

--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -39,7 +39,10 @@ const (
 )
 
 func Test_multipleStack(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	log.Printf("created tempdir: %s", dir)
 
 	path, err := createFile(dir, "docker-compose.yml", firstStack)
@@ -82,7 +85,7 @@ func Test_multipleStack(t *testing.T) {
 		t.Fatalf("Expected %v but got %v", svcResult.Image, svc.Image)
 	}
 
-	t.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
+	os.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
 	svcResult.Image = "test"
 
 	stack, err = model.LoadStack("", paths, true)
@@ -104,8 +107,10 @@ func Test_multipleStack(t *testing.T) {
 }
 
 func Test_overrideFileStack(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	log.Printf("created tempdir: %s", dir)
 
 	path, err := createFile(dir, "docker-compose.yml", firstStack)

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -134,7 +134,10 @@ func TestBuildActionPipeline(t *testing.T) {
 		t.Fatalf("Create namespace action failed: %s", err.Error())
 	}
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	log.Printf("created tempdir: %s", dir)
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine")
@@ -327,7 +330,10 @@ func TestStacksActions(t *testing.T) {
 		t.Fatalf("Create namespace action failed: %s", err.Error())
 	}
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
 	log.Printf("created tempdir: %s", dir)
 	filePath := filepath.Join(dir, "okteto-stack.yaml")
 	if err := os.WriteFile(filePath, []byte(stackFile), 0644); err != nil {

--- a/integration/auto-wake_test.go
+++ b/integration/auto-wake_test.go
@@ -49,7 +49,10 @@ func TestAutoWake(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", tName)
+	if err != nil {
+		t.Fatal(err)
+	}
 	log.Printf("created tempdir: %s", dir)
 
 	dPath := filepath.Join(dir, "deployment.yaml")

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -253,7 +253,10 @@ func TestUpDeployments(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", tName)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(dir)
 
 	log.Printf("created tempdir: %s", dir)
@@ -437,7 +440,10 @@ func TestUpStatefulset(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", tName)
+	if err != nil {
+		t.Fatal(err)
+	}
 	log.Printf("created tempdir: %s", dir)
 
 	sfsPath := filepath.Join(dir, "statefulset.yaml")
@@ -591,7 +597,10 @@ func TestUpAutocreate(t *testing.T) {
 	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", tName)
+	if err != nil {
+		t.Fatal(err)
+	}
 	log.Printf("created tempdir: %s", dir)
 
 	contentPath := filepath.Join(dir, "index.html")

--- a/pkg/analytics/config_test.go
+++ b/pkg/analytics/config_test.go
@@ -1,6 +1,7 @@
 package analytics
 
 import (
+	"os"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -47,9 +48,15 @@ func Test_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
+			dir, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				os.RemoveAll(dir)
+			}()
 
-			t.Setenv(model.OktetoFolderEnvVar, dir)
+			os.Setenv(model.OktetoFolderEnvVar, dir)
 
 			if !tt.currentAnalytics {
 				currentAnalytics = nil

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -66,9 +66,13 @@ func Test_getTrackID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
+			dir, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
 
-			t.Setenv(model.OktetoHomeEnvVar, dir)
+			os.Setenv(model.OktetoHomeEnvVar, dir)
 
 			a := get()
 			a.MachineID = tt.machineID

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -250,6 +251,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv(model.OktetoGitCommitEnvVar)
 			okteto.CurrentStore = &okteto.OktetoContextStore{
 				Contexts: map[string]*okteto.OktetoContext{
 					"test": {
@@ -265,7 +267,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 					tt.serviceName: tt.buildInfo,
 				},
 			}
-			t.Setenv(model.OktetoGitCommitEnvVar, tt.okGitCommitEnv)
+			os.Setenv(model.OktetoGitCommitEnvVar, tt.okGitCommitEnv)
 			result := OptsFromBuildInfo(manifest.Name, tt.serviceName, manifest.Build[tt.serviceName], tt.initialOpts)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,7 +27,14 @@ func TestGetUserHomeDir(t *testing.T) {
 		t.Fatal("got an empty home value")
 	}
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv(model.OktetoHomeEnvVar)
+	}()
 
 	os.Setenv(model.OktetoHomeEnvVar, dir)
 	home = GetUserHomeDir()
@@ -74,13 +81,25 @@ func Test_homedirWindows(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(model.HomeEnvVar, "")
-			t.Setenv(model.UserProfileEnvVar, "")
-			t.Setenv(model.HomePathEnvVar, "")
-			t.Setenv(model.HomeDriveEnvVar, "")
+			home := os.Getenv(model.HomeEnvVar)
+			up := os.Getenv(model.UserProfileEnvVar)
+			hp := os.Getenv(model.HomePathEnvVar)
+			hd := os.Getenv(model.HomeDriveEnvVar)
+
+			os.Unsetenv(model.HomeEnvVar)
+			os.Unsetenv(model.UserProfileEnvVar)
+			os.Unsetenv(model.HomePathEnvVar)
+			os.Unsetenv(model.HomeDriveEnvVar)
+
+			defer func() {
+				os.Setenv(model.HomeEnvVar, home)
+				os.Setenv(model.UserProfileEnvVar, up)
+				os.Setenv(model.HomePathEnvVar, hp)
+				os.Setenv(model.HomeDriveEnvVar, hd)
+			}()
 
 			for k, v := range tt.env {
-				t.Setenv(k, v)
+				os.Setenv(k, v)
 			}
 
 			got, err := homedirWindows()
@@ -96,7 +115,14 @@ func Test_homedirWindows(t *testing.T) {
 }
 
 func TestGetOktetoHome(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv(model.OktetoFolderEnvVar)
+	}()
 
 	os.Setenv(model.OktetoFolderEnvVar, dir)
 
@@ -107,7 +133,11 @@ func TestGetOktetoHome(t *testing.T) {
 }
 
 func TestGetAppHome(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
 
 	os.Setenv(model.OktetoFolderEnvVar, dir)
 

--- a/pkg/linguist/linguist_test.go
+++ b/pkg/linguist/linguist_test.go
@@ -69,15 +69,20 @@ func TestProcessDirectory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
+			tmp, err := os.MkdirTemp("", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			defer os.RemoveAll(tmp)
 
 			for _, f := range tt.files {
-				if _, err := os.Create(filepath.Join(dir, f)); err != nil {
+				if _, err := os.Create(filepath.Join(tmp, f)); err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			got, err := ProcessDirectory(dir)
+			got, err := ProcessDirectory(tmp)
 
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/model/context_test.go
+++ b/pkg/model/context_test.go
@@ -43,7 +43,7 @@ func Test_GetContextResource(t *testing.T) {
 			defer os.RemoveAll(tmpFile.Name())
 
 			for k, v := range tt.env {
-				t.Setenv(k, v)
+				os.Setenv(k, v)
 			}
 			result, err := GetContextResource(tmpFile.Name())
 			if err != nil {

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -325,7 +325,7 @@ services:
 				devName = "n1"
 			}
 
-			t.Setenv("value", tt.value)
+			os.Setenv("value", tt.value)
 			manifest, err := Read(manifestBytes)
 			if err != nil {
 				t.Fatal(err)
@@ -375,7 +375,7 @@ func Test_loadSelector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dev := &Dev{Selector: tt.selector}
-			t.Setenv("value", tt.value)
+			os.Setenv("value", tt.value)
 			if err := dev.loadSelector(); err != nil {
 				t.Fatalf("couldn't load selector")
 			}
@@ -468,7 +468,7 @@ services:
 `, tt.image))
 			}
 
-			t.Setenv("tag", tt.tagValue)
+			os.Setenv("tag", tt.tagValue)
 			manifest, err := Read(manifestBytes)
 			if err != nil {
 				t.Fatal(err)
@@ -715,7 +715,11 @@ func Test_validate(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("/tmp", "okteto-secret-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dir)
 
 	tests := []struct {
 		name      string
@@ -1027,7 +1031,7 @@ func TestPersistentVolumeEnabled(t *testing.T) {
 }
 
 func Test_ExpandEnv(t *testing.T) {
-	t.Setenv("BAR", "bar")
+	os.Setenv("BAR", "bar")
 	tests := []struct {
 		name   string
 		value  string
@@ -1075,10 +1079,13 @@ func TestGetTimeout(t *testing.T) {
 		{name: "bad env var", wantErr: true, env: "bad value"},
 	}
 
+	original := os.Getenv(OktetoTimeoutEnvVar)
+	defer os.Setenv(OktetoTimeoutEnvVar, original)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != "" {
-				t.Setenv(OktetoTimeoutEnvVar, tt.env)
+				os.Setenv(OktetoTimeoutEnvVar, tt.env)
 			}
 			got, err := GetTimeout()
 			if (err != nil) != tt.wantErr {
@@ -1132,7 +1139,7 @@ func Test_loadEnvFile(t *testing.T) {
 			}
 
 			for k, v := range tt.existing {
-				t.Setenv(k, v)
+				os.Setenv(k, v)
 			}
 
 			if err := godotenv.Load(); err != nil {
@@ -1499,7 +1506,7 @@ func Test_expandEnvFiles(t *testing.T) {
 
 			tt.dev.EnvFiles = EnvFiles{file.Name()}
 
-			t.Setenv("OKTETO_TEST", "myvalue")
+			os.Setenv("OKTETO_TEST", "myvalue")
 
 			if _, err = file.Write(tt.envs); err != nil {
 				t.Fatal("Failed to write to temporary file", err)

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -66,7 +67,7 @@ devs:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				t.Setenv(k, v)
+				os.Setenv(k, v)
 			}
 			m, err := Read(tt.manifest)
 			assert.NoError(t, err)
@@ -333,7 +334,7 @@ func TestInferFromStack(t *testing.T) {
 }
 
 func TestSetManifestDefaultsFromDev(t *testing.T) {
-	t.Setenv("my_key", "my_value")
+	os.Setenv("my_key", "my_value")
 	tests := []struct {
 		name              string
 		currentManifest   *Manifest

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -149,8 +149,13 @@ func TestEnvVarMashalling(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			var result EnvVar
-			t.Setenv("DEV_ENV", "test_environment")
-			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
+			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
+				t.Fatal(err)
+			}
 
 			if err := yaml.Unmarshal(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -351,7 +356,9 @@ func TestSecretMarshalling(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	t.Setenv("TEST_HOME", file.Name())
+	if err := os.Setenv("TEST_HOME", file.Name()); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name          string
@@ -673,8 +680,13 @@ func TestLabelsUnmashalling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := make(Labels)
-			t.Setenv("DEV_ENV", "test_environment")
-			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
+			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
+				t.Fatal(err)
+			}
 
 			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -773,8 +785,13 @@ func TestAnnotationsUnmashalling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := make(Annotations)
-			t.Setenv("DEV_ENV", "test_environment")
-			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
+			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
+				t.Fatal(err)
+			}
 
 			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -964,7 +981,7 @@ rescanInterval: 10`),
 }
 
 func TestSyncFoldersUnmashalling(t *testing.T) {
-	t.Setenv("REMOTE_PATH", "/usr/src/app")
+	os.Setenv("REMOTE_PATH", "/usr/src/app")
 	tests := []struct {
 		name     string
 		data     []byte

--- a/pkg/model/stack_expander_test.go
+++ b/pkg/model/stack_expander_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -139,8 +140,9 @@ volumes:
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("CUSTOM_ENV", tt.envValue)
-
+			if err := os.Setenv("CUSTOM_ENV", tt.envValue); err != nil {
+				t.Fatal(err)
+			}
 			result, err := ExpandStackEnvs(tt.file)
 			if err != nil && !tt.expectedError {
 				t.Fatalf("expected no error, but got error: %v", err)
@@ -150,6 +152,7 @@ volumes:
 
 			assert.Equal(t, tt.expectedStack, string(result))
 
+			os.Unsetenv("CUSTOM_ENV")
 		})
 	}
 }

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1587,7 +1587,10 @@ func Test_Environment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("OKTETO_ENVTEST", "myvalue")
+
+			if err := os.Setenv("OKTETO_ENVTEST", "myvalue"); err != nil {
+				t.Fatal(err)
+			}
 
 			s, err := ReadStack(tt.manifest, false)
 			if err != nil {

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -979,7 +979,7 @@ func TestStack_ExpandEnvsAtFileLevel(t *testing.T) {
 			defer os.RemoveAll(tmpFile.Name())
 
 			for key, value := range tt.envs {
-				t.Setenv(key, value)
+				os.Setenv(key, value)
 			}
 
 			stack, err := GetStackFromPath("test", tmpFile.Name(), false)
@@ -1142,7 +1142,7 @@ func Test_getStackName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			t.Setenv(OktetoNameEnvVar, tt.nameEnv)
+			os.Setenv(OktetoNameEnvVar, tt.nameEnv)
 			res, err := getStackName(tt.name, tt.stackPath, tt.actualStackName)
 			resEnv := os.Getenv(OktetoNameEnvVar)
 
@@ -1182,10 +1182,10 @@ func Test_translateEnvVars(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpFile2.Name())
 
-	t.Setenv("B", "2")
-	t.Setenv("ENV_PATH", tmpFile.Name())
-	t.Setenv("ENV_PATH2", tmpFile2.Name())
-	t.Setenv("OKTETO_TEST", "myvalue")
+	os.Setenv("B", "2")
+	os.Setenv("ENV_PATH", tmpFile.Name())
+	os.Setenv("ENV_PATH2", tmpFile2.Name())
+	os.Setenv("OKTETO_TEST", "myvalue")
 	stack := &Stack{
 		Name: "name",
 		Services: map[string]*Service{

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -20,7 +20,12 @@ import (
 )
 
 func TestCopyFile(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(dir)
 
 	from := filepath.Join(dir, "from")
 	to := filepath.Join(dir, "to")
@@ -54,7 +59,12 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(dir)
 
 	p := filepath.Join(dir, "exists")
 	if FileExists(p) {

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -14,26 +14,31 @@
 package okteto
 
 import (
+	"os"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
 )
 
 func TestInDevContainer(t *testing.T) {
-	t.Setenv(model.OktetoNameEnvVar, "")
+	v := os.Getenv(model.OktetoNameEnvVar)
+	os.Setenv(model.OktetoNameEnvVar, "")
+	defer func() {
+		os.Setenv(model.OktetoNameEnvVar, v)
+	}()
 
 	in := InDevContainer()
 	if in {
 		t.Errorf("in dev container when there was no marker env var")
 	}
 
-	t.Setenv(model.OktetoNameEnvVar, "")
+	os.Setenv(model.OktetoNameEnvVar, "")
 	in = InDevContainer()
 	if in {
 		t.Errorf("in dev container when there was an empty marker env var")
 	}
 
-	t.Setenv(model.OktetoNameEnvVar, "1")
+	os.Setenv(model.OktetoNameEnvVar, "1")
 	in = InDevContainer()
 	if !in {
 		t.Errorf("not in dev container when there was a marker env var")

--- a/pkg/ssh/config_test.go
+++ b/pkg/ssh/config_test.go
@@ -41,9 +41,13 @@ func TestWriteToNewFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dir := t.TempDir()
+	d, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	path := filepath.Join(dir, "config")
+	defer os.RemoveAll(d)
+	path := filepath.Join(d, "config")
 
 	if err := config.writeToFilepath(path); err != nil {
 		t.Fatal(err)

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -22,8 +22,18 @@ import (
 )
 
 func TestKeyExists(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv(model.OktetoFolderEnvVar, dir)
+
+	dir, err := os.MkdirTemp("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv(model.OktetoFolderEnvVar)
+	}()
+
+	os.Setenv(model.OktetoFolderEnvVar, dir)
 
 	if KeyExists() {
 		t.Error("keys shouldn't exist in an empty directory")
@@ -48,9 +58,17 @@ func TestKeyExists(t *testing.T) {
 }
 
 func TestGenerateKeys(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv(model.OktetoFolderEnvVar, dir)
+	dir, err := os.MkdirTemp("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv(model.OktetoFolderEnvVar)
+	}()
+
+	os.Setenv(model.OktetoFolderEnvVar, dir)
 	public, private := getKeyPaths()
 	if err := generateKeys(public, private, 128); err != nil {
 		t.Error(err)

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -23,11 +23,16 @@ import (
 )
 
 func Test_addOnEmpty(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if err := os.RemoveAll(dir); err != nil {
 		t.Fatal(err)
 	}
+
+	defer os.RemoveAll(dir)
 
 	sshConfig := filepath.Join(dir, "config")
 
@@ -50,8 +55,12 @@ func Test_addOnEmpty(t *testing.T) {
 	}
 }
 func Test_add(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	defer os.RemoveAll(dir)
 	sshConfig := filepath.Join(dir, "config")
 
 	if err := add(sshConfig, "test.okteto", model.Localhost, 8080); err != nil {
@@ -216,9 +225,18 @@ func Test_removeHost(t *testing.T) {
 }
 
 func TestGetPort(t *testing.T) {
-	dir := t.TempDir()
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	t.Setenv(model.OktetoHomeEnvVar, dir)
+	defer os.RemoveAll(dir)
+
+	if err := os.Setenv(model.OktetoHomeEnvVar, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Unsetenv(model.OktetoHomeEnvVar)
 
 	if _, err := GetPort(t.Name()); err == nil {
 		t.Fatal("expected error on non existing host")

--- a/pkg/syncthing/install_test.go
+++ b/pkg/syncthing/install_test.go
@@ -15,6 +15,7 @@ package syncthing
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -190,9 +191,22 @@ func TestGetMinimumVersion(t *testing.T) {
 		},
 	}
 
+	env := os.Getenv(model.SyncthingVersionEnvVar)
+	if err := os.Setenv(model.SyncthingVersionEnvVar, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if err := os.Setenv(model.SyncthingVersionEnvVar, env); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			t.Setenv(model.SyncthingVersionEnvVar, tt.version)
+			if err := os.Setenv(model.SyncthingVersionEnvVar, tt.version); err != nil {
+				t.Fatal(err)
+			}
 			got := GetMinimumVersion()
 			if got.String() != tt.expected {
 				t.Errorf("got %s, expected %s", got.String(), tt.expected)

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -14,6 +14,7 @@
 package syncthing
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -22,8 +23,16 @@ import (
 
 func TestGetFiles(t *testing.T) {
 
-	dir := t.TempDir()
-	t.Setenv(model.OktetoFolderEnvVar, dir)
+	dir, err := os.MkdirTemp("", t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.RemoveAll(dir)
+		os.Unsetenv(model.OktetoFolderEnvVar)
+	}()
+
+	os.Setenv(model.OktetoFolderEnvVar, dir)
 	log := GetLogFile("test", "application")
 	expected := filepath.Join(dir, "test", "application", "syncthing.log")
 


### PR DESCRIPTION
This reverts commit 999802f7a9cdaf2f3df6550f4065b22144507535.

Signed-off-by: Javier López Barba <javier@okteto.com>

## Proposed changes
- Revert the unit tests refactor until https://github.com/golang/go/issues/51442 gets cherrypicked into Go 1.18 and we update to Go 1.18
