### PR TITLE
Remove global optimisation e2e

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	buildv1 "github.com/okteto/okteto/cmd/build/v1"
 	contextCMD "github.com/okteto/okteto/cmd/context"
@@ -199,22 +198,6 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 		return "", fmt.Errorf("error accessing image at registry %s: %v", options.Tag, err)
 	}
 	return imageTagWithDigest, nil
-}
-
-func (bc *OktetoBuilder) optimizeBuild(buildOptions *types.BuildOptions, svcName string) (string, error) {
-	oktetoLog.Debug("found optimizing the build flow")
-	globalReference := strings.Replace(buildOptions.Tag, okteto.DevRegistry, okteto.GlobalRegistry, 1)
-	if _, err := bc.Registry.GetImageTagWithDigest(globalReference); err == nil {
-		oktetoLog.Debugf("Skipping '%s' build. Image already exists at the Okteto Global Registry: %s", svcName, globalReference)
-		return globalReference, nil
-	}
-	if registry.IsDevRegistry(buildOptions.Tag) {
-		if _, err := bc.Registry.GetImageTagWithDigest(buildOptions.Tag); err == nil {
-			oktetoLog.Debugf("Skipping '%s' build: Image already exists at the Okteto Registry: %s", svcName, buildOptions.Tag)
-			return buildOptions.Tag, nil
-		}
-	}
-	return "", nil
 }
 
 func (bc *OktetoBuilder) addVolumeMounts(ctx context.Context, manifest *model.Manifest, svcName string, options *types.BuildOptions) (string, error) {

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -191,16 +191,6 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 
 	buildOptions := build.OptsFromBuildInfo(manifest.Name, svcName, buildSvcInfo, options)
 
-	// Check if the tag is already on global/dev registry and skip
-	if build.ShouldOptimizeBuild(buildOptions) {
-		tag, err := bc.optimizeBuild(buildOptions, svcName)
-		if err != nil {
-			return "", err
-		}
-		if tag != "" {
-			return tag, nil
-		}
-	}
 	if err := bc.V1Builder.Build(ctx, buildOptions); err != nil {
 		return "", err
 	}
@@ -241,16 +231,6 @@ func (bc *OktetoBuilder) addVolumeMounts(ctx context.Context, manifest *model.Ma
 		return "", err
 	}
 	buildOptions := build.OptsFromBuildInfo(manifest.Name, svcName, svcBuild, options)
-
-	if build.ShouldOptimizeBuild(buildOptions) {
-		tag, err := bc.optimizeBuild(buildOptions, svcName)
-		if err != nil {
-			return "", err
-		}
-		if tag != "" {
-			return tag, nil
-		}
-	}
 
 	if err := bc.V1Builder.Build(ctx, buildOptions); err != nil {
 		return "", err

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -81,18 +81,8 @@ func (bc *OktetoBuilder) checkServicesToBuild(service string, manifest *model.Ma
 		return fmt.Errorf("error getting the image name for the service '%s'. Please specify the full name of the image when using a Kubernetes namespace not managed by Okteto", service)
 	}
 
-	if build.ShouldOptimizeBuild(opts) {
-		oktetoLog.Debug("tag detected, optimizing sha")
-		if skipBuild, err := bc.checkImageAtGlobalAndSetEnvs(service, opts); err != nil {
-			return err
-		} else if skipBuild {
-			oktetoLog.Debugf("Skipping '%s' build. Image already exists at Okteto Registry", service)
-			return nil
-		}
-	}
-
 	imageWithDigest, err := bc.Registry.GetImageTagWithDigest(opts.Tag)
-	if err == oktetoErrors.ErrNotFound {
+	if oktetoErrors.IsNotFound(err) {
 		oktetoLog.Debug("image not found, building image")
 		ch <- service
 		return nil

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -101,21 +101,3 @@ func (bc *OktetoBuilder) checkServicesToBuild(service string, manifest *model.Ma
 	}
 	return nil
 }
-
-func (bc *OktetoBuilder) checkImageAtGlobalAndSetEnvs(service string, options *types.BuildOptions) (bool, error) {
-	globalReference := strings.Replace(options.Tag, okteto.DevRegistry, okteto.GlobalRegistry, 1)
-
-	imageWithDigest, err := bc.Registry.GetImageTagWithDigest(globalReference)
-	if err == oktetoErrors.ErrNotFound {
-		oktetoLog.Debug("image not built at global registry, not running optimization for deployment")
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-
-	bc.SetServiceEnvVars(service, imageWithDigest)
-	oktetoLog.Debug("image already built at global registry, running optimization for deployment")
-	return true, nil
-
-}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -683,8 +683,7 @@ func addEnvVars(ctx context.Context, cwd string) error {
 		if !isClean {
 			sha = utils.GetRandomSHA(ctx, cwd)
 		}
-		value := fmt.Sprintf("%s%s", model.OktetoGitCommitPrefix, sha)
-		os.Setenv(model.OktetoGitCommitEnvVar, value)
+		os.Setenv(model.OktetoGitCommitEnvVar, sha)
 	}
 	if os.Getenv(model.OktetoRegistryURLEnvVar) == "" {
 		os.Setenv(model.OktetoRegistryURLEnvVar, okteto.Context().Registry)

--- a/integration/deploy_manifest_test.go
+++ b/integration/deploy_manifest_test.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 
 	"os"

--- a/integration/deploy_manifest_test.go
+++ b/integration/deploy_manifest_test.go
@@ -159,8 +159,9 @@ spec:
 		deleteNamespace(ctx, oktetoPath, testNamespace)
 		deleteGitRepo(ctx, repoDir)
 	})
+
 	reg := registry.NewOktetoRegistry()
-	t.Run("okteto deploy should build images if not exists at registry", func(t *testing.T) {
+	t.Run("okteto deploy should build images if they aren't already built", func(t *testing.T) {
 
 		output, err := runOktetoDeploy(oktetoPath, repoDir)
 		if err != nil {
@@ -232,7 +233,7 @@ spec:
 
 	})
 
-	t.Run("okteto deploy --build should force the build an image does not change if no code changes", func(t *testing.T) {
+	t.Run("okteto deploy --build should force the build of all images", func(t *testing.T) {
 
 		imageWithDigest, err := reg.GetImageTagWithDigest(expectedImage)
 		if err != nil {
@@ -268,60 +269,6 @@ spec:
 
 	})
 
-	t.Run("okteto deploy --build should force the build an image change if code changes", func(t *testing.T) {
-		imageWithDigest, err := reg.GetImageTagWithDigest(expectedImage)
-		if err != nil {
-			t.Fatalf("image is not at registry: %v", err)
-		}
-		originalSHA := strings.SplitN(imageWithDigest, "@", 2)[1]
-
-		mainFile := filepath.Join(cwd, repoDir, "main.go")
-		mainFileContent, err := ioutil.ReadFile(mainFile)
-		if err != nil {
-			t.Fatal(err)
-		}
-		updatedMainFileContent := strings.Replace(string(mainFileContent), "Hello", "Bye", 1)
-		if err := writeFile(filepath.Join(cwd, repoDir), "main.go", updatedMainFileContent); err != nil {
-			t.Fatal(err)
-		}
-
-		output, err := runOktetoDeployForceBuild(oktetoPath, repoDir)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		newImageWithDigest, err := reg.GetImageTagWithDigest(expectedImage)
-		if err != nil {
-			t.Fatalf("image is not at registry: %v", err)
-		}
-		newSHA := strings.SplitN(newImageWithDigest, "@", 2)[1]
-
-		if originalSHA == newSHA {
-			t.Fatal("image has not been updated")
-		}
-
-		d, err := getDeployment(ctx, testNamespace, releaseName)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := expectDeployment(ctx, d, []string{newImageWithDigest}, 2); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := expectForceBuild(output); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := expectHelm(output, releaseName, testNamespace, 4); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := expectEnvSetting(output, testNamespace, repoDir, newSHA); err != nil {
-			t.Fatal(err)
-		}
-
-	})
 }
 
 func runOktetoDeploy(oktetoPath, repoDir string) (string, error) {

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -15,7 +15,6 @@ package build
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -258,11 +257,6 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 	opts.OutputMode = setOutputMode(outputMode)
 
 	return opts
-}
-
-// ShouldOptimizeBuild returns if optimization should be applied
-func ShouldOptimizeBuild(options *types.BuildOptions) bool {
-	return options.AutogenTag && okteto.IsPipeline() && registry.IsOktetoRegistry(options.Tag) && !options.NoCache && !options.BuildToGlobal
 }
 
 // GetVolumesToInclude checks if the path exists, if it doesn't it skip it

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -319,9 +319,6 @@ const (
 	// OktetoAutogenerateStignoreEnvVar skips the autogenerate stignore dialog and creates the default one
 	OktetoAutogenerateStignoreEnvVar = "OKTETO_AUTOGENERATE_STIGNORE"
 
-	// OktetoGitCommitPrefix prefix added to OKTETO_GIT_COMMIT when inferred by cli
-	OktetoGitCommitPrefix = "dev"
-
 	// OktetoDefaultImageTag default tag assigned to image to build
 	OktetoDefaultImageTag = "okteto"
 

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -480,9 +480,3 @@ func (c *OktetoContext) ToViewer() *OktetoContextViewer {
 		Current:   Context().Name == c.Name,
 	}
 }
-
-func IsPipeline() bool {
-	envGitCommit := os.Getenv(model.OktetoGitCommitEnvVar)
-	isLocalEnvGitCommit := strings.HasPrefix(envGitCommit, model.OktetoGitCommitPrefix)
-	return envGitCommit != "" && !isLocalEnvGitCommit
-}

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -30,7 +30,6 @@ type BuildOptions struct {
 	BuildToGlobal bool
 	K8sContext    string
 	ExportCache   string
-	AutogenTag    bool
 	// CommandArgs comes from the user input on the command
 	CommandArgs  []string
 	EnableStages bool


### PR DESCRIPTION
Fixes #2712 

## Proposed changes

- Remove all logic regarding the use of commit SHA to tag images
- Remove logic that checks images at global and dev registry prior to build
- Remove logic that checks images at global and dev registry prior to deploy - `okteto deploy` will still check if the image is already built, and build if not, and `okteto deploy --build` will build them again, but tag logic will not have the commit sha
- Fix unit tested affected, remove a case at the integration test which no longer applies
