### PR TITLE
Release Channels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,24 @@ aliases:
     echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
     gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
     gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+  # standard semver regex as defined in: https://semver.org/
+  - &release-regex /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+  - &release-branch-regex /^release-\d+\.\d+$/
 version: 2.1
 orbs:
   win: circleci/windows@2.1.0
+
+executors:
+  golang-ci:
+    docker:
+      - image: okteto/golang-ci:1.17.10
+
 jobs:
   build:
-    docker:
-      - image: okteto/golang-ci:1.17.3
+    executor: golang-ci
+    resource_class: large
     steps:
       - checkout
-
       - run:
           command: go mod tidy && git diff --exit-code go.sum > /dev/null
       - run:
@@ -39,11 +47,10 @@ jobs:
       - store_artifacts:
           path: coverage.txt
           destination: coverage.txt
-  integration:
+  test-integration:
+    executor: golang-ci
     environment:
       OKTETO_USER: cindylopez
-    docker:
-      - image: okteto/golang-ci:1.17.3
     steps:
       - checkout
       - restore_cache:
@@ -74,9 +81,8 @@ jobs:
             - /go/pkg
       - store_artifacts:
           path: /root/.okteto
-  mock-release:
-    docker:
-      - image: okteto/golang-ci:1.17.3
+  test-release:
+    executor: golang-ci
     steps:
       - checkout
       - attach_workspace:
@@ -98,10 +104,10 @@ jobs:
             export DOCKER_BUILDKIT=1
             docker build -t okteto --build-arg VERSION_STRING=$CIRCLE_SHA1 .
 
-  windows-unit:
+  test-windows:
+    executor: win/default
     environment:
       OKTETO_USER: cindylopez
-    executor: win/default
     steps:
       - checkout
       - run:
@@ -145,33 +151,24 @@ jobs:
             - C:\Go\pkg
       - store_artifacts:
           path: C:\Users\circleci\.okteto
-  release:
-    docker:
-      - image: okteto/golang-ci:1.17.3
+
+  push-image:
+    executor: golang-ci
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: '19.03.8'
+      - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG"
+
+  release-external:
+    executor: golang-ci
     steps:
       - checkout
       - attach_workspace:
           at: ./artifacts
       - run: *init-gcloud
-      - run:
-          name: Upload release binaries
-          command: |
-            gsutil -m rsync -r ./artifacts/bin gs://downloads.okteto.com/cli/${CIRCLE_TAG}
-            gsutil -m rsync -r gs://downloads.okteto.com/cli/${CIRCLE_TAG}/ gs://downloads.okteto.com/cli/
       - setup_remote_docker:
           version: '19.03.8'
-      - run:
-          name: Publish Docker container
-          command: |
-            export DOCKER_BUILDKIT=1
-            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
-            docker build -t okteto/okteto:${CIRCLE_TAG} --build-arg VERSION_STRING=$CIRCLE_TAG .
-            docker push okteto/okteto:${CIRCLE_TAG}
-      - run:
-          name: Publish Release on GitHub
-          command: |
-            go get -u github.com/tcnksm/ghr
-            ghr -u ${CIRCLE_PROJECT_USERNAME} -n "Okteto CLI ${CIRCLE_TAG}" -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -token $GITHUB_TOKEN -replace $CIRCLE_TAG  ./artifacts/bin/
       - add_ssh_keys:
           fingerprints:
             - f7:81:9f:b4:31:3a:4d:46:ce:cf:54:a2:70:46:5a:df
@@ -185,106 +182,42 @@ jobs:
             git push git@github.com:okteto/homebrew-cli.git master
       - deploy:
           name: Auto-update-actions
-          command: |
-            go get -u github.com/tcnksm/ghr
-            ./scripts/update_actions.sh $CIRCLE_TAG
-  release-candidate:
-    docker:
-      - image: okteto/golang-ci:1.17.3
+          command: ./scripts/update_actions.sh $CIRCLE_TAG
+
+  release:
+    executor: golang-ci
     steps:
       - checkout
       - attach_workspace:
           at: ./artifacts
       - run: *init-gcloud
-      - setup_remote_docker:
-          version: '19.03.8'
-      - run:
-          name: Publish Docker container
-          command: |
-            export DOCKER_BUILDKIT=1
-            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
-            docker build -t okteto/okteto:${CIRCLE_TAG} --build-arg VERSION_STRING=$CIRCLE_TAG .
-            docker push okteto/okteto:${CIRCLE_TAG}
-      - run:
-          name: Publish Prerelease on GitHub
-          command: |
-            go get -u github.com/tcnksm/ghr
-            ghr -u ${CIRCLE_PROJECT_USERNAME} -n "Okteto CLI ${CIRCLE_TAG}" -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -token $GITHUB_TOKEN -prerelease -replace $CIRCLE_TAG ./artifacts/bin/
-  release-master:
-    docker:
-      - image: okteto/golang-ci:1.17.3
+      - run: ./scripts/ci/release.sh
+
+  release-branch:
+    executor: golang-ci
     steps:
       - checkout
-      - setup_remote_docker:
-          version: '19.03.8'
-      - run:
-          name: Publish Docker container
-          command: |
-            export DOCKER_BUILDKIT=1
-            echo "$DOCKER_PASS" | docker login --username $DOCKER_USER --password-stdin
-            docker build -t okteto/okteto:latest --build-arg VERSION_STRING=$CIRCLE_SHA1 .
-            docker push okteto/okteto:latest
-      - attach_workspace:
-          at: ./artifacts
-      - run: *init-gcloud
-      - run:
-          name: Upload latest binaries
-          command: |
-            gsutil -m rsync -r ./artifacts/bin gs://downloads.okteto.com/cli/master
+      - add_ssh_keys:
+          fingerprints:
+            - a1:66:22:e1:67:66:fb:d6:3b:a2:7a:6c:d9:9a:46:ba
+      - run: ./scripts/ci/release-branch.sh
+
 
 workflows:
   version: 2
-  build-release:
+
+  test:
+    when:
+      not:
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - build:
           filters:
+            branches:
+              ignore: *release-branch-regex
             tags:
-              only: /.*/
-      - integration:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
-                - /.*(integration)/
-                - /^release-\d+\.\d+$/
-      - mock-release:
-          context: GKE
-          requires:
-            - build
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: master
-      - release-master:
-          context: GKE
-          requires:
-            - integration
-          filters:
-            branches:
-              only: master
-      - release:
-          context: GKE
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+$/
-            branches:
               ignore: /.*/
-      - release-candidate:
-          context: GKE
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+-rc\.\d+$/
-            branches:
-              ignore: /.*/
-      - windows-unit:
+      - test-windows:
           requires:
             - build
           filters:
@@ -292,3 +225,98 @@ workflows:
               only:
                 - master
                 - /.*(windows|win)/
+      - test-release:
+          context: GKE
+          requires:
+            - build
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              ignore:
+                - master
+                - *release-branch-regex
+      - push-image:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+
+  release-branch:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: *release-branch-regex
+            tags:
+              ignore: /.*/
+      - test-integration:
+          filters:
+            branches:
+              only: *release-branch-regex
+      - release-branch:
+          requires:
+            - build
+            - test-integration
+          filters:
+            branches:
+              only: *release-branch-regex
+
+  release-dev:
+    when:
+      and:
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["release-dev", << pipeline.schedule.name >>]
+    jobs:
+      - build
+      - push-image:
+          requires:
+            - build
+      - release:
+          context: GKE
+          requires:
+            - build
+            - push-image
+
+  release:
+    when:
+      not:
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only:
+                - *release-regex
+      - push-image:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+            tags:
+              only:
+                - *release-regex
+      - release:
+          context: GKE
+          requires:
+            - build
+            - push-image
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only:
+                - *release-regex
+      - release-external:
+          context: GKE
+          requires:
+            - release
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - release/internal
+  categories:
+    - title: Breaking Change
+      labels:
+        - release/breaking-change
+    - title: New Feature
+      labels:
+        - release/new-feature
+    - title: Bug Fix
+      labels:
+        - release/bug-fix

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labels"
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 1
+          # yamllint disable-line rule:line-length
+          labels: "release/internal, release/bug-fix, release/new-feature, release/breaking-change"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: codespell
         name: Run codespell
         description: Check Spelling with codespell
-        entry: codespell --ignore-words=codespell.txt
+        entry: codespell --exclude-file=".circleci/config.yml" --ignore-words=codespell.txt
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.1
     hooks:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.circleci/**
+.github/**

--- a/cmd/utils/upgrade.go
+++ b/cmd/utils/upgrade.go
@@ -75,10 +75,6 @@ func ShouldNotify(latest, current *semver.Version) bool {
 		return false
 	}
 
-	if latest.Prerelease() != "" {
-		return false
-	}
-
 	// check if it's a minor or major change, we don't notify on patch
 	if latest.Major() > current.Major() {
 		return true

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# push-image.sh pushes the docker image to the docker registry
+
+# run in a subshell
+{ (
+
+        set -e # make any error fail the script
+        set -u # make unbound variables fail the script
+
+        # SC2039: In POSIX sh, set option pipefail is undefined
+        # shellcheck disable=SC2039
+        set -o pipefail # make any pipe error fail the script
+
+        # RELEASE_TAG is the release tag that we want to release
+        RELEASE_TAG="${1}"
+
+        if [ -z "$RELEASE_TAG" ]; then
+                branch=$(git rev-parse --abbrev-ref HEAD)
+                commit=$(git rev-parse --short HEAD)
+                if [ "$branch" = "master" ]; then
+                        RELEASE_TAG="latest"
+                elif [ "$branch" = "main" ]; then
+                        RELEASE_TAG="main"
+                else
+                        RELEASE_TAG="$commit"
+                fi
+        fi
+
+        name="okteto/okteto:${RELEASE_TAG}"
+
+        echo "Pushing ${name}"
+        export DOCKER_BUILDKIT=1
+        echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin
+        docker build -t "$name" --build-arg VERSION_STRING="${RELEASE_TAG}" .
+        docker push "$name"
+
+); }

--- a/scripts/ci/release-branch.sh
+++ b/scripts/ci/release-branch.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+# release-branch.sh takes care of releasing an LTS branch when new commits are
+# pushed onto it. It does so by resolving the next git tag that must be created
+# and pushing it to github.
+#
+# Release branches are created for each MAJOR.MINOR release. If the initial
+# patch version of the release branch does not exist (2.4.0 for eg), a beta
+# release is first created: 2.4.0-beta.1.
+# All subsequent pushes to this branch will build a new beta release:
+# 2.4.0-beta.2, 2.4.0-beta.3 etc.
+# To release the first stable version, the 2.4.0 tag must be manually created
+# and pushed from the tip of the release branch after acceptance criteria has
+# been met (decided internally by the team). There is no automation in place
+# for this at the moment.
+
+# run in a subshell
+{ (
+
+        set -e # make any error fail the script
+        set -u # make unbound variables fail the script
+
+        # SC2039: In POSIX sh, set option pipefail is undefined
+        # shellcheck disable=SC2039
+        set -o pipefail # make any pipe error fail the script
+
+        # CURRENT_BRANCH is the branch being released.
+        # It is assumed: release-MAJOR.MINOR here. For eg: release-2.4
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+        # BASE_TAG is the MAJOR.MINOR portion of the current release, extracted from the
+        # current branch
+        BASE_TAG=$(echo "$CURRENT_BRANCH" | cut -d- -f2)
+
+        # stable_regex is a semver version regex for the stable channel
+        stable_regex='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+        # beta_regex is a semver version regex for the beta channel
+        beta_regex='^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$'
+
+        # PREVIOUS_TAGS are the tags to which the previous known ancestor
+        # The known ancestor is that last commit a release points to. It can point to a
+        # beta AND a stable release at the same time so git describe won't work.
+        # This will happen when creating a patch release from an LTS branch and it's
+        # usually how promotion works.
+        known_ancestor="$(git rev-list -n 1 "$(git describe --tags --abbrev=0 --match "*.*.*")")"
+        PREVIOUS_TAGS="$(git tag --points-at "$known_ancestor")"
+
+        # ROOT_MINOR_TAG is the oldest relevant tag we should be able to reach from this
+        # release branch
+        ROOT_MINOR_TAG="${BASE_TAG}.0"
+
+        # NEXT_TAG will be set below
+        NEXT_TAG=""
+
+        # logs the last 20 commits reachable from here for debugging purposes
+        git --no-pager log --pretty=oneline -n 20 --reverse --abbrev-commit
+
+        echo "current release branch: $CURRENT_BRANCH"
+        echo "base tag: $BASE_TAG"
+        printf "PREVIOUS_TAGS:\n%s\n" "${PREVIOUS_TAGS}"
+
+        # All previous commits must be tagged after the first has been created
+        if [ -z "${PREVIOUS_TAGS}" ]; then
+                echo "No tags point to the previous commit ($known_ancestor)"
+                echo "All commits from a release branch must be tagged"
+                echo "Inspect the branch history and re-tag $known_ancestor with the corresponding beta or stable tag"
+                exit 1
+        fi
+
+        # Select the tag from the list all of the tags that point to the last release
+        previous_stable=$(echo "${PREVIOUS_TAGS}" | grep -E "$stable_regex" || echo "")
+        previous_beta=$(echo "${PREVIOUS_TAGS}" | grep -E "$beta_regex" || echo "")
+
+        echo "previous stable: $previous_stable"
+        echo "previous beta: $previous_beta"
+
+        # If the latest tag we can reach belongs to a previous minor/major
+        # version, it means that this is the first push to the branch so we create the
+        # first beta
+        if [ "$previous_stable" != "" ]; then
+                if [ "$(semver compare "${ROOT_MINOR_TAG}" "$previous_stable")" -eq "1" ]; then
+                        NEXT_TAG="${ROOT_MINOR_TAG}-beta.1"
+                        echo "Latest reachable tag from release branch ${CURRENT_BRANCH} is a stable release from a previous release (${previous_stable})"
+                        echo "Initializing beta for ${BASE_TAG} as ${NEXT_TAG}"
+                else
+                        NEXT_TAG="$(semver bump patch "${previous_stable}")-beta.1"
+                        echo "Previous tag is a stable release (${previous_stable})"
+                        echo "Creating the new beta for the patch: ${NEXT_TAG}"
+                fi
+
+        # If the previous release is not a stable release, simply bump the beta prerelease
+        elif [ "$previous_beta" != "" ]; then
+                NEXT_TAG=$(semver bump prerel "${previous_beta}")
+                echo "Latest reachable tag from release branch ${CURRENT_BRANCH} is a prerelease (${previous_beta})"
+                echo "Bumping prerel to ${NEXT_TAG}"
+
+        # this should never happen
+        else
+                echo "Unclear what to build. Skipping release"
+                exit 1
+        fi
+
+        echo "Pushing tag ${NEXT_TAG} to remote repository"
+        git config user.name "okteto"
+        git config user.email "ci@okteto.com"
+        git tag "${NEXT_TAG}" -a -m "Okteto CLI ${NEXT_TAG}"
+        git push origin "${NEXT_TAG}"
+); }

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+# release.sh is the release script to make Okteto CLI versions publicly
+# available.
+#
+# This scripts is meant to be executed by circleci and makes a few assumptions about
+# the environment it runs on. It assumes the golangci executor which has a few
+# binaries required by this script.
+# TODO: parameterize this script to make it able to run locally
+#
+# Releases can be pulled from three distinct channels: stable, beta and dev.
+#
+# Releases are represented by git annotated tags in semver version and have their
+# respective Github release.
+# Releases from the stable channel have the format: MAJOR.MINOR.PATCH
+# Releases from the beta channel have the MAJOR.MINOR.PATCH-beta.n
+# Releases from the dev channel have the MAJOR.MINOR.PATCH-dev.n
+#
+
+# run in a subshell
+{ (
+
+        set -e # make any error fail the script
+        set -u # make unbound variables fail the script
+
+        # SC2039: In POSIX sh, set option pipefail is undefined
+        # shellcheck disable=SC2039
+        set -o pipefail # make any pipe error fail the script
+
+        # RELEASE_TAG is the release tag that we want to release
+        RELEASE_TAG="${CIRCLE_TAG:-""}"
+
+        # RELEASE_COMMIT is the commit being released
+        RELEASE_COMMIT=${CIRCLE_SHA1}
+
+        # PSEUDO_TAG is the short sha that will be used to release in the case
+        # that a release tag is not provided
+        PSEUDO_TAG="$(echo "$RELEASE_COMMIT" | head -c 7)"
+
+        # CURRENT_BRANCH is the branch being released.
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+        # REPO_OWNER is the owner of the repo (okteto)
+        REPO_OWNER="${CIRCLE_PROJECT_USERNAME}"
+
+        # REPO_NAME is the name of the repo (okteto)
+        REPO_NAME="${CIRCLE_PROJECT_REPONAME}"
+
+        # BIN_PATH is where the artifacts are stored. Usually precreated by the circleci
+        # workflow.
+        BIN_PATH="$PWD/artifacts/bin"
+
+        ################################################################################
+        # Sanity check
+        ################################################################################
+
+        if ! semver --version >/dev/null 2>&1; then
+                echo "Binary \"semver\" does is required from running this scripts"
+                echo "Please install it and try again:"
+                echo "  $ curl -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver"
+                exit 1
+        fi
+
+        if ! command -v okteto-ci-utils >/dev/null 2>&1; then
+                echo "Binary \"okteto-ci-utils\" from the golangci circleci executor is required to run this script"
+                echo "If you are running this locally you can go into the golang-ci executor repo and build the script from source:"
+                echo "  $ go build -o /usr/local/bin/okteto-ci-utils ."
+                exit 1
+        fi
+
+        if ! command -v gsutil >/dev/null 2>&1; then
+                echo "Binary \"gsutils\" from Google Cloud is required to run this script. Find installation instructions at https://cloud.google.com/sdk/docs/install"
+                exit 1
+        fi
+
+        if ! command -v ghr >/dev/null 2>&1; then
+                echo "Binary \"ghr\" is required to run this script. Install with:"
+                echo "  $ GOPROXY=direct GOSUMDB=off go install github.com/tcnksm/ghr@latest"
+                exit 1
+        fi
+
+        if [ ! -d "$BIN_PATH" ]; then
+                echo "Release artifacts should be stored in $BIN_PATH but the directory does no exist"
+                exit 1
+        elif [ -z "$(ls -A "$BIN_PATH")" ]; then
+                echo "Release artifacts should be stored in $BIN_PATH but the directory is empty"
+                exit 1
+        fi
+
+        if [ -z "$GITHUB_TOKEN" ]; then
+                echo "GITHUB_TOKEN envvar not provided. It is required to create the Github Release and the release notes"
+                exit 1
+        fi
+
+        echo "Releasing tag '${RELEASE_TAG}' from branch '${CURRENT_BRANCH}' at ${RELEASE_COMMIT}"
+
+        ################################################################################
+        # Resolve release channel
+        ################################################################################
+
+        # Resolve the channel from the tag that is being released
+        # If the channel is unknown the release will fail
+        CHANNELS=
+
+        # dev releases don't have tags
+        if [ "$RELEASE_TAG" = "" ]; then
+                CHANNELS=("dev")
+        else
+                beta_prerel_regex="^beta\.[0-9]+"
+                prerel="$(semver get prerel "${RELEASE_TAG}")"
+
+                # Stable releases are added to all channel
+                if [ -z "$prerel" ]; then
+                        CHANNELS=("stable" "beta" "dev")
+
+                elif [[ $prerel =~ $beta_prerel_regex ]]; then
+                        CHANNELS=("beta" "dev")
+
+                else
+                        echo "Unknown tag"
+                        echo "Expected one of: "
+                        echo "  - stable: MAJOR.MINOR.PATCH "
+                        echo "  - beta: MAJOR.MINOR.PATCH-beta.n"
+                        echo "$RELEASE_TAG matches none"
+                        exit 1
+                fi
+        fi
+
+        for chan in "${CHANNELS[@]}"; do
+                echo "---------------------------------------------------------------------------------"
+                tag="${RELEASE_TAG:-"$PSEUDO_TAG"}"
+                echo "Releasing ${tag} into ${chan} channel"
+
+                ##############################################################################
+                # Update downloads.okteto.com
+                ##############################################################################
+
+                # BIN_BUCKET_NAME is the name of the bucket where the binaries are stored.
+                # Starting at Okteto CLI 2.0, all these binaries are publicly accessible at:
+                # https://downloads.okteto.com/cli/<channel>/<tag>
+                BIN_BUCKET_ROOT="downloads.okteto.com/cli/${chan}"
+                BIN_BUCKET_NAME="${BIN_BUCKET_ROOT}/${tag}"
+
+                # VERSIONS_BUCKET_NAME are all the available versions for a release channel.
+                # This is also publicly accessible at:
+                # https://downloads.okteto.com/cli/<channel>/versions
+                VERSIONS_BUCKET_NAME="downloads.okteto.com/cli/${chan}/versions"
+
+                # upload artifacts
+                echo "Syncing artifacts from $BIN_PATH with $BIN_BUCKET_NAME"
+                gsutil -m rsync -r "$BIN_PATH" "gs://$BIN_BUCKET_NAME"
+
+                # Get the current versions file and add the current version being released.
+                # These are the versions publicly accessible from this channel.
+                # It is important to have them sorted so that the last version from the list
+                # is always the latest and we can keep pushing older tags for maintenance and
+                # whatnot.
+                version_temp_file=$(mktemp)
+                gsutil cat "gs://${VERSIONS_BUCKET_NAME}" >"$version_temp_file"
+                echo "Current version list for ${chan} channel (showing latest 10):"
+                tail "$version_temp_file" -n 10
+
+                printf "%s\n" "${tag}" >>"$version_temp_file"
+
+                # dont sort the dev channel. Not all tags are semver and it's
+                # safe to assume linear history
+                if [ "${chan}" = "dev" ]; then
+                        # SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead
+                        # shellcheck disable=SC2002
+                        cat "$version_temp_file" >"${BIN_PATH}/versions"
+                else
+                        # remove duplicated versions and sort the list
+                        # SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead
+                        # shellcheck disable=SC2002
+                        cat "$version_temp_file" | awk '!seen[$0]++' | okteto-ci-utils semver-sort >"${BIN_PATH}/versions"
+                fi
+
+                echo "Added ${tag} to the version list"
+                echo "New version list for ${chan} channel (showing latest 10):"
+                tail "${BIN_PATH}/versions" -n 10
+
+                # After sorting, if the latest tag is the current tag update the root path
+                # with the current binaries
+                latest="$(tail "${BIN_PATH}/versions" -n1)"
+
+                if [ "$tag" = "$latest" ]; then
+                        gsutil -m rsync "gs://$BIN_BUCKET_NAME" "gs://$BIN_BUCKET_ROOT"
+                fi
+
+                gsutil -m -h "Cache-Control: no-store" -h "Content-Type: text/plain" cp "${BIN_PATH}/versions" "gs://${VERSIONS_BUCKET_NAME}"
+                echo "${chan} channel updated with ${tag}"
+        done
+
+        if [ "$RELEASE_TAG" = "" ]; then
+                echo "No RELEASE_TAG, skipping github release for pseudo tag ${PSEUDO_TAG} from ${CURRENT_BRANCH}"
+                echo "All done"
+                exit 0
+        fi
+
+        ################################################################################
+        # Update Github Release
+        ################################################################################
+        previous_version=$(grep -F "$RELEASE_TAG" -B 1 "${BIN_PATH}/versions" | head -n1)
+
+        # SC2116: Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
+        # SC2128: Expanding an array without an index only gives the first element.
+        # shellcheck disable=SC2116,SC2128
+        preferred_channel="$(echo "$CHANNELS")"
+
+        echo "Gathering ${RELEASE_TAG} release notes. Diffing from ${previous_version}"
+        notes=$(curl \
+                -fsS \
+                -X POST \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -d "{\"tag_name\":\"$RELEASE_TAG\",\"previous_tag_name\":\"$previous_version\"}" \
+                "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/generate-notes" | jq .body)
+
+        printf "RELEASE NOTES:\n%s" "${notes}"
+
+        prerelease=false
+        name="Okteto CLI - ${RELEASE_TAG}"
+        if [ "${preferred_channel}" = "beta" ]; then
+                prerelease=true
+                name="Okteto CLI [${preferred_channel}] - ${RELEASE_TAG}"
+        fi
+
+        echo "Using ghr version: $(ghr -version)"
+        ghr \
+                -u "${REPO_OWNER}" \
+                -n "${name}" \
+                -r "${REPO_NAME}" \
+                -c "${RELEASE_COMMIT}" \
+                -token "${GITHUB_TOKEN}" \
+                -b "${notes}" \
+                -replace \
+                -prerelease="${prerelease}" \
+                "${RELEASE_TAG}" \
+                "${BIN_PATH}"
+
+        echo "Created Github release: '${name}'"
+
+        echo "All done"
+); }

--- a/scripts/get-okteto-beta.sh
+++ b/scripts/get-okteto-beta.sh
@@ -1,95 +1,12 @@
 #!/bin/sh
 
 { # Prevent execution if this script was only partially downloaded
-
-        set -e
-
-        install_dir='/usr/local/bin'
-        install_path='/usr/local/bin/okteto'
-        OS=$(uname | tr '[:upper:]' '[:lower:]')
-        ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
-        gh_api_url='https://api.github.com/repos/okteto/okteto/releases'
-        download_url='https://github.com/okteto/okteto/releases/download/'
-        cmd_exists() {
-                command -v "$@" >/dev/null 2>&1
-        }
-
-        if ! cmd_exists curl; then
-                printf '\033[31m> The command "curl" is not found and is required by this installation script.\n\033[0m'
-                exit 1
-        fi
-
-        if ! cmd_exists jq; then
-                printf '\033[31m> The command "jq" is not found and is required by this installation script.\n\033[0m'
-                exit 1
-        fi
-
-        latestRelease=${download_url}$(curl -s ${gh_api_url} | jq --raw-output '.[0].tag_name')
-
-        case "$OS" in
-        darwin)
-                case "$ARCH" in
-                x86_64)
-                        URL=${latestRelease}/okteto-Darwin-x86_64
-                        ;;
-                arm64)
-                        URL=${latestRelease}/okteto-Darwin-arm64
-                        ;;
-                *)
-                        printf '\033[31m> The architecture (%s) is not supported by this installation script.\n\033[0m' "$ARCH"
-                        exit 1
-                        ;;
-                esac
-                ;;
-        linux)
-                case "$ARCH" in
-                x86_64)
-                        URL=${latestRelease}/okteto-Linux-x86_64
-                        ;;
-                amd64)
-                        URL=${latestRelease}/okteto-Linux-x86_64
-                        ;;
-                armv8*)
-                        URL=${latestRelease}/okteto-Linux-arm64
-                        ;;
-                aarch64)
-                        URL=${latestRelease}/okteto-Linux-arm64
-                        ;;
-                *)
-                        printf '\033[31m> The architecture (%s) is not supported by this installation script.\n\033[0m' "$ARCH"
-                        exit 1
-                        ;;
-                esac
-                ;;
-        *)
-                printf '\033[31m> The OS (%s) is not supported by this installation script.\n\033[0m' "$OS"
-                exit 1
-                ;;
-        esac
-
-        sh_c='sh -c'
-        if [ ! -w "$install_dir" ]; then
-                # use sudo if $USER doesn't have write access to the path
-                if [ "$USER" != 'root' ]; then
-                        if cmd_exists sudo; then
-                                sh_c='sudo -E sh -c'
-                        elif cmd_exists su; then
-                                sh_c='su -c'
-                        else
-                                echo 'This script requires to run commands as sudo. We are unable to find either "sudo" or "su".'
-                                exit 1
-                        fi
-                fi
-        fi
-
-        printf '> Downloading %s\n' "$URL"
-        download_path=$(mktemp)
-        curl -fSL "$URL" -o "$download_path"
-        chmod +x "$download_path"
-
-        printf '> Installing %s\n' "$install_path"
-        $sh_c "mv -f $download_path $install_path"
-
-        printf '\033[32m> Okteto successfully installed!\n\033[0m'
-
+        printf '\033[0;31m'
+        printf '\n'
+        printf 'Installing okteto from https://beta.okteto.com has been deprecated\n'
+        printf '\n'
+        printf '\033[0m'
+        printf 'Please install with:\n'
+        printf '  $ curl https://get.okteto.com -sSfL | sh\n'
+        printf '\n'
 } # End of wrapping

--- a/scripts/get-okteto.sh
+++ b/scripts/get-okteto.sh
@@ -12,16 +12,16 @@
                 command -v "$@" >/dev/null 2>&1
         }
 
-        latestURL=https://github.com/okteto/okteto/releases/latest/download
+        bin_file=
 
         case "$OS" in
         darwin)
                 case "$ARCH" in
                 x86_64)
-                        URL=${latestURL}/okteto-Darwin-x86_64
+                        bin_file=okteto-Darwin-x86_64
                         ;;
                 arm64)
-                        URL=${latestURL}/okteto-Darwin-arm64
+                        bin_file=okteto-Darwin-arm64
                         ;;
                 *)
                         printf '\033[31m> The architecture (%s) is not supported by this installation script.\n\033[0m' "$ARCH"
@@ -32,16 +32,16 @@
         linux)
                 case "$ARCH" in
                 x86_64)
-                        URL=${latestURL}/okteto-Linux-x86_64
+                        bin_file=okteto-Linux-x86_64
                         ;;
                 amd64)
-                        URL=${latestURL}/okteto-Linux-x86_64
+                        bin_file=okteto-Linux-x86_64
                         ;;
                 armv8*)
-                        URL=${latestURL}/okteto-Linux-arm64
+                        bin_file=okteto-Linux-arm64
                         ;;
                 aarch64)
-                        URL=${latestURL}/okteto-Linux-arm64
+                        bin_file=okteto-Linux-arm64
                         ;;
                 *)
                         printf '\033[31m> The architecture (%s) is not supported by this installation script.\n\033[0m' "$ARCH"
@@ -70,6 +70,27 @@
                 fi
         fi
 
+        download_uri="https://downloads.okteto.com/cli"
+        channel_file="${OKTETO_HOME:-$HOME/.okteto}/channel"
+
+        channel="stable"
+
+        if [ -e "$channel_file" ]; then
+                current=$(cat "$channel_file" || echo "")
+                case "$current" in
+                stable) channel="$current" ;;
+                beta) channel="$current" ;;
+                dev) channel="$current" ;;
+                *) channel="stable" ;;
+                esac
+        fi
+
+        printf '> Using Release Channel: %s\n' ${channel}
+
+        version=$(curl -fsSL $download_uri/$channel/versions | tail -n1)
+        printf '> Current Version: %s\n' "$version"
+
+        URL="$download_uri/$channel/$version/$bin_file"
         printf '> Downloading %s\n' "$URL"
         download_path=$(mktemp)
         curl -fSL "$URL" -o "$download_path"


### PR DESCRIPTION
**IMPORTANT:  This is a proposal. There is no expectaction of merging this without further discussion. The end result can be very different from this**

---



NOTE: Whatever is not mentioned below stays exactly the same: releaasing to scoop, homebrew,  github-actions, etc

## Heuristics

We have a bucket created for each channel publicly available at `https://downloads.oketo.com/cli/:channel`. These are the contents of the bucket:

```
.
├── 2.2.2
│   ├── latest
│   ├── okteto-Darwin-arm64
│   ├── okteto-Darwin-arm64.sha256
│   ├── okteto-Darwin-x86_64
│   ├── okteto-Darwin-x86_64.sha256
│   ├── okteto-Linux-arm64
│   ├── okteto-Linux-arm64.sha256
│   ├── okteto-Linux-x86_64
│   ├── okteto-Linux-x86_64.sha256
│   ├── okteto-integration.test
│   ├── okteto.exe
│   └── okteto.exe.sha256
├── 2.3.0-beta.1 ...
├── 2.3.0-beta.2 ...
├── 2.3.0 ...
├── 2.3.1 ...
...
└── versions
```
Available at, for eg, `https://downloads.oketo.com/cli/{stable, beta, dev}/2.3.1/okteto-Darwin-arm64`

We have a versions file stored for every channel which holds the available versions for that channel. Available at:

- https://downloads.okteto.com/cli/stable/versions
- https://downloads.okteto.com/cli/beta/versions
- https://downloads.okteto.com/cli/dev/versions

We update these versions file automatically on every release. Some important consideration about the versions file:
- It is sorted. The latest version is guaranteed to be the latest available release for that channel. 
- There are no duplicates. Re releasing a tag should de idempotent
- All stable releases are included in dev and stable channels

`https://get.okteto.com` uses the versions to pull the latest released from the downloads based on the preferred channel (stable by default). Github releases are no longer in the critical path. We still create the GH release and the release notes in CI but any inconsistencies here should not break anything.


## CI

`release-MAJOR.MINOR` branches are automatically released into the beta channel and made available. Only beta and dev releases are automatically created. **No stable releases are automatic** (yet):

```
---*----------*----------*----------*----------*----------*----------> master
    \ 
     0---------------0---------------0---------------1---------------> release-2.4
      \               \               \               \
       2.4.0.beta.1    2.4.0.beta.2   2.4.0.beta.3   2.4.1.beta.1
                                      2.4.0 (manual)
```

So required human input is:
- Create the `release-MAJOR.MINOR` branch (once for each minor). This will automatically create the beta
- tag HEAD at  `release-MAJOR.MINOR` with the appropriate (next) stable tag when necessary. This can also be done directly from github

No extra steps are required this will:
- Automatically generate the Github release and the release notes based on the PR labels (see `.github/release.yml`)
- Update the channels with the latest versions

## Questions
- [x] Do we want the `okteto channel` command? It is hidden and it's the equivalent of `echo beta > $HOME/.okteto/channel` - **NO WE DON'T**
