### PR TITLE
refactor: added resize window signal to update while ssh

### DIFF
--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -19,10 +19,7 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/signal"
-	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/alessio/shellescape"
@@ -203,42 +200,4 @@ func dial(ctx context.Context, network, addr string, config *ssh.ClientConfig) (
 		return nil, err
 	}
 	return ssh.NewClient(c, chans, reqs), nil
-}
-
-func resizeWindow(session *ssh.Session) {
-	if runtime.GOOS == "windows" {
-		go func() {
-			prevWSize, err := dockerterm.GetWinsize(os.Stdout.Fd())
-			if err != nil {
-				oktetoLog.Infof("request for terminal size failed: %s", err)
-			}
-			for {
-				time.Sleep(time.Millisecond * 250)
-				ws, err := dockerterm.GetWinsize(os.Stdout.Fd())
-				if err != nil {
-					oktetoLog.Infof("request for terminal size failed: %s", err)
-				}
-				if prevWSize.Height != ws.Height || prevWSize.Width != ws.Width {
-					if err := dockerterm.SetWinsize(os.Stdout.Fd(), ws); err != nil {
-						oktetoLog.Infof("request for terminal resize failed: %s", err)
-					}
-				}
-				prevWSize = ws
-			}
-		}()
-
-	} else {
-		resize := make(chan os.Signal, 1)
-		signal.Notify(resize, syscall.SIGWINCH)
-		go func() {
-			for range resize {
-				width, height, err := term.GetSize(int(os.Stdout.Fd()))
-				oktetoLog.Infof("terminal width %d height %d", width, height)
-				if err != nil {
-					oktetoLog.Infof("request for terminal size failed: %s", err)
-				}
-				session.WindowChange(height, width)
-			}
-		}()
-	}
 }

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -48,7 +48,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 	var connection *ssh.Client
 	t := time.NewTicker(100 * time.Millisecond)
 	for i := 0; i < 100; i++ {
-		connection, err = dial(ctx, "tcp", fmt.Sprintf("%s:%d", iface, remotePort), sshConfig)
+		connection, err = dial(ctx, "tcp", net.JoinHostPort(iface, fmt.Sprintf("%d", remotePort)), sshConfig)
 		if err == nil {
 			break
 		}

--- a/pkg/ssh/resize_window_unix.go
+++ b/pkg/ssh/resize_window_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+// +build !windows
+
+package ssh
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
+)
+
+func resizeWindow(session *ssh.Session) {
+	resize := make(chan os.Signal, 1)
+	signal.Notify(resize, syscall.SIGWINCH)
+	go func() {
+		for range resize {
+			width, height, err := term.GetSize(int(os.Stdout.Fd()))
+			oktetoLog.Infof("terminal width %d height %d", width, height)
+			if err != nil {
+				oktetoLog.Infof("request for terminal size failed: %s", err)
+			}
+			session.WindowChange(height, width)
+		}
+	}()
+}

--- a/pkg/ssh/resize_window_unix.go
+++ b/pkg/ssh/resize_window_unix.go
@@ -23,7 +23,9 @@ func resizeWindow(session *ssh.Session) {
 			if err != nil {
 				oktetoLog.Infof("request for terminal size failed: %s", err)
 			}
-			session.WindowChange(height, width)
+			if err := session.WindowChange(height, width); err != nil {
+				oktetoLog.Infof("request for terminal resize failed: %s", err)
+			}
 		}
 	}()
 }

--- a/pkg/ssh/resize_window_windows.go
+++ b/pkg/ssh/resize_window_windows.go
@@ -3,6 +3,15 @@
 
 package ssh
 
+import (
+	"os"
+	"time"
+
+	dockerterm "github.com/moby/term"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"golang.org/x/crypto/ssh"
+)
+
 func resizeWindow(session *ssh.Session) {
 	go func() {
 		prevWSize, err := dockerterm.GetWinsize(os.Stdout.Fd())

--- a/pkg/ssh/resize_window_windows.go
+++ b/pkg/ssh/resize_window_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+// +build windows
+
+package ssh
+
+func resizeWindow(session *ssh.Session) {
+	go func() {
+		prevWSize, err := dockerterm.GetWinsize(os.Stdout.Fd())
+		if err != nil {
+			oktetoLog.Infof("request for terminal size failed: %s", err)
+		}
+		for {
+			time.Sleep(time.Millisecond * 250)
+			ws, err := dockerterm.GetWinsize(os.Stdout.Fd())
+			if err != nil {
+				oktetoLog.Infof("request for terminal size failed: %s", err)
+			}
+			if prevWSize.Height != ws.Height || prevWSize.Width != ws.Width {
+				if err := dockerterm.SetWinsize(os.Stdout.Fd(), ws); err != nil {
+					oktetoLog.Infof("request for terminal resize failed: %s", err)
+				}
+			}
+			prevWSize = ws
+		}
+	}()
+}

--- a/pkg/ssh/resize_window_windows.go
+++ b/pkg/ssh/resize_window_windows.go
@@ -7,29 +7,30 @@ import (
 	"os"
 	"time"
 
-	dockerterm "github.com/moby/term"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
 )
 
 func resizeWindow(session *ssh.Session) {
 	go func() {
-		prevWSize, err := dockerterm.GetWinsize(os.Stdout.Fd())
+		prevW, prevH, err := term.GetSize(int(os.Stdout.Fd()))
 		if err != nil {
 			oktetoLog.Infof("request for terminal size failed: %s", err)
 		}
 		for {
 			time.Sleep(time.Millisecond * 250)
-			ws, err := dockerterm.GetWinsize(os.Stdout.Fd())
+			w, h, err := term.GetSize(int(os.Stdout.Fd()))
 			if err != nil {
 				oktetoLog.Infof("request for terminal size failed: %s", err)
 			}
-			if prevWSize.Height != ws.Height || prevWSize.Width != ws.Width {
-				if err := dockerterm.SetWinsize(os.Stdout.Fd(), ws); err != nil {
+			if prevH != h || prevW != w {
+				if err := session.WindowChange(h, w); err != nil {
 					oktetoLog.Infof("request for terminal resize failed: %s", err)
 				}
 			}
-			prevWSize = ws
+			prevH = h
+			prevW = w
 		}
 	}()
 }


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2630 

## Proposed changes

- when running the ssh connection, add a signal channel to capture the resize or window event and update the session window with the new size
-
