### PR TITLE
fix: stack reference not making public ports

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -423,7 +423,7 @@ func translateService(svcName string, s *model.Stack) *apiv1.Service {
 func getSvcPublicPorts(svcName string, s *model.Stack) []model.Port {
 	result := []model.Port{}
 	for _, p := range s.Services[svcName].Ports {
-		if !model.IsSkippablePort(p.ContainerPort) && p.HostPort != 0 {
+		if !model.IsSkippablePort(p.ContainerPort) && (p.HostPort != 0 || s.Services[svcName].Public) {
 			result = append(result, p)
 		}
 	}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1517,3 +1517,88 @@ func Test_translateAffinity(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSvcPublicPorts(t *testing.T) {
+	tests := []struct {
+		name           string
+		svcName        string
+		stack          *model.Stack
+		expectedLength int
+	}{
+		{
+			name:    "one public port",
+			svcName: "test",
+			stack: &model.Stack{
+				Services: map[string]*model.Service{
+					"test": {
+						Ports: []model.Port{
+							{
+								HostPort:      80,
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			expectedLength: 1,
+		},
+		{
+			name:    "one private port",
+			svcName: "test",
+			stack: &model.Stack{
+				Services: map[string]*model.Service{
+					"test": {
+						Ports: []model.Port{
+							{
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			expectedLength: 0,
+		},
+		{
+			name:    "one public port with public field",
+			svcName: "test",
+			stack: &model.Stack{
+				Services: map[string]*model.Service{
+					"test": {
+						Public: true,
+						Ports: []model.Port{
+							{
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			expectedLength: 1,
+		},
+		{
+			name:    "one public port",
+			svcName: "test",
+			stack: &model.Stack{
+				Services: map[string]*model.Service{
+					"test": {
+						Public: true,
+						Ports: []model.Port{
+							{
+								HostPort:      80,
+								ContainerPort: 80,
+							},
+						},
+					},
+				},
+			},
+			expectedLength: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ports := getSvcPublicPorts(tt.svcName, tt.stack)
+			assert.Len(t, ports, tt.expectedLength)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2734

We introduced the bug when we introduced and removed the okteto for docker-extension.
We didn't detected the issue on the e2e tests because we moved `okteto/stacks-getting-started` to `okteto/compose-getting-started` and we didn't have another test using stacks reference

## Proposed changes
- Add the check for public endpoints on stack manifest
