### PR TITLE
fix: translate stacks to compose ports when unmarshalling

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -420,7 +420,7 @@ func translateService(svcName string, s *model.Stack) *apiv1.Service {
 func getSvcPublicPorts(svcName string, s *model.Stack) []model.Port {
 	result := []model.Port{}
 	for _, p := range s.Services[svcName].Ports {
-		if !model.IsSkippablePort(p.ContainerPort) && (p.HostPort != 0 || s.Services[svcName].Public) {
+		if !model.IsSkippablePort(p.ContainerPort) && p.HostPort != 0 {
 			result = append(result, p)
 		}
 	}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1568,6 +1568,7 @@ func TestGetSvcPublicPorts(t *testing.T) {
 						Ports: []model.Port{
 							{
 								ContainerPort: 80,
+								HostPort:      80,
 							},
 						},
 					},

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -90,6 +90,7 @@ type Service struct {
 	Healtcheck      *HealthCheck          `yaml:"healthcheck,omitempty"`
 	User            *StackSecurityContext `yaml:"user,omitempty"`
 
+	// Fields only for okteto stacks
 	Public    bool            `yaml:"public,omitempty"`
 	Replicas  int32           `yaml:"replicas,omitempty"`
 	Resources *StackResources `yaml:"resources,omitempty"`

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1853,3 +1853,84 @@ func Test_UnmarshalStackUser(t *testing.T) {
 		})
 	}
 }
+
+func Test_TranslateOktetoStackPortsToComposePorts(t *testing.T) {
+	tests := []struct {
+		name     string
+		ports    []PortRaw
+		expected []PortRaw
+	}{
+		{
+			name: "containerPort only",
+			ports: []PortRaw{
+				{
+					ContainerPort: 8080,
+				},
+				{
+					ContainerPort: 3000,
+				},
+			},
+			expected: []PortRaw{
+				{
+					ContainerPort: 8080,
+					HostPort:      8080,
+				},
+				{
+					ContainerPort: 3000,
+					HostPort:      3000,
+				},
+			},
+		},
+		{
+			name: "hostPort:containerPort only",
+			ports: []PortRaw{
+				{
+					ContainerPort: 8080,
+					HostPort:      8081,
+				},
+				{
+					ContainerPort: 3000,
+					HostPort:      2345,
+				},
+			},
+			expected: []PortRaw{
+				{
+					ContainerPort: 8080,
+					HostPort:      8081,
+				},
+				{
+					ContainerPort: 3000,
+					HostPort:      2345,
+				},
+			},
+		},
+		{
+			name: "hostPort:containerPort and containerPort",
+			ports: []PortRaw{
+				{
+					ContainerPort: 8080,
+				},
+				{
+					ContainerPort: 3000,
+					HostPort:      2345,
+				},
+			},
+			expected: []PortRaw{
+				{
+					ContainerPort: 8080,
+					HostPort:      8080,
+				},
+				{
+					ContainerPort: 3000,
+					HostPort:      2345,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := translateOktetoStacksPortsIntoComposeSyntax(tt.ports)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2747

## Proposed changes
- Translates stacks ports to compose syntax when unmarshalling