### PR TITLE
Added condition to skip lines starting with exclamation

### DIFF
--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -80,6 +80,9 @@ func addStignoreSecrets(dev *model.Dev) error {
 			if strings.HasPrefix(line, "#") {
 				continue
 			}
+			if strings.HasPrefix(line, "!") {
+				continue
+			}
 
 			_, err = writer.WriteString(fmt.Sprintf("(?d)%s\n", line))
 			if err != nil {

--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -15,7 +15,7 @@ package up
 
 import (
 	"bufio"
-	"crypto/md5"
+	"crypto/sha512"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -100,7 +100,7 @@ func addStignoreSecrets(dev *model.Dev) error {
 			},
 		)
 	}
-	dev.Metadata.Annotations[model.OktetoStignoreAnnotation] = fmt.Sprintf("%x", md5.Sum([]byte(output)))
+	dev.Metadata.Annotations[model.OktetoStignoreAnnotation] = fmt.Sprintf("%x", sha512.Sum512([]byte(output)))
 	return nil
 }
 
@@ -109,7 +109,7 @@ func addSyncFieldHash(dev *model.Dev) error {
 	if err != nil {
 		return err
 	}
-	dev.Metadata.Annotations[model.OktetoSyncAnnotation] = fmt.Sprintf("%x", md5.Sum([]byte(output)))
+	dev.Metadata.Annotations[model.OktetoSyncAnnotation] = fmt.Sprintf("%x", sha512.Sum512([]byte(output)))
 	return nil
 }
 

--- a/cmd/up/stignore_test.go
+++ b/cmd/up/stignore_test.go
@@ -1,7 +1,7 @@
 package up
 
 import (
-	"crypto/md5"
+	"crypto/sha512"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,7 +48,7 @@ func Test_addStignoreSecrets(t *testing.T) {
 			expectedTransformedStignoreContent: `(?d).ignore
 `,
 			expectedAnnotation: model.Annotations{
-				model.OktetoStignoreAnnotation: fmt.Sprintf("%x", md5.Sum([]byte(`
+				model.OktetoStignoreAnnotation: fmt.Sprintf("%x", sha512.Sum512([]byte(`
 .ignore`))),
 			},
 		},

--- a/cmd/up/stignore_test.go
+++ b/cmd/up/stignore_test.go
@@ -1,0 +1,85 @@
+package up
+
+import (
+	"crypto/md5"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_addStignoreSecrets(t *testing.T) {
+
+	localPath := t.TempDir()
+
+	tests := []struct {
+		name                               string
+		dev                                *model.Dev
+		stignoreContent                    string
+		expectedTransformedStignoreContent string
+		expectedError                      bool
+		expectedAnnotation                 model.Annotations
+	}{
+		{
+			name: "test",
+			dev: &model.Dev{
+				Name:      "test-name",
+				Namespace: "test-namespace",
+				Sync: model.Sync{
+					Folders: []model.SyncFolder{
+						{
+							LocalPath:  localPath,
+							RemotePath: "",
+						},
+					},
+				},
+				Metadata: &model.Metadata{
+					Annotations: model.Annotations{},
+				},
+			},
+			stignoreContent: `.ignore
+#include file
+(?d) folder
+!exclude`,
+			expectedTransformedStignoreContent: `(?d).ignore
+`,
+			expectedAnnotation: model.Annotations{
+				model.OktetoStignoreAnnotation: fmt.Sprintf("%x", md5.Sum([]byte(`
+.ignore`))),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			stignorePath := filepath.Join(localPath, ".stignore")
+			if err := os.WriteFile(stignorePath, []byte(tt.stignoreContent), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			err := addStignoreSecrets(tt.dev)
+			if err == nil && tt.expectedError {
+				t.Fatal("expected Error, but no error")
+			}
+			if err != nil && !tt.expectedError {
+				t.Fatal(err)
+			}
+			assert.Equal(t, tt.expectedAnnotation, tt.dev.Metadata.Annotations)
+
+			transformedStignorePath := filepath.Join(config.GetAppHome(tt.dev.Namespace, tt.dev.Name), ".stignore-1")
+			file, err := os.ReadFile(transformedStignorePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(file) != tt.expectedTransformedStignoreContent {
+				t.Fatalf("expectedTransformedStignoreContent: %s, but got %s", tt.expectedTransformedStignoreContent, string(file))
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2679 

## Proposed changes

- Added the skip condition when parsing the .stignore file - when starts with `!` do not prepend (?d)

## Context

Using the repo from @AgustinRamiroDiaz https://github.com/AgustinRamiroDiaz/okteto-stignore i've been going around the different possibilities. The remote `.stignore` is being parsed from the local one, we add the prefix (?d) in order to be able to delete a directory. Lines regarding `#includes` or `!<file or folder>` where not copied to this remote `.stignore`, i thought this had to be copy to the remote file but when i did, syncing got in an infite loop whith the following error:

```
WARNING: Error on folder \"1\" (okteto-1): loading ignores: parse error: failed to load include file .numbers: open /okteto/.numbers: no such file or directory" process=syncthing
```

So decided to just avoid lines starting with `!` as we do with `#`, as, `synthing` is using the local rules, although the remote rules are different.