### PR TITLE
use default temp dir in tests

### DIFF
--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func Test_translateWithVolumes(t *testing.T) {
-	file, err := os.CreateTemp("/tmp", "okteto-secret-test")
+	file, err := os.CreateTemp("", "okteto-secret-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1143,7 +1143,7 @@ environment:
 }
 
 func Test_translateSfsWithVolumes(t *testing.T) {
-	file, err := os.CreateTemp("/tmp", "okteto-secret-test")
+	file, err := os.CreateTemp("", "okteto-secret-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -709,13 +709,13 @@ func Test_LoadForcePull(t *testing.T) {
 }
 
 func Test_validate(t *testing.T) {
-	file, err := os.CreateTemp("/tmp", "okteto-secret-test")
+	file, err := os.CreateTemp("", "okteto-secret-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(file.Name())
 
-	dir, err := os.MkdirTemp("/tmp", "okteto-secret-test")
+	dir, err := os.MkdirTemp("", "okteto-secret-test")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fix windows unit tests. Not sure why this started happening but windows tests are failing with:

```
--- FAIL: Test_translateWithVolumes (0.00s)
    translate_test.go:47: open /tmp\okteto-secret-test3437656399: The system cannot find the path specified.
--- FAIL: Test_translateSfsWithVolumes (0.00s)
    translate_test.go:1148: open /tmp\okteto-secret-test3355878275: The system cannot find the path specified.
```

We are not using the default temp path as per `CreateTemp` docs:

```
If dir is the empty string, CreateTemp uses the default directory for temporary files, as returned by TempDir.
```



https://app.circleci.com/pipelines/github/okteto/okteto/7374/workflows/d28bf56a-3711-496c-9cc4-669237979e03/jobs/18585