### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/build/v1/build_test.go
+++ b/cmd/build/v1/build_test.go
@@ -44,7 +44,7 @@ func TestBuildWithErrorFromDockerfile(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
 
 	tag := "okteto.dev/test"
@@ -78,9 +78,8 @@ func TestBuildWithNoErrorFromDockerfile(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	tag := "okteto.dev/test"
 	options := &types.BuildOptions{
@@ -113,9 +112,8 @@ func TestBuildWithNoErrorFromDockerfileAndNoTag(t *testing.T) {
 		Builder:  builder,
 		Registry: registry,
 	}
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	options := &types.BuildOptions{
 		CommandArgs: []string{dir},
@@ -129,13 +127,10 @@ func TestBuildWithNoErrorFromDockerfileAndNoTag(t *testing.T) {
 	assert.Empty(t, image)
 }
 
-func createDockerfile() (string, error) {
-	dir, err := os.MkdirTemp("", "build")
-	if err != nil {
-		return "", err
-	}
+func createDockerfile(t *testing.T) (string, error) {
+	dir := t.TempDir()
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
-	err = os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
+	err := os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -119,11 +119,7 @@ func TestOnlyInjectVolumeMountsInOkteto(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	dir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -169,14 +165,9 @@ func TestTwoStepsBuild(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	dir, err := os.MkdirTemp("", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	dir, err = createDockerfile()
+
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -227,9 +218,8 @@ func TestBuildWithoutVolumeMountWithoutImage(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -271,9 +261,8 @@ func TestBuildWithoutVolumeMountWithImage(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -317,9 +306,8 @@ func TestBuildWithStack(t *testing.T) {
 		CurrentContext: "test",
 	}
 
-	dir, err := createDockerfile()
+	dir, err := createDockerfile(t)
 	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
@@ -370,13 +358,10 @@ func Test_getAccessibleVolumeMounts(t *testing.T) {
 	assert.Len(t, volumes, 1)
 }
 
-func createDockerfile() (string, error) {
-	dir, err := os.MkdirTemp("", "build")
-	if err != nil {
-		return "", err
-	}
+func createDockerfile(t *testing.T) (string, error) {
+	dir := t.TempDir()
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
-	err = os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
+	err := os.WriteFile(dockerfilePath, []byte("Hello"), 0755)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/context/context_test.go
+++ b/cmd/context/context_test.go
@@ -54,7 +54,7 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tokenPath, err := createDeprecatedToken(tt.tokenUrl)
+			tokenPath, err := createDeprecatedToken(t, tt.tokenUrl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,12 +73,8 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 	}
 }
 
-func createDeprecatedToken(url string) (string, error) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		return "", err
-	}
-	os.Setenv(model.OktetoFolderEnvVar, dir)
+func createDeprecatedToken(t *testing.T, url string) (string, error) {
+	t.Setenv(model.OktetoFolderEnvVar, t.TempDir())
 	token := &okteto.Token{
 		URL:       url,
 		Buildkit:  "buildkit",

--- a/cmd/manifest/init-v1_test.go
+++ b/cmd/manifest/init-v1_test.go
@@ -41,13 +41,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestRun(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	ctx := context.Background()
-
-	defer os.RemoveAll(dir)
 
 	p := filepath.Join(dir, fmt.Sprintf("okteto-%s", uuid.New().String()))
 
@@ -108,13 +103,8 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunJustCreateNecessaryFields(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	ctx := context.Background()
-
-	defer os.RemoveAll(dir)
 
 	mc := &ManifestCommand{}
 	p := filepath.Join(dir, fmt.Sprintf("okteto-%s", uuid.New().String()))

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -14,7 +14,6 @@
 package pipeline
 
 import (
-	"os"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -69,11 +68,7 @@ func Test_getRepositoryURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			if _, err := model.GetRepositoryURL(dir); err == nil {
 

--- a/cmd/utils/git_test.go
+++ b/cmd/utils/git_test.go
@@ -27,11 +27,7 @@ import (
 )
 
 func Test_getBranch(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	r, err := git.PlainInit(dir, false)
 	if err != nil {

--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -39,10 +39,7 @@ const (
 )
 
 func Test_multipleStack(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 
 	path, err := createFile(dir, "docker-compose.yml", firstStack)
@@ -107,10 +104,7 @@ func Test_multipleStack(t *testing.T) {
 }
 
 func Test_overrideFileStack(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 
 	path, err := createFile(dir, "docker-compose.yml", firstStack)

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -134,10 +134,7 @@ func TestBuildActionPipeline(t *testing.T) {
 		t.Fatalf("Create namespace action failed: %s", err.Error())
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 	dockerfilePath := filepath.Join(dir, "Dockerfile")
 	dockerfileContent := []byte("FROM alpine")

--- a/pkg/analytics/config_test.go
+++ b/pkg/analytics/config_test.go
@@ -48,13 +48,7 @@ func Test_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				os.RemoveAll(dir)
-			}()
+			dir := t.TempDir()
 
 			os.Setenv(model.OktetoFolderEnvVar, dir)
 

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -66,11 +66,7 @@ func Test_getTrackID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			os.Setenv(model.OktetoHomeEnvVar, dir)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,12 +27,8 @@ func TestGetUserHomeDir(t *testing.T) {
 		t.Fatal("got an empty home value")
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	defer func() {
-		os.RemoveAll(dir)
 		os.Unsetenv(model.OktetoHomeEnvVar)
 	}()
 
@@ -115,12 +111,8 @@ func Test_homedirWindows(t *testing.T) {
 }
 
 func TestGetOktetoHome(t *testing.T) {
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	defer func() {
-		os.RemoveAll(dir)
 		os.Unsetenv(model.OktetoFolderEnvVar)
 	}()
 
@@ -133,11 +125,7 @@ func TestGetOktetoHome(t *testing.T) {
 }
 
 func TestGetAppHome(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.Setenv(model.OktetoFolderEnvVar, dir)
 

--- a/pkg/linguist/linguist_test.go
+++ b/pkg/linguist/linguist_test.go
@@ -69,12 +69,7 @@ func TestProcessDirectory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmp, err := os.MkdirTemp("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			defer os.RemoveAll(tmp)
+			tmp := t.TempDir()
 
 			for _, f := range tt.files {
 				if _, err := os.Create(filepath.Join(tmp, f)); err != nil {

--- a/pkg/linguist/linguist_test.go
+++ b/pkg/linguist/linguist_test.go
@@ -72,9 +72,15 @@ func TestProcessDirectory(t *testing.T) {
 			tmp := t.TempDir()
 
 			for _, f := range tt.files {
-				if _, err := os.Create(filepath.Join(tmp, f)); err != nil {
+				file, err := os.Create(filepath.Join(tmp, f))
+				if err != nil {
 					t.Fatal(err)
 				}
+				t.Cleanup(func() {
+					if err := file.Close(); err != nil {
+						t.Fatal(err)
+					}
+				})
 			}
 
 			got, err := ProcessDirectory(tmp)

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -715,11 +715,7 @@ func Test_validate(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	dir, err := os.MkdirTemp("", "okteto-secret-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(dir)
+	dir := t.TempDir()
 
 	tests := []struct {
 		name      string

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -44,6 +44,7 @@ func CopyFile(from, to string) error {
 	if err != nil {
 		return err
 	}
+	defer fromFile.Close()
 
 	// skipcq GSC-G302 syncthing is a binary so it needs exec permissions
 	toFile, err := os.OpenFile(to, os.O_RDWR|os.O_CREATE, 0700)

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -20,12 +20,7 @@ import (
 )
 
 func TestCopyFile(t *testing.T) {
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	from := filepath.Join(dir, "from")
 	to := filepath.Join(dir, "to")
@@ -59,12 +54,7 @@ func TestCopyFile(t *testing.T) {
 }
 
 func TestFileExists(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	p := filepath.Join(dir, "exists")
 	if FileExists(p) {

--- a/pkg/ssh/config_test.go
+++ b/pkg/ssh/config_test.go
@@ -41,13 +41,7 @@ func TestWriteToNewFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(d)
-	path := filepath.Join(d, "config")
+	path := filepath.Join(t.TempDir(), "config")
 
 	if err := config.writeToFilepath(path); err != nil {
 		t.Fatal(err)

--- a/pkg/ssh/config_test.go
+++ b/pkg/ssh/config_test.go
@@ -51,6 +51,11 @@ func TestWriteToNewFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	_, err = parse(f)
 	if err != nil {

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -22,14 +22,9 @@ import (
 )
 
 func TestKeyExists(t *testing.T) {
-
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	defer func() {
-		os.RemoveAll(dir)
 		os.Unsetenv(model.OktetoFolderEnvVar)
 	}()
 
@@ -58,13 +53,9 @@ func TestKeyExists(t *testing.T) {
 }
 
 func TestGenerateKeys(t *testing.T) {
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	defer func() {
-		os.RemoveAll(dir)
 		os.Unsetenv(model.OktetoFolderEnvVar)
 	}()
 

--- a/pkg/ssh/key_test.go
+++ b/pkg/ssh/key_test.go
@@ -34,22 +34,33 @@ func TestKeyExists(t *testing.T) {
 		t.Error("keys shouldn't exist in an empty directory")
 	}
 
-	if _, err := os.Create(filepath.Join(dir, publicKeyFile)); err != nil {
+	f1, err := os.Create(filepath.Join(dir, publicKeyFile))
+	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := f1.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	if KeyExists() {
 		t.Error("keys shouldn't exist when private key is missing")
 	}
 
-	if _, err := os.Create(filepath.Join(dir, privateKeyFile)); err != nil {
+	f2, err := os.Create(filepath.Join(dir, privateKeyFile))
+	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := f2.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	if !KeyExists() {
 		t.Error("keys should exist")
 	}
-
 }
 
 func TestGenerateKeys(t *testing.T) {

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -23,16 +23,11 @@ import (
 )
 
 func Test_addOnEmpty(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	if err := os.RemoveAll(dir); err != nil {
 		t.Fatal(err)
 	}
-
-	defer os.RemoveAll(dir)
 
 	sshConfig := filepath.Join(dir, "config")
 
@@ -55,12 +50,7 @@ func Test_addOnEmpty(t *testing.T) {
 	}
 }
 func Test_add(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	sshConfig := filepath.Join(dir, "config")
 
 	if err := add(sshConfig, "test.okteto", model.Localhost, 8080); err != nil {
@@ -225,12 +215,7 @@ func Test_removeHost(t *testing.T) {
 }
 
 func TestGetPort(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	if err := os.Setenv(model.OktetoHomeEnvVar, dir); err != nil {
 		t.Fatal(err)

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -22,13 +22,8 @@ import (
 )
 
 func TestGetFiles(t *testing.T) {
-
-	dir, err := os.MkdirTemp("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	defer func() {
-		os.RemoveAll(dir)
 		os.Unsetenv(model.OktetoFolderEnvVar)
 	}()
 


### PR DESCRIPTION
## Proposed changes
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	if err != nil {
		t.Fatal(err)
	}
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```
