### PR TITLE
Replace imageref in Okteto Registry by their sha to enforce redeploym…

### DIFF
--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -56,27 +56,15 @@ func digestForReference(reference string) (string, error) {
 	return img.Digest.String(), nil
 }
 
-func configForReference(reference string) (v1.Config, error) {
+func imageForReference(reference string) (v1.Image, error) {
 	ref, err := name.ParseReference(reference)
 	if err != nil {
-		return v1.Config{}, err
+		return nil, err
 	}
 
 	options := clientOptions(ref)
 
-	img, err := remote.Image(ref, options)
-	if err != nil {
-		oktetoLog.Debugf("error getting image from remote")
-		return v1.Config{}, err
-	}
-
-	configFile, err := img.ConfigFile()
-	if err != nil {
-		oktetoLog.Debugf("error getting image config from remote")
-		return v1.Config{}, err
-	}
-
-	return configFile.Config, nil
+	return remote.Image(ref, options)
 }
 
 // GetReferecenceEnvs returns the values to setup the image environment variables


### PR DESCRIPTION
…ents if the image is updated

We aren't handling imageRef properly in compose files like this:
```
services:
  web:
    image: okteto.dev/app:okteto
    build: .
    command: ./run_web.sh
    volumes:
      - .:/app
    ports:
      - "8080:8080"

  worker:
    image: okteto.dev/app:okteto
    command: ./run_celery.sh
    volumes:
      - .:/app
```

because `web.image` is replaced by its sha256, but `worker.image` is not.

This PR always translated by its sha256 any compose image reference to the okteto Registry, to enforce redeployment if the image has changed
