### PR TITLE
Run e2e tests in staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
   test-integration:
     executor: golang-ci
     environment:
+      OKTETO_URL: https://staging.okteto.dev/
       OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.net
     steps:
       - checkout
       - restore_cache:
@@ -68,7 +70,7 @@ jobs:
             curl -L "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
             chmod +x /usr/local/bin/kubectl
             cp $(pwd)/artifacts/bin/okteto-Linux-x86_64 /usr/local/bin/okteto
-            /usr/local/bin/okteto login --token ${API_TOKEN}
+            /usr/local/bin/okteto login --token ${API_STAGING_TOKEN}
       - run:
           name: Integration tests
           environment:
@@ -225,6 +227,14 @@ workflows:
               only:
                 - master
                 - /.*(windows|win)/
+      - test-integration:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - test-release:
           context: GKE
           requires:

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -354,7 +354,7 @@ func TestStacksActions(t *testing.T) {
 
 func getTestNamespace() string {
 	tName := fmt.Sprintf("TestAction-%s", runtime.GOOS)
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 	return namespace
 }

--- a/integration/auto-wake_test.go
+++ b/integration/auto-wake_test.go
@@ -46,7 +46,7 @@ func TestAutoWake(t *testing.T) {
 		t.Fatalf("kubectl is not in the path: %s", err)
 	}
 
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
 	dir, err := os.MkdirTemp("", tName)

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -49,7 +49,7 @@ build:
 	)
 
 	var (
-		testID           = strings.ToLower(fmt.Sprintf("TestBuildCommand-%s-%d", runtime.GOOS, time.Now().Unix()))
+		testID           = strings.ToLower(fmt.Sprintf("TestBuildCommand-%s-%d", runtime.GOOS, time.Now().UnixMilli()))
 		testNamespace    = fmt.Sprintf("%s-%s", testID, user)
 		originNamespace  = getCurrentNamespace()
 		expectedImageTag = fmt.Sprintf("%s/%s/%s-app:okteto", okteto.Context().Registry, testNamespace, repoDir)

--- a/integration/deploy_manifest_test.go
+++ b/integration/deploy_manifest_test.go
@@ -113,7 +113,7 @@ spec:
 	)
 
 	var (
-		testID          = strings.ToLower(fmt.Sprintf("DeployFromManifest-%s-%d", runtime.GOOS, time.Now().Unix()))
+		testID          = strings.ToLower(fmt.Sprintf("DeployFromManifest-%s-%d", runtime.GOOS, time.Now().UnixMilli()))
 		testNamespace   = fmt.Sprintf("%s-%s", testID, user)
 		expectedImage   = fmt.Sprintf("%s/%s/%s-app:okteto", okteto.Context().Registry, testNamespace, repoDir)
 		originNamespace = getCurrentNamespace()
@@ -394,7 +394,7 @@ func TestDeployOutput(t *testing.T) {
 	repoDir := "voting-app"
 
 	var (
-		testID          = strings.ToLower(fmt.Sprintf("TestDeployOutput-%s-%d", runtime.GOOS, time.Now().Unix()))
+		testID          = strings.ToLower(fmt.Sprintf("TestDeployOutput-%s-%d", runtime.GOOS, time.Now().UnixMilli()))
 		testNamespace   = fmt.Sprintf("%s-%s", testID, user)
 		originNamespace = getCurrentNamespace()
 	)
@@ -466,7 +466,7 @@ func TestDeployAndUpEnvVars(t *testing.T) {
 	repoDir := "movies"
 	branch := "pchico83/manifest-v2"
 	var (
-		testID          = strings.ToLower(fmt.Sprintf("TestDeployOutput-%s-%d", runtime.GOOS, time.Now().Unix()))
+		testID          = strings.ToLower(fmt.Sprintf("TestDeployOutput-%s-%d", runtime.GOOS, time.Now().UnixMilli()))
 		testNamespace   = fmt.Sprintf("%s-%s", testID, user)
 		originNamespace = getCurrentNamespace()
 	)

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -57,7 +57,7 @@ func TestDeployDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 	tName := fmt.Sprintf("TestDeploy-%s", runtime.GOOS)
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 	t.Run(tName, func(t *testing.T) {
 		log.Printf("running %s \n", tName)
@@ -124,7 +124,7 @@ func TestDeploySubsetService(t *testing.T) {
 	}
 
 	tName := fmt.Sprintf("TestDeploySubsetService-%s", runtime.GOOS)
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 	desiredDeployments := []string{"vote", "kafka", "zookeeper"}
 	svcToAvoidDeploy := []string{"worker", "result"}

--- a/integration/push_test.go
+++ b/integration/push_test.go
@@ -42,7 +42,7 @@ func TestPush(t *testing.T) {
 		t.Fatal(err)
 	}
 	tName := fmt.Sprintf("TestPush-%s", runtime.GOOS)
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 	t.Run(tName, func(t *testing.T) {
 		log.Printf("running %s \n", tName)

--- a/integration/stacks_test.go
+++ b/integration/stacks_test.go
@@ -47,7 +47,7 @@ func TestStacks(t *testing.T) {
 	}
 
 	tName := fmt.Sprintf("TestStacks-%s", runtime.GOOS)
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 	t.Run(tName, func(t *testing.T) {
 		log.Printf("running %s \n", tName)
@@ -160,7 +160,7 @@ func TestCompose(t *testing.T) {
 	}
 
 	tName := fmt.Sprintf("TestStacks-%s", runtime.GOOS)
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
 	startNamespace := getCurrentNamespace()

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -250,7 +250,7 @@ func TestUpDeployments(t *testing.T) {
 		t.Fatalf("kubectl is not in the path: %s", err)
 	}
 
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
 	dir, err := os.MkdirTemp("", tName)
@@ -437,7 +437,7 @@ func TestUpStatefulset(t *testing.T) {
 		t.Fatalf("kubectl is not in the path: %s", err)
 	}
 
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
 	dir, err := os.MkdirTemp("", tName)
@@ -594,7 +594,7 @@ func TestUpAutocreate(t *testing.T) {
 		t.Fatalf("kubectl is not in the path: %s", err)
 	}
 
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
 	dir, err := os.MkdirTemp("", tName)
@@ -701,7 +701,7 @@ func TestUpCompose(t *testing.T) {
 	if _, err := exec.LookPath(kubectlBinary); err != nil {
 		t.Fatalf("kubectl is not in the path: %s", err)
 	}
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 	log.Printf("running %s \n", tName)
 	startNamespace := getCurrentNamespace()


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Our integration tests go from 45m to 20m when running in staging.
I have been running them 6 times with no flaky result so far.

We can easily optimize them more by running them in parallel, or by removing the dependency in the `build` step, but we should wait for [this PR](https://github.com/okteto/okteto/pull/2755) to be merged before doing changes there.

Given these results, I am restoring integration tests on merges to master, and branches ending in `-e2e`