### PR TITLE
Release Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,13 +152,21 @@ jobs:
       - store_artifacts:
           path: C:\Users\circleci\.okteto
 
-  push-image:
+  push-image-tag:
     executor: golang-ci
     steps:
       - checkout
       - setup_remote_docker:
           version: '19.03.8'
       - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG"
+
+  push-image-latest:
+    executor: golang-ci
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: '19.03.8'
+      - run: ./scripts/ci/push-image.sh latest
 
   release-external:
     executor: golang-ci
@@ -236,7 +244,7 @@ workflows:
               ignore:
                 - master
                 - *release-branch-regex
-      - push-image:
+      - push-image-latest:
           requires:
             - build
           filters:
@@ -270,14 +278,14 @@ workflows:
         - equal: ["release-dev", << pipeline.schedule.name >>]
     jobs:
       - build
-      - push-image:
+      - push-image-tag:
           requires:
             - build
       - release:
           context: GKE
           requires:
             - build
-            - push-image
+            - push-image-tag
 
   release:
     when:
@@ -291,12 +299,12 @@ workflows:
             tags:
               only:
                 - *release-regex
-      - push-image:
+      - push-image-tag:
           requires:
             - build
           filters:
             branches:
-              only: master
+              ignore: /.*/
             tags:
               only:
                 - *release-regex
@@ -304,7 +312,6 @@ workflows:
           context: GKE
           requires:
             - build
-            - push-image
           filters:
             branches:
               ignore: /.*/

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -16,15 +16,8 @@
         RELEASE_TAG="${1}"
 
         if [ -z "$RELEASE_TAG" ]; then
-                branch=$(git rev-parse --abbrev-ref HEAD)
                 commit=$(git rev-parse --short HEAD)
-                if [ "$branch" = "master" ]; then
-                        RELEASE_TAG="latest"
-                elif [ "$branch" = "main" ]; then
-                        RELEASE_TAG="main"
-                else
-                        RELEASE_TAG="$commit"
-                fi
+                RELEASE_TAG="$commit"
         fi
 
         name="okteto/okteto:${RELEASE_TAG}"

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -167,7 +167,7 @@
                 if [ "${chan}" = "dev" ]; then
                         # SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead
                         # shellcheck disable=SC2002
-                        cat "$version_temp_file" >"${BIN_PATH}/versions"
+                        cat "$version_temp_file" | awk '!seen[$0]++' >"${BIN_PATH}/versions"
                 else
                         # remove duplicated versions and sort the list
                         # SC2002: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead


### PR DESCRIPTION
Two fixes:
1. Add deduplication of releases in dev channel. If no commits are pushed over a day the sha is the same but it was still being appended to the versions list.
2. For dev releases we were not creating the corresponding docker image tag with the sha in the nightly