### PR TITLE
fix: could not detect manifest error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,6 +209,7 @@ require sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 
 require (
 	github.com/Sirupsen/logrus v0.0.0-00010101000000-000000000000 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/creack/pty v1.1.17 // indirect
 	github.com/docker/libnetwork v0.5.6 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -218,6 +218,10 @@ func GetStackFromPath(name, stackPath string, isCompose bool) (*Stack, error) {
 		return nil, err
 	}
 
+	if isEmptyManifestFile(b) {
+		return nil, fmt.Errorf("%w: %s", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrEmptyManifest)
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes error on build and deploy that could not detect a file

## Proposed changes
- It was introduced when we fallback to build v1
- Okteto manifest should not know about `Dockerfile` fallback
- If a file is given to an okteto build command we check if the Dockerfile is correct before doing the fallback
