### PR TITLE
fix: integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,8 @@ workflows:
           filters:
             branches:
               only: *release-branch-regex
+          requires:
+            - build
       - release-branch:
           requires:
             - build


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>


## Proposed changes
- Integration tests needs the okteto binary to be available when testing them 
