### PR TITLE
Update kubectl and helm binaries in okteto/okteto image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:experimental
 
-FROM bitnami/kubectl:1.17.4 as kubectl
-FROM alpine/helm:3.3.0 as helm
+FROM bitnami/kubectl:1.21.0 as kubectl
+FROM alpine/helm:3.8.0 as helm
 
 FROM golang:1.17-buster as builder
 WORKDIR /okteto


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

`okteto/okteto` is used in our github actions.

We need helm 3.8.0 in our actions to do samples with helm OCI support in the Okteto Registry