### PR TITLE
Automatically backport  Pull Requests

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -10,6 +10,5 @@ features:
   - comments
   - pr_description_required
   - release_notes
-  - hacktoberfest
 
 contributing_url: https://github.com/okteto/okteto/blob/master/contributing.md

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,25 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds https://github.com/tibdex/backport github action to backport pull request.

If a Pull Request from master needs to be backported to we simply need to add the `backport <branch>` label to the PR and a PR will be created against that branch once the source PR gets merged.

The labels need to be created manually. Right now theres backports in place for `release-2.2` `release-2.3` `release-2.4`.

Example PR: https://github.com/okteto/okteto/pull/2799

There seems to be an issue with Derek tho and the PR is automatically closed. Any ideas?