### PR TITLE
Update build retry conditions

### DIFF
--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -70,9 +70,9 @@ func IsTransientError(err error) bool {
 		return true
 	case strings.Contains(err.Error(), "failed to do request") && strings.Contains(err.Error(), "tls: use of closed connection"):
 		return true
-	case strings.Contains(err.Error(), "Canceled desc") && strings.Contains(err.Error(), "the client connection is closing"):
+	case strings.Contains(err.Error(), "Canceled") && strings.Contains(err.Error(), "the client connection is closing"):
 		return true
-	case strings.Contains(err.Error(), "Canceled desc") && strings.Contains(err.Error(), "context canceled"):
+	case strings.Contains(err.Error(), "Canceled") && strings.Contains(err.Error(), "context canceled"):
 		return true
 	default:
 		return false


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

Users are reporting this error is not automatically retried:

```
build failed: failed to solve: Canceled: grpc: the client connection is closing"
```

In parallel, we have to investigate why this error occurs. https://github.com/okteto/okteto/issues/2803 tracks that effort 