### PR TITLE
fix: compose flag on okteto up

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -983,7 +983,19 @@ func (dev *Dev) ToTranslationRule(main *Dev, reset bool) *TranslationRule {
 	}
 
 	if main.PersistentVolumeEnabled() {
+		wd, err := os.Getwd()
+		if err != nil {
+			oktetoLog.Info("could not retrieve working directory")
+		}
 		for _, v := range dev.Volumes {
+			subpath := v.RemotePath
+			if filepath.IsAbs(subpath) {
+				subpath, err = filepath.Rel(wd, v.RemotePath)
+				if err != nil {
+					oktetoLog.Info("could not retrieve subpath")
+					subpath = filepath.Base(v.RemotePath)
+				}
+			}
 			rule.Volumes = append(
 				rule.Volumes,
 				VolumeMount{
@@ -994,12 +1006,21 @@ func (dev *Dev) ToTranslationRule(main *Dev, reset bool) *TranslationRule {
 			)
 		}
 		for _, sync := range dev.Sync.Folders {
+			subpath := sync.LocalPath
+			if filepath.IsAbs(subpath) {
+				subpath, err = filepath.Rel(wd, sync.LocalPath)
+				if err != nil {
+					oktetoLog.Info("could not retrieve subpath")
+					subpath = filepath.Base(sync.LocalPath)
+				}
+			}
+
 			rule.Volumes = append(
 				rule.Volumes,
 				VolumeMount{
 					Name:      main.GetVolumeName(),
 					MountPath: sync.RemotePath,
-					SubPath:   main.getSourceSubPath(sync.LocalPath),
+					SubPath:   main.getSourceSubPath(subpath),
 				},
 			)
 		}

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -15,7 +15,9 @@ package model
 
 import (
 	"bytes"
+	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -447,6 +449,66 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 		rule := test.manifest.ToTranslationRule(test.manifest, false)
 		if e, a := test.expected, rule.Environment; !reflect.DeepEqual(e, a) {
 			t.Errorf("expected environment:\n%#v\ngot:\n%#v", e, a)
+		}
+	}
+}
+
+func TestVolumeMounts(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("could not detect wd")
+	}
+	tests := []struct {
+		name     string
+		manifest *Dev
+		expected VolumeMount
+	}{
+		{
+			name: "default",
+			manifest: &Dev{
+				Name:  "test",
+				Image: &BuildInfo{},
+				Sync: Sync{
+					Folders: []SyncFolder{
+						{
+							LocalPath:  filepath.Join(wd, "api"),
+							RemotePath: "/usr/src",
+						},
+					},
+				},
+			},
+			expected: VolumeMount{
+				MountPath: "/usr/src",
+				SubPath:   "src/api",
+			},
+		},
+		{
+			name: "default",
+			manifest: &Dev{
+				Name:  "test",
+				Image: &BuildInfo{},
+				Sync: Sync{
+					Folders: []SyncFolder{
+						{
+							LocalPath:  "api",
+							RemotePath: "/usr/src",
+						},
+					},
+				},
+			},
+			expected: VolumeMount{
+				MountPath: "/usr/src",
+				SubPath:   "src/api",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Logf("test: %s", test.name)
+		rule := test.manifest.ToTranslationRule(test.manifest, false)
+		for _, v := range rule.Volumes {
+			if v.MountPath == test.expected.MountPath {
+				assert.Equal(t, test.expected.SubPath, v.SubPath)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2789

## Proposed changes
- We can't do it as part of serialisation because the docker compose can be in another folder
- We check if it's in a relative path and if not we create a new subpath based on the sync folder path
