### PR TITLE
Run release after pushing the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,6 +324,7 @@ workflows:
           context: GKE
           requires:
             - build
+            - push-image-tag
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Tiny race condition in release process. There a 4 min window where the version is available but the docker image doesn't yet exist.