### PR TITLE
Fix condition to force autocreate

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -204,7 +204,7 @@ func Up() *cobra.Command {
 				return fmt.Errorf("failed to load okteto context '%s': %v", up.Dev.Context, err)
 			}
 
-			autocreateDev := true
+			forceNotAutocreateDev := false
 			if upOptions.Deploy || (up.Manifest.IsV2 && !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, up.Client)) {
 				if !upOptions.Deploy {
 					oktetoLog.Information("Deploying development environment '%s'...", up.Manifest.Name)
@@ -215,8 +215,9 @@ func Up() *cobra.Command {
 				if err != nil && oktetoErrors.ErrManifestFoundButNoDeployCommands != err {
 					return err
 				}
-				if oktetoErrors.ErrManifestFoundButNoDeployCommands != err {
-					autocreateDev = false
+				// when manifest has no deploy commands, prevent autocreate dev
+				if errors.Is(err, oktetoErrors.ErrManifestFoundButNoDeployCommands) {
+					forceNotAutocreateDev = true
 				}
 				if err != nil {
 					analytics.TrackDeploy(analytics.TrackDeployMetadata{
@@ -242,7 +243,7 @@ func Up() *cobra.Command {
 			}
 
 			up.Dev = dev
-			if !autocreateDev {
+			if forceNotAutocreateDev {
 				up.Dev.Autocreate = false
 			}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -204,7 +204,7 @@ func Up() *cobra.Command {
 				return fmt.Errorf("failed to load okteto context '%s': %v", up.Dev.Context, err)
 			}
 
-			forceNotAutocreateDev := false
+			forceAutocreateDev := true
 			if upOptions.Deploy || (up.Manifest.IsV2 && !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, up.Client)) {
 				if !upOptions.Deploy {
 					oktetoLog.Information("Deploying development environment '%s'...", up.Manifest.Name)
@@ -217,7 +217,7 @@ func Up() *cobra.Command {
 				}
 				// when manifest has no deploy commands, prevent autocreate dev
 				if errors.Is(err, oktetoErrors.ErrManifestFoundButNoDeployCommands) {
-					forceNotAutocreateDev = true
+					forceAutocreateDev = false
 				}
 				if err != nil {
 					analytics.TrackDeploy(analytics.TrackDeployMetadata{
@@ -243,7 +243,7 @@ func Up() *cobra.Command {
 			}
 
 			up.Dev = dev
-			if forceNotAutocreateDev {
+			if !forceAutocreateDev {
 				up.Dev.Autocreate = false
 			}
 


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2609 

## Proposed changes

- the autocreate condition at the manifest was being forced to be false after deploying the app previous to execute up for a service. Changed this to force NOT autocreate when the deploy section is empty.
