### PR TITLE
Use seconds instead of miliseconds to build the test name for the autowake, this is a quick fix to fix the tests

### DIFF
--- a/integration/auto-wake_test.go
+++ b/integration/auto-wake_test.go
@@ -46,7 +46,7 @@ func TestAutoWake(t *testing.T) {
 		t.Fatalf("kubectl is not in the path: %s", err)
 	}
 
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().UnixMilli()))
+	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
 	namespace := fmt.Sprintf("%s-%s", name, user)
 
 	dir, err := os.MkdirTemp("", tName)


### PR DESCRIPTION
Signed-off-by: Ignacio Fuertes <nacho@okteto.com>

## Proposed changes

- Use seconds instead of milliseconds to build the test case name so the generated endpoint is a valid one (less that 64 chars)
