### PR TITLE
Added prefix to ignore at remote .stignore

### DIFF
--- a/cmd/up/stignore_test.go
+++ b/cmd/up/stignore_test.go
@@ -44,12 +44,23 @@ func Test_addStignoreSecrets(t *testing.T) {
 			stignoreContent: `.ignore
 #include file
 (?d) folder
-!exclude`,
+!exclude
+// this comment should be excluded
+(?i)!case
+*`,
 			expectedTransformedStignoreContent: `(?d).ignore
+(?d) folder
+!exclude
+(?d)(?i)!case
+(?d)*
 `,
 			expectedAnnotation: model.Annotations{
 				model.OktetoStignoreAnnotation: fmt.Sprintf("%x", sha512.Sum512([]byte(`
-.ignore`))),
+(?d).ignore
+(?d) folder
+!exclude
+(?d)(?i)!case
+(?d)*`))),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2679 

## Proposed changes

- The remote .stignore is being transformed when first okteto up is run. This sets the configuration for the files being sync from **local** to **remote**.
- lines empty or comments or starting by `#` are not added to the remote
- adding the `(?d)` prefix to the lines on the **local** `.stignore` to the remote

new issue has been opened to cover the case where the .stignore local has external files to include (https://github.com/okteto/okteto/issues/2832)

