### PR TITLE
Rephrase "managed by Okteto" with "Okteto installed"

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -139,7 +139,7 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 
 		buildSvcInfo := buildManifest[svcToBuild]
 		if !okteto.Context().IsOkteto && buildSvcInfo.Image == "" {
-			return fmt.Errorf("'build.%s.image' is required if your context is not managed by Okteto", svcToBuild)
+			return fmt.Errorf("'build.%s.image' is required if your cluster doesn't have Okteto installed", svcToBuild)
 		}
 
 		imageTag, err := bc.buildService(ctx, options.Manifest, svcToBuild, options)

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -78,7 +78,7 @@ func (bc *OktetoBuilder) checkServicesToBuild(service string, manifest *model.Ma
 	}
 	opts := build.OptsFromBuildInfo(manifest.Name, service, buildInfo, &types.BuildOptions{})
 	if opts.Tag == "" {
-		return fmt.Errorf("error getting the image name for the service '%s'. Please specify the full name of the image when using a Kubernetes namespace not managed by Okteto", service)
+		return fmt.Errorf("error getting the image name for the service '%s'. Please specify the full name of the image when using a cluster that doesn't have Okteto installed", service)
 	}
 
 	imageWithDigest, err := bc.Registry.GetImageTagWithDigest(opts.Tag)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -35,6 +35,7 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/cmd/stack"
 	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/errors"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/diverts"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
@@ -286,7 +287,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	// don't divert if current namespace is the diverted namespace
 	if deployOptions.Manifest.Deploy.Divert != nil {
 		if !okteto.IsOkteto() {
-			return fmt.Errorf("'deploy.divert' is only supported in clusters managed by Okteto")
+			return errors.ErrDivertNotSupported
 		}
 		if deployOptions.Manifest.Deploy.Divert.Namespace != deployOptions.Manifest.Namespace {
 			dc.Proxy.SetDivert(deployOptions.Manifest.Deploy.Divert.Namespace)
@@ -299,7 +300,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	os.Setenv(model.OktetoNameEnvVar, deployOptions.Name)
 
 	if deployOptions.Dependencies && !okteto.IsOkteto() {
-		return fmt.Errorf("'dependencies' is only available in clusters managed by Okteto")
+		return fmt.Errorf("'dependencies' is only supported in clusters that have Okteto installed")
 	}
 
 	setDeployOptionsValuesFromManifest(ctx, deployOptions, cwd, c)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -105,7 +105,7 @@ var (
 	ErrDevPodDeleted = fmt.Errorf("development container has been removed")
 
 	// ErrDivertNotSupported raised if the divert feature is not supported in the current cluster
-	ErrDivertNotSupported = fmt.Errorf("the 'divert' field is only supported in namespaces managed by Okteto")
+	ErrDivertNotSupported = fmt.Errorf("the 'divert' field is only supported in clusters that have Okteto installed")
 
 	// ContextIsNotOktetoCluster raised if the cluster connected is not managed by okteto
 	ErrContextIsNotOktetoCluster = fmt.Errorf("this command is only available on Okteto Cloud or Okteto Enterprise")


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

## Proposed changes

"managed by okteto" has shown to be confusing. Rephrase those sentences with "okteto installed"