### PR TITLE
fix: remove parallel test when writing in map

### DIFF
--- a/cmd/up/forwards_test.go
+++ b/cmd/up/forwards_test.go
@@ -98,7 +98,6 @@ func TestGlobalForwarderAddsProperlyPortsToForward(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := addGlobalForwards(tt.upContext)
 			if !tt.expectedErr {

--- a/cmd/up/forwards_test.go
+++ b/cmd/up/forwards_test.go
@@ -100,7 +100,6 @@ func TestGlobalForwarderAddsProperlyPortsToForward(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			err := addGlobalForwards(tt.upContext)
 			if !tt.expectedErr {
 				assert.Nil(t, err)


### PR DESCRIPTION
Signed-off-by: adripedriza <adripedriza@gmail.com>

## Proposed changes

- remove Parallel option to avoid concurrent map writes
