### PR TITLE
Handle jobs "completed" status properly for the "--wait" flag

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -284,19 +284,27 @@ func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.
 			if err != nil {
 				return err
 			}
-			allRunning := true
-			for _, status := range resourceStatus {
-				if status == "error" {
-					return fmt.Errorf("repository '%s' deployed with errors", name)
-				}
-				if status != "running" {
-					allRunning = false
-					break
-				}
+			allRunning, err := CheckAllResourcesRunning(name, resourceStatus)
+			if err != nil {
+				return err
 			}
 			if allRunning {
 				return nil
 			}
 		}
 	}
+}
+
+func CheckAllResourcesRunning(name string, resourceStatus map[string]string) (bool, error) {
+	allRunning := true
+	for _, status := range resourceStatus {
+		if status == okteto.ErrorStatus {
+			return false, fmt.Errorf("repository '%s' deployed with errors", name)
+		}
+		if status != okteto.RunningStatus && status != okteto.CompletedStatus {
+			allRunning = false
+		}
+
+	}
+	return allRunning, nil
 }

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
 )
 
 func Test_getRepositoryURL(t *testing.T) {
@@ -102,6 +103,58 @@ func Test_getRepositoryURL(t *testing.T) {
 
 			if url != tt.expect {
 				t.Errorf("expected '%s', got '%s", tt.expect, url)
+			}
+		})
+	}
+}
+
+func TestCheckAllResourcesRunning(t *testing.T) {
+
+	var tests = []struct {
+		name           string
+		resourceStatus map[string]string
+		expectError    bool
+		expectResult   bool
+	}{
+		{
+			name: "all-running",
+			resourceStatus: map[string]string{
+				"1": okteto.RunningStatus,
+				"2": okteto.CompletedStatus,
+			},
+			expectError:  false,
+			expectResult: true,
+		},
+		{
+			name: "progressing",
+			resourceStatus: map[string]string{
+				"1": okteto.RunningStatus,
+				"2": okteto.CompletedStatus,
+				"3": okteto.ProgressingStatus,
+			},
+			expectError:  false,
+			expectResult: false,
+		},
+		{
+			name: "error",
+			resourceStatus: map[string]string{
+				"1": okteto.RunningStatus,
+				"2": okteto.CompletedStatus,
+				"3": okteto.ProgressingStatus,
+				"4": okteto.ErrorStatus,
+			},
+			expectError:  true,
+			expectResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := CheckAllResourcesRunning(tt.name, tt.resourceStatus)
+			if tt.expectError && err == nil || !tt.expectError && err != nil {
+				t.Errorf("expected error '%t', got '%v", tt.expectError, err)
+			}
+			if tt.expectResult != result {
+				t.Errorf("expected result '%t', got '%t", tt.expectResult, result)
 			}
 		})
 	}

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/docker/docker/pkg/namesgenerator"
 	contextCMD "github.com/okteto/okteto/cmd/context"
+	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -264,15 +265,9 @@ func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.
 			if err != nil {
 				return err
 			}
-			allRunning := true
-			for _, status := range resourceStatus {
-				if status == "error" {
-					return fmt.Errorf("preview environment '%s' deployed with resource errors", name)
-				}
-				if status != "running" {
-					allRunning = false
-					break
-				}
+			allRunning, err := pipeline.CheckAllResourcesRunning(name, resourceStatus)
+			if err != nil {
+				return err
 			}
 			if allRunning {
 				return nil

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -262,6 +262,31 @@ func TestPipelineActions(t *testing.T) {
 	}
 }
 
+func TestPipelineActionsWithCompose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("this test is not required for windows e2e tests")
+		return
+	}
+
+	ctx := context.Background()
+	namespace := getTestNamespace()
+
+	if err := executeCreateNamespaceAction(ctx, namespace); err != nil {
+		t.Fatalf("Create namespace action failed: %s", err.Error())
+	}
+
+	if err := executeDeployWithComposePipelineAction(ctx, namespace); err != nil {
+		t.Fatalf("Deploy pipeline action failed: %s", err.Error())
+	}
+	if err := executeDestroyPipelineAction(ctx, namespace); err != nil {
+		t.Fatalf("destroy pipeline action failed: %s", err.Error())
+	}
+
+	if err := executeDeleteNamespaceAction(ctx, namespace); err != nil {
+		t.Fatalf("Delete namespace action failed: %s", err.Error())
+	}
+}
+
 func TestPreviewActions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("this test is not required for windows e2e tests")
@@ -452,6 +477,44 @@ func executeDeployPipelineAction(ctx context.Context, namespace string) error {
 	defer deleteGitRepo(ctx, actionFolder)
 	os.Setenv(model.GithubRepositoryEnvVar, pipelineRepo)
 	os.Setenv(model.GithubRefEnvVar, "master")
+	os.Setenv(model.GithubServerURLEnvVar, githubUrl)
+
+	log.Printf("deploying pipeline %s", namespace)
+	command := fmt.Sprintf("%s/entrypoint.sh", actionFolder)
+	args := []string{"movies", namespace}
+
+	cmd := exec.Command(command, args...)
+	cmd.Env = os.Environ()
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %s: %s", command, strings.Join(args, " "), string(o))
+	}
+	log.Printf("Deploy pipeline output: \n%s\n", string(o))
+
+	oktetoClient, err := okteto.NewOktetoClient()
+	if err != nil {
+		return err
+	}
+	okteto.Context().Namespace = namespace
+	pipeline, err := oktetoClient.GetPipelineByName(ctx, "movies")
+	if err != nil || pipeline == nil {
+		return fmt.Errorf("Could not get deployment %s", namespace)
+	}
+	return nil
+}
+
+func executeDeployWithComposePipelineAction(ctx context.Context, namespace string) error {
+	actionRepo := fmt.Sprintf("%s%s.git", githubHttpsUrl, pipelinePath)
+	actionFolder := strings.Split(pipelinePath, "/")[1]
+	log.Printf("cloning pipeline repository: %s", actionRepo)
+	err := cloneGitRepoWithBranch(ctx, actionRepo, "master")
+	if err != nil {
+		return err
+	}
+	log.Printf("cloned repo %s \n", actionRepo)
+	defer deleteGitRepo(ctx, actionFolder)
+	os.Setenv(model.GithubRepositoryEnvVar, "okteto/movies-with-compose")
+	os.Setenv(model.GithubRefEnvVar, "main")
 	os.Setenv(model.GithubServerURLEnvVar, githubUrl)
 
 	log.Printf("deploying pipeline %s", namespace)

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -262,31 +262,6 @@ func TestPipelineActions(t *testing.T) {
 	}
 }
 
-func TestPipelineActionsWithCompose(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("this test is not required for windows e2e tests")
-		return
-	}
-
-	ctx := context.Background()
-	namespace := getTestNamespace()
-
-	if err := executeCreateNamespaceAction(ctx, namespace); err != nil {
-		t.Fatalf("Create namespace action failed: %s", err.Error())
-	}
-
-	if err := executeDeployWithComposePipelineAction(ctx, namespace); err != nil {
-		t.Fatalf("Deploy pipeline action failed: %s", err.Error())
-	}
-	if err := executeDestroyPipelineAction(ctx, namespace); err != nil {
-		t.Fatalf("destroy pipeline action failed: %s", err.Error())
-	}
-
-	if err := executeDeleteNamespaceAction(ctx, namespace); err != nil {
-		t.Fatalf("Delete namespace action failed: %s", err.Error())
-	}
-}
-
 func TestPreviewActions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("this test is not required for windows e2e tests")
@@ -507,7 +482,7 @@ func executeDeployWithComposePipelineAction(ctx context.Context, namespace strin
 	actionRepo := fmt.Sprintf("%s%s.git", githubHttpsUrl, pipelinePath)
 	actionFolder := strings.Split(pipelinePath, "/")[1]
 	log.Printf("cloning pipeline repository: %s", actionRepo)
-	err := cloneGitRepoWithBranch(ctx, actionRepo, "master")
+	err := cloneGitRepoWithBranch(ctx, actionRepo, "main")
 	if err != nil {
 		return err
 	}

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -26,6 +26,10 @@ import (
 const (
 	// Maximum number of characters allowed in a namespace name
 	MAX_ALLOWED_CHARS = 63
+	RunningStatus     = "running"
+	CompletedStatus   = "completed"
+	ProgressingStatus = "progressing"
+	ErrorStatus       = "error"
 )
 
 type namespaceClient struct {


### PR DESCRIPTION
https://github.com/okteto/okteto/pull/2681 intruduces a regression in the --wait flag. It started to check jobs status, but jobs are completed not running.

I refactor the code to add unit tests.

This should be backported to 2.4.2, and also update the latest actions tag