### PR TITLE
consider the context when calculating the path of the Dockerfile

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -86,9 +87,10 @@ func (up *upContext) activate() error {
 	buildDevImage := false
 	if _, err := registry.NewOktetoRegistry().GetImageTagWithDigest(up.Dev.Image.Name); err == oktetoErrors.ErrNotFound {
 		oktetoLog.Infof("image '%s' not found, building it: %s", up.Dev.Image.Name, err.Error())
-		if _, err := os.Stat(up.Dev.Image.Dockerfile); err != nil {
+		path := filepath.Join(up.Dev.Image.Context, up.Dev.Image.Dockerfile)
+		if _, err := os.Stat(path); err != nil {
 			return oktetoErrors.UserError{
-				E:    fmt.Errorf("the image '%s' doesn't exist and can't be build", up.Dev.Image.Name),
+				E:    fmt.Errorf("the image '%s' doesn't exist and Dockerfile '%s' is not accessible", up.Dev.Image.Name, path),
 				Hint: "Please update your build section and try again",
 			}
 		}

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -87,7 +86,7 @@ func (up *upContext) activate() error {
 	buildDevImage := false
 	if _, err := registry.NewOktetoRegistry().GetImageTagWithDigest(up.Dev.Image.Name); err == oktetoErrors.ErrNotFound {
 		oktetoLog.Infof("image '%s' not found, building it: %s", up.Dev.Image.Name, err.Error())
-		path := filepath.Join(up.Dev.Image.Context, up.Dev.Image.Dockerfile)
+		path := up.Dev.Image.GetDockerfilePath()
 		if _, err := os.Stat(path); err != nil {
 			return oktetoErrors.UserError{
 				E:    fmt.Errorf("the image '%s' doesn't exist and Dockerfile '%s' is not accessible", up.Dev.Image.Name, path),

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -650,7 +650,9 @@ func (up *upContext) buildDevImage(ctx context.Context, app apps.App) error {
 			up.Dev.EmptyImage = false
 		}
 	}
-	if _, err := os.Stat(dockerfile); err != nil {
+
+	path := filepath.Join(context, dockerfile)
+	if _, err := os.Stat(path); err != nil {
 		return oktetoErrors.UserError{
 			E:    fmt.Errorf("'--build' argument given but there is no Dockerfile"),
 			Hint: "Try creating a Dockerfile file or specify the 'context' and 'dockerfile' fields in your okteto manifest.",

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -651,8 +651,7 @@ func (up *upContext) buildDevImage(ctx context.Context, app apps.App) error {
 		}
 	}
 
-	path := filepath.Join(context, dockerfile)
-	if _, err := os.Stat(path); err != nil {
+	if _, err := os.Stat(up.Dev.Image.GetDockerfilePath()); err != nil {
 		return oktetoErrors.UserError{
 			E:    fmt.Errorf("'--build' argument given but there is no Dockerfile"),
 			Hint: "Try creating a Dockerfile file or specify the 'context' and 'dockerfile' fields in your okteto manifest.",

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -128,6 +128,11 @@ type BuildInfo struct {
 	ExportCache      string        `yaml:"export_cache,omitempty"`
 }
 
+// Returns the path to the Dockerfile
+func (b *BuildInfo) GetDockerfilePath() string {
+	return filepath.Join(b.Context, b.Dockerfile)
+}
+
 // Volume represents a volume in the development container
 type Volume struct {
 	LocalPath  string

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -30,6 +30,7 @@ import (
 	"github.com/compose-spec/godotenv"
 	"github.com/google/uuid"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/filesystem"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model/forward"
 	yaml "gopkg.in/yaml.v2"
@@ -128,9 +129,23 @@ type BuildInfo struct {
 	ExportCache      string        `yaml:"export_cache,omitempty"`
 }
 
-// Returns the path to the Dockerfile
+// GetDockerfilePath returns the path to the Dockerfile
 func (b *BuildInfo) GetDockerfilePath() string {
-	return filepath.Join(b.Context, b.Dockerfile)
+	if filepath.IsAbs(b.Dockerfile) {
+		return b.Dockerfile
+	}
+
+	joinPath := filepath.Join(b.Context, b.Dockerfile)
+	if !filesystem.FileExistsAndNotDir(joinPath) {
+		oktetoLog.Infof("Dockerfile '%s' is not in a relative path to context '%s'", b.Dockerfile, b.Context)
+		return b.Dockerfile
+	}
+
+	if joinPath != filepath.Clean(b.Dockerfile) && filesystem.FileExistsAndNotDir(b.Dockerfile) {
+		oktetoLog.Infof("Two Dockerfiles discovered in both the root and context path, defaulting to '%s/%s'", b.Context, b.Dockerfile)
+	}
+
+	return joinPath
 }
 
 // Volume represents a volume in the development container

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1515,3 +1515,48 @@ func Test_expandEnvFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildInfo_GetDockerfilePath(t *testing.T) {
+	tests := []struct {
+		name       string
+		context    string
+		dockerfile string
+		want       string
+	}{
+		{
+			name:       "empty",
+			context:    "",
+			dockerfile: "",
+			want:       "",
+		},
+		{
+			name:       "default",
+			context:    "",
+			dockerfile: "Dockerfile",
+			want:       "Dockerfile",
+		},
+		{
+			name:       "with-context",
+			context:    "api",
+			dockerfile: "Dockerfile",
+			want:       "api/Dockerfile",
+		},
+		{
+			name:       "with-context-and-non-dockerfile",
+			context:    "api",
+			dockerfile: "Dockerfile.dev",
+			want:       "api/Dockerfile.dev",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &BuildInfo{
+				Context:    tt.context,
+				Dockerfile: tt.dockerfile,
+			}
+			if got := b.GetDockerfilePath(); got != tt.want {
+				t.Errorf("BuildInfo.GetDockerfilePath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2874

## Proposed changes

- Join the `context` and the `dockerfile` properties when calculating the path of the Dockerfile
