### PR TITLE
Replace to underscore manifest header comment

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1036,7 +1036,7 @@ func (m *Manifest) WriteToFile(filePath string) error {
 				if subsection.Kind != yaml3.ScalarNode {
 					continue
 				}
-				serviceName := strings.ToUpper(subsection.Value)
+				serviceName := strings.ToUpper(strings.ReplaceAll(subsection.Value, "-", "_"))
 				subsection.HeadComment = fmt.Sprintf(buildSvcEnvVars, serviceName, serviceName, serviceName, serviceName)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2596 

## Proposed changes

- dashes at services names are sanitized to underscores when creating the build envs, we were not doing this when parsing the header comment of the build section of the manifest.
-
