### PR TITLE
fix: panic on destroy with wait flag

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -163,10 +163,8 @@ func ExecuteDeployPipeline(ctx context.Context, opts *DeployOptions) error {
 		return nil
 	}
 
-	if resp != nil {
-		if err := waitUntilRunning(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
-			return err
-		}
+	if err := waitUntilRunning(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
+		return err
 	}
 
 	oktetoLog.Success("Repository '%s' successfully deployed", opts.Name)

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -163,9 +163,12 @@ func ExecuteDeployPipeline(ctx context.Context, opts *DeployOptions) error {
 		return nil
 	}
 
-	if err := waitUntilRunning(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
-		return err
+	if resp != nil {
+		if err := waitUntilRunning(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
+			return err
+		}
 	}
+
 	oktetoLog.Success("Repository '%s' successfully deployed", opts.Name)
 	return nil
 }

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -101,8 +101,10 @@ func ExecuteDestroyPipeline(ctx context.Context, opts *DestroyOptions) error {
 		return nil
 	}
 
-	if err := waitUntilDestroyed(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
-		return err
+	if resp != nil {
+		if err := waitUntilDestroyed(ctx, opts.Name, resp.Action, opts.Timeout); err != nil {
+			return err
+		}
 	}
 
 	oktetoLog.Success("Repository '%s' successfully destroyed", opts.Name)


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2788

## Proposed changes
- This fix a panic which affects https://github.com/marketplace/actions/destroy-okteto-pipeline 
- Adds a condition when the response on the backend is nil (response we return when there is a pipeline not found error) and there is no error
