### PR TITLE
feat: ResourceEphemeralStorage

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -242,6 +242,10 @@ func TranslateResources(c *apiv1.Container, r model.ResourceRequirements) {
 		c.Resources.Requests[apiv1.ResourceCPU] = v
 	}
 
+	if v, ok := r.Requests[apiv1.ResourceEphemeralStorage]; ok {
+		c.Resources.Requests[apiv1.ResourceEphemeralStorage] = v
+	}
+
 	if v, ok := r.Requests[model.ResourceAMDGPU]; ok {
 		c.Resources.Requests[model.ResourceAMDGPU] = v
 	}
@@ -260,6 +264,10 @@ func TranslateResources(c *apiv1.Container, r model.ResourceRequirements) {
 
 	if v, ok := r.Limits[apiv1.ResourceCPU]; ok {
 		c.Resources.Limits[apiv1.ResourceCPU] = v
+	}
+
+	if v, ok := r.Limits[apiv1.ResourceEphemeralStorage]; ok {
+		c.Resources.Limits[apiv1.ResourceEphemeralStorage] = v
 	}
 
 	if v, ok := r.Limits[model.ResourceAMDGPU]; ok {

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -777,22 +777,26 @@ func Test_translateResources(t *testing.T) {
 				},
 				r: model.ResourceRequirements{
 					Limits: model.ResourceList{
-						apiv1.ResourceMemory: resource.MustParse("0.250Gi"),
-						apiv1.ResourceCPU:    resource.MustParse("0.125"),
+						apiv1.ResourceMemory:           resource.MustParse("0.250Gi"),
+						apiv1.ResourceCPU:              resource.MustParse("0.125"),
+						apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
 					},
 					Requests: model.ResourceList{
-						apiv1.ResourceMemory: resource.MustParse("2Gi"),
-						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory:           resource.MustParse("2Gi"),
+						apiv1.ResourceCPU:              resource.MustParse("1"),
+						apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 					},
 				},
 			},
 			expectedRequests: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory: resource.MustParse("2Gi"),
-				apiv1.ResourceCPU:    resource.MustParse("1"),
+				apiv1.ResourceMemory:           resource.MustParse("2Gi"),
+				apiv1.ResourceCPU:              resource.MustParse("1"),
+				apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 			},
 			expectedLimits: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory: resource.MustParse("0.250Gi"),
-				apiv1.ResourceCPU:    resource.MustParse("0.125"),
+				apiv1.ResourceMemory:           resource.MustParse("0.250Gi"),
+				apiv1.ResourceCPU:              resource.MustParse("0.125"),
+				apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
 			},
 		},
 		{
@@ -801,24 +805,28 @@ func Test_translateResources(t *testing.T) {
 				c: &apiv1.Container{
 					Resources: apiv1.ResourceRequirements{
 						Limits: map[apiv1.ResourceName]resource.Quantity{
-							apiv1.ResourceMemory: resource.MustParse("0.250Gi"),
-							apiv1.ResourceCPU:    resource.MustParse("0.125"),
+							apiv1.ResourceMemory:           resource.MustParse("0.250Gi"),
+							apiv1.ResourceCPU:              resource.MustParse("0.125"),
+							apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
 						},
 						Requests: map[apiv1.ResourceName]resource.Quantity{
-							apiv1.ResourceMemory: resource.MustParse("2Gi"),
-							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory:           resource.MustParse("2Gi"),
+							apiv1.ResourceCPU:              resource.MustParse("1"),
+							apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 						},
 					},
 				},
 				r: model.ResourceRequirements{},
 			},
 			expectedRequests: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory: resource.MustParse("2Gi"),
-				apiv1.ResourceCPU:    resource.MustParse("1"),
+				apiv1.ResourceMemory:           resource.MustParse("2Gi"),
+				apiv1.ResourceCPU:              resource.MustParse("1"),
+				apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 			},
 			expectedLimits: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory: resource.MustParse("0.250Gi"),
-				apiv1.ResourceCPU:    resource.MustParse("0.125"),
+				apiv1.ResourceMemory:           resource.MustParse("0.250Gi"),
+				apiv1.ResourceCPU:              resource.MustParse("0.125"),
+				apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
 			},
 		},
 		{
@@ -827,12 +835,14 @@ func Test_translateResources(t *testing.T) {
 				c: &apiv1.Container{
 					Resources: apiv1.ResourceRequirements{
 						Limits: map[apiv1.ResourceName]resource.Quantity{
-							apiv1.ResourceMemory: resource.MustParse("0.250Gi"),
-							apiv1.ResourceCPU:    resource.MustParse("0.125"),
+							apiv1.ResourceMemory:           resource.MustParse("0.250Gi"),
+							apiv1.ResourceCPU:              resource.MustParse("0.125"),
+							apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
 						},
 						Requests: map[apiv1.ResourceName]resource.Quantity{
-							apiv1.ResourceMemory: resource.MustParse("2Gi"),
-							apiv1.ResourceCPU:    resource.MustParse("1"),
+							apiv1.ResourceMemory:           resource.MustParse("2Gi"),
+							apiv1.ResourceCPU:              resource.MustParse("1"),
+							apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 						},
 					},
 				},
@@ -848,12 +858,14 @@ func Test_translateResources(t *testing.T) {
 				},
 			},
 			expectedRequests: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory: resource.MustParse("4Gi"),
-				apiv1.ResourceCPU:    resource.MustParse("0.125"),
+				apiv1.ResourceMemory:           resource.MustParse("4Gi"),
+				apiv1.ResourceCPU:              resource.MustParse("0.125"),
+				apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 			},
 			expectedLimits: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory: resource.MustParse("1Gi"),
-				apiv1.ResourceCPU:    resource.MustParse("2"),
+				apiv1.ResourceMemory:           resource.MustParse("1Gi"),
+				apiv1.ResourceCPU:              resource.MustParse("2"),
+				apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
 			},
 		},
 	}
@@ -875,6 +887,13 @@ func Test_translateResources(t *testing.T) {
 				t.Errorf("requests %s: expected %s, got %s", apiv1.ResourceCPU, b.String(), a.String())
 			}
 
+			a = tt.args.c.Resources.Requests[apiv1.ResourceEphemeralStorage]
+			b = tt.expectedRequests[apiv1.ResourceEphemeralStorage]
+
+			if a.Cmp(b) != 0 {
+				t.Errorf("requests %s: expected %s, got %s", apiv1.ResourceEphemeralStorage, b.String(), a.String())
+			}
+
 			a = tt.args.c.Resources.Limits[apiv1.ResourceMemory]
 			b = tt.expectedLimits[apiv1.ResourceMemory]
 
@@ -887,6 +906,13 @@ func Test_translateResources(t *testing.T) {
 
 			if a.Cmp(b) != 0 {
 				t.Errorf("limits %s: expected %s, got %s", apiv1.ResourceCPU, b.String(), a.String())
+			}
+
+			a = tt.args.c.Resources.Limits[apiv1.ResourceEphemeralStorage]
+			b = tt.expectedLimits[apiv1.ResourceEphemeralStorage]
+
+			if a.Cmp(b) != 0 {
+				t.Errorf("limits %s: expected %s, got %s", apiv1.ResourceEphemeralStorage, b.String(), a.String())
 			}
 		})
 	}


### PR DESCRIPTION
Add support for k8s resource type ephemeral-storage

## Proposed changes

Add support for specifying "ephemeral-storage" requests and limits in the Okteto manifest. This is a very small improvement but can be critical in cases where namespace defaults are too restrictive.