### PR TITLE
Retry "okteto build" if buildkit restarts in the middle of the build …

### DIFF
--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -62,6 +62,8 @@ func IsTransientError(err error) bool {
 		return true
 	case strings.Contains(err.Error(), "transport: error while dialing: dial tcp: i/o timeout"):
 		return true
+	case strings.Contains(err.Error(), "error reading from server: EOF"):
+		return true
 	case strings.Contains(err.Error(), "error while dialing: dial tcp: lookup buildkit") && strings.Contains(err.Error(), "no such host"):
 		return true
 	case strings.Contains(err.Error(), "failed commit on ref") && strings.Contains(err.Error(), "400 Bad Request"):


### PR DESCRIPTION
…process

Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

This error happens when buildkit restarts in the middle of the build process. We retry these errors just once.