### PR TITLE
Fix github actions latest release

### DIFF
--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -127,7 +127,7 @@
                                 -token "$GITHUB_TOKEN" \
                                 -recreate \
                                 -replace \
-                                -commitish "$(git rev-parse "${RELEASE_TAG}")" \
+                                -commitish "$(git rev-parse "${LTS_BRANCH}")" \
                                 latest
                 fi
 


### PR DESCRIPTION
The tag is not available locally since the release is created upstream by github so rev-parse fails. At this point the tag and the branch point to HEAD so it should be the same to get the sha from the branch as well.