### PR TITLE
Use GetKubernetesTimeout to configure our k8s proxy timeouts

### DIFF
--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/labels"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -94,9 +95,9 @@ func NewProxy(kubeconfig *KubeConfig) (*Proxy, error) {
 	s := &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
 		Handler:      handler,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		ReadTimeout:  okteto.GetKubernetesTimeout() * time.Second,
+		WriteTimeout: okteto.GetKubernetesTimeout() * time.Second,
+		IdleTimeout:  okteto.GetKubernetesTimeout() * time.Second,
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -27,7 +27,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/okteto/okteto/cmd/utils"
@@ -95,9 +94,9 @@ func NewProxy(kubeconfig *KubeConfig) (*Proxy, error) {
 	s := &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
 		Handler:      handler,
-		ReadTimeout:  okteto.GetKubernetesTimeout() * time.Second,
-		WriteTimeout: okteto.GetKubernetesTimeout() * time.Second,
-		IdleTimeout:  okteto.GetKubernetesTimeout() * time.Second,
+		ReadTimeout:  okteto.GetKubernetesTimeout(),
+		WriteTimeout: okteto.GetKubernetesTimeout(),
+		IdleTimeout:  okteto.GetKubernetesTimeout(),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{cert},
 

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -253,6 +253,9 @@ const (
 	// OktetoNameEnvVar defines if the command is running inside okteot
 	OktetoNameEnvVar = "OKTETO_NAME"
 
+	// OktetoSSHTimeoutEnvVar defines the timeout for ssh operations
+	OktetoSSHTimeoutEnvVar = "OKTETO_SSH_TIMEOUT"
+
 	// OktetoKubernetesTimeoutEnvVar defines the timeout for kubernetes operations
 	OktetoKubernetesTimeoutEnvVar = "OKTETO_KUBERNETES_TIMEOUT"
 

--- a/pkg/okteto/k8s.go
+++ b/pkg/okteto/k8s.go
@@ -47,7 +47,7 @@ func (*K8sClient) GetIngressClient(ctx context.Context) (*ingresses.Client, erro
 	return iClient, nil
 }
 
-func getKubernetesTimeout() time.Duration {
+func GetKubernetesTimeout() time.Duration {
 	tOnce.Do(func() {
 		timeout = 0 * time.Second
 		t, ok := os.LookupEnv(model.OktetoKubernetesTimeoutEnvVar)
@@ -77,7 +77,7 @@ func getK8sClientWithApiConfig(clientApiConfig *clientcmdapi.Config) (*kubernete
 	}
 	config.WarningHandler = rest.NoWarnings{}
 
-	config.Timeout = getKubernetesTimeout()
+	config.Timeout = GetKubernetesTimeout()
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -95,7 +95,7 @@ func getDynamicClient(clientAPIConfig *clientcmdapi.Config) (dynamic.Interface, 
 	}
 	config.WarningHandler = rest.NoWarnings{}
 
-	config.Timeout = getKubernetesTimeout()
+	config.Timeout = GetKubernetesTimeout()
 
 	dc, err := dynamic.NewForConfig(config)
 	if err != nil {
@@ -114,7 +114,7 @@ func getDiscoveryClient(clientAPIConfig *clientcmdapi.Config) (discovery.Discove
 	}
 	config.WarningHandler = rest.NoWarnings{}
 
-	config.Timeout = getKubernetesTimeout()
+	config.Timeout = GetKubernetesTimeout()
 
 	dc, err := discovery.NewDiscoveryClientForConfig(config)
 	if err != nil {


### PR DESCRIPTION
Several users have complained about `okteto deploy` timeouts.
We were using a 10s timeout. By default, kubectl and helm don't use timeouts, I think we should follow the same approach when configuring our k8s proxy. I also added an envvar to configure the `OKTETO_SSH_TIMEOUT`

## Proposed changes

- Configure okteto deploy k8s proxy timeouts based on `OKTETO_KUBERNETES_TIMEOUT`
- Added `OKTETO_SSH_TIMEOUT` envvar to configure the ssh timeout
