### PR TITLE
added condition to avoid dockerfile with "."

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -274,7 +274,7 @@ func extractFromContextAndDockerfile(context, dockerfile, svcName string) string
 		return dockerfile
 	}
 
-	if joinPath != dockerfile && filesystem.FileExistsAndNotDir(dockerfile) {
+	if joinPath != filepath.Join(".", dockerfile) && filesystem.FileExistsAndNotDir(dockerfile) {
 		oktetoLog.Warning(fmt.Sprintf(doubleDockerfileWarning, svcName, context, dockerfile))
 	}
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -274,7 +274,7 @@ func extractFromContextAndDockerfile(context, dockerfile, svcName string) string
 		return dockerfile
 	}
 
-	if joinPath != filepath.Join(".", dockerfile) && filesystem.FileExistsAndNotDir(dockerfile) {
+	if joinPath != filepath.Clean(dockerfile) && filesystem.FileExistsAndNotDir(dockerfile) {
 		oktetoLog.Warning(fmt.Sprintf(doubleDockerfileWarning, svcName, context, dockerfile))
 	}
 

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -334,6 +334,15 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			dockerfilesCreated: []string{"Dockerfile"},
 			expectedError:      "",
 		},
+		{
+			name:               "dockerfile in root, not showing 2 dockerfiles warning",
+			svcName:            "t6",
+			dockerfile:         "./Dockerfile",
+			fileExpected:       "Dockerfile",
+			optionalContext:    ".",
+			dockerfilesCreated: []string{"Dockerfile"},
+			expectedError:      "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
It was showing the warning of two dockerfiles because it was comparing `Dockerfile` with `./Dockerfile`