### PR TITLE
Fallback to Preview endpoint for waiting for dependencies

### DIFF
--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -261,7 +261,7 @@ func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.
 		case <-to.C:
 			return fmt.Errorf("preview environment '%s' didn't finish after %s", name, timeout.String())
 		case <-ticker.C:
-			resourceStatus, err := oktetoClient.GetResourcesStatusFromPreview(ctx, name)
+			resourceStatus, err := oktetoClient.GetResourcesStatusFromPreview(ctx, name, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/errors"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -411,6 +412,10 @@ func (c *pipelineClient) GetResourcesStatus(ctx context.Context, name string) (m
 	}
 
 	if err := query(ctx, &queryStruct, variables, c.client); err != nil {
+		if errors.IsNotFound(err) {
+			okClient := OktetoClient{client: c.client}
+			return okClient.GetResourcesStatusFromPreview(ctx, Context().Namespace, name)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

When we wait for resources to be running, if we are in a preview environment instead of a namespace, the `GetSpace` query returns `not-found`.
This PR fallbacks to the `Preview` endpoint