### PR TITLE
Fallback to Preview endpoint for waiting for dependencies

### DIFF
--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -261,7 +261,7 @@ func waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.
 		case <-to.C:
 			return fmt.Errorf("preview environment '%s' didn't finish after %s", name, timeout.String())
 		case <-ticker.C:
-			resourceStatus, err := oktetoClient.GetResourcesStatusFromPreview(ctx, name)
+			resourceStatus, err := oktetoClient.GetResourcesStatusFromPreview(ctx, name, "")
 			if err != nil {
 				return err
 			}

--- a/integration/okteto/pipeline_test.go
+++ b/integration/okteto/pipeline_test.go
@@ -28,6 +28,7 @@ import (
 const (
 	githubHTTPSURL = "https://github.com"
 	pipelineRepo   = "okteto/movies"
+	pipelineBranch = "cli-e2e"
 )
 
 func TestPipelineCommand(t *testing.T) {
@@ -49,7 +50,7 @@ func TestPipelineCommand(t *testing.T) {
 	pipelineOptions := &commands.DeployPipelineOptions{
 		Namespace:  testNamespace,
 		Repository: fmt.Sprintf("%s/%s", githubHTTPSURL, pipelineRepo),
-		Branch:     "cli-e2e",
+		Branch:     pipelineBranch,
 		Wait:       true,
 		OktetoHome: dir,
 		Token:      token,

--- a/integration/okteto/preview_test.go
+++ b/integration/okteto/preview_test.go
@@ -36,7 +36,7 @@ func TestPreviewCommand(t *testing.T) {
 	previewOptions := &commands.DeployPreviewOptions{
 		Namespace:  testNamespace,
 		Repository: fmt.Sprintf("%s/%s", githubHTTPSURL, pipelineRepo),
-		Branch:     "cli-e2e",
+		Branch:     pipelineBranch,
 		Wait:       true,
 		OktetoHome: dir,
 		Token:      token,
@@ -44,6 +44,18 @@ func TestPreviewCommand(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDeployPreview(oktetoPath, previewOptions))
 
 	contentURL := fmt.Sprintf("https://movies-%s.%s", testNamespace, appsSubdomain)
+	require.NotEmpty(t, integration.GetContentFromURL(contentURL, timeout))
+
+	//test `okteo pipeline deploy --wait` works in the context of a preview environment
+	pipelineOptions := &commands.DeployPipelineOptions{
+		Namespace:  testNamespace,
+		Repository: fmt.Sprintf("%s/%s", githubHTTPSURL, pipelineRepo),
+		Branch:     pipelineBranch,
+		Wait:       true,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoDeployPipeline(oktetoPath, pipelineOptions))
 	require.NotEmpty(t, integration.GetContentFromURL(contentURL, timeout))
 
 	previewDestroyOptions := &commands.DestroyPreviewOptions{

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/errors"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -411,6 +412,10 @@ func (c *pipelineClient) GetResourcesStatus(ctx context.Context, name string) (m
 	}
 
 	if err := query(ctx, &queryStruct, variables, c.client); err != nil {
+		if errors.IsNotFound(err) {
+			okClient := OktetoClient{client: c.client}
+			return okClient.GetResourcesStatusFromPreview(ctx, Context().Namespace, name)
+		}
 		return nil, err
 	}
 

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/okteto/okteto/pkg/config"
-	"github.com/okteto/okteto/pkg/errors"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -412,7 +411,7 @@ func (c *pipelineClient) GetResourcesStatus(ctx context.Context, name string) (m
 	}
 
 	if err := query(ctx, &queryStruct, variables, c.client); err != nil {
-		if errors.IsNotFound(err) {
+		if oktetoErrors.IsNotFound(err) {
 			okClient := OktetoClient{client: c.client}
 			return okClient.GetResourcesStatusFromPreview(ctx, Context().Namespace, name)
 		}


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

When we wait for resources to be running, if we are in a preview environment instead of a namespace, the `GetSpace` query returns `not-found`.
This PR fallbacks to the `Preview` endpoint