### PR TITLE
Fix release-branch workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,15 +384,15 @@ workflows:
       - run-unit-test:
           filters:
             branches:
-              ignore: /.*/
+              only: *release-branch-regex
             tags:
-              ignore: *release-branch-regex
+              ignore: /.*/
       - run-windows-unit-test:
           filters:
             branches:
-              ignore: /.*/
+              only: *release-branch-regex
             tags:
-              ignore: *release-branch-regex
+              ignore: /.*/
       - test-integration:
           filters:
             branches:
@@ -403,6 +403,8 @@ workflows:
           requires:
             - build-binaries
             - test-integration
+            - run-unit-test
+            - run-windows-unit-test
           filters:
             branches:
               only: *release-branch-regex


### PR DESCRIPTION
When we added the split for unit tests the release-branch workflow got misconfigured and it also ran on tags leading to orphaned pipelines. For eg: https://app.circleci.com/pipelines/github/okteto/okteto/7977/workflows/ee9dba49-e1ba-459f-88ec-113b82a06b96