### PR TITLE
Fix okteto destroy manifest not found with k8s.yml

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -222,7 +222,10 @@ func LoadContextFromPath(ctx context.Context, namespace, k8sContext, path string
 	}
 	ctxResource, err := model.GetContextResource(path)
 	if err != nil {
-		return err
+		// here discovery.ErrOktetoManifestNotFound will return as error
+		if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+			return err
+		}
 	}
 
 	if err := ctxResource.UpdateNamespace(namespace); err != nil {

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -222,11 +222,12 @@ func LoadContextFromPath(ctx context.Context, namespace, k8sContext, path string
 	}
 	ctxResource, err := model.GetContextResource(path)
 	if err != nil {
-		// ErrOktetoManifestNotFound belongs to the discovery module and is not the same as ErrManifestNotFound error set at okteto custom errors module
 		// model.GetContextResource will only return discovery.ErrOktetoManifestNotFound in the event that no manifest is found
 		if !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
 			return err
 		}
+		// here ctxResource is nil -> so we get a panic when the func
+		ctxResource = &model.ContextResource{}
 	}
 
 	if err := ctxResource.UpdateNamespace(namespace); err != nil {

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -222,12 +222,7 @@ func LoadContextFromPath(ctx context.Context, namespace, k8sContext, path string
 	}
 	ctxResource, err := model.GetContextResource(path)
 	if err != nil {
-		// model.GetContextResource will only return discovery.ErrOktetoManifestNotFound in the event that no manifest is found
-		if !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
-			return err
-		}
-		// here ctxResource is nil -> so we get a panic when the func
-		ctxResource = &model.ContextResource{}
+		return err
 	}
 
 	if err := ctxResource.UpdateNamespace(namespace); err != nil {

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -222,7 +222,9 @@ func LoadContextFromPath(ctx context.Context, namespace, k8sContext, path string
 	}
 	ctxResource, err := model.GetContextResource(path)
 	if err != nil {
-		if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+		// ErrOktetoManifestNotFound belongs to the discovery module and is not the same as ErrManifestNotFound error set at okteto custom errors module
+		// model.GetContextResource will only return discovery.ErrOktetoManifestNotFound in the event that no manifest is found
+		if !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
 			return err
 		}
 	}

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -121,7 +121,12 @@ func Destroy(ctx context.Context) *cobra.Command {
 				options.ManifestPath = uptManifestPath
 			}
 			if err := contextCMD.LoadContextFromPath(ctx, options.Namespace, options.K8sContext, options.ManifestPath); err != nil {
-				return err
+				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.CloudURL).Error() {
+					return err
+				}
+				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{Namespace: options.Namespace}); err != nil {
+					return err
+				}
 			}
 
 			cwd, err := os.Getwd()

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -32,7 +32,6 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/cmd/utils/executor"
 	"github.com/okteto/okteto/pkg/analytics"
-	"github.com/okteto/okteto/pkg/discovery"
 
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/config"
@@ -131,7 +130,8 @@ func Up() *cobra.Command {
 					return err
 				}
 
-				if !errors.Is(err, oktetoErrors.ErrManifestNotFound) && !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
+				// here if discovery.ErrOktetoManifestNotFound will be returned as error
+				if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
 					return err
 				}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -32,6 +32,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/cmd/utils/executor"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/discovery"
 
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/config"
@@ -130,7 +131,7 @@ func Up() *cobra.Command {
 					return err
 				}
 
-				if !errors.Is(err, oktetoErrors.ErrManifestNotFound) {
+				if !errors.Is(err, oktetoErrors.ErrManifestNotFound) && !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
 					return err
 				}
 

--- a/pkg/discovery/contextresource.go
+++ b/pkg/discovery/contextresource.go
@@ -18,6 +18,7 @@ import (
 )
 
 // GetContextResourcePath returns the file that will load the context resource from
+// here we only include files which have context information - no k8s or helm files
 func GetContextResourcePath(wd string) (string, error) {
 
 	oktetoManifestPath, err := GetOktetoManifestPath(wd)
@@ -38,11 +39,5 @@ func GetContextResourcePath(wd string) (string, error) {
 		return composeManifestPath, nil
 	}
 
-	k8sManifestPath, err := GetK8sManifestPath(wd)
-	if err == nil {
-		oktetoLog.Infof("context will load from %s", k8sManifestPath)
-		return k8sManifestPath, nil
-	}
-	// ErrOktetoManifestNotFound belongs to the discovery module and is not the same as ErrManifestNotFound error set at okteto custom errors module
 	return "", ErrOktetoManifestNotFound
 }

--- a/pkg/discovery/contextresource.go
+++ b/pkg/discovery/contextresource.go
@@ -43,6 +43,6 @@ func GetContextResourcePath(wd string) (string, error) {
 		oktetoLog.Infof("context will load from %s", k8sManifestPath)
 		return k8sManifestPath, nil
 	}
-
+	// ErrOktetoManifestNotFound belongs to the discovery module and is not the same as ErrManifestNotFound error set at okteto custom errors module
 	return "", ErrOktetoManifestNotFound
 }

--- a/pkg/discovery/contextresource.go
+++ b/pkg/discovery/contextresource.go
@@ -38,5 +38,11 @@ func GetContextResourcePath(wd string) (string, error) {
 		return composeManifestPath, nil
 	}
 
+	k8sManifestPath, err := GetK8sManifestPath(wd)
+	if err == nil {
+		oktetoLog.Infof("context will load from %s", k8sManifestPath)
+		return k8sManifestPath, nil
+	}
+
 	return "", ErrOktetoManifestNotFound
 }

--- a/pkg/discovery/contextresource_test.go
+++ b/pkg/discovery/contextresource_test.go
@@ -57,6 +57,11 @@ func TestGetContextResourcePathWhenExists(t *testing.T) {
 			filesToCreate: []string{"docker-compose.yml", "okteto.yml"},
 			expected:      "okteto.yml",
 		},
+		{
+			name:          "k8s manifest file exists",
+			filesToCreate: []string{"k8s.yml"},
+			expected:      "k8s.yml",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/discovery/contextresource_test.go
+++ b/pkg/discovery/contextresource_test.go
@@ -57,11 +57,6 @@ func TestGetContextResourcePathWhenExists(t *testing.T) {
 			filesToCreate: []string{"docker-compose.yml", "okteto.yml"},
 			expected:      "okteto.yml",
 		},
-		{
-			name:          "k8s manifest file exists",
-			filesToCreate: []string{"k8s.yml"},
-			expected:      "k8s.yml",
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Fixes #2968 

## Proposed changes

- Both LoadManifestWithContext and LoadContextFromPath where returning error ErrManifestNotFound as a result of GetContextResourcePath not having k8s as manifest discovery. <del>Added k8s files to be discovered as last resource of priority, when other files are not present.</del> This function only loads context, so k8s files are not present there for discovery for that reason. If no manifest with context info is found, context is init with the default. 
- <del>This solves the issue within the `okteto destroy` as `contextCMD.LoadContextFromPath` was returning the error when not finding the k8s manifest.</del> `okteto destroy` was returning err in case LoadContextFromPath had error, so this has been change to do the same as deploy, if err is ErrNotLogged, return the error, but if not, run context with default or flag values
- Why did `okteto deploy` worked ? <del>When calling `contextCMD.LoadContextFromPath` at this cmd, and we got error, unless this error was logged in error, we were creating a new context and going forward with the deployment. When `RunDeploy -> GetManifestV2 -> GetInferredManifest -> GetK8sManifestPath` so this time, we discovered the k8s manifest and deployment could continue.</del> because when LoadContextFromPath returned err != ErrNotLogged the context is initialized from default or flag values.
- Why did `okteto up` failed also? When `okteto up -> LoadManifestWithContext` returned error, there is an exception to continue and ask for `okteto init` if no manifest is found, error was being returned because we were checking the err was `oktetoErrors.ErrManifestNotFound`, and not `discovery.ErrOktetoManifestNotFound` which is the one returned in case the discovery service has not found any at the `LoadManifestWithContext` . this will still fail but was not scoped of this PR as only min changes to fix the destroy are made
