### PR TITLE
fix: check if resources been destroyed after destroy command

### DIFF
--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -43,6 +43,7 @@ type DestroyOptions struct {
 	Namespace    string
 	OktetoHome   string
 	Token        string
+	Name         string
 }
 
 // RunOktetoDeploy runs an okteto deploy command
@@ -76,6 +77,9 @@ func RunOktetoDestroy(oktetoPath string, destroyOptions *DestroyOptions) error {
 	cmd := exec.Command(oktetoPath, "destroy")
 	if destroyOptions.Workdir != "" {
 		cmd.Dir = destroyOptions.Workdir
+	}
+	if destroyOptions.Name != "" {
+		cmd.Args = append(cmd.Args, "--name", destroyOptions.Name)
 	}
 	if destroyOptions.ManifestPath != "" {
 		cmd.Args = append(cmd.Args, "-f", destroyOptions.ManifestPath)

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -73,7 +73,7 @@ func RunOktetoDeployAndGetOutput(oktetoPath string, deployOptions *DeployOptions
 // RunOktetoDestroy runs an okteto destroy command
 func RunOktetoDestroy(oktetoPath string, destroyOptions *DestroyOptions) error {
 	log.Printf("okteto destroy %s", oktetoPath)
-	cmd := exec.Command(oktetoPath, "deploy")
+	cmd := exec.Command(oktetoPath, "destroy")
 	if destroyOptions.Workdir != "" {
 		cmd.Dir = destroyOptions.Workdir
 	}

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -202,7 +202,11 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 		Namespace:  testNamespace,
 		OktetoHome: dir,
 	}
+
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 // TestDeployPipelineFromComposeOnlyOneSvc tests the following scenario:
@@ -254,7 +258,11 @@ func TestDeployPipelineFromComposeOnlyOneSvc(t *testing.T) {
 		Namespace:  testNamespace,
 		OktetoHome: dir,
 	}
+
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetDeployment(context.Background(), testNamespace, "app", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 // TestDeployPipelineFromOktetoStacks tests the following scenario:
@@ -315,6 +323,9 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetDeployment(context.Background(), testNamespace, "app", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 // TestDeployPipelineFromCompose tests the following scenario:
@@ -388,6 +399,9 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 func createComposeScenarioByManifest(dir string) error {

--- a/integration/deploy/endpoints_test.go
+++ b/integration/deploy/endpoints_test.go
@@ -17,6 +17,7 @@
 package deploy
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +25,10 @@ import (
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -154,6 +158,8 @@ func Test_EndpointsFromOktetoManifest_InferredName(t *testing.T) {
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -177,6 +183,9 @@ func Test_EndpointsFromOktetoManifest_InferredName(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 func createEndpointsFromOktetoManifestInferredName(dir string) error {

--- a/integration/deploy/k8s_manifest_test.go
+++ b/integration/deploy/k8s_manifest_test.go
@@ -17,12 +17,17 @@
 package deploy
 
 import (
+	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -93,6 +98,8 @@ func TestDeployDevEnvFromK8s(t *testing.T) {
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -110,4 +117,7 @@ func TestDeployDevEnvFromK8s(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 }

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -136,8 +136,22 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 
+	// Check that the e2etest service is still running after destroying the outer pipeline
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
-	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, err)
+
+	destroyOptions = &commands.DestroyOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		Name:       "test",
+	}
+	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	// Check that the e2etest service is not running
+	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
+	require.NoError(t, err)
 }
 
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -151,7 +151,7 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 
 	// Check that the e2etest service is not running
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
-	require.NoError(t, err)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -17,6 +17,7 @@
 package deploy
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +25,10 @@ import (
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var (
@@ -62,6 +66,8 @@ func TestDeployPipelineManifest(t *testing.T) {
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -80,6 +86,9 @@ func TestDeployPipelineManifest(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 
 }
 
@@ -102,6 +111,8 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
 
 	require.NoError(t, createPipelineInsidePipelineManifest(dir, oktetoPath, testNamespace))
 	require.NoError(t, createK8sManifest(dir))
@@ -124,6 +135,9 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

This is a follow-up on the tests regression fixed by: https://github.com/okteto/okteto/pull/2972

## Proposed changes
- Fix tests
- Add coverage for destroy command finish correctly
