### PR TITLE
Jlopezbarb/link how to tests from contribution guide

### DIFF
--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -59,6 +59,8 @@ All new features or bug fixes must have unit tests that cover the added code and
 
 Tests should fail with helpful messages saying what was wrong, what inputs were provided, the expected result, and the actual result received in testing. Assume that the person debugging your failing test is not you, and is potentially new to the entire project.
 
+To run unit/e2e tests locally, please check our [How to run tests guidelines](how-to-run-tests.md)
+
 #### Unit tests
 
 The code should be testable by unit functions, which means that each function should perform an action and this action should be testable.
@@ -180,17 +182,11 @@ In order to speed up the CI process, all tests are executed in parallel includin
 - `deploy/destroy` command: This command has the most dependencies, as it is used by all other services:
 
   - The information stored on the `configmap` is used on the UI to show information like structured logs, and repository information or to execute actions like redeploying or destroying the application.
-
   - The logs that are written in the buffer(`JSON`) will be the ones stored in the `configmap`, to later show them in the UI.
-
   - The following actions directly or indirectly use this command: [preview deploy](https://github.com/okteto/deploy-preview)/[pipeline deploy](https://github.com/okteto/pipeline)/[destroy pipeline](https://github.com/okteto/destroy-pipeline)/[preview destroy](https://github.com/okteto/destroy-preview)
-
   - Changes on this command can affect other commands like `preview` or `pipeline`
-
 - `up/down` command: It's mostly used on the `vscode` and `docker extension`
-
 - `stack` command: This command is used by `okteto deploy` command.
-
 - Changes on `graphql` calls: You have to check that your changes should work also with the previous `okteto chart` version.
 
 ### Logs

--- a/docs/how-to-run-tests.md
+++ b/docs/how-to-run-tests.md
@@ -1,8 +1,8 @@
-# Okteto CLI tests
+# How to run tests guidelines
 
 On this document we will cover how to run unit tests and e2e tests locally
 
-- [Okteto CLI tests](#okteto-cli-tests)
+- [How to run tests guidelines](#how-to-run-tests-guidelines)
   - [How to run unit tests locally?](#how-to-run-unit-tests-locally)
     - [Requirements:](#requirements)
     - [Run all unit tests](#run-all-unit-tests)

--- a/docs/how-to-run-tests.md
+++ b/docs/how-to-run-tests.md
@@ -12,6 +12,9 @@ On this document we will cover how to run unit tests and e2e tests locally
     - [Requirements:](#requirements-1)
     - [Run all e2e tests](#run-all-e2e-tests)
     - [Run specific e2e tests](#run-specific-e2e-tests)
+  - [How to run pre-commit on your local branch](#how-to-run-pre-commit-on-your-local-branch)
+    - [Install pre-commit](#install-pre-commit)
+    - [How to run pre-commit locally](#how-to-run-pre-commit-locally)
 
 ## How to run unit tests locally?
 
@@ -25,7 +28,7 @@ You don't need to have any special prerrequisite to run unit tests locally.
 
 You can run all tests by running the following command:
 
-``` bash
+```bash
 make test
 ```
 
@@ -33,7 +36,7 @@ make test
 
 You can run all tests by running the following command:
 
-``` bash
+```bash
 go test packageName
 # for example
 go test github.com/okteto/okteto/cmd/deploy
@@ -43,7 +46,7 @@ go test github.com/okteto/okteto/cmd/deploy
 
 You can run all tests by running the following command:
 
-``` bash
+```bash
 go test -run testRegex packageName
 # for example
 go test -run ^(TestDeployWithErrorChangingKubeConfig)$ github.com/okteto/okteto/cmd/deploy
@@ -65,7 +68,7 @@ You will need to set some environment variables to start running e2e tests
 
 You can run all tests by running the following command:
 
-``` bash
+```bash
 make integration
 ```
 
@@ -107,4 +110,30 @@ There are different e2e tests that can be run individually:
 
 ``` bash
     make integration-deprecated # which is equivalent to run go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m && go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
+```
+
+## How to run pre-commit on your local branch
+
+Okteto CLI uses [pre-commit](https://pre-commit.com) to detect misspellings, yaml and markdown errors, merge conflicts and private keys.
+
+### Install pre-commit
+
+Using pip:
+
+```bash
+pip install pre-commit
+```
+
+Using brew:
+
+```bash
+brew install pre-commit
+```
+
+### How to run pre-commit locally
+
+You'll need to set your working directory on the root of your Okteto CLI project and run:
+
+```bash
+pre-commit run --all-files
 ```


### PR DESCRIPTION
Fixes #2985

## Proposed changes
- Rename Okteto CLI tests to `How to run tests guidelines`
- Link `How to run tests guidelines` from contribution guidelines
