### PR TITLE
Add okteto context to dockerfile build args

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -77,7 +77,6 @@ func (*OktetoBuilder) LoadContext(ctx context.Context, options *types.BuildOptio
 
 	if options.Manifest.Namespace != "" {
 		ctxOpts.Namespace = options.Manifest.Namespace
-		ctxOpts.Namespace = options.Manifest.Namespace
 	}
 	if options.Namespace != "" {
 		ctxOpts.Namespace = options.Namespace

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -248,7 +248,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 
 	if registry.IsOktetoRegistry(b.Image) {
 		defaultBuildArgs := map[string]string{
-			model.OktetoUserNameEnvVar:        okteto.Context().Username,
+			model.OktetoContextEnvVar:        okteto.Context().Name,
 			model.OktetoNamespaceEnvVar:       okteto.Context().Namespace,
 		}
 

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -69,12 +69,18 @@ func Test_validateImage(t *testing.T) {
 }
 
 func Test_OptsFromBuildInfo(t *testing.T) {
+	context := okteto.OktetoContext{
+		Namespace: "test",
+		Registry:  "registry.okteto",
+	}
+
+	namespaceEnvVar := model.EnvVar{
+			Name: model.OktetoNamespaceEnvVar, Value: context.Namespace,
+	}
+
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{
-			"test": {
-				Namespace: "test",
-				Registry:  "registry.okteto",
-			},
+			"test": &context,
 		},
 		CurrentContext: "test",
 	}
@@ -126,7 +132,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			expected: &types.BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
-				BuildArgs:  []string{},
+				BuildArgs:  []string{namespaceEnvVar.String()},
 			},
 		},
 		{
@@ -136,7 +142,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			isOkteto:    false,
 			expected: &types.BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
-				BuildArgs:  []string{},
+				BuildArgs:  []string{namespaceEnvVar.String()},
 			},
 		},
 		{
@@ -165,7 +171,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Target:     "build",
 				Path:       "service",
 				CacheFrom:  []string{"cache-image"},
-				BuildArgs:  []string{"arg1=value1"},
+				BuildArgs:  []string{namespaceEnvVar.String(), "arg1=value1"},
 			},
 		},
 		{
@@ -200,7 +206,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Target:     "build",
 				Path:       "service",
 				CacheFrom:  []string{"cache-image"},
-				BuildArgs:  []string{"arg1=value1"},
+				BuildArgs:  []string{namespaceEnvVar.String(), "arg1=value1"},
 			},
 		},
 		{
@@ -212,7 +218,8 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Dockerfile: serviceDockerfile,
 				Target:     "build",
 				CacheFrom:  []string{"cache-image"},
-				Args: model.Environment{
+				Args: []model.EnvVar {
+					namespaceEnvVar,
 					{
 						Name:  "arg1",
 						Value: "value1",
@@ -230,7 +237,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Target:     "build",
 				Path:       "service",
 				CacheFrom:  []string{"cache-image"},
-				BuildArgs:  []string{"arg1=value1"},
+				BuildArgs:  []string{namespaceEnvVar.String(), "arg1=value1"},
 			},
 		},
 	}

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -142,7 +142,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			isOkteto:    false,
 			expected: &types.BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
-				BuildArgs:  []string{namespaceEnvVar.String()},
+				BuildArgs:  []string{},
 			},
 		},
 		{

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -225,6 +225,10 @@ type EnvVar struct {
 	Value string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
+func (v *EnvVar) String() string {
+	return fmt.Sprintf("%s=%s", v.Name, v.Value)
+}
+
 // Secret represents a development secret
 type Secret struct {
 	LocalPath  string
@@ -856,15 +860,14 @@ func (dev *Dev) Save(path string) error {
 	return nil
 }
 
-//SerializeBuildArgs returns build  aaargs as a llist of strings
+//SerializeBuildArgs returns build  args as a list of strings
 func SerializeBuildArgs(buildArgs Environment) []string {
 	result := []string{}
 	for _, e := range buildArgs {
-		result = append(
-			result,
-			fmt.Sprintf("%s=%s", e.Name, e.Value),
-		)
+		result = append(result,e.String())
 	}
+	// // stable serialization
+	sort.Strings(result)
 	return result
 }
 


### PR DESCRIPTION
## Proposed changes

When building dockerfiles they are unaware of the environment they are being built at. 
This PR added the `OKTETO_NAMESPACE` automatically to the build arguments which can later be consumed by the `Dockerfile`.

This change is needed for a usecase I have where the `Dockerfile` should be aware of the okteto namespace its going to be deployed to.

I think this change is useful given that github actions do something similar: set default env variables to be consumed by the user.