### PR TITLE
Update help message for deploy command

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -97,7 +97,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "deploy [service...]",
-		Short: "Execute the list of commands specified in the 'deploy' section of your okteto manifest",
+		Short: "Execute locally the list of commands specified in the 'deploy' section of your okteto manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// validate cmd options

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -41,10 +41,9 @@ func NewCommand() (*Command, error) {
 //Pipeline pipeline management commands
 func Pipeline(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "pipeline",
-		Short:  "Pipeline management commands",
-		Args:   utils.NoArgsAccepted("https://www.okteto.com/docs/reference/cli/#pipeline"),
-		Hidden: true,
+		Use:   "pipeline",
+		Short: "Pipeline management commands",
+		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/cli/#pipeline"),
 	}
 	cmd.AddCommand(deploy(ctx))
 	cmd.AddCommand(destroy(ctx))


### PR DESCRIPTION
Signed-off-by: Ignacio Fuertes <nacho@okteto.com>


## Proposed changes

- Update help for `deploy` command to indicate that the execution happens locally
- Removed `hidden` flag from pipeline command. I think we added it when we deprecated the command but we didn't remove the flag when we decided to keep it for a while
