### PR TITLE
Fix resolve previous tags in release-branch

### DIFF
--- a/scripts/ci/release-branch.sh
+++ b/scripts/ci/release-branch.sh
@@ -44,7 +44,7 @@
         # This will happen when creating a patch release from an LTS branch and it's
         # usually how promotion works.
         known_ancestor="$(git rev-list -n 1 "$(git describe --tags --abbrev=0 --match "*.*.*")")"
-        PREVIOUS_TAGS="$(git show-ref --tags -d | grep ^${known_ancestor} | sed -e 's,.* refs/tags/,,' -e 's/\^{}//')"
+        PREVIOUS_TAGS="$(git show-ref --tags -d | grep "^${known_ancestor}" | sed -e 's,.* refs/tags/,,' -e 's/\^{}//')"
 
         # ROOT_MINOR_TAG is the oldest relevant tag we should be able to reach from this
         # release branch

--- a/scripts/ci/release-branch.sh
+++ b/scripts/ci/release-branch.sh
@@ -44,7 +44,7 @@
         # This will happen when creating a patch release from an LTS branch and it's
         # usually how promotion works.
         known_ancestor="$(git rev-list -n 1 "$(git describe --tags --abbrev=0 --match "*.*.*")")"
-        PREVIOUS_TAGS="$(git tag --points-at "$known_ancestor")"
+        PREVIOUS_TAGS="$(git show-ref --tags -d | grep ^${known_ancestor} | sed -e 's,.* refs/tags/,,' -e 's/\^{}//')"
 
         # ROOT_MINOR_TAG is the oldest relevant tag we should be able to reach from this
         # release branch


### PR DESCRIPTION
It looks like `git tag --points-at {sha}` does not work as expected.

Running:

```
$ git tag --points-at 911ad8c4
2.5.2-beta.1
```

Although `911ad8c4` points to `2.5.2` and `2.5.2-beta.1`

Running it against a previos versions works correctly:

```
$ git tag --points-at 1779058e
2.5.0
2.5.0-beta.3
```

Got this from: https://stackoverflow.com/questions/4545370/how-to-list-all-tags-pointing-to-a-specific-commit-in-git