### PR TITLE
Use injected logrus when possible

### DIFF
--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -75,55 +75,55 @@ func newJSONWriter(out *logrus.Logger, file *logrus.Entry) *JSONWriter {
 // Debug writes a debug-level log
 func (w *JSONWriter) Debug(args ...interface{}) {
 	w.out.Debug(args...)
-	if log.file != nil {
-		log.file.Debug(args...)
+	if w.file != nil {
+		w.file.Debug(args...)
 	}
 }
 
 // Debugf writes a debug-level log with a format
 func (w *JSONWriter) Debugf(format string, args ...interface{}) {
 	w.out.Debugf(format, args...)
-	if log.file != nil {
-		log.file.Debugf(format, args...)
+	if w.file != nil {
+		w.file.Debugf(format, args...)
 	}
 }
 
 // Info writes a info-level log
 func (w *JSONWriter) Info(args ...interface{}) {
 	w.out.Info(args...)
-	if log.file != nil {
-		log.file.Info(args...)
+	if w.file != nil {
+		w.file.Info(args...)
 	}
 }
 
 // Infof writes a info-level log with a format
 func (w *JSONWriter) Infof(format string, args ...interface{}) {
 	w.out.Infof(format, args...)
-	if log.file != nil {
-		log.file.Infof(format, args...)
+	if w.file != nil {
+		w.file.Infof(format, args...)
 	}
 }
 
 // Error writes a error-level log
 func (w *JSONWriter) Error(args ...interface{}) {
 	w.out.Error(args...)
-	if log.file != nil {
-		log.file.Error(args...)
+	if w.file != nil {
+		w.file.Error(args...)
 	}
 }
 
 // Errorf writes a error-level log with a format
 func (w *JSONWriter) Errorf(format string, args ...interface{}) {
 	w.out.Errorf(format, args...)
-	if log.file != nil {
-		log.file.Errorf(format, args...)
+	if w.file != nil {
+		w.file.Errorf(format, args...)
 	}
 }
 
 // Fatalf writes a error-level log with a format
 func (w *JSONWriter) Fatalf(format string, args ...interface{}) {
-	if log.file != nil {
-		log.file.Errorf(format, args...)
+	if w.file != nil {
+		w.file.Errorf(format, args...)
 	}
 
 	w.out.Fatalf(format, args...)

--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -81,86 +81,86 @@ func (w *JSONWriter) Debug(args ...interface{}) {
 }
 
 // Debugf writes a debug-level log with a format
-func (*JSONWriter) Debugf(format string, args ...interface{}) {
-	log.out.Debugf(format, args...)
+func (w *JSONWriter) Debugf(format string, args ...interface{}) {
+	w.out.Debugf(format, args...)
 	if log.file != nil {
 		log.file.Debugf(format, args...)
 	}
 }
 
 // Info writes a info-level log
-func (*JSONWriter) Info(args ...interface{}) {
-	log.out.Info(args...)
+func (w *JSONWriter) Info(args ...interface{}) {
+	w.out.Info(args...)
 	if log.file != nil {
 		log.file.Info(args...)
 	}
 }
 
 // Infof writes a info-level log with a format
-func (*JSONWriter) Infof(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+func (w *JSONWriter) Infof(format string, args ...interface{}) {
+	w.out.Infof(format, args...)
 	if log.file != nil {
 		log.file.Infof(format, args...)
 	}
 }
 
 // Error writes a error-level log
-func (*JSONWriter) Error(args ...interface{}) {
-	log.out.Error(args...)
+func (w *JSONWriter) Error(args ...interface{}) {
+	w.out.Error(args...)
 	if log.file != nil {
 		log.file.Error(args...)
 	}
 }
 
 // Errorf writes a error-level log with a format
-func (*JSONWriter) Errorf(format string, args ...interface{}) {
-	log.out.Errorf(format, args...)
+func (w *JSONWriter) Errorf(format string, args ...interface{}) {
+	w.out.Errorf(format, args...)
 	if log.file != nil {
 		log.file.Errorf(format, args...)
 	}
 }
 
 // Fatalf writes a error-level log with a format
-func (*JSONWriter) Fatalf(format string, args ...interface{}) {
+func (w *JSONWriter) Fatalf(format string, args ...interface{}) {
 	if log.file != nil {
 		log.file.Errorf(format, args...)
 	}
 
-	log.out.Fatalf(format, args...)
+	w.out.Fatalf(format, args...)
 }
 
 // Green writes a line in green
 func (w *JSONWriter) Green(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Yellow writes a line in yellow
 func (w *JSONWriter) Yellow(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Success prints a message with the success symbol first, and the text in green
 func (w *JSONWriter) Success(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.FPrintln(w.out.Out, fmt.Sprintf("%s %s", successSymbol, fmt.Sprintf(format, args...)))
 }
 
 // Information prints a message with the information symbol first, and the text in blue
 func (w *JSONWriter) Information(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.FPrintln(w.out.Out, fmt.Sprintf("%s %s", informationSymbol, fmt.Sprintf(format, args...)))
 }
 
 // Question prints a message with the question symbol first, and the text in magenta
-func (*JSONWriter) Question(format string, args ...interface{}) error {
+func (w *JSONWriter) Question(format string, args ...interface{}) error {
 	return fmt.Errorf("can't ask questions on json mode")
 }
 
 // Warning prints a message with the warning symbol first, and the text in yellow
 func (w *JSONWriter) Warning(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	msg := fmt.Sprintf("%s %s", warningSymbol, fmt.Sprintf(format, args...))
 	if msg != "" {
 		msg := convertToJSON("warn", log.stage, msg)
@@ -171,8 +171,8 @@ func (w *JSONWriter) Warning(format string, args ...interface{}) {
 }
 
 // FWarning prints a message with the warning symbol first, and the text in yellow
-func (*JSONWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+func (w *JSONWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
+	w.out.Infof(format, args...)
 	msg := fmt.Sprintf("%s %s", warningSymbol, fmt.Sprintf(format, args...))
 	if msg != "" {
 		msg := convertToJSON("warn", log.stage, msg)
@@ -184,13 +184,13 @@ func (*JSONWriter) FWarning(writer io.Writer, format string, args ...interface{}
 
 // Hint prints a message with the text in blue
 func (w *JSONWriter) Hint(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Fail prints a message with the error symbol first, and the text in red
 func (w *JSONWriter) Fail(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	msg := fmt.Sprintf("%s %s", errorSymbol, fmt.Sprintf(format, args...))
 	if msg != "" {
 
@@ -257,7 +257,7 @@ func (w *JSONWriter) Printf(format string, a ...interface{}) {
 }
 
 //IsInteractive checks if the writer is interactive
-func (*JSONWriter) IsInteractive() bool {
+func (w *JSONWriter) IsInteractive() bool {
 	return false
 }
 

--- a/pkg/log/plain.go
+++ b/pkg/log/plain.go
@@ -43,107 +43,107 @@ func (w *PlainWriter) Debug(args ...interface{}) {
 }
 
 // Debugf writes a debug-level log with a format
-func (*PlainWriter) Debugf(format string, args ...interface{}) {
-	log.out.Debugf(format, args...)
+func (w *PlainWriter) Debugf(format string, args ...interface{}) {
+	w.out.Debugf(format, args...)
 	if log.file != nil {
 		log.file.Debugf(format, args...)
 	}
 }
 
 // Info writes a info-level log
-func (*PlainWriter) Info(args ...interface{}) {
-	log.out.Info(args...)
+func (w *PlainWriter) Info(args ...interface{}) {
+	w.out.Info(args...)
 	if log.file != nil {
 		log.file.Info(args...)
 	}
 }
 
 // Infof writes a info-level log with a format
-func (*PlainWriter) Infof(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+func (w *PlainWriter) Infof(format string, args ...interface{}) {
+	w.out.Infof(format, args...)
 	if log.file != nil {
 		log.file.Infof(format, args...)
 	}
 }
 
 // Error writes a error-level log
-func (*PlainWriter) Error(args ...interface{}) {
-	log.out.Error(args...)
+func (w *PlainWriter) Error(args ...interface{}) {
+	w.out.Error(args...)
 	if log.file != nil {
 		log.file.Error(args...)
 	}
 }
 
 // Errorf writes a error-level log with a format
-func (*PlainWriter) Errorf(format string, args ...interface{}) {
-	log.out.Errorf(format, args...)
+func (w *PlainWriter) Errorf(format string, args ...interface{}) {
+	w.out.Errorf(format, args...)
 	if log.file != nil {
 		log.file.Errorf(format, args...)
 	}
 }
 
 // Fatalf writes a error-level log with a format
-func (*PlainWriter) Fatalf(format string, args ...interface{}) {
+func (w *PlainWriter) Fatalf(format string, args ...interface{}) {
 	if log.file != nil {
 		log.file.Errorf(format, args...)
 	}
 
-	log.out.Fatalf(format, args...)
+	w.out.Fatalf(format, args...)
 }
 
 // Green writes a line in green
 func (w *PlainWriter) Green(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Yellow writes a line in yellow
 func (w *PlainWriter) Yellow(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.FPrintln(w.out.Out, fmt.Sprintf(format, args...))
 }
 
 // Success prints a message with the success symbol first, and the text in green
 func (w *PlainWriter) Success(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.Fprintf(w.out.Out, "SUCCESS: %s\n", fmt.Sprintf(format, args...))
 }
 
 // Information prints a message with the information symbol first, and the text in blue
 func (w *PlainWriter) Information(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.Fprintf(w.out.Out, "INFO: %s\n", fmt.Sprintf(format, args...))
 }
 
 // Question prints a message with the question symbol first, and the text in magenta
 func (w *PlainWriter) Question(format string, args ...interface{}) error {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.Fprintf(w.out.Out, "%s %s", questionSymbol, fmt.Sprintf(format, args...))
 	return nil
 }
 
 // Warning prints a message with the warning symbol first, and the text in yellow
 func (w *PlainWriter) Warning(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.Fprintf(w.out.Out, "WARNING: %s\n", fmt.Sprintf(format, args...))
 }
 
 // FWarning prints a message with the warning symbol first, and the text in yellow into an specific writer
 func (w *PlainWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.Fprintf(writer, "WARNING: %s\n", fmt.Sprintf(format, args...))
 }
 
 // Hint prints a message with the text in blue
 func (w *PlainWriter) Hint(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	w.Fprintf(w.out.Out, "%s\n", fmt.Sprintf(format, args...))
 }
 
 // Fail prints a message with the error symbol first, and the text in red
 func (w *PlainWriter) Fail(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	log.out.Info(msg)
+	w.out.Info(msg)
 	w.Fprintf(w.out.Out, "ERROR: %s\n", fmt.Sprintf(format, args...))
 	if msg != "" {
 		msg = convertToJSON(ErrorLevel, log.stage, msg)
@@ -157,7 +157,7 @@ func (w *PlainWriter) Fail(format string, args ...interface{}) {
 // Println writes a line with colors
 func (w *PlainWriter) Println(args ...interface{}) {
 	msg := fmt.Sprint(args...)
-	log.out.Info(msg)
+	w.out.Info(msg)
 	w.FPrintln(w.out.Out, args...)
 	if msg != "" {
 		msg = convertToJSON(InfoLevel, log.stage, msg)
@@ -211,12 +211,12 @@ func (w *PlainWriter) Printf(format string, a ...interface{}) {
 }
 
 //IsInteractive checks if the writer is interactive
-func (*PlainWriter) IsInteractive() bool {
+func (w *PlainWriter) IsInteractive() bool {
 	return false
 }
 
 // AddToBuffer logs into the buffer but does not print anything
-func (*PlainWriter) AddToBuffer(level, format string, a ...interface{}) {
+func (w *PlainWriter) AddToBuffer(level, format string, a ...interface{}) {
 	msg := fmt.Sprintf(format, a...)
 	if msg != "" {
 		msg = convertToJSON(level, log.stage, msg)

--- a/pkg/log/plain.go
+++ b/pkg/log/plain.go
@@ -37,55 +37,55 @@ func newPlainWriter(out *logrus.Logger, file *logrus.Entry) *PlainWriter {
 // Debug writes a debug-level log
 func (w *PlainWriter) Debug(args ...interface{}) {
 	w.out.Debug(args...)
-	if log.file != nil {
-		log.file.Debug(args...)
+	if w.file != nil {
+		w.file.Debug(args...)
 	}
 }
 
 // Debugf writes a debug-level log with a format
 func (w *PlainWriter) Debugf(format string, args ...interface{}) {
 	w.out.Debugf(format, args...)
-	if log.file != nil {
-		log.file.Debugf(format, args...)
+	if w.file != nil {
+		w.file.Debugf(format, args...)
 	}
 }
 
 // Info writes a info-level log
 func (w *PlainWriter) Info(args ...interface{}) {
 	w.out.Info(args...)
-	if log.file != nil {
-		log.file.Info(args...)
+	if w.file != nil {
+		w.file.Info(args...)
 	}
 }
 
 // Infof writes a info-level log with a format
 func (w *PlainWriter) Infof(format string, args ...interface{}) {
 	w.out.Infof(format, args...)
-	if log.file != nil {
-		log.file.Infof(format, args...)
+	if w.file != nil {
+		w.file.Infof(format, args...)
 	}
 }
 
 // Error writes a error-level log
 func (w *PlainWriter) Error(args ...interface{}) {
 	w.out.Error(args...)
-	if log.file != nil {
-		log.file.Error(args...)
+	if w.file != nil {
+		w.file.Error(args...)
 	}
 }
 
 // Errorf writes a error-level log with a format
 func (w *PlainWriter) Errorf(format string, args ...interface{}) {
 	w.out.Errorf(format, args...)
-	if log.file != nil {
-		log.file.Errorf(format, args...)
+	if w.file != nil {
+		w.file.Errorf(format, args...)
 	}
 }
 
 // Fatalf writes a error-level log with a format
 func (w *PlainWriter) Fatalf(format string, args ...interface{}) {
-	if log.file != nil {
-		log.file.Errorf(format, args...)
+	if w.file != nil {
+		w.file.Errorf(format, args...)
 	}
 
 	w.out.Fatalf(format, args...)

--- a/pkg/log/tty.go
+++ b/pkg/log/tty.go
@@ -49,57 +49,57 @@ func (w *TTYWriter) Debug(args ...interface{}) {
 }
 
 // Debugf writes a debug-level log with a format
-func (*TTYWriter) Debugf(format string, args ...interface{}) {
-	log.out.Debugf(format, args...)
+func (w *TTYWriter) Debugf(format string, args ...interface{}) {
+	w.out.Debugf(format, args...)
 	if log.file != nil {
 		log.file.Debugf(format, args...)
 	}
 }
 
 // Info writes a info-level log
-func (*TTYWriter) Info(args ...interface{}) {
-	log.out.Info(args...)
+func (w *TTYWriter) Info(args ...interface{}) {
+	w.out.Info(args...)
 	if log.file != nil {
 		log.file.Info(args...)
 	}
 }
 
 // Infof writes a info-level log with a format
-func (*TTYWriter) Infof(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+func (w *TTYWriter) Infof(format string, args ...interface{}) {
+	w.out.Infof(format, args...)
 	if log.file != nil {
 		log.file.Infof(format, args...)
 	}
 }
 
 // Error writes a error-level log
-func (*TTYWriter) Error(args ...interface{}) {
-	log.out.Error(args...)
+func (w *TTYWriter) Error(args ...interface{}) {
+	w.out.Error(args...)
 	if log.file != nil {
 		log.file.Error(args...)
 	}
 }
 
 // Errorf writes a error-level log with a format
-func (*TTYWriter) Errorf(format string, args ...interface{}) {
-	log.out.Errorf(format, args...)
+func (w *TTYWriter) Errorf(format string, args ...interface{}) {
+	w.out.Errorf(format, args...)
 	if log.file != nil {
 		log.file.Errorf(format, args...)
 	}
 }
 
 // Fatalf writes a error-level log with a format
-func (*TTYWriter) Fatalf(format string, args ...interface{}) {
+func (w *TTYWriter) Fatalf(format string, args ...interface{}) {
 	if log.file != nil {
 		log.file.Errorf(format, args...)
 	}
 
-	log.out.Fatalf(format, args...)
+	w.out.Fatalf(format, args...)
 }
 
 // Green writes a line in green
 func (w *TTYWriter) Green(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.FPrintln(w.out.Out, greenString(format, args...))
 	log.spinner.unhold()
@@ -107,7 +107,7 @@ func (w *TTYWriter) Green(format string, args ...interface{}) {
 
 // Yellow writes a line in yellow
 func (w *TTYWriter) Yellow(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.FPrintln(w.out.Out, yellowString(format, args...))
 	log.spinner.unhold()
@@ -115,7 +115,7 @@ func (w *TTYWriter) Yellow(format string, args ...interface{}) {
 
 // Success prints a message with the success symbol first, and the text in green
 func (w *TTYWriter) Success(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.Fprintf(w.out.Out, "%s %s\n", coloredSuccessSymbol, greenString(format, args...))
 	log.spinner.unhold()
@@ -123,7 +123,7 @@ func (w *TTYWriter) Success(format string, args ...interface{}) {
 
 // Information prints a message with the information symbol first, and the text in blue
 func (w *TTYWriter) Information(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.Fprintf(w.out.Out, "%s %s\n", coloredInformationSymbol, blueString(format, args...))
 	log.spinner.unhold()
@@ -131,7 +131,7 @@ func (w *TTYWriter) Information(format string, args ...interface{}) {
 
 // Question prints a message with the question symbol first, and the text in magenta
 func (w *TTYWriter) Question(format string, args ...interface{}) error {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.Fprintf(w.out.Out, "%s %s", coloredQuestionSymbol, color.MagentaString(format, args...))
 	log.spinner.unhold()
@@ -140,7 +140,7 @@ func (w *TTYWriter) Question(format string, args ...interface{}) error {
 
 // Warning prints a message with the warning symbol first, and the text in yellow
 func (w *TTYWriter) Warning(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.Fprintf(w.out.Out, "%s %s\n", coloredWarningSymbol, yellowString(format, args...))
 	log.spinner.unhold()
@@ -148,7 +148,7 @@ func (w *TTYWriter) Warning(format string, args ...interface{}) {
 
 // FWarning prints a message with the warning symbol first, and the text in yellow into an specific writer
 func (w *TTYWriter) FWarning(writer io.Writer, format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.Fprintf(writer, "%s %s\n", coloredWarningSymbol, yellowString(format, args...))
 	log.spinner.unhold()
@@ -156,7 +156,7 @@ func (w *TTYWriter) FWarning(writer io.Writer, format string, args ...interface{
 
 // Hint prints a message with the text in blue
 func (w *TTYWriter) Hint(format string, args ...interface{}) {
-	log.out.Infof(format, args...)
+	w.out.Infof(format, args...)
 	log.spinner.hold()
 	w.Fprintf(w.out.Out, "%s\n", blueString(format, args...))
 	log.spinner.unhold()
@@ -165,7 +165,7 @@ func (w *TTYWriter) Hint(format string, args ...interface{}) {
 // Fail prints a message with the error symbol first, and the text in red
 func (w *TTYWriter) Fail(format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
-	log.out.Info(msg)
+	w.out.Info(msg)
 	log.spinner.hold()
 	w.Fprintf(w.out.Out, "%s %s\n", coloredErrorSymbol, redString(format, args...))
 	log.spinner.unhold()
@@ -180,7 +180,7 @@ func (w *TTYWriter) Fail(format string, args ...interface{}) {
 
 // Println writes a line with colors
 func (w *TTYWriter) Println(args ...interface{}) {
-	log.out.Info(args...)
+	w.out.Info(args...)
 	log.spinner.hold()
 	w.FPrintln(w.out.Out, args...)
 	log.spinner.unhold()

--- a/pkg/log/tty.go
+++ b/pkg/log/tty.go
@@ -43,55 +43,55 @@ func newTTYWriter(out *logrus.Logger, file *logrus.Entry) *TTYWriter {
 // Debug writes a debug-level log
 func (w *TTYWriter) Debug(args ...interface{}) {
 	w.out.Debug(args...)
-	if log.file != nil {
-		log.file.Debug(args...)
+	if w.file != nil {
+		w.file.Debug(args...)
 	}
 }
 
 // Debugf writes a debug-level log with a format
 func (w *TTYWriter) Debugf(format string, args ...interface{}) {
 	w.out.Debugf(format, args...)
-	if log.file != nil {
-		log.file.Debugf(format, args...)
+	if w.file != nil {
+		w.file.Debugf(format, args...)
 	}
 }
 
 // Info writes a info-level log
 func (w *TTYWriter) Info(args ...interface{}) {
 	w.out.Info(args...)
-	if log.file != nil {
-		log.file.Info(args...)
+	if w.file != nil {
+		w.file.Info(args...)
 	}
 }
 
 // Infof writes a info-level log with a format
 func (w *TTYWriter) Infof(format string, args ...interface{}) {
 	w.out.Infof(format, args...)
-	if log.file != nil {
-		log.file.Infof(format, args...)
+	if w.file != nil {
+		w.file.Infof(format, args...)
 	}
 }
 
 // Error writes a error-level log
 func (w *TTYWriter) Error(args ...interface{}) {
 	w.out.Error(args...)
-	if log.file != nil {
-		log.file.Error(args...)
+	if w.file != nil {
+		w.file.Error(args...)
 	}
 }
 
 // Errorf writes a error-level log with a format
 func (w *TTYWriter) Errorf(format string, args ...interface{}) {
 	w.out.Errorf(format, args...)
-	if log.file != nil {
-		log.file.Errorf(format, args...)
+	if w.file != nil {
+		w.file.Errorf(format, args...)
 	}
 }
 
 // Fatalf writes a error-level log with a format
 func (w *TTYWriter) Fatalf(format string, args ...interface{}) {
-	if log.file != nil {
-		log.file.Errorf(format, args...)
+	if w.file != nil {
+		w.file.Errorf(format, args...)
 	}
 
 	w.out.Fatalf(format, args...)


### PR DESCRIPTION
## Proposed changes

- Use the injected logrus instead of referencing the `log` global variable when possible
