### PR TITLE
Fix prompt dev selector

### DIFF
--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -124,8 +124,8 @@ func (c *ContextCommand) Run(ctx context.Context, ctxOptions *ContextOptions) er
 
 func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error) {
 	ctxs := getContextsSelection(ctxOptions)
-	selector := utils.NewOktetoSelector("A context defines the default cluster/namespace for any Okteto CLI command.\nSelect the context you want to use:", "Context")
-	selector.SetOptions(getSelectorItemsFromContextSelector(ctxs))
+	selectorItems := getSelectorItemsFromContextSelector(ctxs)
+	selector := utils.NewOktetoSelector("A context defines the default cluster/namespace for any Okteto CLI command.\nSelect the context you want to use:", selectorItems, "Context")
 	ctxSelected, err := selector.Ask(ctx)
 	if err != nil {
 		return "", err

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -125,23 +125,22 @@ func (c *ContextCommand) Run(ctx context.Context, ctxOptions *ContextOptions) er
 func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error) {
 	ctxs := getContextsSelection(ctxOptions)
 	selector := utils.NewOktetoSelector("A context defines the default cluster/namespace for any Okteto CLI command.\nSelect the context you want to use:", "Context")
-	selector.Items = ctxs
-	selector.Size = len(ctxs)
-	oktetoContext, isOkteto, err := selector.Ask(ctx)
+	selector.SetOptions(getSelectorItemsFromContextSelector(ctxs))
+	ctxSelected, err := selector.Ask(ctx)
 	if err != nil {
 		return "", err
 	}
-	ctxOptions.IsOkteto = isOkteto
+	ctxOptions.IsOkteto = isOktetoContextSelected(ctxs, ctxSelected)
 
-	if isCreateNewContextOption(oktetoContext) {
-		oktetoContext, err = askForOktetoURL()
+	if isCreateNewContextOption(ctxSelected) {
+		ctxSelected, err = askForOktetoURL()
 		if err != nil {
 			return "", err
 		}
 		ctxOptions.IsOkteto = true
 	}
 
-	return oktetoContext, nil
+	return ctxSelected, nil
 }
 
 func setSecrets(secrets []types.Secret) {

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -124,7 +124,10 @@ func (c *ContextCommand) Run(ctx context.Context, ctxOptions *ContextOptions) er
 
 func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error) {
 	ctxs := getContextsSelection(ctxOptions)
-	oktetoContext, isOkteto, err := utils.AskForOptionsOkteto(ctx, ctxs, "A context defines the default cluster/namespace for any Okteto CLI command.\nSelect the context you want to use:", "Context")
+	selector := utils.NewOktetoSelector("A context defines the default cluster/namespace for any Okteto CLI command.\nSelect the context you want to use:", "Context")
+	selector.Items = ctxs
+	selector.Size = len(ctxs)
+	oktetoContext, isOkteto, err := selector.Ask(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -70,7 +70,8 @@ func Doctor() *cobra.Command {
 					return err
 				}
 
-				selector := utils.NewOktetoSelector("Select the development container you want to generate zip with logs:", "Development container")
+				selectorItems := utils.GetItemsForDevSelector(manifest.Dev)
+				selector := utils.NewOktetoSelector("Select the development container you want to generate zip with logs:", selectorItems, "Development container")
 				dev, err = utils.SelectDevFromManifest(manifest, selector)
 				if err != nil {
 					return err

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
@@ -65,7 +66,15 @@ func Doctor() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+					return err
+				}
+
+				selector := utils.NewOktetoSelector("Select the development container you want to generate zip with logs:", "Development container")
+				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				if err != nil {
+					return err
+				}
 			}
 			filename, err := doctor.Run(ctx, dev, doctorOpts.DevPath, c)
 			if err == nil {

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -66,7 +66,7 @@ func Doctor() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -83,7 +83,8 @@ func Down() *cobra.Command {
 						return err
 					}
 
-					selector := utils.NewOktetoSelector("Select the development container you want to deactivate:", "Development container")
+					selectorItems := utils.GetItemsForDevSelector(manifest.Dev)
+					selector := utils.NewOktetoSelector("Select the development container you want to deactivate:", selectorItems, "Development container")
 					dev, err = utils.SelectDevFromManifest(manifest, selector)
 					if err != nil {
 						return err

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -78,7 +79,15 @@ func Down() *cobra.Command {
 				}
 				dev, err := utils.GetDevFromManifest(manifest, devName)
 				if err != nil {
-					return err
+					if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+						return err
+					}
+
+					selector := utils.NewOktetoSelector("Select the development container you want to deactivate:", "Development container")
+					dev, err = utils.SelectDevFromManifest(manifest, selector)
+					if err != nil {
+						return err
+					}
 				}
 
 				c, _, err := okteto.GetK8sClient()

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -79,7 +79,7 @@ func Down() *cobra.Command {
 				}
 				dev, err := utils.GetDevFromManifest(manifest, devName)
 				if err != nil {
-					if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+					if !errors.Is(err, utils.ErrNoDevSelected) {
 						return err
 					}
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -208,7 +208,8 @@ func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error)
 		if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
 			return nil, err
 		}
-		selector := utils.NewOktetoSelector("Select the development container where you want to execute:", "Development container")
+		selectorItems := utils.GetItemsForDevSelector(manifest.Dev)
+		selector := utils.NewOktetoSelector("Select the development container where you want to execute:", selectorItems, "Development container")
 		dev, err = utils.SelectDevFromManifest(manifest, selector)
 		if err != nil {
 			return nil, err

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -205,7 +205,7 @@ func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error)
 
 	dev, err = utils.GetDevFromManifest(manifest, devName)
 	if err != nil {
-		if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+		if !errors.Is(err, utils.ErrNoDevSelected) {
 			return nil, err
 		}
 		selectorItems := utils.GetItemsForDevSelector(manifest.Dev)

--- a/cmd/manifest/selector.go
+++ b/cmd/manifest/selector.go
@@ -85,19 +85,9 @@ func selectDockerfiles(ctx context.Context, cwd string) ([]string, error) {
 		if len(dockerfiles) == 1 {
 			break
 		}
-		dockerfilesItems := []utils.SelectorItem{}
-		for _, d := range dockerfiles {
-			dockerfilesItems = append(dockerfilesItems, utils.SelectorItem{
-				Name:   d,
-				Label:  d,
-				Enable: true,
-			})
-		}
 
-		selector := utils.NewOktetoSelector("Do you need to build any of the following Dockerfiles as part of your development environment?", "")
-		selector.Items = dockerfilesItems
-		selector.Size = len(dockerfilesItems)
-
+		selectorItems := getDockerfilesSelectorItems(dockerfiles)
+		selector := utils.NewOktetoSelector("Do you need to build any of the following Dockerfiles as part of your development environment?", selectorItems, "")
 		selection, err := selector.Ask(ctx)
 		if err != nil {
 			return nil, err
@@ -133,4 +123,16 @@ func validateDockerfileSelection(dockerfiles []string) error {
 		}
 	}
 	return nil
+}
+
+func getDockerfilesSelectorItems(items []string) []utils.SelectorItem {
+	dockerfilesItems := make([]utils.SelectorItem, len(items))
+	for _, d := range items {
+		dockerfilesItems = append(dockerfilesItems, utils.SelectorItem{
+			Name:   d,
+			Label:  d,
+			Enable: true,
+		})
+	}
+	return dockerfilesItems
 }

--- a/cmd/manifest/selector.go
+++ b/cmd/manifest/selector.go
@@ -98,7 +98,7 @@ func selectDockerfiles(ctx context.Context, cwd string) ([]string, error) {
 		selector.Items = dockerfilesItems
 		selector.Size = len(dockerfilesItems)
 
-		selection, _, err := selector.Ask(ctx)
+		selection, err := selector.Ask(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/manifest/selector.go
+++ b/cmd/manifest/selector.go
@@ -94,8 +94,11 @@ func selectDockerfiles(ctx context.Context, cwd string) ([]string, error) {
 			})
 		}
 
-		selection, _, err := utils.AskForOptionsOkteto(ctx, dockerfilesItems, "Do you need to build any of the following Dockerfiles as part of your development environment?", "")
+		selector := utils.NewOktetoSelector("Do you need to build any of the following Dockerfiles as part of your development environment?", "")
+		selector.Items = dockerfilesItems
+		selector.Size = len(dockerfilesItems)
 
+		selection, _, err := selector.Ask(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -99,8 +99,7 @@ func (nc *NamespaceCommand) getNamespaceFromSelector(ctx context.Context) (strin
 	if err != nil {
 		return "", err
 	}
-	selector := utils.NewOktetoSelector("Select the namespace you want to use:", "Namespace")
-	selector.SetOptions(namespaces)
+	selector := utils.NewOktetoSelector("Select the namespace you want to use:", namespaces, "Namespace")
 
 	ns, err := selector.Ask(ctx)
 	if err != nil {

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -99,7 +99,10 @@ func (nc *NamespaceCommand) getNamespaceFromSelector(ctx context.Context) (strin
 	if err != nil {
 		return "", err
 	}
-	ns, _, err := utils.AskForOptionsOkteto(ctx, namespaces, "Select the namespace you want to use:", "Namespace")
+	selector := utils.NewOktetoSelector("Select the namespace you want to use:", "Namespace")
+	selector.Items = namespaces
+	selector.Size = len(namespaces)
+	ns, _, err := selector.Ask(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -100,9 +100,9 @@ func (nc *NamespaceCommand) getNamespaceFromSelector(ctx context.Context) (strin
 		return "", err
 	}
 	selector := utils.NewOktetoSelector("Select the namespace you want to use:", "Namespace")
-	selector.Items = namespaces
-	selector.Size = len(namespaces)
-	ns, _, err := selector.Ask(ctx)
+	selector.SetOptions(namespaces)
+
+	ns, err := selector.Ask(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -99,7 +99,7 @@ func Push(ctx context.Context) *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -98,7 +99,15 @@ func Push(ctx context.Context) *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+					return err
+				}
+
+				selector := utils.NewOktetoSelector("Select the development container you want to push:", "Development container")
+				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				if err != nil {
+					return err
+				}
 			}
 
 			if len(pushOpts.AppName) > 0 && pushOpts.AppName != dev.Name {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -103,7 +103,8 @@ func Push(ctx context.Context) *cobra.Command {
 					return err
 				}
 
-				selector := utils.NewOktetoSelector("Select the development container you want to push:", "Development container")
+				selectorItems := utils.GetItemsForDevSelector(manifest.Dev)
+				selector := utils.NewOktetoSelector("Select the development container you want to push:", selectorItems, "Development container")
 				dev, err = utils.SelectDevFromManifest(manifest, selector)
 				if err != nil {
 					return err

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -63,7 +63,8 @@ func Restart() *cobra.Command {
 					return err
 				}
 
-				selector := utils.NewOktetoSelector("Select the development container you want to restart:", "Development container")
+				selectorItems := utils.GetItemsForDevSelector(manifest.Dev)
+				selector := utils.NewOktetoSelector("Select the development container you want to restart:", selectorItems, "Development container")
 				dev, err = utils.SelectDevFromManifest(manifest, selector)
 				if err != nil {
 					return err

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -59,7 +59,7 @@ func Restart() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -58,7 +59,15 @@ func Restart() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+					return err
+				}
+
+				selector := utils.NewOktetoSelector("Select the development container you want to restart:", "Development container")
+				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				if err != nil {
+					return err
+				}
 			}
 
 			if len(dev.Services) == 0 {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 	"time"
@@ -62,7 +63,15 @@ func Status() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+					return err
+				}
+
+				selector := utils.NewOktetoSelector("Select the development container you want to check sync status:", "Development container")
+				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				if err != nil {
+					return err
+				}
 			}
 
 			waitForStates := []config.UpState{config.Synchronizing, config.Ready}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -67,7 +67,8 @@ func Status() *cobra.Command {
 					return err
 				}
 
-				selector := utils.NewOktetoSelector("Select the development container you want to check sync status:", "Development container")
+				selectorItems := utils.GetItemsForDevSelector(manifest.Dev)
+				selector := utils.NewOktetoSelector("Select the development container you want to check sync status:", selectorItems, "Development container")
 				dev, err = utils.SelectDevFromManifest(manifest, selector)
 				if err != nil {
 					return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -63,7 +63,7 @@ func Status() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -262,7 +262,7 @@ func Up() *cobra.Command {
 
 			dev, err := utils.GetDevFromManifest(oktetoManifest, upOptions.DevName)
 			if err != nil {
-				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -266,7 +266,8 @@ func Up() *cobra.Command {
 					return err
 				}
 
-				selector := utils.NewOktetoSelector("Select the development container you want to activate:", "Development container")
+				selectorItems := utils.GetItemsForDevSelector(oktetoManifest.Dev)
+				selector := utils.NewOktetoSelector("Select the development container you want to activate:", selectorItems, "Development container")
 				dev, err = utils.SelectDevFromManifest(oktetoManifest, selector)
 				if err != nil {
 					return err

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -262,7 +262,15 @@ func Up() *cobra.Command {
 
 			dev, err := utils.GetDevFromManifest(oktetoManifest, upOptions.DevName)
 			if err != nil {
-				return err
+				if !errors.Is(err, oktetoErrors.ErrNoDevSelected) {
+					return err
+				}
+
+				selector := utils.NewOktetoSelector("Select the development container you want to activate:", "Development container")
+				dev, err = utils.SelectDevFromManifest(oktetoManifest, selector)
+				if err != nil {
+					return err
+				}
 			}
 
 			up.Dev = dev

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -190,12 +190,13 @@ func sortOptions(in []string) {
 	})
 }
 
-func SelectDevFromManifest(manifest *model.Manifest, selector *OktetoSelector) (*model.Dev, error) {
+func getItemsForDevSelector(devs model.ManifestDevs) []SelectorItem {
 	devNames := []string{}
-	for name := range manifest.Dev {
+	for name := range devs {
 		devNames = append(devNames, name)
 	}
 
+	// items get sorted alfabetically
 	sortOptions(devNames)
 
 	items := []SelectorItem{}
@@ -206,8 +207,12 @@ func SelectDevFromManifest(manifest *model.Manifest, selector *OktetoSelector) (
 			Enable: true,
 		})
 	}
-	selector.Items = items
-	selector.Size = len(items)
+	return items
+}
+
+func SelectDevFromManifest(manifest *model.Manifest, selector OktetoSelectorInterface) (*model.Dev, error) {
+	items := getItemsForDevSelector(manifest.Dev)
+	selector.SetOptions(items)
 	devName, _, err := selector.Ask(context.Background())
 	if err != nil {
 		return nil, err

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -211,9 +211,9 @@ func getItemsForDevSelector(devs model.ManifestDevs) []SelectorItem {
 }
 
 func SelectDevFromManifest(manifest *model.Manifest, selector OktetoSelectorInterface) (*model.Dev, error) {
-	items := getItemsForDevSelector(manifest.Dev)
-	selector.SetOptions(items)
-	devName, _, err := selector.Ask(context.Background())
+	selector.SetOptions(getItemsForDevSelector(manifest.Dev))
+
+	devName, err := selector.Ask(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -165,11 +165,7 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 	}
 
 	if devName == "" {
-		selectedDev, err := selectDevFromManifest(manifest, "Select the development container you want to activate:")
-		if err != nil {
-			return nil, err
-		}
-		return selectedDev, nil
+		return nil, oktetoErrors.ErrNoDevSelected
 	}
 
 	// iterate though options to look fot devName and return
@@ -194,7 +190,7 @@ func sortOptions(in []string) {
 	})
 }
 
-func selectDevFromManifest(manifest *model.Manifest, selectionPrompt string) (*model.Dev, error) {
+func SelectDevFromManifest(manifest *model.Manifest, selector *OktetoSelector) (*model.Dev, error) {
 	devNames := []string{}
 	for name := range manifest.Dev {
 		devNames = append(devNames, name)
@@ -210,8 +206,9 @@ func selectDevFromManifest(manifest *model.Manifest, selectionPrompt string) (*m
 			Enable: true,
 		})
 	}
-
-	devName, _, err := AskForOptionsOkteto(context.Background(), items, selectionPrompt, "Development container")
+	selector.Items = items
+	selector.Size = len(items)
+	devName, _, err := selector.Ask(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -15,6 +15,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -33,6 +34,11 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	// ErrNoDevSelected is raised when no development environment is selected
+	ErrNoDevSelected = errors.New("No Development Environment selected")
 )
 
 const (
@@ -165,7 +171,7 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 	}
 
 	if devName == "" {
-		return nil, oktetoErrors.ErrNoDevSelected
+		return nil, ErrNoDevSelected
 	}
 
 	for _, item := range options {

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -168,7 +168,6 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 		return nil, oktetoErrors.ErrNoDevSelected
 	}
 
-	// iterate though options to look fot devName and return
 	for _, item := range options {
 		if item == devName {
 			return manifest.Dev[devName], nil

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -190,7 +190,7 @@ func sortOptions(in []string) {
 	})
 }
 
-func getItemsForDevSelector(devs model.ManifestDevs) []SelectorItem {
+func GetItemsForDevSelector(devs model.ManifestDevs) []SelectorItem {
 	devNames := []string{}
 	for name := range devs {
 		devNames = append(devNames, name)
@@ -211,8 +211,6 @@ func getItemsForDevSelector(devs model.ManifestDevs) []SelectorItem {
 }
 
 func SelectDevFromManifest(manifest *model.Manifest, selector OktetoSelectorInterface) (*model.Dev, error) {
-	selector.SetOptions(getItemsForDevSelector(manifest.Dev))
-
 	devName, err := selector.Ask(context.Background())
 	if err != nil {
 		return nil, err

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -361,8 +361,6 @@ func (fs *FakeSelector) Ask(ctx context.Context) (string, error) {
 	return fs.selected, fs.err
 }
 
-func (fs *FakeSelector) SetOptions(i []SelectorItem) {}
-
 func Test_SelectDevFromManifest(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -519,7 +517,7 @@ func Test_getItemsForDevSelector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			items := getItemsForDevSelector(tt.devs)
+			items := GetItemsForDevSelector(tt.devs)
 			assert.EqualValues(t, tt.expected, items)
 		})
 	}

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -357,7 +357,7 @@ func NewFakeSelector(selected string, err error) *FakeSelector {
 	}
 }
 
-func (fs *FakeSelector) Ask(ctx context.Context) (string, error) {
+func (fs *FakeSelector) Ask(_ context.Context) (string, error) {
 	return fs.selected, fs.err
 }
 

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -287,6 +287,21 @@ func Test_GetDevFromManifest(t *testing.T) {
 			err:     fmt.Errorf(oktetoErrors.ErrDevContainerNotExists, wrongDevName),
 		},
 		{
+			name: "manifest has one dev section and devName is empty",
+			manifest: &model.Manifest{
+				Dev: model.ManifestDevs{
+					"test": &model.Dev{
+						Name: "test",
+					},
+				},
+			},
+			devName: "",
+			dev: &model.Dev{
+				Name: "test",
+			},
+			err: nil,
+		},
+		{
 			name: "manifest has several dev section user introduces wrong one",
 			manifest: &model.Manifest{
 				Dev: model.ManifestDevs{
@@ -302,13 +317,19 @@ func Test_GetDevFromManifest(t *testing.T) {
 			name: "manifest has several dev section user introduces correct one",
 			manifest: &model.Manifest{
 				Dev: model.ManifestDevs{
-					"test":   &model.Dev{},
-					"test-2": &model.Dev{},
+					"test": &model.Dev{
+						Name: "test",
+					},
+					"test-2": &model.Dev{
+						Name: "test-2",
+					},
 				},
 			},
 			devName: "test",
-			dev:     &model.Dev{},
-			err:     nil,
+			dev: &model.Dev{
+				Name: "test",
+			},
+			err: nil,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -357,8 +357,8 @@ func NewFakeSelector(selected string, err error) *FakeSelector {
 	}
 }
 
-func (fs *FakeSelector) Ask(ctx context.Context) (string, bool, error) {
-	return fs.selected, false, fs.err
+func (fs *FakeSelector) Ask(ctx context.Context) (string, error) {
+	return fs.selected, fs.err
 }
 
 func (fs *FakeSelector) SetOptions(i []SelectorItem) {}

--- a/cmd/utils/selector.go
+++ b/cmd/utils/selector.go
@@ -44,7 +44,6 @@ var ErrInvalidOption = errors.New("invalid option")
 
 type OktetoSelectorInterface interface {
 	Ask(ctx context.Context) (string, error)
-	SetOptions(items []SelectorItem)
 }
 
 // OktetoSelector represents the selector
@@ -78,13 +77,15 @@ type SelectorItem struct {
 	Enable bool
 }
 
-func NewOktetoSelector(label string, selectedTpl string) *OktetoSelector {
+func NewOktetoSelector(label string, items []SelectorItem, selectedTpl string) *OktetoSelector {
 	selectedTemplate := getSelectedTemplate(selectedTpl)
 	activeTemplate := getActiveTemplate()
 	inactiveTemplate := getInactiveTemplate()
 
 	return &OktetoSelector{
 		Label: label,
+		Items: items,
+		Size:  len(items),
 		Templates: &promptui.SelectTemplates{
 			Label:    "{{ .Label }}",
 			Selected: selectedTemplate,
@@ -105,12 +106,6 @@ func (s *OktetoSelector) Ask(ctx context.Context) (string, error) {
 	}
 
 	return optionSelected, nil
-}
-
-// Ask given some options ask the user to select one
-func (s *OktetoSelector) SetOptions(items []SelectorItem) {
-	s.Items = items
-	s.Size = len(items)
 }
 
 func isValidOption(options []SelectorItem, optionSelected string) bool {

--- a/cmd/utils/selector.go
+++ b/cmd/utils/selector.go
@@ -44,6 +44,7 @@ var ErrInvalidOption = errors.New("invalid option")
 
 type OktetoSelectorInterface interface {
 	Ask(ctx context.Context) (string, bool, error)
+	SetOptions(items []SelectorItem)
 }
 
 // OktetoSelector represents the selector
@@ -108,6 +109,12 @@ func (s *OktetoSelector) Ask(ctx context.Context) (string, bool, error) {
 	}
 
 	return optionSelected, isOkteto, nil
+}
+
+// Ask given some options ask the user to select one
+func (s *OktetoSelector) SetOptions(items []SelectorItem) {
+	s.Items = items
+	s.Size = len(items)
 }
 
 func isValidOption(options []SelectorItem, optionSelected string) bool {

--- a/cmd/utils/selector.go
+++ b/cmd/utils/selector.go
@@ -332,7 +332,7 @@ func (s *OktetoSelector) prepareTemplates() error {
 	tpls.inactive = tpl
 
 	if s.Templates.Selected == "" {
-		s.Templates.Selected = fmt.Sprintf(`{{ "%s" | green }} {{ . | faint }}`, promptui.IconGood)
+		s.Templates.Selected = fmt.Sprintf(`{{ %q | green }} {{ . | faint }}`, promptui.IconGood)
 	}
 
 	tpl, err = template.New("").Funcs(tpls.FuncMap).Parse(s.Templates.Selected)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -178,6 +178,9 @@ var (
 
 	// ErrCouldNotInferAnyManifest is raised when we can't detect any manifest to load
 	ErrCouldNotInferAnyManifest = errors.New("couldn't detect any manifest (okteto manifest, pipeline, compose, helm chart, k8s manifest)")
+
+	// ErrNoDevSelected is raised when no development environment is selected
+	ErrNoDevSelected = errors.New("No Development Environment selected")
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -179,8 +179,6 @@ var (
 	// ErrCouldNotInferAnyManifest is raised when we can't detect any manifest to load
 	ErrCouldNotInferAnyManifest = errors.New("couldn't detect any manifest (okteto manifest, pipeline, compose, helm chart, k8s manifest)")
 
-	// ErrNoDevSelected is raised when no development environment is selected
-	ErrNoDevSelected = errors.New("No Development Environment selected")
 )
 
 // IsForbidden raised if the Okteto API returns 401


### PR DESCRIPTION
Fixes #2778 

## Proposed changes

- Development container selector was displaying "activate" action on every command, this was wrong as this selector appears at: `down`, `doctor`, `exec`, `push`, `restart`, `status`. Refactored `GetDevFromManifest` and separate the logic between get the dev from manifest and asking for the user to select it by creating new function `SelectDevFromManifest`.
- Refactored OktetoSelector and created NewOktetoSelector to create a new selector with the labels and options for each case. 
- Refactor of SelectorItem: this struct was having fields just used for the context selector in order to return if the selected context was Okteto Context. Moved this logic to the context logic and kept the SelectorItem standard for all the different selectors.
- selector logic now has its own pkg `prompt` which also handles any other input from the user (questions, yes/no questions, etc)
- some format changes have also come up and i've added them to this PR (spaces to func comments)
