### PR TITLE
fix: use specific terminal

### DIFF
--- a/cmd/utils/executor/executor.go
+++ b/cmd/utils/executor/executor.go
@@ -61,7 +61,7 @@ func NewExecutor(output string) *Executor {
 // Execute executes the specified command adding `env` to the execution environment
 func (e *Executor) Execute(cmdInfo model.DeployCommand, env []string) error {
 
-	cmd := exec.Command("bash", "-c", cmdInfo.Command)
+	cmd := exec.Command(cmdInfo.Command)
 	cmd.Env = append(os.Environ(), env...)
 	if err := e.displayer.startCommand(cmd); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #2592 #2820

## Proposed changes
- Use the same terminal as the one executing the main okteto command

## Concerns
Since this is running remote and local I want to make sure it doesn't have any other implications. 

I have been testing in Windows on different terminals and it returns the correct user and we don't have the problem of absolute paths anymore.
<img width="918" alt="Captura de pantalla 2022-08-19 125148" src="https://user-images.githubusercontent.com/25170843/185604499-0d197255-6e9e-4cf4-ad68-d57efe00c0ed.png">

I have also tested on Linux machines and there seems to be no problem, but as this is a change that affects one of the main okteto commands I would like to know your opinion regarding this change.


