### PR TITLE
add warning msg when sanitize dev

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -505,6 +505,9 @@ func (up *upContext) getManifest(path string) (*model.Manifest, error) {
 }
 
 func (up *upContext) start() error {
+	for previousName, newName := range up.Manifest.DevWarnings.SanitizedDevs {
+		oktetoLog.Warning("Service '%s' has been sanitized into '%s'. This may affect discovery service.", previousName, newName)
+	}
 
 	if err := createPIDFile(up.Dev.Namespace, up.Dev.Name); err != nil {
 		oktetoLog.Infof("failed to create pid file for %s - %s: %s", up.Dev.Namespace, up.Dev.Name, err)


### PR DESCRIPTION
Fixes #2888

## Proposed changes

- sanitize devs and store warning. Same approach than`okteto deploy` cmd.
- show warning when `up` sequence starts
