### PR TITLE
Add PreUpdate hook to newSpinner

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -23,9 +23,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
-
-	sp "github.com/briandowns/spinner"
 
 	"github.com/fatih/color"
 	"github.com/google/uuid"
@@ -93,7 +90,6 @@ func init() {
 		successSymbol = color.New(color.BgGreen, color.FgBlack).Sprint(" + ")
 	}
 	Init(logrus.WarnLevel)
-	initSpinnerLog()
 }
 
 // Init configures the logger for the package to use.
@@ -104,12 +100,12 @@ func Init(level logrus.Level) {
 	log.maskedWords = []string{}
 	log.buf = &bytes.Buffer{}
 	log.spinner = &spinnerLogger{
-		sp:             sp.New(sp.CharSets[14], 100*time.Millisecond, sp.WithHiddenCursor(true)),
+		sp:             newSpinner(),
 		spinnerSupport: !loadBool(OktetoDisableSpinnerEnvVar) && IsInteractive(),
 	}
 }
 
-//ConfigureFileLogger configures the file to write
+// ConfigureFileLogger configures the file to write
 func ConfigureFileLogger(dir, version string) {
 	fileLogger := logrus.New()
 	fileLogger.SetFormatter(&logrus.TextFormatter{

--- a/pkg/log/spinner.go
+++ b/pkg/log/spinner.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 	"unicode"
 
 	sp "github.com/briandowns/spinner"
@@ -54,9 +55,9 @@ func (sl *spinnerLogger) unhold() {
 	StartSpinner()
 }
 
-// initSpinnerLog configures the spinner PreUpdate
-func initSpinnerLog() {
-	log.spinner.sp.PreUpdate = func(spinner *sp.Spinner) {
+func newSpinner() *sp.Spinner {
+	spinner := sp.New(sp.CharSets[14], 100*time.Millisecond, sp.WithHiddenCursor(true))
+	spinner.PreUpdate = func(spinner *sp.Spinner) {
 		width, _, _ := term.GetSize(int(os.Stdout.Fd()))
 		if width > 4 && len(spinner.FinalMSG)+2 > width {
 			spinner.Suffix = spinner.FinalMSG[:width-5] + "..."
@@ -64,6 +65,7 @@ func initSpinnerLog() {
 			spinner.Suffix = spinner.FinalMSG
 		}
 	}
+	return spinner
 }
 
 // Spinner sets the text provided as Suffix and FinalMSG of the spinner instance


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

The issue found while testing 2.6 beta:

When we have a spinner that exceeds the terminal width, it starts to repeat the line until it stops. This bug was introduced at https://github.com/okteto/okteto/pull/2994.

Fix: 
When refactoring the spinner logic and add it to the log module, the hook that spinner has `PreUpdate` was not being added when initialising the spinner. This was not checking terminal width when updating the message at the spinner so it was repeating the message along the terminal.

This fix adds the `PreUpdate` hook when instantiating the spinner with a new func `newSpinner` this way is attached to the spinner since the spinner is created. 
