### PR TITLE
fix: delete te wrong folder

### DIFF
--- a/cmd/context/delete_test.go
+++ b/cmd/context/delete_test.go
@@ -16,9 +16,11 @@ package context
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/okteto/okteto/internal/test"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 )
 
@@ -65,6 +67,7 @@ func Test_deleteContext(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer os.Remove(file)
+			t.Setenv(model.OktetoHomeEnvVar, filepath.Dir(file))
 			okteto.CurrentStore = tt.ctxStore
 			if err := Delete(ctx, tt.toDelete); err == nil && tt.expectedErr || err != nil && !tt.expectedErr {
 				t.Fatal(err)


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

Fixes #3010 

## Proposed changes
- Fixes `okteto context delete` to remove the temporal dir instead of the one used for production
