### PR TITLE
fix: warn when a secret is being overridden by local-env

### DIFF
--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -143,9 +143,11 @@ func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error)
 
 func setSecrets(secrets []types.Secret) {
 	for _, secret := range secrets {
-		if _, exists := os.LookupEnv(secret.Name); !exists {
-			os.Setenv(secret.Name, secret.Value)
-			oktetoLog.AddMaskedWord(secret.Value)
+		if _, exists := os.LookupEnv(secret.Name); exists {
+			oktetoLog.Warning("$%s secret is being overridden by a local environment variable by the same name.", secret.Name)
+			continue
 		}
+		os.Setenv(secret.Name, secret.Value)
+		oktetoLog.AddMaskedWord(secret.Value)
 	}
 }

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -143,8 +143,9 @@ func getContext(ctx context.Context, ctxOptions *ContextOptions) (string, error)
 
 func setSecrets(secrets []types.Secret) {
 	for _, secret := range secrets {
-		if _, exists := os.LookupEnv(secret.Name); exists {
+		if value, exists := os.LookupEnv(secret.Name); exists {
 			oktetoLog.Warning("$%s secret is being overridden by a local environment variable by the same name.", secret.Name)
+			oktetoLog.AddMaskedWord(value)
 			continue
 		}
 		os.Setenv(secret.Name, secret.Value)


### PR DESCRIPTION
Signed-off-by: Oded Lazar <odedl@talon-sec.com>

Fixes issue #2963

 - Warn when a local env variable overrides a secret
 - Mask the local env value since it's probably a secret :)

<img width="930" alt="image" src="https://user-images.githubusercontent.com/2660175/186225688-6e17b5ef-cc60-4cbe-966f-cec19f8c9082.png">


