### PR TITLE
Fix dev selector typo

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -69,7 +69,7 @@ func Doctor() *cobra.Command {
 				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
-				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want download logs:")
+				dev, err = utils.SelectDevFromManifest(manifest, "Select which development container's logs to download:")
 				if err != nil {
 					return err
 				}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//doctorOptions refers to all the options that can be passed to Doctor command
+// doctorOptions refers to all the options that can be passed to Doctor command
 type doctorOptions struct {
 	DevPath    string
 	Namespace  string

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
@@ -65,7 +66,13 @@ func Doctor() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, utils.ErrNoDevSelected) {
+					return err
+				}
+				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want download logs:")
+				if err != nil {
+					return err
+				}
 			}
 			filename, err := doctor.Run(ctx, dev, doctorOpts.DevPath, c)
 			if err == nil {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -78,7 +79,13 @@ func Down() *cobra.Command {
 				}
 				dev, err := utils.GetDevFromManifest(manifest, devName)
 				if err != nil {
-					return err
+					if !errors.Is(err, utils.ErrNoDevSelected) {
+						return err
+					}
+					dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want to deactivate:")
+					if err != nil {
+						return err
+					}
 				}
 
 				c, _, err := okteto.GetK8sClient()

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -82,7 +82,7 @@ func Down() *cobra.Command {
 					if !errors.Is(err, utils.ErrNoDevSelected) {
 						return err
 					}
-					dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want to deactivate:")
+					dev, err = utils.SelectDevFromManifest(manifest, "Select which development container to deactivate:")
 					if err != nil {
 						return err
 					}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -193,7 +193,7 @@ func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error)
 	defer oktetoLog.StopSpinner()
 
 	devName := ""
-	if len(args) == 1 || manifest.Dev.HasDev(args[0]) {
+	if len(args) != 1 || manifest.Dev.HasDev(args[0]) {
 		devName = args[0]
 	}
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -191,15 +192,17 @@ func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error)
 	oktetoLog.StartSpinner()
 	defer oktetoLog.StopSpinner()
 
-	var dev *model.Dev
-	var err error
-	if len(args) == 1 || !manifest.Dev.HasDev(args[0]) {
-		dev, err = utils.GetDevFromManifest(manifest, "")
-		if err != nil {
+	devName := ""
+	if len(args) == 1 || manifest.Dev.HasDev(args[0]) {
+		devName = args[0]
+	}
+
+	dev, err := utils.GetDevFromManifest(manifest, devName)
+	if err != nil {
+		if !errors.Is(err, utils.ErrNoDevSelected) {
 			return nil, err
 		}
-	} else {
-		dev, err = utils.GetDevFromManifest(manifest, args[0])
+		dev, err = utils.SelectDevFromManifest(manifest, "Select the development container where you want to exec:")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -202,7 +202,7 @@ func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error)
 		if !errors.Is(err, utils.ErrNoDevSelected) {
 			return nil, err
 		}
-		dev, err = utils.SelectDevFromManifest(manifest, "Select the development container where you want to exec:")
+		dev, err = utils.SelectDevFromManifest(manifest, "Select which development container to exec:")
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -14,9 +14,10 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/okteto/okteto/cmd/utils"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -72,14 +73,16 @@ func TestGetDevFromArgs(t *testing.T) {
 			},
 			args:        []string{"not-api", "autocreate"},
 			expectedDev: nil,
-			expectedErr: utils.ErrInvalidOption,
+			expectedErr: fmt.Errorf(oktetoErrors.ErrDevContainerNotExists, "not-api"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dev, err := getDevFromArgs(tt.manifest, tt.args)
 			assert.Equal(t, tt.expectedDev, dev)
-			assert.ErrorIs(t, err, tt.expectedErr)
+			if err != nil {
+				assert.Error(t, err, tt.expectedErr.Error())
+			}
 		})
 	}
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -98,7 +99,13 @@ func Push(ctx context.Context) *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, utils.ErrNoDevSelected) {
+					return err
+				}
+				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container where you want to push:")
+				if err != nil {
+					return err
+				}
 			}
 
 			if len(pushOpts.AppName) > 0 && pushOpts.AppName != dev.Name {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-//pushOptions refers to all the options that can be passed to Push command
+// pushOptions refers to all the options that can be passed to Push command
 type pushOptions struct {
 	DevPath    string
 	Namespace  string

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -102,7 +102,7 @@ func Push(ctx context.Context) *cobra.Command {
 				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
-				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container where you want to push:")
+				dev, err = utils.SelectDevFromManifest(manifest, "Select which development container to push to:")
 				if err != nil {
 					return err
 				}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -62,7 +62,7 @@ func Restart() *cobra.Command {
 				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
-				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want to restart:")
+				dev, err = utils.SelectDevFromManifest(manifest, "Select which development container to restart:")
 				if err != nil {
 					return err
 				}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -58,7 +59,13 @@ func Restart() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, utils.ErrNoDevSelected) {
+					return err
+				}
+				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want to restart:")
+				if err != nil {
+					return err
+				}
 			}
 
 			if len(dev.Services) == 0 {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 	"time"
@@ -62,7 +63,13 @@ func Status() *cobra.Command {
 			}
 			dev, err := utils.GetDevFromManifest(manifest, devName)
 			if err != nil {
-				return err
+				if !errors.Is(err, utils.ErrNoDevSelected) {
+					return err
+				}
+				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want to get sync status:")
+				if err != nil {
+					return err
+				}
 			}
 
 			waitForStates := []config.UpState{config.Synchronizing, config.Ready}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -66,7 +66,7 @@ func Status() *cobra.Command {
 				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
-				dev, err = utils.SelectDevFromManifest(manifest, "Select the development container you want to get sync status:")
+				dev, err = utils.SelectDevFromManifest(manifest, "Select which development container's sync status is needed:")
 				if err != nil {
 					return err
 				}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -265,7 +265,7 @@ func Up() *cobra.Command {
 				if !errors.Is(err, utils.ErrNoDevSelected) {
 					return err
 				}
-				dev, err = utils.SelectDevFromManifest(oktetoManifest, "Select the development container you want to activate:")
+				dev, err = utils.SelectDevFromManifest(oktetoManifest, "Select which development container to activate:")
 				if err != nil {
 					return err
 				}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -262,7 +262,13 @@ func Up() *cobra.Command {
 
 			dev, err := utils.GetDevFromManifest(oktetoManifest, upOptions.DevName)
 			if err != nil {
-				return err
+				if !errors.Is(err, utils.ErrNoDevSelected) {
+					return err
+				}
+				dev, err = utils.SelectDevFromManifest(oktetoManifest, "Select the development container you want to activate:")
+				if err != nil {
+					return err
+				}
 			}
 
 			up.Dev = dev

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -15,6 +15,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -33,6 +34,11 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	// ErrNoDevSelected is raised when no development environment is selected
+	ErrNoDevSelected = errors.New("No Development Environment selected")
 )
 
 const (

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -42,7 +42,7 @@ var (
 )
 
 const (
-	//DefaultManifest default okteto manifest file
+	// DefaultManifest default okteto manifest file
 	DefaultManifest   = "okteto.yml"
 	secondaryManifest = "okteto.yaml"
 )

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -185,6 +185,7 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 	}
 }
 
+// SelectDevFromManifest prompts the selector to choose a development container and returns the dev selected or error
 func SelectDevFromManifest(manifest *model.Manifest, label string) (*model.Dev, error) {
 	devs := []string{}
 	for k := range manifest.Dev {

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -60,7 +60,7 @@ func LoadManifestContext(devPath string) (*model.ContextResource, error) {
 	return model.GetContextResource(devPath)
 }
 
-//LoadManifest loads an okteto manifest checking "yml" and "yaml"
+// LoadManifest loads an okteto manifest checking "yml" and "yaml"
 func LoadManifest(devPath string) (*model.Manifest, error) {
 	if !filesystem.FileExists(devPath) {
 		if devPath == DefaultManifest {
@@ -127,7 +127,7 @@ func LoadManifestRc(dev *model.Dev) error {
 	return nil
 }
 
-//LoadManifestOrDefault loads an okteto manifest or a default one if does not exist
+// LoadManifestOrDefault loads an okteto manifest or a default one if does not exist
 func LoadManifestOrDefault(devPath, name string) (*model.Manifest, error) {
 	dev, err := LoadManifest(devPath)
 	if err == nil {
@@ -226,7 +226,7 @@ func SelectDevFromManifest(manifest *model.Manifest, label string) (*model.Dev, 
 	return manifest.Dev[devKey], nil
 }
 
-//AskYesNo prompts for yes/no confirmation
+// AskYesNo prompts for yes/no confirmation
 func AskYesNo(q string) (bool, error) {
 	var answer string
 	for {
@@ -278,7 +278,7 @@ func AskForOptions(options []string, label string) (string, error) {
 	return options[i], nil
 }
 
-//AskIfOktetoInit asks if okteto init should be executed
+// AskIfOktetoInit asks if okteto init should be executed
 func AskIfOktetoInit(devPath string) bool {
 	result, err := AskYesNo(fmt.Sprintf("okteto manifest (%s) doesn't exist, do you want to create it? [y/n] ", devPath))
 	if err != nil {
@@ -299,7 +299,7 @@ func AsksQuestion(q string) (string, error) {
 	return answer, nil
 }
 
-//AskIfDeploy asks if a new deployment must be created
+// AskIfDeploy asks if a new deployment must be created
 func AskIfDeploy(name, namespace string) error {
 	deploy, err := AskYesNo(fmt.Sprintf("Deployment %s doesn't exist in namespace %s. Do you want to create a new one? [y/n]: ", name, namespace))
 	if err != nil {
@@ -314,7 +314,7 @@ func AskIfDeploy(name, namespace string) error {
 	return nil
 }
 
-//ParseURL validates a URL
+// ParseURL validates a URL
 func ParseURL(u string) (string, error) {
 	url, err := url.Parse(u)
 	if err != nil {
@@ -328,7 +328,7 @@ func ParseURL(u string) (string, error) {
 	return strings.TrimRight(url.String(), "/"), nil
 }
 
-//CheckIfDirectory checks if a path is a directory
+// CheckIfDirectory checks if a path is a directory
 func CheckIfDirectory(path string) error {
 	fileInfo, err := os.Stat(path)
 	if err != nil {
@@ -341,7 +341,7 @@ func CheckIfDirectory(path string) error {
 	return fmt.Errorf("'%s' is not a directory", path)
 }
 
-//CheckIfRegularFile checks if a path is a regular file
+// CheckIfRegularFile checks if a path is a regular file
 func CheckIfRegularFile(path string) error {
 	fileInfo, err := os.Stat(path)
 	if err != nil {

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -168,19 +168,24 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 		}
 	}
 
-	if devName != "" {
-		options := []string{}
-		for k := range manifest.Dev {
-			if k == devName {
-				return manifest.Dev[devName], nil
-			}
-			options = append(options, k)
-		}
-		return nil, oktetoErrors.UserError{
-			E:    fmt.Errorf(oktetoErrors.ErrDevContainerNotExists, devName),
-			Hint: fmt.Sprintf("Available options are: [%s]", strings.Join(options, ", ")),
-		}
+	if devName == "" {
+		return nil, ErrNoDevSelected
 	}
+
+	options := []string{}
+	for k := range manifest.Dev {
+		if k == devName {
+			return manifest.Dev[devName], nil
+		}
+		options = append(options, k)
+	}
+	return nil, oktetoErrors.UserError{
+		E:    fmt.Errorf(oktetoErrors.ErrDevContainerNotExists, devName),
+		Hint: fmt.Sprintf("Available options are: [%s]", strings.Join(options, ", ")),
+	}
+}
+
+func SelectDevFromManifest(manifest *model.Manifest, label string) (*model.Dev, error) {
 	devs := []string{}
 	for k := range manifest.Dev {
 		devs = append(devs, k)
@@ -200,7 +205,7 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 			Enable: true,
 		})
 	}
-	devKey, _, err := AskForOptionsOkteto(context.Background(), items, "Select the development container you want to activate:", "Development container")
+	devKey, _, err := AskForOptionsOkteto(context.Background(), items, label, "Development container")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -311,7 +311,7 @@ func Test_GetDevFromManifest(t *testing.T) {
 			err:     nil,
 		},
 		{
-			name: "manifest has one dev section and user intrudices empty devName",
+			name: "manifest has one dev section and user introduces empty devName",
 			manifest: &model.Manifest{
 				Dev: model.ManifestDevs{
 					"test": &model.Dev{},
@@ -322,7 +322,7 @@ func Test_GetDevFromManifest(t *testing.T) {
 			err:     nil,
 		},
 		{
-			name: "manifest has several dev section user introduces emtpy devName",
+			name: "manifest has several dev section user introduces empty devName",
 			manifest: &model.Manifest{
 				Dev: model.ManifestDevs{
 					"test":   &model.Dev{},

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -310,6 +310,29 @@ func Test_GetDevFromManifest(t *testing.T) {
 			dev:     &model.Dev{},
 			err:     nil,
 		},
+		{
+			name: "manifest has one dev section and user intrudices empty devName",
+			manifest: &model.Manifest{
+				Dev: model.ManifestDevs{
+					"test": &model.Dev{},
+				},
+			},
+			devName: "",
+			dev:     &model.Dev{},
+			err:     nil,
+		},
+		{
+			name: "manifest has several dev section user introduces emtpy devName",
+			manifest: &model.Manifest{
+				Dev: model.ManifestDevs{
+					"test":   &model.Dev{},
+					"test-2": &model.Dev{},
+				},
+			},
+			devName: "",
+			dev:     nil,
+			err:     ErrNoDevSelected,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #2778 

## Proposed changes

- Separate selection logic from GetDevFromManifest. This function will though an error (ErrNoDevSelected) if devName is empty and manifest has multiple devs defined.
- new SelectDevFromManifest fallback function when err is ErrNoDevSelected, where label is a param that represents the question of the selector
