### PR TITLE
Add a flag to show a specific field in `okteto context show`

### DIFF
--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -56,6 +56,7 @@ func Show() *cobra.Command {
 			}
 			ctxStore := okteto.ContextStore()
 			current := ctxStore.Contexts[ctxStore.CurrentContext]
+			current.Certificate = ""
 
 			if err := validateOutput(output); err != nil {
 				return err
@@ -65,7 +66,6 @@ func Show() *cobra.Command {
 				return printContextMember(current, args[0], output)
 			}
 
-			current.Certificate = ""
 			switch output {
 			case "json":
 				bytes, err := json.MarshalIndent(current, "", "  ")

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -17,12 +17,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
-	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -31,17 +30,13 @@ import (
 const hintUrl = "https://okteto.com/docs/reference/cli/#show"
 
 func printContextMember(ctx *okteto.OktetoContext, key string) error {
-	element := reflect.ValueOf(ctx).Elem()
-	for i := 0; i < element.NumField(); i++ {
-		if strings.EqualFold(element.Type().Field(i).Name, key) {
-			memberValue := fmt.Sprintf("%v", element.Field(i).Interface())
-			oktetoLog.Println(memberValue)
-			return nil
-		}
+	if value, ok := model.GetFieldValueByTag(ctx, key, "json"); ok {
+		oktetoLog.Println(value)
+		return nil
 	}
 
 	return oktetoErrors.UserError{
-		E:    fmt.Errorf("unknown context key: '%s'", key),
+		E:    fmt.Errorf("unknown context key: %s", key),
 		Hint: hintUrl,
 	}
 }

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -31,11 +31,11 @@ import (
 const hintUrl = "https://okteto.com/docs/reference/cli/#show"
 
 func printContextMember(ctx *okteto.OktetoContext, key string) error {
-	val := reflect.ValueOf(ctx).Elem()
-	for i := 0; i < val.NumField(); i++ {
-		if strings.EqualFold(val.Type().Field(i).Name, key) {
-			val := fmt.Sprintf("%v", val.Field(i).Interface())
-			oktetoLog.Println(val)
+	element := reflect.ValueOf(ctx).Elem()
+	for i := 0; i < element.NumField(); i++ {
+		if strings.EqualFold(element.Type().Field(i).Name, key) {
+			memberValue := fmt.Sprintf("%v", element.Field(i).Interface())
+			oktetoLog.Println(memberValue)
 			return nil
 		}
 	}

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -29,8 +29,8 @@ import (
 
 const hintUrl = "https://okteto.com/docs/reference/cli/#show"
 
-func printContextMember(ctx *okteto.OktetoContext, key string) error {
-	if value, ok := model.GetFieldValueByTag(ctx, key, "json"); ok {
+func printContextMember(ctx *okteto.OktetoContext, key string, tag string) error {
+	if value, ok := model.GetFieldValueByTag(ctx, key, tag); ok {
 		oktetoLog.Println(value)
 		return nil
 	}
@@ -57,12 +57,12 @@ func Show() *cobra.Command {
 			ctxStore := okteto.ContextStore()
 			current := ctxStore.Contexts[ctxStore.CurrentContext]
 
-			if len(args) == 1 {
-				return printContextMember(current, args[0])
-			}
-
 			if err := validateOutput(output); err != nil {
 				return err
+			}
+
+			if len(args) == 1 {
+				return printContextMember(current, args[0], output)
 			}
 
 			current.Certificate = ""

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -144,4 +145,26 @@ func pathExistsAndDir(path string) bool {
 		return false
 	}
 	return info.IsDir()
+}
+
+func GetFieldValueByTag[T any](obj *T, key string, tagKey string) (any, bool) {
+	element := reflect.ValueOf(obj).Elem()
+	for i := 0; i < element.NumField(); i++ {
+		tag, ok := element.Type().Field(i).Tag.Lookup(tagKey)
+		if (!ok) {
+			continue
+		}
+
+		name := strings.Split(tag, ",")[0]
+
+		// ignore omitted fields
+		if (name == "-") {
+			continue
+		}
+
+		if strings.EqualFold(name, key) {
+			return element.Field(i).Interface(), true
+		}
+	}
+	return nil, false
 }

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -17,6 +17,49 @@ import (
 	"testing"
 )
 
+func Test_getFieldValueByTag(t *testing.T) {
+	newCar := struct {
+		Name              string               `json:"name" yaml:"yamlName,omitempty"`
+		Flag              bool               `json:"flag" yaml:"yamlFlag,omitempty"`
+	}{
+		Name:    "Okteto",
+		Flag: true,
+	}
+
+	var tests = []struct {
+		name     string
+		fieldName string
+		tag string
+		shouldExist bool
+		expected any
+	}{
+		{name: "get string from struct [json tag]", fieldName: "name", tag: "json", shouldExist: true, expected: "Okteto"},
+		{name: "get boolean from struct [json tag]", fieldName: "flag", tag: "json", shouldExist: true,expected: true},
+		{name: "get missing key from struct [json tag]", fieldName: "missing-key", shouldExist: false, tag: "json"},
+		{name: "get string from struct [yaml tag]", fieldName: "yamlName", tag: "yaml", shouldExist: true,expected: "Okteto"},
+		{name: "get boolean from struct [yaml tag]", fieldName: "yamlFlag", tag: "yaml", shouldExist: true,expected: true},
+		{name: "get missing key from struct [yaml tag]", fieldName: "missing-key", shouldExist: false, tag: "yaml"},
+		{name: "get unknown key from unknown tag", fieldName: "unknown-key", tag: "unknown-tag", shouldExist: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, ok := GetFieldValueByTag(&newCar, tt.fieldName, tt.tag)
+			if !ok && tt.shouldExist {
+				t.Errorf("%s: couldn't find key: '%s'", tt.name, tt.fieldName)
+			}
+			
+			if ok && !tt.shouldExist {
+				t.Errorf("%s: found a key that doesn't exist: '%s'", tt.name, tt.fieldName)
+			}
+
+			if ok && actual != tt.expected {
+				t.Errorf("'%s' got '%v' expected: '%v'", tt.name, actual, tt.expected)
+			}
+		})
+	}
+}
+
 func Test_GetValidNameFromFolder(t *testing.T) {
 	var tests = []struct {
 		name     string


### PR DESCRIPTION
Signed-off-by: Oded Lazar <odedl@talon-sec.com>

## Proposed changes

`okteto context show` prints the entire context to `stdout`. In some scenarios this is unwanted. For example, we have an automation that uses the context to infer the `namespace`. We use `jq` to extract the field we want, but that incurs an added dependency.

This PR adds a flag to `okteto context show` which is the key of the context. example:

![image](https://user-images.githubusercontent.com/2660175/186492569-7f00d4e3-fa32-47e9-bb6d-99fb77057dc3.png)


