### PR TITLE
Log syncthing api error before return

### DIFF
--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -55,16 +55,17 @@ func (s *Syncthing) APICall(ctx context.Context, url, method string, code int, p
 				return result, nil
 			}
 
-			if retries >= maxRetries {
-				return nil, err
-			}
-			retries++
-
 			if strings.Contains(err.Error(), "connection refused") {
 				oktetoLog.Infof("syncthing is not ready, retrying local=%t", local)
 			} else {
 				oktetoLog.Infof("retrying syncthing call[%s] local=%t: %s", url, local, err.Error())
 			}
+
+			if retries >= maxRetries {
+				return nil, err
+			}
+			retries++
+
 		case <-ctx.Done():
 			oktetoLog.Infof("call to syncthing.APICall %s canceled", url)
 			return nil, ctx.Err()

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -368,6 +368,7 @@ func (s *Syncthing) Ping(ctx context.Context, local bool) bool {
 	if strings.Contains(err.Error(), "Client.Timeout") {
 		return true
 	}
+	oktetoLog.Infof("error pinging syncthing: %s", err.Error())
 	return false
 }
 


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

We aren't logging the synching error if `retries` is 0, as happens for the `ping` syncthing call. This is preventing us from troubleshooting synching connectivity issues