### PR TITLE
TrackReconnect new param to track dev pod recreation

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -126,9 +126,11 @@ func (up *upContext) activate() error {
 	}
 
 	if up.isRetry {
-		// isDevPodRecreated if the pod UID has changed from last retry
-		isDevPodRecreated := lastPodUID != up.Pod.UID
-		analytics.TrackReconnect(true, isDevPodRecreated)
+		cause := analytics.ReconnectCauseDefault
+		if lastPodUID != up.Pod.UID {
+			cause = analytics.ReconnectCauseDevPodRecreated
+		}
+		analytics.TrackReconnect(true, cause)
 	}
 
 	up.isRetry = true

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -109,10 +109,10 @@ func (up *upContext) activate() error {
 		return err
 	}
 
-	var retryPodUID types.UID
+	var lastPodUID types.UID
 	if up.Pod != nil {
-		// keep the original up.Pod.UID before devMode starts
-		retryPodUID = up.Pod.UID
+		// if up.Pod exists save the UID before devMode to compare when retry
+		lastPodUID = up.Pod.UID
 	}
 
 	if err := up.devMode(ctx, app, create); err != nil {
@@ -126,7 +126,8 @@ func (up *upContext) activate() error {
 	}
 
 	if up.isRetry {
-		isDevPodRecreated := retryPodUID != up.Pod.UID
+		// isDevPodRecreated if the pod UID has changed from last retry
+		isDevPodRecreated := lastPodUID != up.Pod.UID
 		analytics.TrackReconnect(true, isDevPodRecreated)
 	}
 

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -130,6 +130,14 @@ func TrackPreviewDestroy(success bool) {
 	track(previewDestroyEvent, success, nil)
 }
 
+const (
+	// ReconnectCauseDefault is the default cause for a reconnection
+	ReconnectCauseDefault = "unrecognised"
+
+	// ReconnectCauseDevPodRecreated is cause when pods UID change between retrys
+	ReconnectCauseDevPodRecreated = "dev-pod-recreated"
+)
+
 // TrackReconnect sends a tracking event to mixpanel when the development container reconnect
 func TrackReconnect(success bool, isDevPodRecreated bool) {
 	props := map[string]interface{}{

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -131,8 +131,11 @@ func TrackPreviewDestroy(success bool) {
 }
 
 // TrackReconnect sends a tracking event to mixpanel when the development container reconnect
-func TrackReconnect(success bool) {
-	track(reconnectEvent, success, nil)
+func TrackReconnect(success bool, isDevPodRecreated bool) {
+	props := map[string]interface{}{
+		"isDevPodRecreated": isDevPodRecreated,
+	}
+	track(reconnectEvent, success, props)
 }
 
 // TrackSyncError sends a tracking event to mixpanel when the init sync fails

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -139,9 +139,9 @@ const (
 )
 
 // TrackReconnect sends a tracking event to mixpanel when the development container reconnect
-func TrackReconnect(success bool, isDevPodRecreated bool) {
+func TrackReconnect(success bool, cause string) {
 	props := map[string]interface{}{
-		"isDevPodRecreated": isDevPodRecreated,
+		"cause": cause,
 	}
 	track(reconnectEvent, success, props)
 }


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

Resolves #3046 

## Proposed changes

- added new param to TrackReconnect
- isDepPodRecreated as cause for retry

## Test
- run `okteto up` 
- while being in sync session with dev container, kill dev pod
- when reconnecting the tracking of this event should have the reason for reconnection
