### PR TITLE
Okteto down and exec selector only active options

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -70,7 +70,7 @@ func Doctor() *cobra.Command {
 					return err
 				}
 				selector := utils.NewOktetoSelector("Select which development container's logs to download:", "Development container")
-				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
 				if err != nil {
 					return err
 				}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -83,7 +83,7 @@ func Down() *cobra.Command {
 						return err
 					}
 					selector := utils.NewOktetoSelector("Select which development container to deactivate:", "Development container")
-					dev, err = utils.SelectDevFromManifest(manifest, selector)
+					dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
 					if err != nil {
 						return err
 					}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -92,6 +92,7 @@ func Down() *cobra.Command {
 
 					if len(options) < 1 {
 						oktetoLog.Success("All development containers are deactivated")
+						return nil
 					}
 					dev, err = utils.SelectDevFromManifest(manifest, selector, options)
 					if err != nil {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -90,7 +90,7 @@ func Down() *cobra.Command {
 					selector := utils.NewOktetoSelector("Select which development container to deactivate:", "Development container")
 					options := apps.ListDevModeOn(ctx, manifest, c)
 
-					if len(options) < 1 {
+					if len(options) == 0 {
 						oktetoLog.Success("All development containers are deactivated")
 						return nil
 					}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -88,7 +88,14 @@ func Down() *cobra.Command {
 						return err
 					}
 					selector := utils.NewOktetoSelector("Select which development container to deactivate:", "Development container")
-					dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
+					options, err := apps.ListDevModeOn(ctx, manifest.Namespace, c)
+					if err != nil {
+						return err
+					}
+					if len(options) < 1 {
+						oktetoLog.Success("All development containers are deactivated")
+					}
+					dev, err = utils.SelectDevFromManifest(manifest, selector, options)
 					if err != nil {
 						return err
 					}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -88,10 +88,8 @@ func Down() *cobra.Command {
 						return err
 					}
 					selector := utils.NewOktetoSelector("Select which development container to deactivate:", "Development container")
-					options, err := apps.ListDevModeOn(ctx, manifest.Namespace, c)
-					if err != nil {
-						return err
-					}
+					options := apps.ListDevModeOn(ctx, manifest, c)
+
 					if len(options) < 1 {
 						oktetoLog.Success("All development containers are deactivated")
 					}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -64,6 +64,11 @@ func Down() *cobra.Command {
 				return err
 			}
 
+			c, _, err := okteto.GetK8sClient()
+			if err != nil {
+				return err
+			}
+
 			if all {
 				err := allDown(ctx, manifest, rm)
 				if err != nil {
@@ -87,11 +92,6 @@ func Down() *cobra.Command {
 					if err != nil {
 						return err
 					}
-				}
-
-				c, _, err := okteto.GetK8sClient()
-				if err != nil {
-					return err
 				}
 
 				app, _, err := utils.GetApp(ctx, dev, c, false)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -61,7 +61,23 @@ func Exec() *cobra.Command {
 				return err
 			}
 
-			dev, err := getDevFromArgs(manifest, args)
+			c, _, err := okteto.GetK8sClient()
+			if err != nil {
+				return err
+			}
+
+			activeDevMode, err := apps.ListDevModeOn(ctx, manifest.Namespace, c)
+			if err != nil {
+				return err
+			}
+			if len(activeDevMode) < 1 {
+				return oktetoErrors.UserError{
+					E:    fmt.Errorf("development containers not found in namespace '%s'", manifest.Namespace),
+					Hint: "Run 'okteto up' to launch your development container or use 'okteto context' to change your current context",
+				}
+			}
+
+			dev, err := getDevFromArgs(manifest, args, activeDevMode)
 			if err != nil {
 				return err
 			}
@@ -187,7 +203,7 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 	return exec.Exec(ctx, c, cfg, dev.Namespace, pod.Name, dev.Container, true, os.Stdin, os.Stdout, os.Stderr, wrapped)
 }
 
-func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error) {
+func getDevFromArgs(manifest *model.Manifest, args, activeDevMode []string) (*model.Dev, error) {
 	oktetoLog.Spinner("Selecting dev manifest")
 	oktetoLog.StartSpinner()
 	defer oktetoLog.StopSpinner()
@@ -203,7 +219,7 @@ func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error)
 			return nil, err
 		}
 		selector := utils.NewOktetoSelector("Select which development container to exec:", "Development container")
-		dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
+		dev, err = utils.SelectDevFromManifest(manifest, selector, activeDevMode)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -66,10 +66,7 @@ func Exec() *cobra.Command {
 				return err
 			}
 
-			activeDevMode, err := apps.ListDevModeOn(ctx, manifest.Namespace, c)
-			if err != nil {
-				return err
-			}
+			activeDevMode := apps.ListDevModeOn(ctx, manifest, c)
 			if len(activeDevMode) < 1 {
 				return oktetoErrors.UserError{
 					E:    fmt.Errorf("development containers not found in namespace '%s'", manifest.Namespace),

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -203,7 +203,7 @@ func getDevFromArgs(manifest *model.Manifest, args []string) (*model.Dev, error)
 			return nil, err
 		}
 		selector := utils.NewOktetoSelector("Select which development container to exec:", "Development container")
-		dev, err = utils.SelectDevFromManifest(manifest, selector)
+		dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -67,7 +67,7 @@ func Exec() *cobra.Command {
 			}
 
 			activeDevMode := apps.ListDevModeOn(ctx, manifest, c)
-			if len(activeDevMode) < 1 {
+			if len(activeDevMode) == 0 {
 				return oktetoErrors.UserError{
 					E:    fmt.Errorf("development containers not found in namespace '%s'", manifest.Namespace),
 					Hint: "Run 'okteto up' to launch your development container or use 'okteto context' to change your current context",

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -24,11 +24,12 @@ import (
 
 func TestGetDevFromArgs(t *testing.T) {
 	tests := []struct {
-		name        string
-		manifest    *model.Manifest
-		args        []string
-		expectedDev *model.Dev
-		expectedErr error
+		name          string
+		manifest      *model.Manifest
+		args          []string
+		activeDevMode []string
+		expectedDev   *model.Dev
+		expectedErr   error
 	}{
 		{
 			name: "first arg is on dev section",
@@ -78,7 +79,7 @@ func TestGetDevFromArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dev, err := getDevFromArgs(tt.manifest, tt.args)
+			dev, err := getDevFromArgs(tt.manifest, tt.args, tt.activeDevMode)
 			assert.Equal(t, tt.expectedDev, dev)
 			if err != nil {
 				assert.Error(t, err, tt.expectedErr.Error())

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -103,7 +103,7 @@ func Push(ctx context.Context) *cobra.Command {
 					return err
 				}
 				selector := utils.NewOktetoSelector("Select which development container to push to:", "Development container")
-				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
 				if err != nil {
 					return err
 				}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -63,7 +63,7 @@ func Restart() *cobra.Command {
 					return err
 				}
 				selector := utils.NewOktetoSelector("Select which development container to restart:", "Development container")
-				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
 				if err != nil {
 					return err
 				}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -67,7 +67,7 @@ func Status() *cobra.Command {
 					return err
 				}
 				selector := utils.NewOktetoSelector("Select which development container's sync status is needed:", "Development container")
-				dev, err = utils.SelectDevFromManifest(manifest, selector)
+				dev, err = utils.SelectDevFromManifest(manifest, selector, manifest.Dev.GetDevs())
 				if err != nil {
 					return err
 				}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -266,7 +266,7 @@ func Up() *cobra.Command {
 					return err
 				}
 				selector := utils.NewOktetoSelector("Select which development container to activate:", "Development container")
-				dev, err = utils.SelectDevFromManifest(oktetoManifest, selector)
+				dev, err = utils.SelectDevFromManifest(oktetoManifest, selector, oktetoManifest.Dev.GetDevs())
 				if err != nil {
 					return err
 				}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -186,11 +186,7 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 }
 
 // SelectDevFromManifest prompts the selector to choose a development container and returns the dev selected or error
-func SelectDevFromManifest(manifest *model.Manifest, selector OktetoSelectorInterface) (*model.Dev, error) {
-	devs := []string{}
-	for k := range manifest.Dev {
-		devs = append(devs, k)
-	}
+func SelectDevFromManifest(manifest *model.Manifest, selector OktetoSelectorInterface, devs []string) (*model.Dev, error) {
 	sort.Slice(devs, func(i, j int) bool {
 		l1, l2 := len(devs[i]), len(devs[j])
 		if l1 != l2 {

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -426,7 +426,7 @@ func Test_SelectDevFromManifest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dev, err := SelectDevFromManifest(tt.manifest, tt.selector)
+			dev, err := SelectDevFromManifest(tt.manifest, tt.selector, tt.manifest.Dev.GetDevs())
 			assert.Equal(t, tt.dev, dev)
 			if tt.err != nil {
 				assert.Equal(t, tt.err.Error(), err.Error())

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -48,12 +48,12 @@ func Get(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Int
 	return &StatefulSetApp{sfs: sfs}, nil
 }
 
-//IsDevModeOn returns if a statefulset is in devmode
+// IsDevModeOn returns if a statefulset is in devmode
 func IsDevModeOn(app App) bool {
 	return app.ObjectMeta().Labels[model.DevLabel] == "true" || len(app.ObjectMeta().Labels[model.DevCloneLabel]) > 0
 }
 
-//SetLastBuiltAnnotation sets the app timestamp
+// SetLastBuiltAnnotation sets the app timestamp
 func SetLastBuiltAnnotation(app App) {
 	app.ObjectMeta().Annotations[model.LastBuiltAnnotation] = time.Now().UTC().Format(model.TimeFormat)
 }
@@ -100,7 +100,7 @@ func GetRunningPodInLoop(ctx context.Context, dev *model.Dev, app App, c kuberne
 	}
 }
 
-//GetTranslations fills all the deployments pointed by a development container
+// GetTranslations fills all the deployments pointed by a development container
 func GetTranslations(ctx context.Context, dev *model.Dev, app App, reset bool, c kubernetes.Interface) (map[string]*Translation, error) {
 	mainTr := &Translation{
 		MainDev: dev,
@@ -155,7 +155,7 @@ func loadServiceTranslations(ctx context.Context, dev *model.Dev, reset bool, re
 	return nil
 }
 
-//TranslateDevMode translates the deployment manifests to put them in dev mode
+// TranslateDevMode translates the deployment manifests to put them in dev mode
 func TranslateDevMode(trMap map[string]*Translation) error {
 	for _, tr := range trMap {
 		err := tr.translate()

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -171,6 +171,11 @@ func TranslateDevMode(trMap map[string]*Translation) error {
 func ListDevModeOn(ctx context.Context, manifest *model.Manifest, c kubernetes.Interface) []string {
 	devModeApps := make([]string, 0)
 	for name, dev := range manifest.Dev {
+		// when autocreate is active, the app name has suffix -okteto
+		// this should be taken into account when searching for dev mode apps
+		if dev.Autocreate {
+			dev.Name = fmt.Sprintf("%s-okteto", name)
+		}
 		app, err := Get(ctx, dev, manifest.Namespace, c)
 		if err != nil {
 			oktetoLog.Debugf("error listing dev-mode %s: %v", name, err)

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -165,3 +165,26 @@ func TranslateDevMode(trMap map[string]*Translation) error {
 	}
 	return nil
 }
+
+// ListDevModeOn returns a list of strings with the names of deployments or statefulsets in DevMode
+func ListDevModeOn(ctx context.Context, namespace string, c kubernetes.Interface) ([]string, error) {
+	devModeApps := make([]string, 0)
+
+	deploymentsDev, err := deployments.List(ctx, namespace, model.DevLabel, c)
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range deploymentsDev {
+		devModeApps = append(devModeApps, i.Name)
+	}
+
+	statefulsetsDev, err := statefulsets.List(ctx, namespace, model.DevLabel, c)
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range statefulsetsDev {
+		devModeApps = append(devModeApps, i.Name)
+	}
+
+	return devModeApps, nil
+}

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -170,7 +170,7 @@ func TranslateDevMode(trMap map[string]*Translation) error {
 func ListDevModeOn(ctx context.Context, namespace string, c kubernetes.Interface) ([]string, error) {
 	devModeApps := make([]string, 0)
 
-	deploymentsDev, err := deployments.List(ctx, namespace, model.DevLabel, c)
+	deploymentsDev, err := deployments.List(ctx, namespace, fmt.Sprintf("%s=true", model.DevLabel), c)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func ListDevModeOn(ctx context.Context, namespace string, c kubernetes.Interface
 		devModeApps = append(devModeApps, i.Name)
 	}
 
-	statefulsetsDev, err := statefulsets.List(ctx, namespace, model.DevLabel, c)
+	statefulsetsDev, err := statefulsets.List(ctx, namespace, fmt.Sprintf("%s=true", model.DevLabel), c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -179,9 +179,8 @@ func ListDevModeOn(ctx context.Context, manifest *model.Manifest, c kubernetes.I
 		app, err := Get(ctx, dev, manifest.Namespace, c)
 		if err != nil {
 			oktetoLog.Debugf("error listing dev-mode %s: %v", name, err)
-			return devModeApps
 		}
-		if IsDevModeOn(app) {
+		if app != nil && IsDevModeOn(app) {
 			// only add to slice the dev apps
 			devModeApps = append(devModeApps, name)
 		}

--- a/pkg/k8s/apps/crud_test.go
+++ b/pkg/k8s/apps/crud_test.go
@@ -293,6 +293,17 @@ func TestListDevModeOn(t *testing.T) {
 					Enabled: true,
 				},
 			},
+			"autocreate": &model.Dev{
+				Name:      "autocreate",
+				Namespace: "test",
+				Image: &model.BuildInfo{
+					Name: "image",
+				},
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Enabled: true,
+				},
+				Autocreate: true,
+			},
 		},
 	}
 	tests := []struct {
@@ -477,6 +488,35 @@ func TestListDevModeOn(t *testing.T) {
 			},
 			ds:           &appsv1.Deployment{},
 			expectedList: []string{},
+		},
+		{
+			name: "autocreate-dev",
+			sfs:  &appsv1.StatefulSet{},
+			ds: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "autocreate-okteto",
+					Namespace: "test",
+					Labels: map[string]string{
+						model.DevLabel: "true",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									VolumeMounts: []v1.VolumeMount{
+										{
+											MountPath: "/data",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedList: []string{"autocreate"},
 		},
 	}
 

--- a/pkg/k8s/apps/crud_test.go
+++ b/pkg/k8s/apps/crud_test.go
@@ -518,6 +518,35 @@ func TestListDevModeOn(t *testing.T) {
 			},
 			expectedList: []string{"autocreate"},
 		},
+		{
+			name: "dev-is-not-at-manifest",
+			sfs:  &appsv1.StatefulSet{},
+			ds: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "not-manifest",
+					Namespace: "test",
+					Labels: map[string]string{
+						model.DevLabel: "true",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									VolumeMounts: []v1.VolumeMount{
+										{
+											MountPath: "/data",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedList: []string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1178,3 +1178,12 @@ func (d ManifestDevs) HasDev(name string) bool {
 	_, ok := d[name]
 	return ok
 }
+
+// GetDevs returns a list of strings with the keys of devs defined
+func (d ManifestDevs) GetDevs() []string {
+	devs := make([]string, 0)
+	for k := range d {
+		devs = append(devs, k)
+	}
+	return devs
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1181,7 +1181,7 @@ func (d ManifestDevs) HasDev(name string) bool {
 
 // GetDevs returns a list of strings with the keys of devs defined
 func (d ManifestDevs) GetDevs() []string {
-	devs := make([]string, len(d))
+	devs := []string{}
 	for k := range d {
 		devs = append(devs, k)
 	}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1181,7 +1181,7 @@ func (d ManifestDevs) HasDev(name string) bool {
 
 // GetDevs returns a list of strings with the keys of devs defined
 func (d ManifestDevs) GetDevs() []string {
-	devs := make([]string, 0)
+	devs := make([]string, len(d))
 	for k := range d {
 		devs = append(devs, k)
 	}


### PR DESCRIPTION
Resolves #2946 

## Proposed changes

In order to make the `okteto down` command selector only display the current containers that are in dev mode, the options passed to the selector had to be customise.
- Refactor `SelectDevFromManifest` so the options are passed as a list of strings
- Create new method for the Dev Manifest to get the list of keys from dev manifest
- Create new function under apps to retrieve the Deployments and Statefulsets that are in DevMode
- get options at `okteto down` from the active ones
- Added same logic to `okteto exec` in order to be able to select only the dev containers that are active
