### PR TITLE
chore: fix template for pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
-# <title>
+# Proposed changes
 
-Fixes #<issue>
+Fixes # (issue)
 
-## Proposed changes**
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

After the merge of the Audit PR, in order to comply with the markdownlint rules we have in place i changed the pull request template. I've experience the new one is being wierd, this proposes a cleaner version of the template.
