### PR TITLE
Sanitize uppercase srv names

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -682,7 +682,7 @@ func (m *Manifest) SanitizeSvcNames() error {
 			}
 			m.Build[sanitizedSvcName] = build
 			sanitizedServicesNames[buildKey] = sanitizedSvcName
-			delete(m.Dev, buildKey)
+			delete(m.Build, buildKey)
 		}
 	}
 

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -1199,12 +1199,13 @@ func hasUppercase(name string) bool {
 	return false
 }
 func shouldBeSanitized(name string) bool {
-	return strings.Contains(name, " ") || strings.Contains(name, "_")
+	return strings.Contains(name, " ") || strings.Contains(name, "_") || hasUppercase(name)
 }
 
 func sanitizeName(name string) string {
 	name = strings.ReplaceAll(name, " ", "-")
 	name = strings.ReplaceAll(name, "_", "-")
+	name = strings.ToLower(name)
 	return name
 }
 

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/kballard/go-shellquote"
 	"github.com/okteto/okteto/pkg/filesystem"
@@ -1189,6 +1190,14 @@ func getProtocol(protocolName string) (apiv1.Protocol, error) {
 	}
 }
 
+func hasUppercase(name string) bool {
+	for _, s := range name {
+		if unicode.IsUpper(s) {
+			return true
+		}
+	}
+	return false
+}
 func shouldBeSanitized(name string) bool {
 	return strings.Contains(name, " ") || strings.Contains(name, "_")
 }

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -35,7 +35,7 @@ const (
 	DefaultReplicasNumber = 1
 )
 
-//Stack represents an okteto stack
+// Stack represents an okteto stack
 type StackRaw struct {
 	Version   string                     `yaml:"version,omitempty"`
 	Name      string                     `yaml:"name"`
@@ -57,7 +57,7 @@ type StackRaw struct {
 	Warnings StackWarnings
 }
 
-//Service represents an okteto stack service
+// Service represents an okteto stack service
 type ServiceRaw struct {
 	Deploy                   *DeployInfoRaw        `yaml:"deploy,omitempty"`
 	Build                    *BuildInfo            `yaml:"build,omitempty"`
@@ -591,6 +591,7 @@ func getSvcPorts(public bool, rawPorts, rawExpose []PortRaw) (bool, []Port, erro
 // ports:         | ports:
 //   - 5000       |   - 5000:5000
 //   - 3000       |   - 3000:3000
+//
 // public: true   |
 func translateOktetoStacksPortsIntoComposeSyntax(ports []PortRaw) []PortRaw {
 	for idx, p := range ports {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -1198,8 +1198,17 @@ func hasUppercase(name string) bool {
 	}
 	return false
 }
+
+func hasEmptySpace(name string) bool {
+	return strings.Contains(name, " ")
+}
+
+func hasUnderscore(name string) bool {
+	return strings.Contains(name, "_")
+}
+
 func shouldBeSanitized(name string) bool {
-	return strings.Contains(name, " ") || strings.Contains(name, "_") || hasUppercase(name)
+	return hasEmptySpace(name) || hasUnderscore(name) || hasUppercase(name)
 }
 
 func sanitizeName(name string) string {


### PR DESCRIPTION
# Proposed changes

Fixes #2639 

When services apper with uppercase at the okteto manifest or stack we need to sanitize this strings so they are lowercase while performing commands with the manifest.

- Added hasUppercase function to detect if the service name has uppercase
-  Refactored `shouldBeSanitized` to include this condition
- Refactored conditions on `shouldBeSanitized` for better understanding
- Refactored `sanitizeName` to apply this condition for all being lowecase
- Fix a found bug: when sanitizing the Build Manifest, the key deletion was being done under manifest.Dev instead of manifest.Build
