### PR TITLE
Change logic for which images to build when deploying

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -614,9 +614,9 @@ func (dc *DeployCommand) buildImages(ctx context.Context, cfg *corev1.ConfigMap,
 
 		stackServicesToBuild := setIntersection(stackServices, sliceToSet(deployOptions.servicesToDeploy))
 
-		manifestBuildImages := deployOptions.Manifest.GetBuildServices()
+		manifestBuildServices := deployOptions.Manifest.GetBuildServices()
 
-		servicesToBuildSet := setUnion(stackServicesToBuild, manifestBuildImages)
+		servicesToBuildSet := setUnion(stackServicesToBuild, manifestBuildServices)
 
 		servicesToBuild := setToSlice(servicesToBuildSet)
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -321,35 +321,6 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		return err
 	}
 
-	// TODO: take this out to a new function build images
-	if deployOptions.Build {
-		buildOptions := &types.BuildOptions{
-			EnableStages: true,
-			Manifest:     deployOptions.Manifest,
-			CommandArgs:  deployOptions.servicesToDeploy,
-		}
-		oktetoLog.Debug("force build from manifest definition")
-		if errBuild := dc.Builder.Build(ctx, buildOptions); errBuild != nil {
-			return updateConfigMapStatusError(ctx, cfg, c, data, errBuild)
-		}
-	} else {
-		svcsToBuild, errBuild := dc.Builder.GetServicesToBuild(ctx, deployOptions.Manifest, deployOptions.servicesToDeploy)
-		if errBuild != nil {
-			return updateConfigMapStatusError(ctx, cfg, c, data, errBuild)
-		}
-		if len(svcsToBuild) != 0 {
-			buildOptions := &types.BuildOptions{
-				CommandArgs:  svcsToBuild,
-				EnableStages: true,
-				Manifest:     deployOptions.Manifest,
-			}
-
-			if errBuild := dc.Builder.Build(ctx, buildOptions); errBuild != nil {
-				return updateConfigMapStatusError(ctx, cfg, c, data, errBuild)
-			}
-		}
-	}
-
 	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Deploying '%s'...", deployOptions.Name)
 
 	defer dc.cleanUp(ctx)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -606,12 +606,11 @@ func buildImages(ctx context.Context, build func(context.Context, *types.BuildOp
 			return errBuild
 		}
 	} else {
-		stack := deployOptions.Manifest.GetStack()
-		if stack == nil {
-			return nil
-		}
-		stackServices := stack.GetServicesWithBuildSection()
+		var stackServices map[string]bool
 
+		if stack := deployOptions.Manifest.GetStack(); stack != nil {
+			stackServices = stack.GetServicesWithBuildSection()
+		}
 		stackServicesToBuild := setIntersection(stackServices, sliceToSet(deployOptions.servicesToDeploy))
 
 		manifestBuildServices := deployOptions.Manifest.GetBuildServices()

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -346,7 +346,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		}
 	}
 
-	if err := dc.buildImages(ctx, deployOptions); err != nil {
+	if err := buildImages(ctx, dc.Builder.Build, deployOptions); err != nil {
 		return updateConfigMapStatusError(ctx, cfg, c, data, err)
 	}
 
@@ -594,7 +594,7 @@ func (dc *DeployCommand) cleanUp(ctx context.Context) {
 	}
 }
 
-func (dc *DeployCommand) buildImages(ctx context.Context, deployOptions *Options) error {
+func buildImages(ctx context.Context, build func(context.Context, *types.BuildOptions) error, deployOptions *Options) error {
 	if deployOptions.Build {
 		buildOptions := &types.BuildOptions{
 			EnableStages: true,
@@ -602,7 +602,7 @@ func (dc *DeployCommand) buildImages(ctx context.Context, deployOptions *Options
 			CommandArgs:  deployOptions.servicesToDeploy,
 		}
 		oktetoLog.Debug("force build from manifest definition")
-		if errBuild := dc.Builder.Build(ctx, buildOptions); errBuild != nil {
+		if errBuild := build(ctx, buildOptions); errBuild != nil {
 			return errBuild
 		}
 	} else {
@@ -627,7 +627,7 @@ func (dc *DeployCommand) buildImages(ctx context.Context, deployOptions *Options
 				CommandArgs:  servicesToBuild,
 			}
 
-			if errBuild := dc.Builder.Build(ctx, buildOptions); errBuild != nil {
+			if errBuild := build(ctx, buildOptions); errBuild != nil {
 				return errBuild
 			}
 		}

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -562,6 +562,18 @@ func TestBuildImages(t *testing.T) {
 			expectedError:    nil,
 			expectedImages:   []string{"manifest A", "stack C"},
 		},
+		{
+			name:          "force build",
+			build:         true,
+			buildServices: []string{"manifest A", "manifest B", "stack A", "stack B"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"stack A": {Build: &model.BuildInfo{}},
+				"stack B": {Build: &model.BuildInfo{}},
+			}},
+			servicesToDeploy: []string{"manifest A", "stack A"},
+			expectedError:    nil,
+			expectedImages:   []string{"manifest A", "stack A"},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -519,11 +519,9 @@ func TestBuildImages(t *testing.T) {
 			name:          "no build services",
 			build:         false,
 			buildServices: []string{},
-			stack: &model.Stack{
-				Services: map[string]*model.Service{
-					"A": {Build: &model.BuildInfo{}},
-				},
-			},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"A": {Build: &model.BuildInfo{}},
+			}},
 			servicesToDeploy: []string{"A", "B"},
 			expectedError:    nil,
 			expectedImages:   []string{"A"},
@@ -536,6 +534,29 @@ func TestBuildImages(t *testing.T) {
 			servicesToDeploy: []string{"A"},
 			expectedError:    nil,
 			expectedImages:   []string{"B"},
+		},
+		{
+			name:          "no services to deploy",
+			build:         false,
+			buildServices: []string{"B"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"A": {Build: &model.BuildInfo{}},
+			}},
+			servicesToDeploy: []string{},
+			expectedError:    nil,
+			expectedImages:   []string{"B"},
+		},
+		{
+			name:          "build services, stack and services to deploy",
+			build:         false,
+			buildServices: []string{"A", "B"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"B": {Build: &model.BuildInfo{}},
+				"C": {Build: &model.BuildInfo{}},
+			}},
+			servicesToDeploy: []string{"A", "C"},
+			expectedError:    nil,
+			expectedImages:   []string{"A", "B", "C"},
 		},
 	}
 
@@ -567,7 +588,7 @@ func TestBuildImages(t *testing.T) {
 
 			err := buildImages(context.Background(), build, deployOptions)
 			assert.Equal(t, testCase.expectedError, err)
-			assert.Equal(t, testCase.expectedImages, buildOptionsStorage.CommandArgs)
+			assert.Equal(t, sliceToSet(testCase.expectedImages), sliceToSet(buildOptionsStorage.CommandArgs))
 		})
 	}
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1221,3 +1221,18 @@ func (d ManifestDevs) GetDevs() []string {
 	}
 	return devs
 }
+
+func (m *Manifest) GetBuildServices() map[string]bool {
+	images := map[string]bool{}
+	for service := range m.Build {
+		images[service] = true
+	}
+	return images
+}
+
+func (m *Manifest) GetStack() *Stack {
+	if m.Deploy == nil || m.Deploy.ComposeSection == nil {
+		return nil
+	}
+	return m.Deploy.ComposeSection.Stack
+}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -853,3 +853,13 @@ func (s composeServices) toGraph() graph {
 	}
 	return g
 }
+
+func (stack *Stack) GetServicesWithBuildSection() map[string]bool {
+	result := make(map[string]bool)
+	for name, service := range stack.Services {
+		if service != nil && service.Build != nil {
+			result[name] = true
+		}
+	}
+	return result
+}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -857,7 +857,7 @@ func (s composeServices) toGraph() graph {
 func (stack *Stack) GetServicesWithBuildSection() map[string]bool {
 	result := make(map[string]bool)
 	for name, service := range stack.Services {
-		if svc.Build != nil || len(svc.VolumeMounts) != 0 {
+		if service.Build != nil || len(service.VolumeMounts) != 0 {
 			result[name] = true
 		}
 	}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -857,7 +857,7 @@ func (s composeServices) toGraph() graph {
 func (stack *Stack) GetServicesWithBuildSection() map[string]bool {
 	result := make(map[string]bool)
 	for name, service := range stack.Services {
-		if service != nil && service.Build != nil {
+		if svc.Build != nil || len(svc.VolumeMounts) != 0 {
 			result[name] = true
 		}
 	}


### PR DESCRIPTION
# Change logic for which images to build when deploying

Fixes #2795

## Proposed changes**
On the deploy command, we'll build the images which:
- are in the manifest build section
- are in the `servicesToDeploy` defined by the user (all by default) **AND** are in the `stack` services which have a `Build` section

