### PR TITLE
improved usage of `okteto ctx` with vanilla clusters

### DIFF
--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -79,6 +79,7 @@ type OktetoContextViewer struct {
 	Builder   string `json:"builder,omitempty" yaml:"builder,omitempty"`
 	Registry  string `json:"registry,omitempty" yaml:"registry,omitempty"`
 	Current   bool   `json:"current" yaml:"current"`
+	Managed   bool   `json:"managed,omitempty" yaml:"managed,omitempty"`
 }
 
 // InitContextWithDeprecatedToken initializes the okteto context if an old fashion exists and it matches the current kubernetes context


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

# Proposed changes

Fixes #2984, #2957

- `okteto ctx ls` now shows which clusters are managed by Okteto and which aren't
- For vanilla clusters `okteto ctx delete` now says cluster can't be deleted instead of saying it cluster doesn't exist like earlier


https://user-images.githubusercontent.com/56963264/188114843-1048e5ec-5fb4-4a16-8e3a-f023dc3d3c3a.mov


