### PR TITLE
add build depends on okteto manifest v2 

### DIFF
--- a/cmd/build/v2/environment_test.go
+++ b/cmd/build/v2/environment_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	buildv1 "github.com/okteto/okteto/cmd/build/v1"
 	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -78,9 +77,7 @@ func Test_SetServiceEnvVars(t *testing.T) {
 			}
 
 			registry := test.NewFakeOktetoRegistry(nil)
-			bc := &OktetoBuilder{
-				Registry: registry,
-			}
+			bc := NewBuilder(nil, registry)
 			bc.SetServiceEnvVars(tt.service, tt.reference)
 
 			registryEnvValue := os.Getenv(registryEnv)
@@ -122,11 +119,7 @@ func TestExpandStackVariables(t *testing.T) {
 
 	registry := test.NewFakeOktetoRegistry(nil)
 	builder := test.NewFakeOktetoBuilder(registry)
-	bc := &OktetoBuilder{
-		Builder:   builder,
-		Registry:  registry,
-		V1Builder: buildv1.NewBuilder(builder, registry),
-	}
+	bc := NewBuilder(builder, registry)
 	stack := &model.Stack{
 		Services: map[string]*model.Service{
 			"test": {

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -25,9 +25,7 @@ import (
 
 func TestAllServicesAlreadyBuilt(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
-	bc := &OktetoBuilder{
-		Registry: fakeReg,
-	}
+	bc := NewBuilder(nil, fakeReg)
 	alreadyBuilt := []string{}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
@@ -39,9 +37,8 @@ func TestAllServicesAlreadyBuilt(t *testing.T) {
 
 func TestServicesNotAreAlreadyBuilt(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
-	bc := &OktetoBuilder{
-		Registry: fakeReg,
-	}
+	bc := NewBuilder(nil, fakeReg)
+
 	alreadyBuilt := []string{"test/test-1"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
@@ -53,9 +50,7 @@ func TestServicesNotAreAlreadyBuilt(t *testing.T) {
 
 func TestNoServiceBuilt(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
-	bc := &OktetoBuilder{
-		Registry: fakeReg,
-	}
+	bc := NewBuilder(nil, fakeReg)
 	alreadyBuilt := []string{"test/test-1", "test/test-2"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
@@ -67,9 +62,7 @@ func TestNoServiceBuilt(t *testing.T) {
 
 func TestServicesNotInStack(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
-	bc := &OktetoBuilder{
-		Registry: fakeReg,
-	}
+	bc := NewBuilder(nil, fakeReg)
 	alreadyBuilt := []string{"test/test-1"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
@@ -90,9 +83,7 @@ func TestServicesNotInStack(t *testing.T) {
 
 func TestAllServicesAlreadyBuiltWithSubset(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
-	bc := &OktetoBuilder{
-		Registry: fakeReg,
-	}
+	bc := NewBuilder(nil, fakeReg)
 	alreadyBuilt := []string{}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
@@ -104,9 +95,7 @@ func TestAllServicesAlreadyBuiltWithSubset(t *testing.T) {
 
 func TestServicesNotAreAlreadyBuiltWithSubset(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
-	bc := &OktetoBuilder{
-		Registry: fakeReg,
-	}
+	bc := NewBuilder(nil, fakeReg)
 	alreadyBuilt := []string{"test/test-1"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()
@@ -118,9 +107,7 @@ func TestServicesNotAreAlreadyBuiltWithSubset(t *testing.T) {
 
 func TestNoServiceBuiltWithSubset(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
-	bc := &OktetoBuilder{
-		Registry: fakeReg,
-	}
+	bc := NewBuilder(nil, fakeReg)
 	alreadyBuilt := []string{"test/test-1", "test/test-2"}
 	fakeReg.AddImageByName(alreadyBuilt...)
 	ctx := context.Background()

--- a/internal/test/build.go
+++ b/internal/test/build.go
@@ -41,8 +41,9 @@ func (fb *FakeOktetoBuilder) Run(_ context.Context, opts *types.BuildOptions) er
 		fb.Err = fb.Err[1:]
 		return err
 	}
+
 	if opts.Tag != "" {
-		fb.Registry.AddImageByName(opts.Tag)
+		fb.Registry.AddImageByOpts(opts)
 	}
 	return nil
 }
@@ -59,6 +60,7 @@ type FakeImage struct {
 	Repo     string
 	Tag      string
 	ImageRef string
+	Args     []string
 }
 
 // NewFakeOktetoRegistry creates a new registry if not already created
@@ -74,6 +76,12 @@ func (fb *FakeOktetoRegistry) AddImageByName(images ...string) error {
 	for _, image := range images {
 		fb.Registry[image] = &FakeImage{}
 	}
+	return nil
+}
+
+// AddImageByOpts adds an image to the registry
+func (fb *FakeOktetoRegistry) AddImageByOpts(opts *types.BuildOptions) error {
+	fb.Registry[opts.Tag] = &FakeImage{Args: opts.BuildArgs}
 	return nil
 }
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -36,15 +36,16 @@ import (
 
 // BuildInfoRaw represents the build info for serialization
 type buildInfoRaw struct {
-	Name             string        `yaml:"name,omitempty"`
-	Context          string        `yaml:"context,omitempty"`
-	Dockerfile       string        `yaml:"dockerfile,omitempty"`
-	CacheFrom        []string      `yaml:"cache_from,omitempty"`
-	Target           string        `yaml:"target,omitempty"`
-	Args             Environment   `yaml:"args,omitempty"`
-	Image            string        `yaml:"image,omitempty"`
-	VolumesToInclude []StackVolume `yaml:"-"`
-	ExportCache      string        `yaml:"export_cache,omitempty"`
+	Name             string         `yaml:"name,omitempty"`
+	Context          string         `yaml:"context,omitempty"`
+	Dockerfile       string         `yaml:"dockerfile,omitempty"`
+	CacheFrom        []string       `yaml:"cache_from,omitempty"`
+	Target           string         `yaml:"target,omitempty"`
+	Args             Environment    `yaml:"args,omitempty"`
+	Image            string         `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume  `yaml:"-"`
+	ExportCache      string         `yaml:"export_cache,omitempty"`
+	DependsOn        BuildDependsOn `yaml:"depends_on,omitempty"`
 }
 
 type syncRaw struct {
@@ -290,6 +291,24 @@ func (sync Sync) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (d *BuildDependsOn) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var rawString string
+	err := unmarshal(&rawString)
+	if err == nil {
+		*d = BuildDependsOn{rawString}
+		return nil
+	}
+
+	var rawStringList []string
+	err = unmarshal(&rawStringList)
+	if err == nil {
+		*d = rawStringList
+		return nil
+	}
+	return err
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
 func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var rawString string
 	err := unmarshal(&rawString)
@@ -312,6 +331,7 @@ func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) err
 	buildInfo.Image = rawBuildInfo.Image
 	buildInfo.CacheFrom = rawBuildInfo.CacheFrom
 	buildInfo.ExportCache = rawBuildInfo.ExportCache
+	buildInfo.DependsOn = rawBuildInfo.DependsOn
 	return nil
 }
 

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -2153,3 +2153,32 @@ func TestManifestBuildUnmarshalling(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildDependsOnUnmarshalling(t *testing.T) {
+	tests := []struct {
+		name          string
+		buildManifest []byte
+		expected      BuildDependsOn
+	}{
+		{
+			name:          "single string",
+			buildManifest: []byte(`a`),
+			expected:      BuildDependsOn{"a"},
+		},
+		{
+			name: "list",
+			buildManifest: []byte(`- a
+- b`),
+			expected: BuildDependsOn{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result BuildDependsOn
+			err := yaml.UnmarshalStrict(tt.buildManifest, &result)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -406,6 +406,45 @@ func Test_HealthcheckUnmarshalling(t *testing.T) {
 	}
 }
 
+func TestComposeBuildSectionUnmarshalling(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    []byte
+		expected *composeBuildInfo
+	}{
+		{
+			name:     "with depends on fail",
+			bytes:    []byte(`depends_on: a`),
+			expected: nil,
+		},
+		{
+			name:  "context",
+			bytes: []byte(`context: .`),
+			expected: &composeBuildInfo{
+				Context: ".",
+			},
+		},
+		{
+			name:  "image direct",
+			bytes: []byte(`nginx`),
+			expected: &composeBuildInfo{
+				Name: "nginx",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result composeBuildInfo
+			err := yaml.UnmarshalStrict(tt.bytes, &result)
+			if err != nil && tt.expected == nil {
+				return
+			}
+
+			assert.Equal(t, tt.expected, &result)
+		})
+	}
+}
+
 func Test_HealthcheckTestUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -511,7 +511,7 @@ func TestStack_readImageContext(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(stack.Services["test"].Build, tt.expected) {
-				t.Fatalf("Expected %v but got %v", tt.expected, stack.Services["test"].Build)
+				assert.Equal(t, tt.expected, stack.Services["test"].Build)
 			}
 		})
 	}
@@ -1236,5 +1236,102 @@ func Test_translateEnvVars(t *testing.T) {
 		if e.Name == "EMPTY_VAR" && e.Value != "" {
 			t.Errorf("Wrong environment variable EMPTY_VAR: %s", e.Value)
 		}
+	}
+}
+
+func TestServicesToGraph(t *testing.T) {
+	tests := []struct {
+		name          string
+		services      composeServices
+		expectedGraph graph
+	}{
+		{
+			name: "no cycle - no connections",
+			services: composeServices{
+				"a": &Service{},
+				"b": &Service{},
+				"c": &Service{},
+			},
+			expectedGraph: graph{
+				"a": []string{},
+				"b": []string{},
+				"c": []string{},
+			},
+		},
+		{
+			name: "no cycle - connections",
+			services: composeServices{
+				"a": &Service{
+					DependsOn: DependsOn{
+						"b": DependsOnConditionSpec{},
+					},
+				},
+				"b": &Service{
+					DependsOn: DependsOn{
+						"c": DependsOnConditionSpec{},
+					},
+				},
+				"c": &Service{},
+			},
+			expectedGraph: graph{
+				"a": []string{"b"},
+				"b": []string{"c"},
+				"c": []string{},
+			},
+		},
+		{
+			name: "cycle - direct cycle",
+			services: composeServices{
+				"a": &Service{
+					DependsOn: DependsOn{
+						"b": DependsOnConditionSpec{},
+					},
+				},
+				"b": &Service{
+					DependsOn: DependsOn{
+						"a": DependsOnConditionSpec{},
+					},
+				},
+				"c": &Service{},
+			},
+			expectedGraph: graph{
+				"a": []string{"b"},
+				"b": []string{"a"},
+				"c": []string{},
+			},
+		},
+		{
+			name: "cycle - indirect cycle",
+			services: composeServices{
+				"a": &Service{
+					DependsOn: DependsOn{
+						"b": DependsOnConditionSpec{},
+					},
+				},
+				"b": &Service{
+					DependsOn: DependsOn{
+						"c": DependsOnConditionSpec{},
+					},
+				},
+				"c": &Service{
+					DependsOn: DependsOn{
+						"a": DependsOnConditionSpec{},
+					},
+				},
+			},
+			expectedGraph: graph{
+				"a": []string{"b"},
+				"b": []string{"c"},
+				"c": []string{"a"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.services.toGraph()
+			assert.Equal(t, tt.expectedGraph, result)
+		})
+
 	}
 }

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -168,3 +168,30 @@ func pathExistsAndDir(path string) bool {
 	}
 	return info.IsDir()
 }
+
+func getListDiff(l1, l2 []string) []string {
+	var (
+		longerList  []string
+		shorterList []string
+	)
+	if len(l1) < len(l2) {
+		shorterList = l1
+		longerList = l2
+
+	} else {
+		shorterList = l2
+		shorterList = l1
+	}
+
+	shorterListSet := map[string]bool{}
+	for _, svc := range shorterList {
+		shorterListSet[svc] = true
+	}
+	added := []string{}
+	for _, svcName := range longerList {
+		if _, ok := shorterListSet[svcName]; ok {
+			added = append(added, svcName)
+		}
+	}
+	return added
+}

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -15,6 +15,8 @@ package model
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_GetValidNameFromFolder(t *testing.T) {
@@ -67,6 +69,59 @@ func Test_GetValidNameFromGitRepo(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("'%s' got '%s' expected '%s'", tt.name, result, tt.expected)
 			}
+		})
+	}
+
+}
+
+func TestGetCycles(t *testing.T) {
+	var tests = []struct {
+		name          string
+		g             graph
+		expectedCycle bool
+	}{
+		{
+			name: "no cycle - no connections",
+			g: graph{
+				"a": []string{},
+				"b": []string{},
+				"c": []string{},
+			},
+			expectedCycle: false,
+		},
+		{
+			name: "no cycle - connections",
+			g: graph{
+				"a": []string{"b"},
+				"b": []string{"c"},
+				"c": []string{},
+			},
+			expectedCycle: false,
+		},
+		{
+			name: "cycle - direct cycle",
+			g: graph{
+				"a": []string{"b"},
+				"b": []string{"a"},
+				"c": []string{},
+			},
+			expectedCycle: true,
+		},
+		{
+			name: "cycle - indirect cycle",
+			g: graph{
+				"a": []string{"b"},
+				"b": []string{"c"},
+				"c": []string{"a"},
+			},
+			expectedCycle: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getDependentCyclic(tt.g)
+			assert.Equal(t, tt.expectedCycle, len(result) > 0)
 		})
 	}
 


### PR DESCRIPTION
# Proposed changes

Fixes #2884

## Changes:
- Refactor `composeBuildInfo`: We don't have to support adding a `depends_on` field on the build section of the compose. Adding a new field that translates the build without the `depends_on` to the common interface of build solves the issue
- Refactor `getdependentCycles` function: Since we were already checking if a cycle between the services on a compose existed, I refactored the code to support a new struct called graph that has the nodes as keys and the edges as values. That way we only have to transform the `ManifestBuildSection` from the `okteto manifest v2` and the `Services` section from the compose to that new struct and can reuse the function for both
- Adds `depends_on` on manifest v2 build section: Adds a new field to the `buildInformation` to require the name of the images that need to be built first. The code validates that it doesn't have any cyclic dependency while validating the manifest and uses that order to build the image.
- Adds previous build environment as args for a new image: Now you can use the build environment as args on your Dockerfile because we inject previous built images environment variables as build args