### PR TITLE
fix: improve tokern error message inside non ctx cmd

### DIFF
--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -88,7 +88,10 @@ func (c *ContextCommand) Run(ctx context.Context, ctxOptions *ContextOptions) er
 	ctxOptions.initFromEnvVars()
 
 	if ctxOptions.Token == "" && kubeconfig.InCluster() && !isValidCluster(ctxOptions.Context) {
-		return oktetoErrors.ErrTokenFlagNeeded
+		if ctxOptions.IsCtxCommand {
+			return oktetoErrors.ErrTokenFlagNeeded
+		}
+		return oktetoErrors.ErrTokenEnvVarNeeded
 	}
 
 	if ctxOptions.Context == "" {

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -15,6 +15,7 @@ package context
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -27,6 +28,10 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
+)
+
+const (
+	personalAccessTokenURL = "https://www.okteto.com/docs/cloud/personal-access-tokens/"
 )
 
 // Use context points okteto to a cluster.
@@ -91,7 +96,10 @@ func (c *ContextCommand) Run(ctx context.Context, ctxOptions *ContextOptions) er
 		if ctxOptions.IsCtxCommand {
 			return oktetoErrors.ErrTokenFlagNeeded
 		}
-		return oktetoErrors.ErrTokenEnvVarNeeded
+		return oktetoErrors.UserError{
+			E:    oktetoErrors.ErrTokenEnvVarNeeded,
+			Hint: fmt.Sprintf("Visit %s for more information about getting your token.", personalAccessTokenURL),
+		}
 	}
 
 	if ctxOptions.Context == "" {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -111,7 +111,7 @@ var (
 	ErrTokenFlagNeeded = fmt.Errorf("this command is not supported without the '--token' flag from inside a container")
 
 	// ErrTokenEnvVarNeeded is raised when the command is executed from inside a pod from a non ctx command
-	ErrTokenEnvVarNeeded = fmt.Errorf("this command is not supported without the 'OKTETO_TOKEN' environment variable set from inside a container")
+	ErrTokenEnvVarNeeded = fmt.Errorf("the 'OKTETO_TOKEN' environment variable is required when running this command from within a container")
 
 	// ErrNamespaceNotFound is raised when the namespace is not found on an okteto instance
 	ErrNamespaceNotFound = "namespace '%s' not found. Please verify that the namespace exists and that you have access to it"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -107,8 +107,11 @@ var (
 	// ContextIsNotOktetoCluster raised if the cluster connected is not managed by okteto
 	ErrContextIsNotOktetoCluster = fmt.Errorf("this command is only available on Okteto Cloud or Okteto Enterprise")
 
-	// ErrTokenFlagNeeded is raised when the command is executed from inside a pod
+	// ErrTokenFlagNeeded is raised when the command is executed from inside a pod from a ctx command
 	ErrTokenFlagNeeded = fmt.Errorf("this command is not supported without the '--token' flag from inside a container")
+
+	// ErrTokenEnvVarNeeded is raised when the command is executed from inside a pod from a non ctx command
+	ErrTokenEnvVarNeeded = fmt.Errorf("this command is not supported without the 'OKTETO_TOKEN' environment variable set from inside a container")
 
 	// ErrNamespaceNotFound is raised when the namespace is not found on an okteto instance
 	ErrNamespaceNotFound = "namespace '%s' not found. Please verify that the namespace exists and that you have access to it"


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #2868

- Update error message when load context is inside the cluster but is a non ctx command

<img width="683" alt="Captura de Pantalla 2022-09-06 a las 16 03 37" src="https://user-images.githubusercontent.com/25170843/188669129-bf06f8ba-5f1f-445e-93e8-96df651f2a02.png">
