### PR TITLE
show warning only when secret value is different

### DIFF
--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -146,8 +146,11 @@ func getContext(ctxOptions *ContextOptions) (string, error) {
 
 func setSecrets(secrets []types.Secret) {
 	for _, secret := range secrets {
-		if value, exists := os.LookupEnv(secret.Name); exists {
-			oktetoLog.Warning("$%s secret is being overridden by a local environment variable by the same name.", secret.Name)
+		value, exists := os.LookupEnv(secret.Name)
+		if exists {
+			if value != secret.Value {
+				oktetoLog.Warning("$%s secret is being overridden by a local environment variable by the same name.", secret.Name)
+			}
 			oktetoLog.AddMaskedWord(value)
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #3078

- If the secret name is the same as the env var skip continue with the execution and skip the warning message
