### PR TITLE
Show `preview deploy` logs when running the command with `--wait` flag

### DIFF
--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -292,7 +292,7 @@ func Test_createContext(t *testing.T) {
 			fakeOktetoClient := &client.FakeOktetoClient{
 				Namespace: client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
 				Users:     client.NewFakeUsersClient(tt.user),
-				Preview:   client.NewFakePreviewClient(nil, nil),
+				Preview:   client.NewFakePreviewClient(nil, nil, nil),
 			}
 
 			ctxController := newFakeContextCommand(fakeOktetoClient, tt.user, tt.fakeObjects)
@@ -318,7 +318,7 @@ func TestAutoAuthWhenNotValidTokenOnlyWhenOktetoContextIsRun(t *testing.T) {
 	fakeOktetoClient := &client.FakeOktetoClient{
 		Namespace: client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
 		Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
-		Preview:   client.NewFakePreviewClient(nil, nil),
+		Preview:   client.NewFakePreviewClient(nil, nil, nil),
 	}
 
 	ctxController := newFakeContextCommand(fakeOktetoClient, user, nil)
@@ -377,7 +377,7 @@ func TestCheckAccessToNamespace(t *testing.T) {
 	fakeOktetoClient := &client.FakeOktetoClient{
 		Namespace: client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
 		Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
-		Preview:   client.NewFakePreviewClient(nil, nil),
+		Preview:   client.NewFakePreviewClient(nil, nil, nil),
 	}
 
 	fakeCtxCommand := newFakeContextCommand(fakeOktetoClient, user, []runtime.Object{

--- a/cmd/namespace/create_test.go
+++ b/cmd/namespace/create_test.go
@@ -75,7 +75,7 @@ func Test_createNamespace(t *testing.T) {
 			}
 			fakeOktetoClient := &client.FakeOktetoClient{
 				Namespace: client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
-				Preview:   client.NewFakePreviewClient(nil, nil),
+				Preview:   client.NewFakePreviewClient(nil, nil, nil),
 				Users:     client.NewFakeUsersClient(usr),
 			}
 			nsCmd := &NamespaceCommand{

--- a/cmd/namespace/delete_test.go
+++ b/cmd/namespace/delete_test.go
@@ -105,7 +105,7 @@ func Test_deleteNamespace(t *testing.T) {
 			}
 			fakeOktetoClient := &client.FakeOktetoClient{
 				Namespace: client.NewFakeNamespaceClient(tt.currentNamespaces, nil),
-				Preview:   client.NewFakePreviewClient(nil, nil),
+				Preview:   client.NewFakePreviewClient(nil, nil, nil),
 				Users:     client.NewFakeUsersClient(usr),
 			}
 			nsCmd := &NamespaceCommand{

--- a/cmd/namespace/list_test.go
+++ b/cmd/namespace/list_test.go
@@ -67,7 +67,7 @@ func Test_listNamespace(t *testing.T) {
 			}
 			fakeOktetoClient := &client.FakeOktetoClient{
 				Namespace: client.NewFakeNamespaceClient(tt.currentNamespaces, tt.err),
-				Preview:   client.NewFakePreviewClient(nil, nil),
+				Preview:   client.NewFakePreviewClient(nil, nil, nil),
 				Users:     client.NewFakeUsersClient(usr),
 			}
 			nsCmd := &NamespaceCommand{

--- a/cmd/namespace/use_test.go
+++ b/cmd/namespace/use_test.go
@@ -83,7 +83,7 @@ func Test_useNamespace(t *testing.T) {
 			}
 			fakeOktetoClient := &client.FakeOktetoClient{
 				Namespace: client.NewFakeNamespaceClient(tt.currentNamespaces, nil),
-				Preview:   client.NewFakePreviewClient(nil, nil),
+				Preview:   client.NewFakePreviewClient(nil, nil, nil),
 				Users:     client.NewFakeUsersClient(usr),
 			}
 			nsCmd := &NamespaceCommand{

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -198,11 +198,7 @@ func (pw *Command) executeDeployPreview(ctx context.Context, name, scope, reposi
 	oktetoLog.StartSpinner()
 	defer oktetoLog.StopSpinner()
 
-	oktetoClient, err := okteto.NewOktetoClient()
-	if err != nil {
-		return nil, err
-	}
-	resp, err := oktetoClient.DeployPreview(ctx, name, scope, repository, branch, sourceUrl, filename, variables)
+	resp, err := pw.okClient.Previews().DeployPreview(ctx, name, scope, repository, branch, sourceUrl, filename, variables)
 
 	if err != nil {
 		return nil, err

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -252,17 +252,12 @@ func (pw *Command) waitForResourcesToBeRunning(ctx context.Context, name string,
 	ticker := time.NewTicker(5 * time.Second)
 	to := time.NewTicker(timeout)
 
-	oktetoClient, err := okteto.NewOktetoClient()
-	if err != nil {
-		return err
-	}
-
 	for {
 		select {
 		case <-to.C:
 			return fmt.Errorf("preview environment '%s' didn't finish after %s", name, timeout.String())
 		case <-ticker.C:
-			resourceStatus, err := oktetoClient.GetResourcesStatusFromPreview(ctx, name, "")
+			resourceStatus, err := pw.okClient.Previews().GetResourcesStatusFromPreview(ctx, name, "")
 			if err != nil {
 				return err
 			}

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -108,7 +108,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			resp, err := previewCmd.executeDeployPreview(ctx, name, scope, repository, branch, sourceUrl, file, varList, wait, timeout)
+			resp, err := previewCmd.executeDeployPreview(ctx, name, scope, repository, branch, sourceUrl, file, varList)
 			analytics.TrackPreviewDeploy(err == nil)
 			if err != nil {
 				return err
@@ -194,7 +194,7 @@ func getRandomName(ctx context.Context, scope string) string {
 	return name
 }
 
-func (pw *Command) executeDeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []types.Variable, wait bool, timeout time.Duration) (*types.PreviewResponse, error) {
+func (pw *Command) executeDeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []types.Variable) (*types.PreviewResponse, error) {
 	oktetoLog.Spinner("Deploying your preview environment...")
 	oktetoLog.StartSpinner()
 	defer oktetoLog.StopSpinner()

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -241,11 +241,7 @@ func (pw *Command) waitUntilRunning(ctx context.Context, name string, a *types.A
 	return nil
 }
 func (pw *Command) waitToBeDeployed(ctx context.Context, name string, a *types.Action, timeout time.Duration) error {
-	oktetoClient, err := okteto.NewOktetoClient()
-	if err != nil {
-		return err
-	}
-	return oktetoClient.Pipeline().WaitForActionToFinish(ctx, name, a.Name, timeout)
+	return pw.okClient.Pipeline().WaitForActionToFinish(ctx, name, a.Name, timeout)
 }
 
 func (pw *Command) waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.Duration) error {

--- a/cmd/preview/preview.go
+++ b/cmd/preview/preview.go
@@ -16,8 +16,25 @@ package preview
 import (
 	"context"
 
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
 )
+
+type Command struct {
+	okClient types.OktetoInterface
+}
+
+// NewCommand creates a namespace command for previews
+func NewCommand() (*Command, error) {
+	c, err := okteto.NewOktetoClient()
+	if err != nil {
+		return nil, err
+	}
+	return &Command{
+		okClient: c,
+	}, nil
+}
 
 // Preview preview management commands
 func Preview(ctx context.Context) *cobra.Command {

--- a/cmd/utils/okteto_test.go
+++ b/cmd/utils/okteto_test.go
@@ -82,7 +82,7 @@ func Test_createContext(t *testing.T) {
 
 			fakeClient := client.NewFakeOktetoClient()
 			fakeClient.Namespace = client.NewFakeNamespaceClient(tt.namespaces, tt.err)
-			fakeClient.Preview = client.NewFakePreviewClient(tt.previews, tt.err)
+			fakeClient.Preview = client.NewFakePreviewClient(tt.previews, nil, tt.err)
 			hasAccess, err := HasAccessToOktetoClusterNamespace(ctx, "test", fakeClient)
 
 			assert.Equal(t, tt.expectedErr, err != nil)

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -26,6 +26,7 @@ type FakePreviewsClient struct {
 	err error
 }
 
+// NewFakePreviewClient returns a new fake preview client
 func NewFakePreviewClient(previewList []types.Preview, preview *types.PreviewResponse, err error) *FakePreviewsClient {
 	return &FakePreviewsClient{
 		previewList: previewList,
@@ -39,11 +40,12 @@ func (c *FakePreviewsClient) List(_ context.Context) ([]types.Preview, error) {
 	return c.previewList, c.err
 }
 
-// List list namespaces
+// DeployPreview deploys a preview
 func (c *FakePreviewsClient) DeployPreview(_ context.Context, _, _, _, _, _, _ string, _ []types.Variable) (*types.PreviewResponse, error) {
 	return c.preview, c.err
 }
 
-func (c *FakePreviewsClient) GetResourcesStatusFromPreview(ctx context.Context, previewName, devName string) (map[string]string, error) {
+// GetResourcesStatusFromPreview gets resources from a fake preview
+func (c *FakePreviewsClient) GetResourcesStatusFromPreview(_ context.Context, _, _ string) (map[string]string, error) {
 	return c.resourceStatus, c.err
 }

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -19,9 +19,11 @@ import (
 
 // FakePreviewsClient mocks the previews interface
 type FakePreviewsClient struct {
-	preview     *types.PreviewResponse
-	previewList []types.Preview
-	err         error
+	preview        *types.PreviewResponse
+	previewList    []types.Preview
+	resourceStatus map[string]string
+
+	err error
 }
 
 func NewFakePreviewClient(previewList []types.Preview, preview *types.PreviewResponse, err error) *FakePreviewsClient {
@@ -40,4 +42,8 @@ func (c *FakePreviewsClient) List(_ context.Context) ([]types.Preview, error) {
 // List list namespaces
 func (c *FakePreviewsClient) DeployPreview(_ context.Context, _, _, _, _, _, _ string, _ []types.Variable) (*types.PreviewResponse, error) {
 	return c.preview, c.err
+}
+
+func (c *FakePreviewsClient) GetResourcesStatusFromPreview(ctx context.Context, previewName, devName string) (map[string]string, error) {
+	return c.resourceStatus, c.err
 }

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -19,15 +19,25 @@ import (
 
 // FakePreviewsClient mocks the previews interface
 type FakePreviewsClient struct {
-	preview []types.Preview
-	err     error
+	preview     *types.PreviewResponse
+	previewList []types.Preview
+	err         error
 }
 
-func NewFakePreviewClient(previews []types.Preview, err error) *FakePreviewsClient {
-	return &FakePreviewsClient{preview: previews, err: err}
+func NewFakePreviewClient(previewList []types.Preview, preview *types.PreviewResponse, err error) *FakePreviewsClient {
+	return &FakePreviewsClient{
+		previewList: previewList,
+		preview:     preview,
+		err:         err,
+	}
 }
 
 // List list namespaces
 func (c *FakePreviewsClient) List(_ context.Context) ([]types.Preview, error) {
+	return c.previewList, c.err
+}
+
+// List list namespaces
+func (c *FakePreviewsClient) DeployPreview(_ context.Context, _, _, _, _, _, _ string, _ []types.Variable) (*types.PreviewResponse, error) {
 	return c.preview, c.err
 }

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -421,7 +421,7 @@ func (c *pipelineClient) GetResourcesStatus(ctx context.Context, name string) (m
 	if err := query(ctx, &queryStruct, variables, c.client); err != nil {
 		if oktetoErrors.IsNotFound(err) {
 			okClient := OktetoClient{client: c.client}
-			return okClient.GetResourcesStatusFromPreview(ctx, Context().Namespace, name)
+			return okClient.Previews().GetResourcesStatusFromPreview(ctx, Context().Namespace, name)
 		}
 		return nil, err
 	}

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -33,7 +33,7 @@ func newPreviewClient(client *graphql.Client) *previewClient {
 	return &previewClient{client: client}
 }
 
-//PreviewEnv represents an Okteto preview environment
+// PreviewEnv represents an Okteto preview environment
 type PreviewEnv struct {
 	ID       string `json:"id" yaml:"id"`
 	Job      string `json:"job" yaml:"job"`
@@ -49,7 +49,7 @@ type InputVariable struct {
 type PreviewScope graphql.String
 
 // DeployPreview creates a preview environment
-func (c *OktetoClient) DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []types.Variable) (*types.PreviewResponse, error) {
+func (c *previewClient) DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []types.Variable) (*types.PreviewResponse, error) {
 	if err := validateNamespace(name, "preview environment"); err != nil {
 		return nil, err
 	}

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -272,7 +272,7 @@ func (c *OktetoClient) GetPreviewEnvByName(ctx context.Context, name string) (*t
 	return nil, oktetoErrors.ErrNotFound
 }
 
-func (c *OktetoClient) GetResourcesStatusFromPreview(ctx context.Context, previewName, devName string) (map[string]string, error) {
+func (c *previewClient) GetResourcesStatusFromPreview(ctx context.Context, previewName, devName string) (map[string]string, error) {
 	var queryStruct struct {
 		Preview struct {
 			Deployments []struct {

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -44,6 +44,7 @@ type NamespaceInterface interface {
 type PreviewInterface interface {
 	List(ctx context.Context) ([]Preview, error)
 	DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []Variable) (*PreviewResponse, error)
+	GetResourcesStatusFromPreview(ctx context.Context, previewName, devName string) (map[string]string, error)
 }
 
 // PipelineInterface represents the client that connects to the pipeline functions

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -43,6 +43,7 @@ type NamespaceInterface interface {
 // PreviewInterface represents the client that connects to the preview functions
 type PreviewInterface interface {
 	List(ctx context.Context) ([]Preview, error)
+	DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []Variable) (*PreviewResponse, error)
 }
 
 // PipelineInterface represents the client that connects to the pipeline functions


### PR DESCRIPTION
# Proposed changes

Fixes #2794 

As the Preview cmd was not using the okclient interface, this PR has a refactor of the preview cmd to be able to use the StreamLogs function created at the pipeline logs PR #3073 

Added capabilities to the preview cmd to show the logs from the installer when `--wait` option is enabled
