### PR TITLE
deprecate manifestv1

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -321,6 +321,11 @@ func Up() *cobra.Command {
 				upOptions.Deploy = true
 			}
 
+			if up.Manifest.Type == model.OktetoManifestType && !up.Manifest.IsV2 {
+				oktetoLog.Warning("okteto manifest v1 is deprecated and will be removed in okteto 3.0")
+				oktetoLog.Println(fmt.Sprintf("    %s", oktetoLog.BlueString("Consider upgrading to the new manifest schema: https://www.okteto.com/docs/reference/manifest-migration/")))
+			}
+
 			err = up.start()
 
 			if err != nil {
@@ -525,6 +530,7 @@ func (up *upContext) start() error {
 	analytics.TrackUp(analytics.TrackUpMetadata{
 		IsInteractive:          up.getInteractive(),
 		IsOktetoRepository:     utils.IsOktetoRepo(),
+		IsV2:                   up.Manifest.IsV2,
 		HasDependenciesSection: up.Manifest.IsV2 && len(up.Manifest.Dependencies) > 0,
 		HasBuildSection:        up.Manifest.IsV2 && len(up.Manifest.Build) > 0,
 		HasDeploySection: (up.Manifest.IsV2 &&

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -323,7 +323,8 @@ func Up() *cobra.Command {
 
 			if up.Manifest.Type == model.OktetoManifestType && !up.Manifest.IsV2 {
 				oktetoLog.Warning("okteto manifest v1 is deprecated and will be removed in okteto 3.0")
-				oktetoLog.Println(fmt.Sprintf("    %s", oktetoLog.BlueString("Consider upgrading to the new manifest schema: https://www.okteto.com/docs/reference/manifest-migration/")))
+				oktetoLog.Println(oktetoLog.BlueString(`    Follow this guide to upgrade to the new okteto manifest schema:
+    https://www.okteto.com/docs/reference/manifest-migration/`))
 			}
 
 			err = up.start()

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -164,7 +164,10 @@ func TrackResetDatabase(success bool) {
 	track(syncResetDatabase, success, nil)
 }
 
+// TrackUpMetadata defines the properties an up can have
 type TrackUpMetadata struct {
+	IsV2                   bool
+	ManifestType           model.Archetype
 	IsInteractive          bool
 	IsOktetoRepository     bool
 	HasDependenciesSection bool
@@ -177,6 +180,8 @@ type TrackUpMetadata struct {
 func TrackUp(m TrackUpMetadata) {
 	props := map[string]interface{}{
 		"isInteractive":          m.IsInteractive,
+		"isV2":                   m.IsV2,
+		"manifestType":           m.ManifestType,
 		"isOktetoRepository":     m.IsOktetoRepository,
 		"hasDependenciesSection": m.HasDependenciesSection,
 		"hasBuildSection":        m.HasBuildSection,

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -651,6 +651,7 @@ func Read(bytes []byte) (*Manifest, error) {
 		return nil, err
 	}
 	manifest.Manifest = bytes
+	manifest.Type = OktetoManifestType
 	return manifest, nil
 }
 

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1070,6 +1070,7 @@ deploy:
 				Dependencies: map[string]*Dependency{},
 				Context:      "context-to-use",
 				IsV2:         true,
+				Type:         OktetoManifestType,
 			},
 			isErrorExpected: false,
 		},
@@ -1088,6 +1089,7 @@ dev:
 `),
 			expected: &Manifest{
 				IsV2:  true,
+				Type:  OktetoManifestType,
 				Build: map[string]*BuildInfo{},
 				Deploy: &DeployInfo{
 					Commands: []DeployCommand{
@@ -1240,6 +1242,7 @@ dev:
 sync:
   - app:/app`),
 			expected: &Manifest{
+				Type:          OktetoManifestType,
 				Build:         map[string]*BuildInfo{},
 				Deploy:        &DeployInfo{},
 				Dependencies:  map[string]*Dependency{},
@@ -1322,6 +1325,7 @@ sync:
 services:
   - name: svc`),
 			expected: &Manifest{
+				Type:          OktetoManifestType,
 				Build:         map[string]*BuildInfo{},
 				Deploy:        &DeployInfo{},
 				Dependencies:  map[string]*Dependency{},
@@ -1452,6 +1456,7 @@ dev:
     - app:/app
 `),
 			expected: &Manifest{
+				Type:         OktetoManifestType,
 				IsV2:         true,
 				Build:        map[string]*BuildInfo{},
 				Dependencies: map[string]*Dependency{},
@@ -1537,6 +1542,7 @@ dev:
     - app:/app
 `),
 			expected: &Manifest{
+				Type:         OktetoManifestType,
 				IsV2:         true,
 				Build:        map[string]*BuildInfo{},
 				Dependencies: map[string]*Dependency{},
@@ -1702,6 +1708,7 @@ deploy:
   - okteto stack deploy
 `),
 			expected: &Manifest{
+				Type:         OktetoManifestType,
 				IsV2:         true,
 				Dev:          map[string]*Dev{},
 				Build:        map[string]*BuildInfo{},
@@ -1727,6 +1734,7 @@ devs:
   - test
 `),
 			expected: &Manifest{
+				Type:         OktetoManifestType,
 				IsV2:         true,
 				Dev:          map[string]*Dev{},
 				Build:        map[string]*BuildInfo{},


### PR DESCRIPTION
# Proposed changes

Fixes #3066 

- Include a warning and an event to track how many people are using manifest v1 on the up command

## Screenshot

<img width="636" alt="Captura de Pantalla 2022-09-09 a las 13 42 53" src="https://user-images.githubusercontent.com/25170843/189342438-74d7389e-f9c7-4c32-8985-bc52794f0b35.png">


