### PR TITLE
feat: add keep annotation

### DIFF
--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -41,6 +41,8 @@ const (
     ports:
       - 8080
       - 8913
+	labels:
+	  dev.okteto.com/policy: keep
   nginx:
     image: nginx
     volumes:
@@ -477,6 +479,9 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
+	require.True(t, k8sErrors.IsNotFound(err))
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -41,8 +41,8 @@ const (
     ports:
       - 8080
       - 8913
-	labels:
-	  dev.okteto.com/policy: keep
+    labels:
+      dev.okteto.com/policy: keep
   nginx:
     image: nginx
     volumes:

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -413,9 +413,6 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 
-	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
-	require.NoError(t, err)
-
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
 }

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -208,6 +208,9 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 
 	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
+	require.NoError(t, err)
+
+	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
@@ -286,6 +289,9 @@ func TestReDeployPipelineFromCompose(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 
 	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
+	require.NoError(t, err)
+
+	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
@@ -341,7 +347,10 @@ func TestDeployPipelineFromComposeOnlyOneSvc(t *testing.T) {
 
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 
-	_, err = integration.GetDeployment(context.Background(), testNamespace, "app", c)
+	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
+	require.NoError(t, err)
+
+	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
@@ -404,7 +413,10 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 
-	_, err = integration.GetDeployment(context.Background(), testNamespace, "app", c)
+	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
+	require.NoError(t, err)
+
+	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
@@ -481,7 +493,7 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 
 	_, err = integration.GetService(context.Background(), testNamespace, "app", c)
-	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, err)
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))

--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -112,8 +112,8 @@ func (n *Namespaces) DestroyWithLabel(ctx context.Context, ns string, opts Delet
 			return nil
 		}
 
-		if gvk.Kind == volumeKind && m.GetAnnotations()[resourcePolicyAnnotation] == keepPolicy {
-			oktetoLog.Debugf("skipping deletion of pvc '%s' because of policy annotation", m.GetName())
+		if m.GetAnnotations()[resourcePolicyAnnotation] == keepPolicy {
+			oktetoLog.Debugf("skipping deletion of %s '%s' because of policy annotation", gvk.Kind, m.GetName())
 			return nil
 		}
 

--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -183,6 +183,10 @@ func (n *Namespaces) DestroySFSVolumes(ctx context.Context, ns string, opts Dele
 		return fmt.Errorf("error getting volumes: %s", err)
 	}
 	for _, v := range vList {
+		if v.Annotations[resourcePolicyAnnotation] == keepPolicy {
+			oktetoLog.Debugf("skipping deletion of pvc '%s' because of policy annotation", v.GetName())
+			continue
+		}
 		for _, pvcName := range pvcNames {
 			if strings.HasPrefix(v.Name, pvcName) {
 				if err := volumes.DestroyWithoutTimeout(ctx, v.Name, ns, n.k8sClient); err != nil {

--- a/pkg/k8s/namespaces/namespace_test.go
+++ b/pkg/k8s/namespaces/namespace_test.go
@@ -231,6 +231,84 @@ func TestDestroySFSVolumesIfNeeded(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "WithVolumeClaimTemplateOnlyDeleteTheOnesWithoutKeepPolicy",
+			includeVolumes: true,
+			k8Resources: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sfs-1",
+						Namespace: ns,
+						Labels: map[string]string{
+							model.DeployedByLabel: appName,
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						VolumeClaimTemplates: []apiv1.PersistentVolumeClaim{
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "pvc",
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "mysql",
+								},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "redis",
+								},
+							},
+						},
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+						Annotations: map[string]string{
+							resourcePolicyAnnotation: keepPolicy,
+						},
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mysql-sfs-1-afahrret34",
+						Namespace: ns,
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "redis-sfs-1-jdtrtqwetq",
+						Namespace: ns,
+					},
+				},
+				&apiv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mongodb",
+						Namespace: ns,
+					},
+				},
+			},
+			expectedPVCs: []apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pvc-sfs-1-aadfwt312ad",
+						Namespace: ns,
+						Annotations: map[string]string{
+							resourcePolicyAnnotation: keepPolicy,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "mongodb",
+						Namespace: ns,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #3082

- Skip the deletion of the volume if it has `dev.okteto.com/policy` set to `keep`.

## Concerns

The annotation is just working on volumes, do we need to extend the behavior to every resource(if  `dev.okteto.com/policy` set to `keep` we shouldn't delete the resource)
cc: @pchico83 