### PR TITLE
Added BuildSecrets to build manifest

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -273,7 +273,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 
 	if len(b.Secrets) > 0 {
 		if o.Secrets == nil {
-			o.Secrets = make([]string, 0)
+			o.Secrets = []string{}
 		}
 		// add to the build the secrets at the manifest
 		for id, src := range b.Secrets {

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -271,16 +271,6 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		}
 	}
 
-	if len(b.Secrets) > 0 {
-		if o.Secrets == nil {
-			o.Secrets = []string{}
-		}
-		// add to the build the secrets at the manifest
-		for id, src := range b.Secrets {
-			o.Secrets = append(o.Secrets, fmt.Sprintf("id=%s,src=%s", id, src))
-		}
-	}
-
 	opts := &types.BuildOptions{
 		CacheFrom: b.CacheFrom,
 		Target:    b.Target,
@@ -290,6 +280,11 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		BuildArgs: model.SerializeBuildArgs(b.Args),
 		NoCache:   o.NoCache,
 		Secrets:   o.Secrets,
+	}
+
+	// add to the build the secrets at the manifest
+	for id, src := range b.Secrets {
+		opts.Secrets = append(opts.Secrets, fmt.Sprintf("id=%s,src=%s", id, src))
 	}
 
 	outputMode := oktetoLog.GetOutputFormat()

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -248,21 +248,21 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 
 	if registry.IsOktetoRegistry(b.Image) {
 		defaultBuildArgs := map[string]string{
-			model.OktetoContextEnvVar:        okteto.Context().Name,
-			model.OktetoNamespaceEnvVar:       okteto.Context().Namespace,
+			model.OktetoContextEnvVar:   okteto.Context().Name,
+			model.OktetoNamespaceEnvVar: okteto.Context().Namespace,
 		}
 
 		for _, e := range b.Args {
 			if _, exists := defaultBuildArgs[e.Name]; !exists {
-				continue;
+				continue
 			}
 			// we don't want to replace build arguments that were already set by the user
 			delete(defaultBuildArgs, e.Name)
 		}
 
 		for key, val := range defaultBuildArgs {
-			if (val == "") {
-				continue;
+			if val == "" {
+				continue
 			}
 
 			b.Args = append(b.Args, model.EnvVar{
@@ -271,9 +271,14 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		}
 	}
 
-	// add to the build the secrets at the manifest
-	for id, src := range b.Secrets {
-		o.Secrets = append(o.Secrets, fmt.Sprintf("id=%s,src=%s", id, src))
+	if len(b.Secrets) > 0 {
+		if o.Secrets == nil {
+			o.Secrets = make([]string, 0)
+		}
+		// add to the build the secrets at the manifest
+		for id, src := range b.Secrets {
+			o.Secrets = append(o.Secrets, fmt.Sprintf("id=%s,src=%s", id, src))
+		}
 	}
 
 	opts := &types.BuildOptions{

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -271,6 +271,11 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		}
 	}
 
+	// add to the build the secrets at the manifest
+	for id, src := range b.Secrets {
+		o.Secrets = append(o.Secrets, fmt.Sprintf("id=%s,src=%s", id, src))
+	}
+
 	opts := &types.BuildOptions{
 		CacheFrom: b.CacheFrom,
 		Target:    b.Target,
@@ -279,6 +284,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		File:      file,
 		BuildArgs: model.SerializeBuildArgs(b.Args),
 		NoCache:   o.NoCache,
+		Secrets:   o.Secrets,
 	}
 
 	outputMode := oktetoLog.GetOutputFormat()

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -279,10 +279,13 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		File:      file,
 		BuildArgs: model.SerializeBuildArgs(b.Args),
 		NoCache:   o.NoCache,
-		Secrets:   o.Secrets,
 	}
 
-	// add to the build the secrets at the manifest
+	// if secrets are present at the cmd flag, copy them to opts.Secrets
+	if o.Secrets != nil {
+		opts.Secrets = o.Secrets
+	}
+	// add to the build the secrets from the manifest build
 	for id, src := range b.Secrets {
 		opts.Secrets = append(opts.Secrets, fmt.Sprintf("id=%s,src=%s", id, src))
 	}

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -225,6 +225,9 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 						Value: "value1",
 					},
 				},
+				Secrets: map[string]string{
+					"mysecret": "source",
+				},
 			},
 			initialOpts: &types.BuildOptions{
 				OutputMode: "tty",
@@ -238,6 +241,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Path:       "service",
 				CacheFrom:  []string{"cache-image"},
 				BuildArgs:  []string{namespaceEnvVar.String(), "arg1=value1"},
+				Secrets:    []string{"id=mysecret,src=source"},
 			},
 		},
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -128,10 +128,14 @@ type BuildInfo struct {
 	VolumesToInclude []StackVolume  `yaml:"-"`
 	ExportCache      string         `yaml:"export_cache,omitempty"`
 	DependsOn        BuildDependsOn `yaml:"depends_on,omitempty"`
+	Secrets          BuildSecrets   `yaml:"secrets,omitempty"`
 }
 
 // BuildDependsOn represents the images that needs to be built before
 type BuildDependsOn []string
+
+// BuildSecrets represents the secrets to be injected to the build of the image
+type BuildSecrets map[string]string
 
 // GetDockerfilePath returns the path to the Dockerfile
 func (b *BuildInfo) GetDockerfilePath() string {

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -46,6 +46,7 @@ type buildInfoRaw struct {
 	VolumesToInclude []StackVolume  `yaml:"-"`
 	ExportCache      string         `yaml:"export_cache,omitempty"`
 	DependsOn        BuildDependsOn `yaml:"depends_on,omitempty"`
+	Secrets          BuildSecrets   `yaml:"secrets,omitempty"`
 }
 
 type syncRaw struct {
@@ -332,6 +333,7 @@ func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) err
 	buildInfo.CacheFrom = rawBuildInfo.CacheFrom
 	buildInfo.ExportCache = rawBuildInfo.ExportCache
 	buildInfo.DependsOn = rawBuildInfo.DependsOn
+	buildInfo.Secrets = rawBuildInfo.Secrets
 	return nil
 }
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -82,7 +82,7 @@ type AffinityRaw struct {
 	PodAntiAffinity *PodAntiAffinity `yaml:"podAntiAffinity,omitempty" json:"podAntiAffinity,omitempty"`
 }
 
-// Describes node affinity scheduling rules for the pod.
+// NodeAffinity describes node affinity scheduling rules for the pod.
 type NodeAffinity struct {
 	RequiredDuringSchedulingIgnoredDuringExecution  *NodeSelector             `yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty" json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
 	PreferredDuringSchedulingIgnoredDuringExecution []PreferredSchedulingTerm `yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty" json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
@@ -110,13 +110,13 @@ type PreferredSchedulingTerm struct {
 	Preference NodeSelectorTerm `yaml:"preference" json:"preference"`
 }
 
-// Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+// PodAffinity describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
 type PodAffinity struct {
 	RequiredDuringSchedulingIgnoredDuringExecution  []PodAffinityTerm         `yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty" json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
 	PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty" json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
 }
 
-// Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+// PodAntiAffinity describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
 type PodAntiAffinity struct {
 	RequiredDuringSchedulingIgnoredDuringExecution  []PodAffinityTerm         `yaml:"requiredDuringSchedulingIgnoredDuringExecution,omitempty" json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
 	PreferredDuringSchedulingIgnoredDuringExecution []WeightedPodAffinityTerm `yaml:"preferredDuringSchedulingIgnoredDuringExecution,omitempty" json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -2112,7 +2112,10 @@ func TestManifestBuildUnmarshalling(t *testing.T) {
   args:
     key1: value1
   cache_from:
-    - cache-image`),
+    - cache-image
+  secrets:
+    mysecret: source
+    othersecret: othersource`),
 			expected: ManifestBuild{
 				"service2": {
 					Context:    "./service2",
@@ -2125,6 +2128,10 @@ func TestManifestBuildUnmarshalling(t *testing.T) {
 						},
 					},
 					CacheFrom: []string{"cache-image"},
+					Secrets: BuildSecrets{
+						"mysecret":    "source",
+						"othersecret": "othersource",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
# Proposed changes

Fixes #2566 

Secrets was supported via `okteto build` flag, now secrets can be added to the okteto manifest under the build section
