### PR TITLE
Return clear error when docker compose doesn't have dev section

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -158,6 +158,9 @@ func Up() *cobra.Command {
 			os.Setenv(model.OktetoNameEnvVar, oktetoManifest.Name)
 
 			if len(oktetoManifest.Dev) == 0 {
+				if oktetoManifest.Type == model.StackType {
+					return fmt.Errorf("couldn't find any dev environment from your docker compose %q. Only services with local volumes are transformed into devs: https://www.okteto.com/docs/reference/compose/#volumes-string-optional", oktetoManifest.Name)
+				}
 				oktetoLog.Warning("okteto manifest has no 'dev' section.")
 				answer, err := utils.AskYesNo("Do you want to configure okteto manifest now? [y/n]")
 				if err != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -53,6 +53,8 @@ import (
 // ReconnectingMessage is the message shown when we are trying to reconnect
 const ReconnectingMessage = "Trying to reconnect to your cluster. File synchronization will automatically resume when the connection improves."
 
+const composeVolumesUrl = "https://www.okteto.com/docs/reference/compose/#volumes-string-optional"
+
 // UpOptions represents the options available on up command
 type UpOptions struct {
 	// ManifestPathFlag is the option -f as introduced by the user when executing this command.
@@ -159,7 +161,7 @@ func Up() *cobra.Command {
 
 			if len(oktetoManifest.Dev) == 0 {
 				if oktetoManifest.Type == model.StackType {
-					return fmt.Errorf("couldn't find any dev environment from your docker compose %q. Only services with local volumes are transformed into devs: https://www.okteto.com/docs/reference/compose/#volumes-string-optional", oktetoManifest.Name)
+					return fmt.Errorf("your docker compose file is not currently supported: Okteto requires a 'host volume' to be defined. See %s", composeVolumesUrl)
 				}
 				oktetoLog.Warning("okteto manifest has no 'dev' section.")
 				answer, err := utils.AskYesNo("Do you want to configure okteto manifest now? [y/n]")

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -51,9 +51,11 @@ import (
 )
 
 // ReconnectingMessage is the message shown when we are trying to reconnect
-const ReconnectingMessage = "Trying to reconnect to your cluster. File synchronization will automatically resume when the connection improves."
+const (
+	ReconnectingMessage = "Trying to reconnect to your cluster. File synchronization will automatically resume when the connection improves."
 
-const composeVolumesUrl = "https://www.okteto.com/docs/reference/compose/#volumes-string-optional"
+	composeVolumesUrl = "https://www.okteto.com/docs/reference/compose/#volumes-string-optional"
+)
 
 // UpOptions represents the options available on up command
 type UpOptions struct {


### PR DESCRIPTION
# Proposed changes

Fixes #2876

Checks `oktetoManifest.Type` to return an error when 
- there are not any dev sections
- type is `compose`