### PR TITLE
Context store may just be non-existent rather than corrupt

### DIFF
--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -37,6 +37,9 @@ func List() *cobra.Command {
 		Short:   "List available contexts",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+			if err := NewContextCommand().Run(ctx, &ContextOptions{raiseNotCtxError: true}); err != nil {
+				return err
+			}
 			return executeListContext(ctx)
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Zaheer Abbas Merali <zaheerabbas@merali.org>

# Proposed changes

Fixes #3107 

Amends the error message saying the context store may be corrupted by suggesting it is missing and recommends also to try running 'okteto ctx'
