### PR TITLE
redeploy stack with 0 downtime

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -63,7 +63,7 @@ const (
 	recreateUpdateStrategy updateStrategy = "recreate"
 
 	// onDeleteUpdateStrategy represents a recreate update strategy
-	onDeleteUpdateStrategy updateStrategy = "onDelete"
+	onDeleteUpdateStrategy updateStrategy = "on-delete"
 )
 
 func buildStackImages(ctx context.Context, s *model.Stack, options *StackDeployOptions) error {

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -114,7 +114,7 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 				MatchLabels: translateLabelSelector(svcName, s),
 			},
 			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RecreateDeploymentStrategyType,
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
 
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -48,6 +50,20 @@ const (
 	destroyingStatus  = "destroying"
 
 	pvcName = "pvc"
+)
+
+// +enum
+type updateStrategy string
+
+const (
+	// rollingUpdateStrategy represent a rolling update strategy
+	rollingUpdateStrategy updateStrategy = "rolling"
+
+	// recreateUpdateStrategy represents a recreate update strategy
+	recreateUpdateStrategy updateStrategy = "recreate"
+
+	// onDeleteUpdateStrategy represents a recreate update strategy
+	onDeleteUpdateStrategy updateStrategy = "onDelete"
 )
 
 func buildStackImages(ctx context.Context, s *model.Stack, options *StackDeployOptions) error {
@@ -113,9 +129,7 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: translateLabelSelector(svcName, s),
 			},
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RollingUpdateDeploymentStrategyType,
-			},
+			Strategy: getDeploymentUpdateStrategy(svc),
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      translateLabels(svcName, s),
@@ -171,6 +185,7 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 
 	initContainers := getInitContainers(svcName, s)
 	healthcheckProbe := getSvcProbe(svc)
+
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -184,7 +199,8 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: translateLabelSelector(svcName, s),
 			},
-			ServiceName: svcName,
+			UpdateStrategy: getStatefulsetUpdateStrategy(svc),
+			ServiceName:    svcName,
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      translateLabels(svcName, s),
@@ -679,4 +695,91 @@ func getSvcProbe(svc *model.Service) *apiv1.Probe {
 		}
 	}
 	return nil
+}
+
+type updateStrategyGetter interface {
+	validate(updateStrategy) error
+	getDefault() updateStrategy
+}
+
+type deploymentStrategyGetter struct{}
+
+func (*deploymentStrategyGetter) validate(updateStrategy updateStrategy) error {
+	if updateStrategy != rollingUpdateStrategy && updateStrategy != recreateUpdateStrategy {
+		return fmt.Errorf("invalid deployment update strategy: '%s'", updateStrategy)
+	}
+	return nil
+}
+
+func (*deploymentStrategyGetter) getDefault() updateStrategy {
+	return recreateUpdateStrategy
+}
+
+type statefulSetStrategyGetter struct{}
+
+func (*statefulSetStrategyGetter) validate(updateStrategy updateStrategy) error {
+	if updateStrategy != rollingUpdateStrategy && updateStrategy != onDeleteUpdateStrategy {
+		return fmt.Errorf("invalid statefulset update strategy: '%s'", updateStrategy)
+	}
+	return nil
+}
+
+func (*statefulSetStrategyGetter) getDefault() updateStrategy {
+	return rollingUpdateStrategy
+}
+
+func getDeploymentUpdateStrategy(svc *model.Service) appsv1.DeploymentStrategy {
+	result := getUpdateStrategy(svc, &deploymentStrategyGetter{})
+	if result == rollingUpdateStrategy {
+		return appsv1.DeploymentStrategy{
+			Type: appsv1.RollingUpdateDeploymentStrategyType,
+		}
+	}
+	return appsv1.DeploymentStrategy{
+		Type: appsv1.RecreateDeploymentStrategyType,
+	}
+}
+
+func getStatefulsetUpdateStrategy(svc *model.Service) appsv1.StatefulSetUpdateStrategy {
+	result := getUpdateStrategy(svc, &statefulSetStrategyGetter{})
+	if result == rollingUpdateStrategy {
+		return appsv1.StatefulSetUpdateStrategy{
+			Type: appsv1.RollingUpdateStatefulSetStrategyType,
+		}
+	}
+	return appsv1.StatefulSetUpdateStrategy{
+		Type: appsv1.OnDeleteStatefulSetStrategyType,
+	}
+}
+
+func getUpdateStrategy(svc *model.Service, strategy updateStrategyGetter) updateStrategy {
+	if result := getUpdateStrategyByAnnotation(svc); result != "" {
+		err := strategy.validate(result)
+		if err == nil {
+			return result
+		}
+		oktetoLog.Debugf("invalid strategy: %w", err)
+	}
+	if result := getUpdateStrategyByEnvVar(); result != "" {
+		err := strategy.validate(result)
+		if err == nil {
+			return result
+		}
+		oktetoLog.Debugf("invalid strategy: %w", err)
+	}
+	return strategy.getDefault()
+}
+
+func getUpdateStrategyByAnnotation(svc *model.Service) updateStrategy {
+	if v, ok := svc.Annotations[model.OktetoComposeUpdateStrategyAnnotation]; ok {
+		return updateStrategy(v)
+	}
+	return ""
+}
+
+func getUpdateStrategyByEnvVar() updateStrategy {
+	if v := os.Getenv(model.OktetoComposeUpdateStrategyEnvVar); v != "" {
+		return updateStrategy(v)
+	}
+	return ""
 }

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,7 +153,7 @@ func Test_translateDeployment(t *testing.T) {
 	if !reflect.DeepEqual(c.Resources, apiv1.ResourceRequirements{}) {
 		t.Errorf("Wrong container.resources: '%v'", c.Resources)
 	}
-
+	assert.Equal(t, result.Spec.Strategy, appsv1.RollingUpdateDeploymentStrategyType)
 }
 
 func Test_translateStatefulSet(t *testing.T) {
@@ -346,7 +347,7 @@ func Test_translateStatefulSet(t *testing.T) {
 	if !reflect.DeepEqual(vct.Spec, volumeClaimTemplateSpec) {
 		t.Errorf("Wrong statefulset volume claim template: '%v'", vct.Spec)
 	}
-
+	assert.Equal(t, result.Spec.UpdateStrategy, appsv1.RollingUpdateStatefulSetStrategyType)
 }
 
 func Test_translateJobWithoutVolumes(t *testing.T) {

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -153,7 +153,7 @@ func Test_translateDeployment(t *testing.T) {
 	if !reflect.DeepEqual(c.Resources, apiv1.ResourceRequirements{}) {
 		t.Errorf("Wrong container.resources: '%v'", c.Resources)
 	}
-	assert.Equal(t, result.Spec.Strategy.Type, appsv1.RollingUpdateDeploymentStrategyType)
+
 }
 
 func Test_translateStatefulSet(t *testing.T) {
@@ -347,7 +347,7 @@ func Test_translateStatefulSet(t *testing.T) {
 	if !reflect.DeepEqual(vct.Spec, volumeClaimTemplateSpec) {
 		t.Errorf("Wrong statefulset volume claim template: '%v'", vct.Spec)
 	}
-	assert.Equal(t, result.Spec.UpdateStrategy.Type, appsv1.RollingUpdateStatefulSetStrategyType)
+
 }
 
 func Test_translateJobWithoutVolumes(t *testing.T) {
@@ -1413,6 +1413,236 @@ func TestGetSvcPublicPorts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ports := getSvcPublicPorts(tt.svcName, tt.stack)
 			assert.Len(t, ports, tt.expectedLength)
+		})
+	}
+}
+
+func TestGetDeploymentStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		svc      *model.Service
+		envs     map[string]string
+		expected appsv1.DeploymentStrategy
+	}{
+		{
+			name: "default",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+		{
+			name: "annotation ok - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(rollingUpdateStrategy),
+				},
+			},
+			envs: map[string]string{},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+		},
+		{
+			name: "annotation ok with different env var - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(rollingUpdateStrategy),
+				},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(recreateUpdateStrategy),
+			},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+		},
+		{
+			name: "annotation not ok - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(onDeleteUpdateStrategy),
+				},
+			},
+			envs: map[string]string{},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+		{
+			name: "annotation ok - recreate",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(recreateUpdateStrategy),
+				},
+			},
+			envs: map[string]string{},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+		{
+			name: "env var ok - recreate",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(recreateUpdateStrategy),
+			},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+		{
+			name: "env var ok - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(rollingUpdateStrategy),
+			},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+		},
+		{
+			name: "env var not ok",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(onDeleteUpdateStrategy),
+			},
+			expected: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+			result := getDeploymentUpdateStrategy(tt.svc)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetStrategyStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		svc      *model.Service
+		envs     map[string]string
+		expected appsv1.StatefulSetUpdateStrategy
+	}{
+		{
+			name: "default",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+		},
+		{
+			name: "annotation ok - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(rollingUpdateStrategy),
+				},
+			},
+			envs: map[string]string{},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+		},
+		{
+			name: "annotation ok with different env var - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(rollingUpdateStrategy),
+				},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(recreateUpdateStrategy),
+			},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+		},
+		{
+			name: "annotation not ok - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(recreateUpdateStrategy),
+				},
+			},
+			envs: map[string]string{},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+		},
+		{
+			name: "annotation ok - onDelete",
+			svc: &model.Service{
+				Annotations: model.Annotations{
+					model.OktetoComposeUpdateStrategyAnnotation: string(onDeleteUpdateStrategy),
+				},
+			},
+			envs: map[string]string{},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.OnDeleteStatefulSetStrategyType,
+			},
+		},
+		{
+			name: "env var ok - onDelete",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(onDeleteUpdateStrategy),
+			},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.OnDeleteStatefulSetStrategyType,
+			},
+		},
+		{
+			name: "env var ok - rolling",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(rollingUpdateStrategy),
+			},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+		},
+		{
+			name: "env var not ok",
+			svc: &model.Service{
+				Annotations: model.Annotations{},
+			},
+			envs: map[string]string{
+				model.OktetoComposeUpdateStrategyEnvVar: string(recreateUpdateStrategy),
+			},
+			expected: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envs {
+				t.Setenv(k, v)
+			}
+			result := getStatefulsetUpdateStrategy(tt.svc)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -153,7 +153,7 @@ func Test_translateDeployment(t *testing.T) {
 	if !reflect.DeepEqual(c.Resources, apiv1.ResourceRequirements{}) {
 		t.Errorf("Wrong container.resources: '%v'", c.Resources)
 	}
-	assert.Equal(t, result.Spec.Strategy, appsv1.RollingUpdateDeploymentStrategyType)
+	assert.Equal(t, result.Spec.Strategy.Type, appsv1.RollingUpdateDeploymentStrategyType)
 }
 
 func Test_translateStatefulSet(t *testing.T) {
@@ -347,7 +347,7 @@ func Test_translateStatefulSet(t *testing.T) {
 	if !reflect.DeepEqual(vct.Spec, volumeClaimTemplateSpec) {
 		t.Errorf("Wrong statefulset volume claim template: '%v'", vct.Spec)
 	}
-	assert.Equal(t, result.Spec.UpdateStrategy, appsv1.RollingUpdateStatefulSetStrategyType)
+	assert.Equal(t, result.Spec.UpdateStrategy.Type, appsv1.RollingUpdateStatefulSetStrategyType)
 }
 
 func Test_translateJobWithoutVolumes(t *testing.T) {

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1588,7 +1588,7 @@ func TestGetStrategyStrategy(t *testing.T) {
 			},
 		},
 		{
-			name: "annotation ok - onDelete",
+			name: "annotation ok - on-delete",
 			svc: &model.Service{
 				Annotations: model.Annotations{
 					model.OktetoComposeUpdateStrategyAnnotation: string(onDeleteUpdateStrategy),
@@ -1600,7 +1600,7 @@ func TestGetStrategyStrategy(t *testing.T) {
 			},
 		},
 		{
-			name: "env var ok - onDelete",
+			name: "env var ok - on-delete",
 			svc: &model.Service{
 				Annotations: model.Annotations{},
 			},

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -34,6 +34,9 @@ const (
 	// OktetoSampleAnnotation indicates that the repo is a okteto sample
 	OktetoSampleAnnotation = "dev.okteto.com/sample"
 
+	// OktetoComposeUpdateStrategyAnnotation indicates how a compose service must be updated
+	OktetoComposeUpdateStrategyAnnotation = "dev.okteto.com/update"
+
 	// DetachedDevLabel indicates the detached dev pods
 	DetachedDevLabel = "detached.dev.okteto.com"
 
@@ -317,6 +320,9 @@ const (
 
 	// OktetoActionNameEnvVar defines the name of the pipeline action name
 	OktetoActionNameEnvVar = "OKTETO_ACTION_NAME"
+
+	// OktetoComposeUpdateStrategyEnvVar defines the strategy on compose to update the services
+	OktetoComposeUpdateStrategyEnvVar = "OKTETO_COMPOSE_UPDATE_STRATEGY"
 
 	// OktetoAutogenerateStignoreEnvVar skips the autogenerate stignore dialog and creates the default one
 	OktetoAutogenerateStignoreEnvVar = "OKTETO_AUTOGENERATE_STIGNORE"


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #3083

- Change from recreate strategy to rolling update

# Concerns

This change can generate new quota issues that we cannot detect if the command is not executed with the `--wait` flag.
<img width="1343" alt="Captura de Pantalla 2022-09-16 a las 10 45 10" src="https://user-images.githubusercontent.com/25170843/190611717-df717439-86d4-49f7-a9c7-addf7bd5fd90.png">
