### PR TITLE
Fix secret copy

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -59,6 +59,21 @@ services:
 `
 	dockerfileName    = "Dockerfile"
 	dockerfileContent = "FROM alpine"
+
+	dockerfileContentSecrets = `FROM alpine
+RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
+RUN --mount=type=secret,id=mysecret,dst=/other cat /other`
+
+	secretFile             = "mysecret.txt"
+	secretFileContent      = "secret"
+	manifestContentSecrets = `
+build:
+    test:
+      context: .
+      dockerfile: Dockerfile
+      secrets:
+        mysecret: mysecret.txt
+`
 )
 
 func TestMain(m *testing.M) {
@@ -269,6 +284,42 @@ func TestBuildCommandV2VolumeMounts(t *testing.T) {
 	require.True(t, isImageBuilt(expectedImageWithVolumes), "%s not found", expectedImageWithVolumes)
 }
 
+// TestTestBuildCommandV2Secrets tests the following scenario:
+// - build having an okteto manifest v2
+// - inject secrets from manifest to build
+func TestBuildCommandV2Secrets(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, createDockerfileWithSecretMount(dir))
+	require.NoError(t, createManifestV2Secrets(dir))
+	require.NoError(t, createSecretFile(dir))
+
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	testNamespace := integration.GetTestNamespace("TestBuildSecretsV2", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+
+	expectedBuildImage := fmt.Sprintf("%s/%s/%s-test:okteto", okteto.Context().Registry, testNamespace, filepath.Base(dir))
+	require.False(t, isImageBuilt(expectedBuildImage))
+
+	options := &commands.BuildOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		Token:      token,
+		OktetoHome: dir,
+		NoCache:    true,
+	}
+	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
+	require.True(t, isImageBuilt(expectedBuildImage), "%s not found", expectedBuildImage)
+}
+
 func createDockerfile(dir string) error {
 	dockerfilePath := filepath.Join(dir, dockerfileName)
 	dockerfileContent := []byte(dockerfileContent)
@@ -278,9 +329,36 @@ func createDockerfile(dir string) error {
 	return nil
 }
 
+func createDockerfileWithSecretMount(dir string) error {
+	dockerfilePath := filepath.Join(dir, dockerfileName)
+	dockerfileContent := []byte(dockerfileContentSecrets)
+	if err := os.WriteFile(dockerfilePath, dockerfileContent, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createSecretFile(dir string) error {
+	secretFilePath := filepath.Join(dir, secretFile)
+	secretFileContent := []byte(secretFileContent)
+	if err := os.WriteFile(secretFilePath, secretFileContent, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
 func createManifestV2(dir string) error {
 	manifestPath := filepath.Join(dir, manifestName)
 	manifestBytes := []byte(manifestContent)
+	if err := os.WriteFile(manifestPath, manifestBytes, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createManifestV2Secrets(dir string) error {
+	manifestPath := filepath.Join(dir, manifestName)
+	manifestBytes := []byte(manifestContentSecrets)
 	if err := os.WriteFile(manifestPath, manifestBytes, 0600); err != nil {
 		return err
 	}

--- a/integration/commands/build.go
+++ b/integration/commands/build.go
@@ -30,6 +30,7 @@ type BuildOptions struct {
 	Namespace    string
 	OktetoHome   string
 	Token        string
+	NoCache      bool
 }
 
 // RunOktetoBuild runs an okteto build command
@@ -61,6 +62,10 @@ func RunOktetoBuild(oktetoPath string, buildOptions *BuildOptions) error {
 	}
 	if buildOptions.Token != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, buildOptions.Token))
+	}
+
+	if buildOptions.NoCache {
+		cmd.Args = append(cmd.Args, "--no-cache")
 	}
 
 	o, err := cmd.CombinedOutput()

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -377,9 +377,9 @@ func parseTempSecrets(buildOptions *types.BuildOptions) (string, error) {
 		}
 
 		// save expanded to temp file
-		writter := bufio.NewWriter(tmpfile)
-		_, _ = writter.Write([]byte(fmt.Sprintf("%s\n", srcContent)))
-		writter.Flush()
+		writer := bufio.NewWriter(tmpfile)
+		_, _ = writer.Write([]byte(fmt.Sprintf("%s\n", srcContent)))
+		writer.Flush()
 
 		// replace src
 		buildOptions.Secrets[indx] = fmt.Sprintf("%ssrc=%s", splitSecret[0], tmpfile.Name())

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -362,7 +362,6 @@ func parseTempSecrets(buildOptions *types.BuildOptions) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		defer srcFile.Close()
 
 		// create temp file
 		tmpfile, err := os.CreateTemp(secretTempFolder, "secret-")
@@ -382,6 +381,9 @@ func parseTempSecrets(buildOptions *types.BuildOptions) (string, error) {
 			// save expanded to temp file
 			_, _ = writer.Write([]byte(fmt.Sprintf("%s\n", srcContent)))
 			writer.Flush()
+		}
+		if err := srcFile.Close(); err != nil {
+			return "", err
 		}
 		if sc.Err() != nil {
 			return "", sc.Err()

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1299,11 +1299,12 @@ func getLocalhost() string {
 // Copy clones the buildInfo without the pointers
 func (b *BuildInfo) Copy() *BuildInfo {
 	result := &BuildInfo{
-		Name:       b.Name,
-		Context:    b.Context,
-		Dockerfile: b.Dockerfile,
-		Target:     b.Target,
-		Image:      b.Image,
+		Name:        b.Name,
+		Context:     b.Context,
+		Dockerfile:  b.Dockerfile,
+		Target:      b.Target,
+		Image:       b.Image,
+		ExportCache: b.ExportCache,
 	}
 	cacheFrom := []string{}
 	cacheFrom = append(cacheFrom, b.CacheFrom...)
@@ -1322,5 +1323,10 @@ func (b *BuildInfo) Copy() *BuildInfo {
 	volumesToMount := []StackVolume{}
 	volumesToMount = append(volumesToMount, b.VolumesToInclude...)
 	result.VolumesToInclude = volumesToMount
+
+	dependsOn := BuildDependsOn{}
+	dependsOn = append(dependsOn, b.DependsOn...)
+	result.DependsOn = dependsOn
+
 	return result
 }

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1306,6 +1306,8 @@ func (b *BuildInfo) Copy() *BuildInfo {
 		Image:       b.Image,
 		ExportCache: b.ExportCache,
 	}
+
+	// copy to new pointers
 	cacheFrom := []string{}
 	cacheFrom = append(cacheFrom, b.CacheFrom...)
 	result.CacheFrom = cacheFrom

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1313,6 +1313,12 @@ func (b *BuildInfo) Copy() *BuildInfo {
 	args = append(args, b.Args...)
 	result.Args = args
 
+	secrets := BuildSecrets{}
+	for k, v := range b.Secrets {
+		secrets[k] = v
+	}
+	result.Secrets = secrets
+
 	volumesToMount := []StackVolume{}
 	volumesToMount = append(volumesToMount, b.VolumesToInclude...)
 	result.VolumesToInclude = volumesToMount

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1574,3 +1574,37 @@ func TestBuildInfo_GetDockerfilePath(t *testing.T) {
 		})
 	}
 }
+
+func Test_BuildInfoCopy(t *testing.T) {
+	b := &BuildInfo{
+		Name:        "test",
+		Context:     "context",
+		Dockerfile:  "dockerfile",
+		Target:      "target",
+		Image:       "image",
+		CacheFrom:   []string{"cache"},
+		ExportCache: "export",
+		Args: Environment{
+			EnvVar{
+				Name:  "env",
+				Value: "test",
+			},
+		},
+		Secrets: BuildSecrets{
+			"sec": "test",
+		},
+		VolumesToInclude: []StackVolume{
+			{
+				LocalPath:  "local",
+				RemotePath: "remote",
+			},
+		},
+		DependsOn: BuildDependsOn{"other"},
+	}
+
+	copy := b.Copy()
+	assert.EqualValues(t, b, copy)
+
+	samePointer := &copy == &b
+	assert.False(t, samePointer)
+}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1602,9 +1602,9 @@ func Test_BuildInfoCopy(t *testing.T) {
 		DependsOn: BuildDependsOn{"other"},
 	}
 
-	copy := b.Copy()
-	assert.EqualValues(t, b, copy)
+	copyB := b.Copy()
+	assert.EqualValues(t, b, copyB)
 
-	samePointer := &copy == &b
+	samePointer := &copyB == &b
 	assert.False(t, samePointer)
 }


### PR DESCRIPTION
# Proposed changes


Secrets declared at the manifest, or via the cmd flag `--secret` where removed when creating a Copy of the BuildInfo struct.
- This PR adds Secrets and other fields from BuildInfo that where being removed as nil pointers.
- Added integration and unit test for Copy function.

On the other hand, this PR also implements the use of templates at secret files, this way a secret can be mounted not only having  a local file, but using a template for the secret and having envs that will be replaced when running the build and mounting the secret.
- Parses the content of the secret file into builtkit as a temp file
