### PR TITLE
If insecure-skip-tls-verify set in context, don't put certificate-authority-data in temporal kubeconfig

### DIFF
--- a/cmd/deploy/kubeconfig.go
+++ b/cmd/deploy/kubeconfig.go
@@ -67,7 +67,9 @@ func (k *KubeConfig) Modify(port int, sessionToken, destKubeconfigFile string) e
 	if clusterInfo.CertificateAuthority != "" {
 		clusterInfo.CertificateAuthority = ""
 	}
-	clusterInfo.CertificateAuthorityData = cert
+	if !clusterInfo.InsecureSkipTLSVerify {
+		clusterInfo.CertificateAuthorityData = cert
+	}
 
 	// Save on disk the config changes
 	if err := clientcmd.WriteToFile(*proxyCfg, destKubeconfigFile); err != nil {


### PR DESCRIPTION
# Proposed changes

Fixes #3124

When writing temporal kubeconfig, only write certificate authority data if insecure-skip-tls-verify unset for the context. This allows okteto cli to be able to use the cluster rather than getting an error like: "error: specifying a root certificates file with the insecure flag is not allowed"
