### PR TITLE
Interrupt command deploy

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -221,7 +221,6 @@ func Deploy(ctx context.Context) *cobra.Command {
 				})
 
 				exit <- err
-				return
 			}()
 
 			select {


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

# Proposed changes

Fixes #2929 

The wrapper for detecting the signal was just wrapping the deploy section of the cmd. This PR poposes to wrap RunDeploy func into the go func so any signal detected during all the process (build, dependencies, deploy) is tracked and process can be exited.
