### PR TITLE
update init container logs

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -303,7 +303,7 @@ func getInitializeVolumeContentContainer(svcName string, svc *model.Service) *ap
 	var command string
 	for idx, v := range svc.Volumes {
 		volumeClaimName := getVolumeClaimName(&v)
-		command = fmt.Sprintf("echo initializing volume %s with content of the image '%s'...", volumeClaimName, svc.Image)
+		command = fmt.Sprintf(`echo initializing volume %s with content of the image %s...`, volumeClaimName, svc.Image)
 		subpath := fmt.Sprintf("data-%d", idx)
 		if v.LocalPath != "" {
 			subpath = v.LocalPath
@@ -317,7 +317,7 @@ func getInitializeVolumeContentContainer(svcName string, svc *model.Service) *ap
 			},
 		)
 
-		copyVolumeCmd := fmt.Sprintf("cp -Rv %s/. /init-volume-%d 2>&1 | sed -E 's/cp: (.*): No such file or directory/the image '%s' does not have any content in \\1/g'", v.RemotePath, idx, svc.Image)
+		copyVolumeCmd := fmt.Sprintf("cp -Rv %s/. /init-volume-%d 2>&1 | sed -E 's/cp: cannot stat (.*): No such file or directory/the image '%s' does not have any content in \\1/g'", v.RemotePath, idx, svc.Image)
 		command = fmt.Sprintf("%s && (%s || true)", command, copyVolumeCmd)
 	}
 	if len(c.VolumeMounts) != 0 {

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -303,7 +303,7 @@ func getInitializeVolumeContentContainer(svcName string, svc *model.Service) *ap
 	var command string
 	for idx, v := range svc.Volumes {
 		volumeClaimName := getVolumeClaimName(&v)
-		command = fmt.Sprintf("echo initilizing volume %s with content of the image '%s'...", volumeClaimName, svc.Image)
+		command = fmt.Sprintf("echo initializing volume %s with content of the image '%s'...", volumeClaimName, svc.Image)
 		subpath := fmt.Sprintf("data-%d", idx)
 		if v.LocalPath != "" {
 			subpath = v.LocalPath

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -255,7 +255,7 @@ func Test_translateStatefulSet(t *testing.T) {
 		Name:            fmt.Sprintf("init-volume-%s", "svcName"),
 		Image:           "image",
 		ImagePullPolicy: apiv1.PullIfNotPresent,
-		Command:         []string{"sh", "-c", "echo initializing volume... && (cp -Rv /volume1/. /init-volume-0 || true) && (cp -Rv /volume2/. /init-volume-1 || true)"},
+		Command:         []string{"sh", "-c", "echo initializing volume pvc with content of the image image... && (cp -Rv /volume1/. /init-volume-0 2>&1 | sed -E 's/cp: cannot stat (.*): No such file or directory/the image 'image' does not have any content in \\1/g' || true) && echo initializing volume pvc with content of the image image... && (cp -Rv /volume2/. /init-volume-1 2>&1 | sed -E 's/cp: cannot stat (.*): No such file or directory/the image 'image' does not have any content in \\1/g' || true)"},
 		VolumeMounts: []apiv1.VolumeMount{
 			{
 				MountPath: "/init-volume-0",
@@ -587,7 +587,7 @@ func Test_translateJobWithVolumes(t *testing.T) {
 		Name:            fmt.Sprintf("init-volume-%s", "svcName"),
 		Image:           "image",
 		ImagePullPolicy: apiv1.PullIfNotPresent,
-		Command:         []string{"sh", "-c", "echo initializing volume... && (cp -Rv /volume1/. /init-volume-0 || true) && (cp -Rv /volume2/. /init-volume-1 || true)"},
+		Command:         []string{"sh", "-c", "echo initializing volume pvc with content of the image image... && (cp -Rv /volume1/. /init-volume-0 2>&1 | sed -E 's/cp: cannot stat (.*): No such file or directory/the image 'image' does not have any content in \\1/g' || true) && echo initializing volume pvc with content of the image image... && (cp -Rv /volume2/. /init-volume-1 2>&1 | sed -E 's/cp: cannot stat (.*): No such file or directory/the image 'image' does not have any content in \\1/g' || true)"},
 		VolumeMounts: []apiv1.VolumeMount{
 			{
 				MountPath: "/init-volume-0",


### PR DESCRIPTION
# Proposed changes

Fixes #3060 

- updated commands executed in init container
- replace error output with a more explanatory message

Proposed output in the PR: 

<img width="926" alt="Captura de pantalla 2022-09-26 a las 11 38 13" src="https://user-images.githubusercontent.com/22500940/192244452-01f263c5-9de4-4815-b6d2-3a4070319578.png">
