### PR TITLE
Followup unit test for secrets

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -381,6 +381,9 @@ func parseTempSecrets(secretTempFolder string, buildOptions *types.BuildOptions)
 			_, _ = writer.Write([]byte(fmt.Sprintf("%s\n", srcContent)))
 			writer.Flush()
 		}
+		if err := tmpfile.Close(); err != nil {
+			return err
+		}
 		if err := srcFile.Close(); err != nil {
 			return err
 		}

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -432,7 +432,6 @@ func Test_parseTempSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tmpTestSecretFile.Close()
 
 	writer := bufio.NewWriter(tmpTestSecretFile)
 	_, _ = writer.Write([]byte(fmt.Sprintf("%s\n", "content for ${SECRET_ENV}")))
@@ -449,6 +448,10 @@ func Test_parseTempSecrets(t *testing.T) {
 	}
 
 	if err := parseTempSecrets(tempFolder, buildOpts); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tmpTestSecretFile.Close(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -432,6 +432,7 @@ func Test_parseTempSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tmpTestSecretFile.Close()
 
 	writer := bufio.NewWriter(tmpTestSecretFile)
 	_, _ = writer.Write([]byte(fmt.Sprintf("%s\n", "content for ${SECRET_ENV}")))

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"log"
@@ -75,7 +76,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 	}
 
 	namespaceEnvVar := model.EnvVar{
-			Name: model.OktetoNamespaceEnvVar, Value: context.Namespace,
+		Name: model.OktetoNamespaceEnvVar, Value: context.Namespace,
 	}
 
 	okteto.CurrentStore = &okteto.OktetoContextStore{
@@ -218,7 +219,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Dockerfile: serviceDockerfile,
 				Target:     "build",
 				CacheFrom:  []string{"cache-image"},
-				Args: []model.EnvVar {
+				Args: []model.EnvVar{
 					namespaceEnvVar,
 					{
 						Name:  "arg1",
@@ -423,4 +424,41 @@ func removeFile(s string) error {
 	}
 
 	return nil
+}
+
+func Test_parseTempSecrets(t *testing.T) {
+	secretDir := t.TempDir()
+	tmpTestSecretFile, err := os.CreateTemp(secretDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writer := bufio.NewWriter(tmpTestSecretFile)
+	_, _ = writer.Write([]byte(fmt.Sprintf("%s\n", "content for ${SECRET_ENV}")))
+	writer.Flush()
+
+	tempFolder := t.TempDir()
+	envValue := "secret env value"
+	t.Setenv("SECRET_ENV", envValue)
+
+	buildOpts := &types.BuildOptions{
+		Secrets: []string{
+			fmt.Sprintf("id=mysecret,src=%s", tmpTestSecretFile.Name()),
+		},
+	}
+
+	if err := parseTempSecrets(tempFolder, buildOpts); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotContains(t, buildOpts.Secrets[0], tmpTestSecretFile.Name())
+	assert.Contains(t, buildOpts.Secrets[0], "secret-")
+
+	newSecretPath := strings.SplitN(buildOpts.Secrets[0], "id=mysecret,src=", 2)
+	b, err := os.ReadFile(newSecretPath[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, string(b), envValue)
+
 }


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

# Proposed changes

This PR adds unit test for the recently implemented parseSecrets where a template file for the secret is used with env substitution for mounting when the image is built
