### PR TITLE
Review info messages shown at the beginning of each command

### DIFF
--- a/cmd/build/v1/build.go
+++ b/cmd/build/v1/build.go
@@ -85,10 +85,7 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 		return fmt.Errorf("%s: %s", oktetoErrors.InvalidDockerfile, err.Error())
 	}
 
-	buildMsg := "Building the image"
-	if options.Tag != "" {
-		buildMsg = fmt.Sprintf("Building the image '%s'", options.Tag)
-	}
+	buildMsg := fmt.Sprintf("Building '%s'", options.File)
 	if okteto.Context().Builder == "" {
 		oktetoLog.Information("%s using your local docker daemon", buildMsg)
 	} else {

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -180,7 +180,6 @@ func (bc *OktetoBuilder) buildService(ctx context.Context, manifest *model.Manif
 }
 
 func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *model.Manifest, svcName string, options *types.BuildOptions) (string, error) {
-	oktetoLog.Information("Building image for service '%s'", svcName)
 	isStackManifest := manifest.Type == model.StackType
 	buildSvcInfo := getBuildInfoWithoutVolumeMounts(manifest.Build[svcName], isStackManifest)
 

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -180,7 +180,7 @@ func (bc *OktetoBuilder) buildService(ctx context.Context, manifest *model.Manif
 }
 
 func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *model.Manifest, svcName string, options *types.BuildOptions) (string, error) {
-	oktetoLog.Info("Building image for service '%s'", svcName)
+	oktetoLog.Infof("Building image for service '%s'", svcName)
 	isStackManifest := manifest.Type == model.StackType
 	buildSvcInfo := getBuildInfoWithoutVolumeMounts(manifest.Build[svcName], isStackManifest)
 

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -180,6 +180,7 @@ func (bc *OktetoBuilder) buildService(ctx context.Context, manifest *model.Manif
 }
 
 func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *model.Manifest, svcName string, options *types.BuildOptions) (string, error) {
+	oktetoLog.Info("Building image for service '%s'", svcName)
 	isStackManifest := manifest.Type == model.StackType
 	buildSvcInfo := getBuildInfoWithoutVolumeMounts(manifest.Build[svcName], isStackManifest)
 

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -47,7 +47,6 @@ func (bc *OktetoBuilder) GetServicesToBuild(ctx context.Context, manifest *model
 	close(toBuild)
 
 	if len(toBuild) == 0 {
-		oktetoLog.Information("Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'")
 		if err := manifest.ExpandEnvVars(); err != nil {
 			return nil, err
 		}

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -47,6 +47,7 @@ func (bc *OktetoBuilder) GetServicesToBuild(ctx context.Context, manifest *model
 	close(toBuild)
 
 	if len(toBuild) == 0 {
+		oktetoLog.Information("Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'")
 		if err := manifest.ExpandEnvVars(); err != nil {
 			return nil, err
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -446,7 +446,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 func (dc *DeployCommand) deploy(ctx context.Context, opts *Options) error {
 	// deploy commands if any
 	for _, command := range opts.Manifest.Deploy.Commands {
-		oktetoLog.Information("Running %s", command.Name)
+		oktetoLog.Information("Running '%s'", command.Name)
 		oktetoLog.SetStage(command.Name)
 		if err := dc.Executor.Execute(command, opts.Variables); err != nil {
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error executing command '%s': %s", command.Name, err.Error())

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -405,10 +405,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		if err == oktetoErrors.ErrIntSig {
 			return nil
 		}
-		err = oktetoErrors.UserError{
-			E:    err,
-			Hint: "Update the 'deploy' section of your okteto manifest and try again",
-		}
+		err = oktetoErrors.UserError{E: err}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, err.Error())
 		data.Status = pipeline.ErrorStatus
 	} else {

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -283,7 +283,7 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
 
 	go func() {
 		for _, command := range manifest.Destroy {
-			oktetoLog.Information("Running %s", command.Name)
+			oktetoLog.Information("Running '%s'", command.Name)
 			oktetoLog.SetStage(command.Name)
 			if err := dc.executor.Execute(command, opts.Variables); err != nil {
 				err = fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
@@ -398,7 +398,7 @@ func (dc *destroyCommand) destroyHelmReleasesIfPresent(ctx context.Context, opts
 		oktetoLog.Debugf("uninstalling helm release '%s'", releaseName)
 		cmd := fmt.Sprintf(helmUninstallCommand, releaseName)
 		cmdInfo := model.DeployCommand{Command: cmd, Name: cmd}
-		oktetoLog.Information("Running %s", cmdInfo.Name)
+		oktetoLog.Information("Running '%s'", cmdInfo.Name)
 		if err := dc.executor.Execute(cmdInfo, opts.Variables); err != nil {
 			oktetoLog.Infof("could not uninstall helm release '%s': %s", releaseName, err)
 			if !opts.ForceDestroy {

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -286,7 +286,7 @@ func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
 			oktetoLog.Information("Running %s", command.Name)
 			oktetoLog.SetStage(command.Name)
 			if err := dc.executor.Execute(command, opts.Variables); err != nil {
-				oktetoLog.Fail("error executing command '%s': %s", command.Name, err.Error())
+				err = fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
 				if !opts.ForceDestroy {
 					if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
 						exit <- err

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -64,6 +64,7 @@ func deploy(ctx context.Context) *cobra.Command {
 
 			ctxOptions := &contextCMD.ContextOptions{
 				Namespace: ctxResource.Namespace,
+				Show:      true,
 			}
 			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
 				return err

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -55,6 +55,7 @@ func destroy(ctx context.Context) *cobra.Command {
 
 			ctxOptions := &contextCMD.ContextOptions{
 				Namespace: ctxResource.Namespace,
+				Show:      true,
 			}
 			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
 				return err

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -70,6 +70,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{
 				Namespace: opts.name,
+				Show:      true,
 			}); err != nil {
 				return err
 			}

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -45,6 +45,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 
 			ctxOptions := &contextCMD.ContextOptions{
 				Namespace: ctxResource.Namespace,
+				Show:      true,
 			}
 			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
 				return err

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -237,10 +237,6 @@ func Up() *cobra.Command {
 				// the autocreate property is forced to be true
 				forceAutocreate = true
 			} else if upOptions.Deploy || (up.Manifest.IsV2 && !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, up.Client)) {
-				if !upOptions.Deploy {
-					oktetoLog.Information("Deploying development environment '%s'...", up.Manifest.Name)
-					oktetoLog.Information("To redeploy your development environment manually run 'okteto deploy' or 'okteto up --deploy'")
-				}
 				startTime := time.Now()
 				err := up.deployApp(ctx)
 
@@ -262,9 +258,6 @@ func Up() *cobra.Command {
 					return err
 				}
 
-			} else if !upOptions.Deploy && (up.Manifest.IsV2 && pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, up.Client)) {
-				oktetoLog.Information("Development environment '%s' already deployed.", up.Manifest.Name)
-				oktetoLog.Information("To redeploy your development environment run 'okteto deploy' or 'okteto up [devName] --deploy'")
 			}
 
 			dev, err := utils.GetDevFromManifest(oktetoManifest, upOptions.DevName)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -258,6 +258,8 @@ func Up() *cobra.Command {
 					return err
 				}
 
+			} else if !upOptions.Deploy && (up.Manifest.IsV2 && pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, up.Client)) {
+				oktetoLog.Information("'%s' was already deployed. To redeploy run 'okteto deploy' or 'okteto up --deploy'", up.Manifest.Name)
 			}
 
 			dev, err := utils.GetDevFromManifest(oktetoManifest, upOptions.DevName)


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

Fixes https://github.com/okteto/okteto/issues/2732 https://github.com/okteto/okteto/issues/2450

I made a general pass to our info messages at the beginning of each command execution and the errors messages we have when commands fail. I will show the changes with screenshots for each modification, let me know what you think :-)

## Okteto Build

Before:
<img width="699" alt="Screenshot 2022-09-27 at 23 21 22" src="https://user-images.githubusercontent.com/7474696/192644411-85ab043c-fde4-4f66-9189-636da59ca789.png">

After (less redundant and more accurate about the Dockerfile being built):
<img width="710" alt="Screenshot 2022-09-27 at 23 22 51" src="https://user-images.githubusercontent.com/7474696/192644498-3fcaebc2-5259-4f39-b10d-18d67ab4a642.png">

## Okteto Deploy with an error

Before:
<img width="628" alt="Screenshot 2022-09-28 at 00 04 07" src="https://user-images.githubusercontent.com/7474696/192645922-60777b62-68d1-4c13-bf40-77457094cadc.png">

After (help message was misleading, users might need to just retry):
<img width="507" alt="Screenshot 2022-09-28 at 00 04 26" src="https://user-images.githubusercontent.com/7474696/192645999-710e3fc3-e916-41ad-9971-91bfd0471cf8.png">


## Okteto Destroy with an error

Before:
<img width="517" alt="Screenshot 2022-09-28 at 00 02 55" src="https://user-images.githubusercontent.com/7474696/192645591-4d3aa6ee-a1d5-4628-8395-d1500ce8f99b.png">

After (less redundant):
<img width="539" alt="Screenshot 2022-09-28 at 00 03 14" src="https://user-images.githubusercontent.com/7474696/192645668-a2e541b6-54ec-45c4-893c-447534dd243f.png">

## Okteto Up deploying `deploy` commands

Before:
<img width="883" alt="Screenshot 2022-09-28 at 00 06 07" src="https://user-images.githubusercontent.com/7474696/192646147-b74d7f7f-25b6-467a-b5df-5e8da6710ebf.png">

After (less noisy):
<img width="1283" alt="Screenshot 2022-09-28 at 00 06 50" src="https://user-images.githubusercontent.com/7474696/192646224-7f9311e1-f6df-4e19-a1ba-e75e3750e963.png">

## Okteto Up with deploy commands already executed

Before:
<img width="904" alt="Screenshot 2022-09-28 at 00 07 26" src="https://user-images.githubusercontent.com/7474696/192646398-632df06a-5c37-4a19-8c45-e0cfbf825701.png">

After (less noisy):
<img width="916" alt="Screenshot 2022-09-28 at 13 30 56" src="https://user-images.githubusercontent.com/7474696/192768228-c29b4d74-be9a-4b83-8d39-27f5494680c8.png">
