### PR TITLE
Jlopezbarb/add local depencies

### DIFF
--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -177,7 +177,7 @@ dependencies:
 				Dev:  model.ManifestDevs{},
 				Type: model.OktetoManifestType,
 				Dependencies: model.ManifestDependencies{
-					"one": &model.Dependency{
+					"one": &model.RemoteDependency{
 						Repository: "https://repo.url",
 					},
 				},

--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -177,9 +177,7 @@ dependencies:
 				Dev:  model.ManifestDevs{},
 				Type: model.OktetoManifestType,
 				Dependencies: model.ManifestDependencies{
-					"one": &model.RemoteDependency{
-						Repository: "https://repo.url",
-					},
+					"one": model.NewRemoteDependencyFromRepository("https://repo.url"),
 				},
 			},
 		},

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -212,6 +212,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 				IsPreview:              os.Getenv(model.OktetoCurrentDeployBelongsToPreview) == "true",
 				HasDependenciesSection: hasDependencySection,
 				HasBuildSection:        hasBuildSection,
+				RemoteDependencies:     len(options.Manifest.Dependencies.GetRemoteDependencies()),
+				LocalDependencies:      len(options.Manifest.Dependencies.GetLocalDependencies()),
 			})
 
 			return err

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -191,6 +191,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 			deployType := "custom"
 			hasDependencySection := false
 			hasBuildSection := false
+			remoteDependenciesLength := 0
+			localDependenciesLength := 0
 			if options.Manifest != nil {
 				if options.Manifest.IsV2 &&
 					options.Manifest.Deploy != nil &&
@@ -201,6 +203,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 
 				hasDependencySection = options.Manifest.IsV2 && len(options.Manifest.Dependencies) > 0
 				hasBuildSection = options.Manifest.IsV2 && len(options.Manifest.Build) > 0
+				remoteDependenciesLength = len(options.Manifest.Dependencies.GetRemoteDependencies())
+				localDependenciesLength = len(options.Manifest.Dependencies.GetLocalDependencies())
 			}
 
 			analytics.TrackDeploy(analytics.TrackDeployMetadata{
@@ -212,8 +216,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 				IsPreview:              os.Getenv(model.OktetoCurrentDeployBelongsToPreview) == "true",
 				HasDependenciesSection: hasDependencySection,
 				HasBuildSection:        hasBuildSection,
-				RemoteDependencies:     len(options.Manifest.Dependencies.GetRemoteDependencies()),
-				LocalDependencies:      len(options.Manifest.Dependencies.GetLocalDependencies()),
+				RemoteDependencies:     remoteDependenciesLength,
+				LocalDependencies:      localDependenciesLength,
 			})
 
 			return err

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -318,19 +318,17 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	}
 
 	// TODO: take this out to a new function deploy dependencies
-	for depName, dep := range deployOptions.Manifest.Dependencies {
+	for depName, dep := range deployOptions.Manifest.Dependencies.GetRemoteDependencies() {
 		oktetoLog.Information("Deploying dependency '%s'", depName)
-		dep.Variables = append(dep.Variables, model.EnvVar{
-			Name:  "OKTETO_ORIGIN",
-			Value: "okteto-deploy",
-		})
+		dep.AddVariable("OKTETO_ORIGIN", "okteto-deploy")
+
 		pipOpts := &pipelineCMD.DeployOptions{
 			Name:         depName,
-			Repository:   dep.Repository,
-			Branch:       dep.Branch,
-			File:         dep.ManifestPath,
-			Variables:    model.SerializeBuildArgs(dep.Variables),
-			Wait:         dep.Wait,
+			Repository:   dep.GetRepository(),
+			Branch:       dep.GetBranch(),
+			File:         dep.GetManifestPath(),
+			Variables:    model.SerializeBuildArgs(dep.GetVariables()),
+			Wait:         dep.HasToWait(),
 			Timeout:      deployOptions.Timeout,
 			SkipIfExists: !deployOptions.Dependencies,
 		}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -255,6 +255,8 @@ func Up() *cobra.Command {
 					HasDependenciesSection: up.Manifest.IsV2 && len(up.Manifest.Dependencies) > 0,
 					HasBuildSection:        up.Manifest.IsV2 && len(up.Manifest.Build) > 0,
 					Err:                    err,
+					RemoteDependencies:     len(up.Manifest.Dependencies.GetRemoteDependencies()),
+					LocalDependencies:      len(up.Manifest.Dependencies.GetLocalDependencies()),
 				})
 
 				// only allow error.ErrManifestFoundButNoDeployCommands to go forward - autocreate property will deploy the app
@@ -544,6 +546,8 @@ func (up *upContext) start() error {
 		HasDeploySection: (up.Manifest.IsV2 &&
 			up.Manifest.Deploy != nil &&
 			(len(up.Manifest.Deploy.Commands) > 0 || up.Manifest.Deploy.ComposeSection.ComposesInfo != nil)),
+		RemoteDependencies: len(up.Manifest.Dependencies.GetRemoteDependencies()),
+		LocalDependencies:  len(up.Manifest.Dependencies.GetLocalDependencies()),
 	})
 
 	go up.activateLoop()

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -174,6 +174,8 @@ type TrackUpMetadata struct {
 	HasBuildSection        bool
 	HasDeploySection       bool
 	Success                bool
+	RemoteDependencies     int
+	LocalDependencies      int
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
@@ -303,6 +305,8 @@ type TrackDeployMetadata struct {
 	IsPreview              bool
 	HasDependenciesSection bool
 	HasBuildSection        bool
+	RemoteDependencies     int
+	LocalDependencies      int
 }
 
 // TrackDeploy sends a tracking event to mixpanel when the user deploys a pipeline

--- a/pkg/model/dependency.go
+++ b/pkg/model/dependency.go
@@ -25,6 +25,14 @@ import (
 // ManifestDependencies represents the map of dependencies at a manifest
 type ManifestDependencies map[string]Dependency
 
+func (ManifestDependencies) merge(other ManifestDependencies) []string {
+	warnings := []string{}
+	if len(other) > 0 {
+		warnings = append(warnings, "dependencies: dependencies are only supported on the main manifest")
+	}
+	return warnings
+}
+
 // GetRemoteDependencies returns a map of the remotes dependencies
 func (md ManifestDependencies) GetRemoteDependencies() map[string]*RemoteDependency {
 	result := map[string]*RemoteDependency{}

--- a/pkg/model/dependency.go
+++ b/pkg/model/dependency.go
@@ -13,6 +13,11 @@
 
 package model
 
+import (
+	"net/url"
+	"strings"
+)
+
 // ManifestDependencies represents the map of dependencies at a manifest
 type ManifestDependencies map[string]*Dependency
 
@@ -23,4 +28,9 @@ type Dependency struct {
 	Branch       string      `json:"branch,omitempty" yaml:"branch,omitempty"`
 	Variables    Environment `json:"variables,omitempty" yaml:"variables,omitempty"`
 	Wait         bool        `json:"wait,omitempty" yaml:"wait,omitempty"`
+
+
+func getDependencyNameFromGitURL(repo *url.URL) string {
+	repoPath := strings.Split(strings.TrimPrefix(repo.Path, "/"), "/")
+	return strings.ReplaceAll(repoPath[1], ".git", "")
 }

--- a/pkg/model/dependency.go
+++ b/pkg/model/dependency.go
@@ -122,13 +122,12 @@ type localPath struct {
 
 // LocalDependency represents a remote dependency object at the manifest
 type LocalDependency struct {
-	manifestPath *localPath
-	variables    Environment
+	manifestPath string
 }
 
 // GetManifestPath returns the manifest path of the dependency
 func (rd *LocalDependency) GetManifestPath() string {
-	return rd.manifestPath.absolutePath
+	return rd.manifestPath
 }
 
 type dependencyMarshaller struct {
@@ -146,7 +145,7 @@ func (dm *dependencyMarshaller) toDependency() Dependency {
 
 func (dm *dependencyMarshaller) getName() string {
 	if dm.localDependency != nil {
-		return ""
+		return dm.localDependency.manifestPath
 	}
 	repo, err := url.Parse(dm.remoteDependency.GetRepository())
 	if err != nil {
@@ -184,14 +183,12 @@ func (ld *remoteDependencyMarshaller) toRemoteDependency() *RemoteDependency {
 }
 
 type localDependencyMarshaller struct {
-	ManifestPath *localPath  `json:"manifest,omitempty" yaml:"manifest,omitempty"`
-	Variables    Environment `json:"variables,omitempty" yaml:"variables,omitempty"`
+	ManifestPath string `json:"manifest,omitempty" yaml:"manifest,omitempty"`
 }
 
 func (ld *localDependencyMarshaller) toLocalDependency() *LocalDependency {
 	return &LocalDependency{
 		manifestPath: ld.ManifestPath,
-		variables:    ld.Variables,
 	}
 }
 

--- a/pkg/model/dependency.go
+++ b/pkg/model/dependency.go
@@ -23,6 +23,30 @@ import (
 // ManifestDependencies represents the map of dependencies at a manifest
 type ManifestDependencies map[string]Dependency
 
+// GetRemoteDependencies returns a list of the remotes dependencies
+func (md ManifestDependencies) GetRemoteDependencies() []RemoteDependency {
+	result := []RemoteDependency{}
+	for _, dependency := range md {
+		remoteDependency, ok := dependency.(*RemoteDependency)
+		if ok {
+			result = append(result, *remoteDependency)
+		}
+	}
+	return result
+}
+
+// GetLocalDependencies returns a list of the local dependencies
+func (md ManifestDependencies) GetLocalDependencies() []LocalDependency {
+	result := []LocalDependency{}
+	for _, dependency := range md {
+		localDependency, ok := dependency.(*LocalDependency)
+		if ok {
+			result = append(result, *localDependency)
+		}
+	}
+	return result
+}
+
 // Dependency represents a dependency object at the manifest
 type Dependency interface{}
 

--- a/pkg/model/dependency.go
+++ b/pkg/model/dependency.go
@@ -123,11 +123,6 @@ func (rd *RemoteDependency) AddVariable(key, value string) {
 	})
 }
 
-type localPath struct {
-	absolutePath string
-	relativePath string
-}
-
 // LocalDependency represents a remote dependency object at the manifest
 type LocalDependency struct {
 	manifestPath string
@@ -141,7 +136,6 @@ func (rd *LocalDependency) GetManifestPath() string {
 type dependencyMarshaller struct {
 	remoteDependency *RemoteDependency
 	localDependency  *LocalDependency
-	name             string
 }
 
 func (dm *dependencyMarshaller) toDependency() Dependency {

--- a/pkg/model/dependency.go
+++ b/pkg/model/dependency.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// ManifestDependencies represents the map of dependencies at a manifest
+type ManifestDependencies map[string]*Dependency
+
+// Dependency represents a dependency object at the manifest
+type Dependency struct {
+	Repository   string      `json:"repository" yaml:"repository"`
+	ManifestPath string      `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+	Branch       string      `json:"branch,omitempty" yaml:"branch,omitempty"`
+	Variables    Environment `json:"variables,omitempty" yaml:"variables,omitempty"`
+	Wait         bool        `json:"wait,omitempty" yaml:"wait,omitempty"`
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -654,9 +654,15 @@ func Read(bytes []byte) (*Manifest, error) {
 
 func (m *Manifest) validate() error {
 	if err := m.Build.validate(); err != nil {
-		return err
+		return fmt.Errorf("error validating manifest build section: %s", err)
 	}
-	return m.validateDivert()
+	if err := m.Dependencies.validate(); err != nil {
+		return fmt.Errorf("error validating manifest dependencies: %s", err)
+	}
+	if err := m.validateDivert(); err != nil {
+		return fmt.Errorf("error validating divert: %s", err)
+	}
+	return nil
 }
 
 func (b *ManifestBuild) validate() error {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -110,15 +110,12 @@ type ManifestDevs map[string]*Dev
 // ManifestBuild defines all the build section
 type ManifestBuild map[string]*BuildInfo
 
-// ManifestDependencies represents the map of dependencies at a manifest
-type ManifestDependencies map[string]*Dependency
-
 // NewManifest creates a new empty manifest
 func NewManifest() *Manifest {
 	return &Manifest{
 		Dev:           map[string]*Dev{},
 		Build:         map[string]*BuildInfo{},
-		Dependencies:  map[string]*Dependency{},
+		Dependencies:  ManifestDependencies{},
 		Deploy:        &DeployInfo{},
 		GlobalForward: []forward.GlobalForward{},
 	}
@@ -882,15 +879,6 @@ func (manifest *Manifest) ExpandEnvVars() error {
 	}
 
 	return nil
-}
-
-// Dependency represents a dependency object at the manifest
-type Dependency struct {
-	Repository   string      `json:"repository" yaml:"repository"`
-	ManifestPath string      `json:"manifest,omitempty" yaml:"manifest,omitempty"`
-	Branch       string      `json:"branch,omitempty" yaml:"branch,omitempty"`
-	Variables    Environment `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Wait         bool        `json:"wait,omitempty" yaml:"wait,omitempty"`
 }
 
 // InferFromStack infers data from a stackfile

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -180,9 +180,7 @@ type DeployInfo struct {
 }
 
 func (b *DeployInfo) merge(other *DeployInfo) []string {
-	for _, buildInfo := range other.Commands {
-		b.Commands = append(b.Commands, buildInfo)
-	}
+	b.Commands = append(b.Commands, other.Commands...)
 	warnings := []string{}
 	if other.ComposeSection != nil {
 		warnings = append(warnings, "deploy.compose: compose can only be defined in main manifest")

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -115,7 +115,7 @@ func NewManifest() *Manifest {
 	return &Manifest{
 		Dev:           map[string]*Dev{},
 		Build:         map[string]*BuildInfo{},
-		Dependencies:  ManifestDependencies{},
+		Dependencies:  NewManifestDependenciesSection(),
 		Deploy:        &DeployInfo{},
 		GlobalForward: []forward.GlobalForward{},
 	}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -355,9 +355,7 @@ func Test_validateManifestBuild(t *testing.T) {
 			name: "local dependency pointing to folder - error",
 			dependencies: ManifestDependencies{
 				"test": LocalDependency{
-					manifestPath: &localPath{
-						absolutePath: tmpTestSecretFile.Name(),
-					},
+					manifestPath: tmpTestSecretFile.Name(),
 				},
 			},
 		},
@@ -365,9 +363,7 @@ func Test_validateManifestBuild(t *testing.T) {
 			name: "local dependency pointing to non existen path - error",
 			dependencies: ManifestDependencies{
 				"test": LocalDependency{
-					manifestPath: &localPath{
-						absolutePath: filepath.Clean("/test/test/test"),
-					},
+					manifestPath: filepath.Clean("/test/test/test"),
 				},
 			},
 		},
@@ -375,9 +371,7 @@ func Test_validateManifestBuild(t *testing.T) {
 			name: "local dependency pointing to correct file - no error",
 			dependencies: ManifestDependencies{
 				"test": LocalDependency{
-					manifestPath: &localPath{
-						absolutePath: tmpTestSecretFile.Name(),
-					},
+					manifestPath: tmpTestSecretFile.Name(),
 				},
 			},
 		},

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -277,9 +277,15 @@ func Test_validateDivert(t *testing.T) {
 }
 
 func Test_validateManifestBuild(t *testing.T) {
+	dir := t.TempDir()
+	tmpTestSecretFile, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	tests := []struct {
 		name         string
 		buildSection ManifestBuild
+		dependencies ManifestDependencies
 		expectedErr  bool
 	}{
 		{
@@ -344,6 +350,36 @@ func Test_validateManifestBuild(t *testing.T) {
 				},
 			},
 			expectedErr: true,
+		},
+		{
+			name: "local dependency pointing to folder - error",
+			dependencies: ManifestDependencies{
+				"test": LocalDependency{
+					manifestPath: &localPath{
+						absolutePath: tmpTestSecretFile.Name(),
+					},
+				},
+			},
+		},
+		{
+			name: "local dependency pointing to non existen path - error",
+			dependencies: ManifestDependencies{
+				"test": LocalDependency{
+					manifestPath: &localPath{
+						absolutePath: filepath.Clean("/test/test/test"),
+					},
+				},
+			},
+		},
+		{
+			name: "local dependency pointing to correct file - no error",
+			dependencies: ManifestDependencies{
+				"test": LocalDependency{
+					manifestPath: &localPath{
+						absolutePath: tmpTestSecretFile.Name(),
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -282,6 +282,9 @@ func Test_validateManifestBuild(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		_ = tmpTestSecretFile.Close()
+	}()
 	tests := []struct {
 		name         string
 		buildSection ManifestBuild

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -776,7 +776,7 @@ func (dm *dependencyMarshaller) UnmarshalYAML(unmarshal func(interface{}) error)
 	var remoteDependency remoteDependencyMarshaller
 	err := unmarshal(&remoteDependency)
 	if err == nil {
-		dm.remoteDependency = (*RemoteDependency)(&remoteDependency)
+		dm.remoteDependency = remoteDependency.toRemoteDependency()
 		return nil
 	}
 	var localDependency localDependencyMarshaller
@@ -803,9 +803,7 @@ func getDependencyFromString(dependency string) (*dependencyMarshaller, error) {
 	r, err := giturls.Parse(dependency)
 	if err == nil {
 		return &dependencyMarshaller{
-			remoteDependency: &RemoteDependency{
-				Repository: r.String(),
-			},
+			remoteDependency: NewRemoteDependencyFromRepository(r.String()),
 		}, nil
 	}
 	oktetoLog.Debugf("dependency '%s' could not been transformed to remote dependency. Trying transforming to local dependency", dependency)

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -755,6 +755,10 @@ func (md *manifestDependenciesMarshaller) UnmarshalYAML(unmarshal func(interface
 			if err != nil {
 				return fmt.Errorf("could not unmarshall manifest dependencies: %w", err)
 			}
+			dependencyName := d.getName()
+			if _, ok := rawManifestDependencies[d.getName()]; ok {
+				oktetoLog.Warning("dependency '%s' is declared twice", dependencyName)
+			}
 			rawManifestDependencies[d.getName()] = d
 		}
 		*md = rawManifestDependencies

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -16,7 +16,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -733,10 +732,6 @@ type dependenciesRaw struct {
 	Wait         bool        `json:"wait,omitempty" yaml:"wait,omitempty"`
 }
 
-func getRepoNameFromGitURL(repo *url.URL) string {
-	repoPath := strings.Split(strings.TrimPrefix(repo.Path, "/"), "/")
-	return strings.ReplaceAll(repoPath[1], ".git", "")
-}
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
 func (md *ManifestDependencies) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -725,14 +725,6 @@ type manifestRaw struct {
 	DeprecatedDevs []string `yaml:"devs"`
 }
 
-type dependenciesRaw struct {
-	Repository   string      `json:"repository,omitempty" yaml:"repository,omitempty"`
-	ManifestPath string      `json:"manifest,omitempty" yaml:"manifest,omitempty"`
-	Branch       string      `json:"branch,omitempty" yaml:"branch,omitempty"`
-	Variables    Environment `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Wait         bool        `json:"wait,omitempty" yaml:"wait,omitempty"`
-}
-
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
 func (md *ManifestDependencies) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var dependencies manifestDependenciesMarshaller

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -2213,6 +2213,10 @@ func TestManifestDependenciesUnmarshalling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		tmpDependenciesFile.Close()
+		tmpDependenciesFile2.Close()
+	}()
 	tests := []struct {
 		name     string
 		bytes    []byte

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1067,7 +1067,7 @@ deploy:
 					},
 				},
 				Dev:          map[string]*Dev{},
-				Dependencies: map[string]*Dependency{},
+				Dependencies: NewManifestDependenciesSection(),
 				Context:      "context-to-use",
 				IsV2:         true,
 				Type:         OktetoManifestType,
@@ -1099,7 +1099,7 @@ dev:
 						},
 					},
 				},
-				Dependencies: map[string]*Dependency{},
+				Dependencies: NewManifestDependenciesSection(),
 				Dev: map[string]*Dev{
 					"test-1": {
 						Name: "test-1",
@@ -1245,7 +1245,7 @@ sync:
 				Type:          OktetoManifestType,
 				Build:         map[string]*BuildInfo{},
 				Deploy:        &DeployInfo{},
-				Dependencies:  map[string]*Dependency{},
+				Dependencies:  NewManifestDependenciesSection(),
 				GlobalForward: []forward.GlobalForward{},
 				Dev: map[string]*Dev{
 					"test": {
@@ -1328,7 +1328,7 @@ services:
 				Type:          OktetoManifestType,
 				Build:         map[string]*BuildInfo{},
 				Deploy:        &DeployInfo{},
-				Dependencies:  map[string]*Dependency{},
+				Dependencies:  NewManifestDependenciesSection(),
 				GlobalForward: []forward.GlobalForward{},
 				Dev: map[string]*Dev{
 					"test": {
@@ -1459,7 +1459,7 @@ dev:
 				Type:         OktetoManifestType,
 				IsV2:         true,
 				Build:        map[string]*BuildInfo{},
-				Dependencies: map[string]*Dependency{},
+				Dependencies: NewManifestDependenciesSection(),
 				Dev: map[string]*Dev{
 					"test": {
 						Name: "test",
@@ -1545,7 +1545,7 @@ dev:
 				Type:         OktetoManifestType,
 				IsV2:         true,
 				Build:        map[string]*BuildInfo{},
-				Dependencies: map[string]*Dependency{},
+				Dependencies: NewManifestDependenciesSection(),
 				Dev: map[string]*Dev{
 					"test-1": {
 						Name: "test-1",
@@ -1712,7 +1712,7 @@ deploy:
 				IsV2:         true,
 				Dev:          map[string]*Dev{},
 				Build:        map[string]*BuildInfo{},
-				Dependencies: map[string]*Dependency{},
+				Dependencies: NewManifestDependenciesSection(),
 				Deploy: &DeployInfo{
 					Commands: []DeployCommand{
 						{
@@ -1738,7 +1738,7 @@ devs:
 				IsV2:         true,
 				Dev:          map[string]*Dev{},
 				Build:        map[string]*BuildInfo{},
-				Dependencies: map[string]*Dependency{},
+				Dependencies: NewManifestDependenciesSection(),
 				Deploy: &DeployInfo{
 					Commands: []DeployCommand{
 						{


### PR DESCRIPTION
# Proposed changes

Fixes #2254

## Changes:
- Create `RemoteDependency` and `LocalDependency` that implements `Dependency` and the proper serialisation methods.
- No expose `RemoteDependency` or `LocalDependency` attributes. This way it's easier to know where these dependencies are used and have only one way of initialised/modify/get
- Create `GetRemoteDependencies` and `GetLocalDependencies` to use only the part that the CLI needs. For example when deploying dependencies the local dependencies are not needed and when loading the local dependencies the remote ones are not needed
- The merge between two manifest is as follows:
  - Build: Only is merged when the key doesn't exist in the main manifest.
  - Dependencies: Not allowed in the secondary manifests
  - Deploy: Only the commands are appended. Other fields like compose and divert are not allowed
  - Dev: Only is merged when the key doesn't exist on the main manifest.
  - Context/Namespace/Icon: Not allowed in the secondary manifest.
- Add a warning on every non allowed merge, that way the user knows what to change 

## Example:
Having an okteto manifest `okteto.yml`:
```yaml
deploy:
  - ls
dependencies:
  - okteto2.yml
```
and an `okteto2.yml`
```yaml
deploy:
  - echo a
dependencies:
  - okteto.yml
```
The output would be:
<img width="713" alt="Captura de Pantalla 2022-09-28 a las 16 20 18" src="https://user-images.githubusercontent.com/25170843/192803944-b102dbb3-e4a4-48ac-bc24-cc425dd77a19.png">
