### PR TITLE
Inject OKTETO_TOKEN in okteto deploy

### DIFF
--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -153,6 +153,7 @@ func addEnvVars(ctx context.Context, cwd string) error {
 	if os.Getenv(model.OktetoTokenEnvVar) == "" {
 		os.Setenv(model.OktetoTokenEnvVar, okteto.Context().Token)
 	}
+	oktetoLog.AddMaskedWord(os.Getenv(model.OktetoTokenEnvVar))
 	if os.Getenv(model.OktetoUserEnvVar) == "" {
 		os.Setenv(model.OktetoUserEnvVar, okteto.Context().Username)
 	}

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -153,6 +153,9 @@ func addEnvVars(ctx context.Context, cwd string) error {
 	if os.Getenv(model.OktetoTokenEnvVar) == "" {
 		os.Setenv(model.OktetoTokenEnvVar, okteto.Context().Token)
 	}
+	if os.Getenv(model.OktetoUserEnvVar) == "" {
+		os.Setenv(model.OktetoUserEnvVar, okteto.Context().Username)
+	}
 	return nil
 }
 

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -150,6 +150,9 @@ func addEnvVars(ctx context.Context, cwd string) error {
 	if os.Getenv(model.OktetoBuildkitHostURLEnvVar) == "" {
 		os.Setenv(model.OktetoBuildkitHostURLEnvVar, okteto.Context().Builder)
 	}
+	if os.Getenv(model.OktetoTokenEnvVar) == "" {
+		os.Setenv(model.OktetoTokenEnvVar, okteto.Context().Token)
+	}
 	return nil
 }
 

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -154,9 +154,6 @@ func addEnvVars(ctx context.Context, cwd string) error {
 		os.Setenv(model.OktetoTokenEnvVar, okteto.Context().Token)
 	}
 	oktetoLog.AddMaskedWord(os.Getenv(model.OktetoTokenEnvVar))
-	if os.Getenv(model.OktetoUserEnvVar) == "" {
-		os.Setenv(model.OktetoUserEnvVar, okteto.Context().Username)
-	}
 	return nil
 }
 

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -204,7 +204,7 @@ const (
 	OktetoSkipCleanupEnvVar = "OKTETO_SKIP_CLEANUP"
 
 	// OktetoUserEnvVar defines the user is using okteto
-	OktetoUserEnvVar = "OKTETO_USER"
+	OktetoUserEnvVar = "OKTETO_USER_ID"
 
 	// OktetoUserNameEnvVar defines the user is using okteto
 	OktetoUserNameEnvVar = "OKTETO_USERNAME"

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -204,7 +204,7 @@ const (
 	OktetoSkipCleanupEnvVar = "OKTETO_SKIP_CLEANUP"
 
 	// OktetoUserEnvVar defines the user using okteto
-	OktetoUserEnvVar = "OKTETO_USER_ID"
+	OktetoUserEnvVar = "OKTETO_USER"
 
 	// OktetoUserNameEnvVar defines the user is using okteto
 	OktetoUserNameEnvVar = "OKTETO_USERNAME"

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -203,7 +203,7 @@ const (
 	// OktetoSkipCleanupEnvVar defines the okteto binary that should be used
 	OktetoSkipCleanupEnvVar = "OKTETO_SKIP_CLEANUP"
 
-	// OktetoUserEnvVar defines the user is using okteto
+	// OktetoUserEnvVar defines the user using okteto
 	OktetoUserEnvVar = "OKTETO_USER_ID"
 
 	// OktetoUserNameEnvVar defines the user is using okteto


### PR DESCRIPTION
Signed-off-by: Agustin Ramiro Diaz <agustin.ramiro.diaz@gmail.com>

After this PR we'll have the 3 envvars injected into the deploy commands to be able to run things like
```
helm registry login ${OKTETO_REGISTRY_URL} -u ${OKTETO_USERNAME} -p ${OKTETO_TOKEN}
```

- `OKTETO_REGISTRY_URL` is already set at the beggining of the deploy command
- `OKTETO_USERNAME` is already set at the beggining of the context command, which gets run before the deploy command

# Proposed changes

- If not defined, add `OKTETO_TOKEN` from context as envvar in deploy command
- Mask `OKTETO_TOKEN`'s value
