### PR TITLE
add okteto healthchecks to compose

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -116,7 +116,8 @@ func translateConfigMap(s *model.Stack) *apiv1.ConfigMap {
 func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 	svc := s.Services[svcName]
 
-	healthcheckProbe := getSvcProbe(svc)
+	svcHealthchecks := getSvcProbe(svc)
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -148,7 +149,8 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 							SecurityContext: translateSecurityContext(svc),
 							Resources:       translateResources(svc),
 							WorkingDir:      svc.Workdir,
-							ReadinessProbe:  healthcheckProbe,
+							ReadinessProbe:  svcHealthchecks.readiness,
+							LivenessProbe:   svcHealthchecks.liveness,
 						},
 					},
 				},
@@ -184,7 +186,7 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 	svc := s.Services[svcName]
 
 	initContainers := getInitContainers(svcName, s)
-	healthcheckProbe := getSvcProbe(svc)
+	svcHealthchecks := getSvcProbe(svc)
 
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -223,7 +225,8 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 							VolumeMounts:    translateVolumeMounts(svc),
 							Resources:       translateResources(svc),
 							WorkingDir:      svc.Workdir,
-							ReadinessProbe:  healthcheckProbe,
+							ReadinessProbe:  svcHealthchecks.readiness,
+							LivenessProbe:   svcHealthchecks.liveness,
 						},
 					},
 				},
@@ -237,7 +240,7 @@ func translateJob(svcName string, s *model.Stack) *batchv1.Job {
 	svc := s.Services[svcName]
 
 	initContainers := getInitContainers(svcName, s)
-	healthcheckProbe := getSvcProbe(svc)
+	svcHealthchecks := getSvcProbe(svc)
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -271,7 +274,8 @@ func translateJob(svcName string, s *model.Stack) *batchv1.Job {
 							VolumeMounts:    translateVolumeMounts(svc),
 							Resources:       translateResources(svc),
 							WorkingDir:      svc.Workdir,
-							ReadinessProbe:  healthcheckProbe,
+							ReadinessProbe:  svcHealthchecks.readiness,
+							LivenessProbe:   svcHealthchecks.liveness,
 						},
 					},
 					Volumes: translateVolumes(svc),
@@ -680,7 +684,13 @@ func translateResources(svc *model.Service) apiv1.ResourceRequirements {
 	return result
 }
 
-func getSvcProbe(svc *model.Service) *apiv1.Probe {
+type healtcheckProbes struct {
+	readiness *apiv1.Probe
+	liveness  *apiv1.Probe
+}
+
+func getSvcProbe(svc *model.Service) *healtcheckProbes {
+	result := &healtcheckProbes{}
 	if svc.Healtcheck != nil {
 		var handler apiv1.ProbeHandler
 		if len(svc.Healtcheck.Test) != 0 {
@@ -697,15 +707,22 @@ func getSvcProbe(svc *model.Service) *apiv1.Probe {
 				},
 			}
 		}
-		return &apiv1.Probe{
+		probe := &apiv1.Probe{
 			ProbeHandler:        handler,
 			TimeoutSeconds:      int32(svc.Healtcheck.Timeout.Seconds()),
 			PeriodSeconds:       int32(svc.Healtcheck.Interval.Seconds()),
 			FailureThreshold:    int32(svc.Healtcheck.Retries),
 			InitialDelaySeconds: int32(svc.Healtcheck.StartPeriod.Seconds()),
 		}
+
+		if svc.Healtcheck.Readiness {
+			result.readiness = probe
+		}
+		if svc.Healtcheck.Liveness {
+			result.liveness = probe
+		}
 	}
-	return nil
+	return result
 }
 
 type updateStrategyGetter interface {

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -113,6 +113,8 @@ type HealthCheck struct {
 	Retries     int             `yaml:"retries,omitempty"`
 	StartPeriod time.Duration   `yaml:"start_period,omitempty"`
 	Disable     bool            `yaml:"disable,omitempty"`
+	Liveness    bool            `yaml:"x-okteto-liveness,omitempty"`
+	Readiness   bool            `default:"true" yaml:"x-okteto-readiness,omitempty"`
 }
 
 type HTTPHealtcheck struct {

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -311,7 +311,7 @@ func Test_HealthcheckUnmarshalling(t *testing.T) {
 		{
 			name:          "healthcheck http through test with https",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl https://0.0.0.0:8080/readiness\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/readiness", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/readiness", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: true},
 			expectedError: false,
 		},
 		{
@@ -329,13 +329,13 @@ func Test_HealthcheckUnmarshalling(t *testing.T) {
 		{
 			name:          "just healthcheck command",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      test: cat file.txt\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{Test: []string{"cat", "file.txt"}},
+			expected:      &HealthCheck{Test: []string{"cat", "file.txt"}, Readiness: true},
 			expectedError: false,
 		},
 		{
 			name:          "normal healthcheck",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: cat file.txt\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{Test: []string{"cat", "file.txt"}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second},
+			expected:      &HealthCheck{Test: []string{"cat", "file.txt"}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Readiness: true},
 			expectedError: false,
 		},
 		{
@@ -359,31 +359,55 @@ func Test_HealthcheckUnmarshalling(t *testing.T) {
 		{
 			name:          "healthcheck http",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      http:\n        path: /\n        port: 8080\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second},
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Readiness: true},
 			expectedError: false,
 		},
 		{
 			name:          "healthcheck http through test without failing flag",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl 0.0.0.0:8080/readiness\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/readiness", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/readiness", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: true},
 			expectedError: false,
 		},
 		{
 			name:          "healthcheck http through test with -f",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl -f localhost:8080/\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: true},
 			expectedError: false,
 		},
 		{
 			name:          "healthcheck http through test with --fail",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080/\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: true},
 			expectedError: false,
 		},
 		{
 			name:          "healthcheck http through test without /",
 			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080\n    image: okteto/vote:1"),
-			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}},
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: true},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck readiness=false liveness=true",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      x-okteto-readiness: false\n      x-okteto-liveness: true\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: false, Liveness: true},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck readiness=false liveness=false",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      x-okteto-readiness: false\n      x-okteto-liveness: false\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080\n    image: okteto/vote:1"),
+			expected:      nil,
+			expectedError: true,
+		},
+		{
+			name:          "healthcheck readiness=true liveness=false",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      x-okteto-readiness: true\n      x-okteto-liveness: false\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: true, Liveness: false},
+			expectedError: false,
+		},
+		{
+			name:          "healthcheck readiness=true liveness=true",
+			manifest:      []byte("services:\n  app:\n    healthcheck:\n      interval: 10s\n      x-okteto-readiness: true\n      x-okteto-liveness: true\n      timeout: 10m\n      retries: 5\n      start_period: 30s\n      test: curl --fail 0.0.0.0:8080\n    image: okteto/vote:1"),
+			expected:      &HealthCheck{HTTP: &HTTPHealtcheck{Path: "/", Port: 8080}, Interval: 10 * time.Second, Timeout: 10 * time.Minute, Retries: 5, StartPeriod: 30 * time.Second, Test: []string{}, Readiness: true, Liveness: true},
 			expectedError: false,
 		},
 	}
@@ -395,11 +419,9 @@ func Test_HealthcheckUnmarshalling(t *testing.T) {
 			} else if err == nil && tt.expectedError {
 				t.Fatal("error not thrown")
 			}
+
 			if !tt.expectedError {
-				if !reflect.DeepEqual(s.Services["app"].Healtcheck, tt.expected) {
-					fmt.Printf("GOT: %+v", s.Services["app"].Healtcheck.HTTP)
-					t.Fatalf("Expected %+v, but got %+v", tt.expected, s.Services["app"].Healtcheck)
-				}
+				assert.Equal(t, tt.expected, s.Services["app"].Healtcheck)
 			}
 
 		})


### PR DESCRIPTION
# Proposed changes

Fixes #3135 

- Added `x-okteto-readiness` and `x-okteto-liveness` to the compose healthcheck section
- Add serialisation of those new fields, without modifying the current behavior (added tests to get that expected behavior)
- Add the translation from compose healthcheck to k8s healthcheck. Check that the current implementation is the same by doing tests
