### PR TITLE
Add "okteto@" as a prefix in OKTETO_BUILD_XXX_SHA

### DIFF
--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -404,6 +404,7 @@ func TestBuildWithDependsOn(t *testing.T) {
 		"OKTETO_BUILD_A_REGISTRY":   false,
 		"OKTETO_BUILD_A_REPOSITORY": false,
 		"OKTETO_BUILD_A_TAG":        false,
+		"OKTETO_BUILD_A_SHA":        false,
 	}
 	for _, arg := range registry.Registry[secondImage].Args {
 		parts := strings.SplitN(arg, "=", 2)

--- a/cmd/build/v2/environment.go
+++ b/cmd/build/v2/environment.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/registry"
 )
 
@@ -57,7 +58,7 @@ func (bc *OktetoBuilder) SetServiceEnvVars(service, reference string) {
 
 	sha := tag
 	if strings.HasPrefix(sha, "sha256:") {
-		sha = fmt.Sprintf("okteto@%s", sha)
+		sha = fmt.Sprintf("%s@%s", model.OktetoDefaultImageTag, sha)
 	}
 	shaKey := fmt.Sprintf("OKTETO_BUILD_%s_SHA", sanitizedSvc)
 	bc.lock.Lock()

--- a/cmd/build/v2/environment.go
+++ b/cmd/build/v2/environment.go
@@ -55,5 +55,15 @@ func (bc *OktetoBuilder) SetServiceEnvVars(service, reference string) {
 	os.Setenv(tagKey, tag)
 	bc.lock.Unlock()
 
+	sha := tag
+	if strings.HasPrefix(sha, "sha256:") {
+		sha = fmt.Sprintf("okteto@%s", sha)
+	}
+	shaKey := fmt.Sprintf("OKTETO_BUILD_%s_SHA", sanitizedSvc)
+	bc.lock.Lock()
+	bc.buildEnvironments[shaKey] = sha
+	os.Setenv(shaKey, sha)
+	bc.lock.Unlock()
+
 	oktetoLog.Debug("manifest env vars set")
 }

--- a/cmd/build/v2/environment_test.go
+++ b/cmd/build/v2/environment_test.go
@@ -36,6 +36,7 @@ func Test_SetServiceEnvVars(t *testing.T) {
 		expRepository string
 		expImage      string
 		expTag        string
+		expSHA        string
 	}{
 		{
 			name:          "setting-variables",
@@ -45,6 +46,7 @@ func Test_SetServiceEnvVars(t *testing.T) {
 			expRepository: "namespace/frontend",
 			expImage:      "registry.url/namespace/frontend@sha256:7075f1094117e418764bb9b47a5dfc093466e714ec385223fb582d78220c7252",
 			expTag:        "sha256:7075f1094117e418764bb9b47a5dfc093466e714ec385223fb582d78220c7252",
+			expSHA:        "okteto@sha256:7075f1094117e418764bb9b47a5dfc093466e714ec385223fb582d78220c7252",
 		},
 		{
 			name:          "setting-variables-no-tag",
@@ -54,6 +56,7 @@ func Test_SetServiceEnvVars(t *testing.T) {
 			expRepository: "namespace/frontend",
 			expImage:      "registry.url/namespace/frontend",
 			expTag:        "latest",
+			expSHA:        "latest",
 		},
 	}
 
@@ -63,6 +66,7 @@ func Test_SetServiceEnvVars(t *testing.T) {
 			imageEnv := fmt.Sprintf("OKTETO_BUILD_%s_IMAGE", strings.ToUpper(tt.service))
 			repositoryEnv := fmt.Sprintf("OKTETO_BUILD_%s_REPOSITORY", strings.ToUpper(tt.service))
 			tagEnv := fmt.Sprintf("OKTETO_BUILD_%s_TAG", strings.ToUpper(tt.service))
+			shaEnv := fmt.Sprintf("OKTETO_BUILD_%s_SHA", strings.ToUpper(tt.service))
 
 			envs := []string{registryEnv, imageEnv, repositoryEnv, tagEnv}
 			for _, e := range envs {
@@ -84,23 +88,23 @@ func Test_SetServiceEnvVars(t *testing.T) {
 			imageEnvValue := os.Getenv(imageEnv)
 			repositoryEnvValue := os.Getenv(repositoryEnv)
 			tagEnvValue := os.Getenv(tagEnv)
+			shaEnvValue := os.Getenv(shaEnv)
 
 			if registryEnvValue != tt.expRegistry {
 				t.Errorf("registry - expected %s , got %s", tt.expRegistry, registryEnvValue)
 			}
 			if imageEnvValue != tt.expImage {
 				t.Errorf("image - expected %s , got %s", tt.expImage, imageEnvValue)
-
 			}
 			if repositoryEnvValue != tt.expRepository {
 				t.Errorf("repository - expected %s , got %s", tt.expRepository, repositoryEnvValue)
-
 			}
 			if tagEnvValue != tt.expTag {
 				t.Errorf("tag - expected %s , got %s", tt.expTag, tagEnvValue)
-
 			}
-
+			if shaEnvValue != tt.expSHA {
+				t.Errorf("sha - expected %s , got %s", tt.expSHA, shaEnvValue)
+			}
 		})
 	}
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -56,7 +56,7 @@ const (
 	buildExample     = `build:
   my-service:
     context: .`
-	buildSvcEnvVars   = "You can use the following env vars to refer to this image in your deploy commands:\n - OKTETO_BUILD_%s_REGISTRY: image registry\n - OKTETO_BUILD_%s_REPOSITORY: image repo\n - OKTETO_BUILD_%s_IMAGE: image name\n - OKTETO_BUILD_%s_TAG: image tag"
+	buildSvcEnvVars   = "You can use the following env vars to refer to this image in your deploy commands:\n - OKTETO_BUILD_%s_REGISTRY: image registry\n - OKTETO_BUILD_%s_REPOSITORY: image repo\n - OKTETO_BUILD_%s_IMAGE: image name\n - OKTETO_BUILD_%s_SHA: image tag sha256"
 	deployHeadComment = "The deploy section defines how to deploy your development environment\nMore info: https://www.okteto.com/docs/reference/manifest/#deploy"
 	deployExample     = `deploy:
   commands:


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

The current value of `OKTETO_BUILD_XXX_TAG` is of the form `sha256:xxxxxx`. 
This value cannot be used directly as a tag. For example, if you have a helm chart like this:
```
image: {{ .Values.repository}}:{{ .Values.tag}}
```
`.Values.tag` must be `okteto@${OKTETO_BUILD_XXX_TAG}` instead of just `OKTETO_BUILD_XXX_TAG`, which is very hard to discover by a user.

This PR is adding a new envvar `OKTETO_BUILD_XXX_SHA` whose value is `okteto@${OKTETO_BUILD_XXX_TAG}`. `OKTETO_BUILD_XXX_SHA` will be documented in favor of `OKTETO_BUILD_XXX_TAG`, but `OKTETO_BUILD_XXX_TAG` will keep the current behavior to avoid breaking changes
