### PR TITLE
fix build when is buildv1 but dockerfile need to be inferred

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -170,7 +170,14 @@ func (*Command) loadContext(ctx context.Context, options *types.BuildOptions) er
 		}
 
 		if ctxResource != nil {
+			if err := ctxResource.UpdateNamespace(options.Namespace); err != nil {
+				return err
+			}
 			ctxOpts.Namespace = ctxResource.Namespace
+
+			if err := ctxResource.UpdateContext(options.K8sContext); err != nil {
+				return err
+			}
 			ctxOpts.Context = ctxResource.Context
 		}
 	}

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -169,6 +169,9 @@ func (*Command) loadContext(ctx context.Context, options *types.BuildOptions) er
 			return err
 		}
 
+		// if ctxResource == nil (we cannot obtain context and namespace from the
+		// manifest used) then /context/config.json file from okteto home will be
+		// used to obtain the current context and the namespace associated with it.
 		if ctxResource != nil {
 			if err := ctxResource.UpdateNamespace(options.Namespace); err != nil {
 				return err

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -130,6 +130,17 @@ func TestBuildCommandV1(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedImage))
+
+	options = &commands.BuildOptions{
+		Workdir:    dir,
+		Tag:        "okteto.dev/test:okteto",
+		Namespace:  "",
+		Token:      token,
+		OktetoHome: dir,
+	}
+	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
+	require.True(t, isImageBuilt(expectedImage))
+
 }
 
 // TestBuildCommandV2 tests the following scenario:


### PR DESCRIPTION
Signed-off-by: adripedriza <adripedriza@gmail.com>

# Proposed changes

Fixes #3157

- instead of propagating the `ErrOktetoManifestNotFound` error, we control it to allow the context to be loaded even if it cannot be obtained from the file given by the user (in this case, the user does not indicate any). Subsequently, after finding no manifest a fallback to builder v1 will be made.
- added test case covering this scenario
