### PR TITLE
Add option to display message if build section is not defined in okte…

### DIFF
--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -26,9 +26,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// GetServicesToBuild returns the services it has to built because they are not already built
+// GetServicesToBuild returns the services it has to build if they are not already built
 func (bc *OktetoBuilder) GetServicesToBuild(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error) {
 	buildManifest := manifest.Build
+
+	if len(buildManifest) == 0 {
+		oktetoLog.Information("Build section is not defined in your okteto manifest")
+		return nil, nil
+	}
 
 	// check if images are at registry (global or dev) and set envs or send to build
 	toBuild := make(chan string, len(buildManifest))

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -105,6 +105,19 @@ func TestServicesNotAreAlreadyBuiltWithSubset(t *testing.T) {
 	assert.Equal(t, 0, len(toBuild))
 }
 
+func TestServicesBuildSection(t *testing.T) {
+	fakeReg := test.NewFakeOktetoRegistry(nil)
+	bc := NewBuilder(nil, fakeReg)
+	alreadyBuilt := []string{}
+	fakeReg.AddImageByName(alreadyBuilt...)
+	ctx := context.Background()
+	fakeManifest.Build = map[string]*model.BuildInfo{}
+	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{})
+	// should not throw error
+	assert.NoError(t, err)
+	assert.Empty(t, toBuild)
+}
+
 func TestNoServiceBuiltWithSubset(t *testing.T) {
 	fakeReg := test.NewFakeOktetoRegistry(nil)
 	bc := NewBuilder(nil, fakeReg)


### PR DESCRIPTION
Signed-off-by: Abhisman Sarkar <abhisman.sarkar@gmail.com>

# Proposed changes

Fixes #3149

This pr includes the option to display a new message in-case the build section isn't defined in the okteto manifest. Also a small grammar fix.

Previous message:
```
abhisman@pop-os:~/Documents/movies-with-helm$ $okteto up
 i  Using nodejs @ okteto_test as context
 i  Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'
 i  Running 'helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}'
Error: UPGRADE FAILED: failed to create resource: Deployment.apps "api" is invalid: [spec.template.spec.containers[0].image: Required value, spec.template.spec.initContainers[0].image: Required value]
 x  Error executing command 'helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}': exit status 1

```
New message:
```
abhisman@pop-os:~/Documents/movies-with-helm$ $okteto up
 i  Using nodejs @ okteto_test as context
 i  Build section is not defined in your okteto manifest
 i  Running 'helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}'
Error: UPGRADE FAILED: failed to create resource: Deployment.apps "api" is invalid: [spec.template.spec.containers[0].image: Required value, spec.template.spec.initContainers[0].image: Required value]
 x  Error executing command 'helm upgrade --install movies chart --set api.image=${OKTETO_BUILD_API_IMAGE} --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}': exit status 1

```
