### PR TITLE
Support both string and sequence of string in a manifest's `cache_from` property

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -121,7 +121,7 @@ type BuildInfo struct {
 	Name             string         `yaml:"name,omitempty"`
 	Context          string         `yaml:"context,omitempty"`
 	Dockerfile       string         `yaml:"dockerfile,omitempty"`
-	CacheFrom        []string       `yaml:"cache_from,omitempty"`
+	CacheFrom        CacheFrom      `yaml:"cache_from,omitempty"`
 	Target           string         `yaml:"target,omitempty"`
 	Args             BuildArgs      `yaml:"args,omitempty"`
 	Image            string         `yaml:"image,omitempty"`
@@ -130,6 +130,9 @@ type BuildInfo struct {
 	DependsOn        BuildDependsOn `yaml:"depends_on,omitempty"`
 	Secrets          BuildSecrets   `yaml:"secrets,omitempty"`
 }
+
+// CacheFrom is a list of images to import cache from.
+type CacheFrom []string
 
 // BuildArg is an argument used on the build step.
 type BuildArg struct {

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -39,7 +39,7 @@ type buildInfoRaw struct {
 	Name             string         `yaml:"name,omitempty"`
 	Context          string         `yaml:"context,omitempty"`
 	Dockerfile       string         `yaml:"dockerfile,omitempty"`
-	CacheFrom        interface{}    `yaml:"cache_from,omitempty"`
+	CacheFrom        CacheFrom      `yaml:"cache_from,omitempty"`
 	Target           string         `yaml:"target,omitempty"`
 	Args             BuildArgs      `yaml:"args,omitempty"`
 	Image            string         `yaml:"image,omitempty"`
@@ -141,6 +141,34 @@ type LabelSelectorRequirement struct {
 type WeightedPodAffinityTerm struct {
 	Weight          int32           `yaml:"weight" json:"weight"`
 	PodAffinityTerm PodAffinityTerm `yaml:"podAffinityTerm" json:"podAffinityTerm"`
+}
+
+// UnmarshalYAML implements the Unmarshaler interface of the yaml pkg.
+func (cf *CacheFrom) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var single string
+	err := unmarshal(&single)
+	if err == nil {
+		*cf = CacheFrom{single}
+		return nil
+	}
+
+	var multi []string
+	err = unmarshal(&multi)
+	if err == nil {
+		*cf = multi
+		return nil
+	}
+
+	return err
+}
+
+// MarshalYAML implements the marshaler interface of the yaml pkg.
+func (cf CacheFrom) MarshalYAML() (interface{}, error) {
+	if len(cf) == 1 {
+		return cf[0], nil
+	}
+
+	return cf, nil
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
@@ -345,31 +373,13 @@ func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) err
 		return err
 	}
 
-	// allow cache_from to support both string and sequence of strings
-	if rawBuildInfo.CacheFrom != nil {
-		switch cacheFrom := rawBuildInfo.CacheFrom.(type) {
-		case string:
-			buildInfo.CacheFrom = []string{cacheFrom}
-		case []interface{}:
-			cfStrings := []string{}
-			for _, cf := range cacheFrom {
-				if cacheFromStr, ok := cf.(string); ok {
-					cfStrings = append(cfStrings, cacheFromStr)
-				}
-			}
-
-			buildInfo.CacheFrom = cfStrings
-		default:
-			return fmt.Errorf("cache_from only supports string or sequence of strings, not %T", cacheFrom)
-		}
-	}
-
 	buildInfo.Name = rawBuildInfo.Name
 	buildInfo.Context = rawBuildInfo.Context
 	buildInfo.Dockerfile = rawBuildInfo.Dockerfile
 	buildInfo.Target = rawBuildInfo.Target
 	buildInfo.Args = rawBuildInfo.Args
 	buildInfo.Image = rawBuildInfo.Image
+	buildInfo.CacheFrom = rawBuildInfo.CacheFrom
 	buildInfo.ExportCache = rawBuildInfo.ExportCache
 	buildInfo.DependsOn = rawBuildInfo.DependsOn
 	buildInfo.Secrets = rawBuildInfo.Secrets
@@ -379,44 +389,18 @@ func (buildInfo *BuildInfo) UnmarshalYAML(unmarshal func(interface{}) error) err
 // MarshalYAML Implements the marshaler interface of the yaml pkg.
 func (buildInfo *BuildInfo) MarshalYAML() (interface{}, error) {
 	if buildInfo.Context != "" && buildInfo.Context != "." {
-		return buildInfoToRaw(*buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	if buildInfo.Dockerfile != "" && buildInfo.Dockerfile != "./Dockerfile" {
-		return buildInfoToRaw(*buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	if buildInfo.Target != "" {
-		return buildInfoToRaw(*buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	if buildInfo.Args != nil && len(buildInfo.Args) != 0 {
-		return buildInfoToRaw(*buildInfo), nil
+		return buildInfoRaw(*buildInfo), nil
 	}
 	return buildInfo.Name, nil
-}
-
-// buildInfoToRaw creates a new buildInfoRaw struct from the data in buildInfo.
-func buildInfoToRaw(bi BuildInfo) buildInfoRaw {
-	raw := buildInfoRaw{
-		Name:             bi.Name,
-		Context:          bi.Context,
-		Dockerfile:       bi.Dockerfile,
-		CacheFrom:        bi.CacheFrom,
-		Target:           bi.Target,
-		Args:             bi.Args,
-		Image:            bi.Image,
-		VolumesToInclude: bi.VolumesToInclude,
-		ExportCache:      bi.ExportCache,
-		DependsOn:        bi.DependsOn,
-		Secrets:          bi.Secrets,
-	}
-
-	// buildInfoRaw.CacheFrom is an interface{}. It won't be nil if assigned an
-	// empty array and the default marshaler will serialize the field in the
-	// output even when 'omitempty' is set
-	if len(bi.CacheFrom) == 0 {
-		raw.CacheFrom = nil
-	}
-
-	return raw
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func TestReverseMashalling(t *testing.T) {
+func TestReverseMarshalling(t *testing.T) {
 	tests := []struct {
 		name      string
 		data      string
@@ -88,7 +88,7 @@ func TestReverseMashalling(t *testing.T) {
 	}
 }
 
-func TestEnvVarMashalling(t *testing.T) {
+func TestEnvVarMarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -174,7 +174,7 @@ func TestEnvVarMashalling(t *testing.T) {
 	}
 }
 
-func TestCommandUnmashalling(t *testing.T) {
+func TestCommandUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -217,7 +217,7 @@ func TestCommandUnmashalling(t *testing.T) {
 	}
 }
 
-func TestCommandMashalling(t *testing.T) {
+func TestCommandMarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		command  Command
@@ -249,7 +249,7 @@ func TestCommandMashalling(t *testing.T) {
 	}
 }
 
-func TestImageMashalling(t *testing.T) {
+func TestImageMarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		image    *BuildInfo
@@ -286,7 +286,7 @@ func TestImageMashalling(t *testing.T) {
 	}
 }
 
-func TestProbesMashalling(t *testing.T) {
+func TestProbesMarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		probes   Probes
@@ -318,7 +318,7 @@ func TestProbesMashalling(t *testing.T) {
 	}
 }
 
-func TestLifecycleMashalling(t *testing.T) {
+func TestLifecycleMarshalling(t *testing.T) {
 	tests := []struct {
 		name      string
 		lifecycle Lifecycle
@@ -447,7 +447,7 @@ func TestSecretMarshalling(t *testing.T) {
 	}
 }
 
-func TestVolumeMashalling(t *testing.T) {
+func TestVolumeMarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -595,7 +595,7 @@ func TestEndpointUnmarshalling(t *testing.T) {
 	}
 }
 
-func TestLabelsUnmashalling(t *testing.T) {
+func TestLabelsUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -705,7 +705,7 @@ func TestLabelsUnmashalling(t *testing.T) {
 	}
 }
 
-func TestAnnotationsUnmashalling(t *testing.T) {
+func TestAnnotationsUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -810,7 +810,7 @@ func TestAnnotationsUnmashalling(t *testing.T) {
 	}
 }
 
-func TestEnvFileUnmashalling(t *testing.T) {
+func TestEnvFileUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -843,7 +843,7 @@ func TestEnvFileUnmashalling(t *testing.T) {
 	}
 }
 
-func TestDurationUnmashalling(t *testing.T) {
+func TestDurationUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -881,7 +881,7 @@ func TestDurationUnmashalling(t *testing.T) {
 	}
 }
 
-func TestTimeoutUnmashalling(t *testing.T) {
+func TestTimeoutUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -931,7 +931,7 @@ resources: 30s
 	}
 }
 
-func TestSyncUnmashalling(t *testing.T) {
+func TestSyncUnmarshalling(t *testing.T) {
 	tests := []struct {
 		name     string
 		data     []byte
@@ -986,7 +986,7 @@ rescanInterval: 10`),
 	}
 }
 
-func TestSyncFoldersUnmashalling(t *testing.T) {
+func TestSyncFoldersUnmarshalling(t *testing.T) {
 	os.Setenv("REMOTE_PATH", "/usr/src/app")
 	tests := []struct {
 		name     string
@@ -2154,6 +2154,16 @@ func TestManifestBuildUnmarshalling(t *testing.T) {
   file: Dockerfile`),
 			expected:        ManifestBuild{},
 			isErrorExpected: true,
+		},
+		{
+			name: "cache_from-supports-str",
+			buildManifest: []byte(`service3:
+  cache_from: cache-image`),
+			expected: ManifestBuild{
+				"service3": {
+					CacheFrom: []string{"cache-image"},
+				},
+			},
 		},
 	}
 

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -240,7 +240,7 @@ type composeBuildInfo struct {
 	Name             string        `yaml:"name,omitempty"`
 	Context          string        `yaml:"context,omitempty"`
 	Dockerfile       string        `yaml:"dockerfile,omitempty"`
-	CacheFrom        []string      `yaml:"cache_from,omitempty"`
+	CacheFrom        CacheFrom     `yaml:"cache_from,omitempty"`
 	Target           string        `yaml:"target,omitempty"`
 	Args             BuildArgs     `yaml:"args,omitempty"`
 	Image            string        `yaml:"image,omitempty"`


### PR DESCRIPTION
# Proposed changes

Fixes #2908 

To allow the `cache_from` property to support both alternatives, the `CacheFrom` field's type is changed to `interface{}` and custom conversions are implemented during marshalling and unmarshalling.