### PR TITLE
fix patch in release-branch (#2961)

### DIFF
--- a/scripts/ci/release-branch.sh
+++ b/scripts/ci/release-branch.sh
@@ -92,7 +92,7 @@
                         ;;
 
                 # normal bound of the release branch
-                prerelease | patch)
+                prerelease | patch | "")
                         if [ "$(semver compare "${ROOT_MINOR_TAG}" "$previous_stable")" -eq "1" ]; then
                                 NEXT_TAG="${ROOT_MINOR_TAG}-beta.1"
                                 echo "Latest reachable tag from release branch ${CURRENT_BRANCH} is a stable release from a previous release (${previous_stable})"


### PR DESCRIPTION
# Proposed changes


In #2961 there was a fix for the release-branch.sh script for handling the case when `"${ROOT_MINOR_TAG}" == "$previous_stable"`

This pr adds that change to the main branch and should be backported to other release branches