### PR TITLE
Backport #3164 to release-2.8 

### DIFF
--- a/scripts/ci/release-branch.sh
+++ b/scripts/ci/release-branch.sh
@@ -92,7 +92,7 @@
                         ;;
 
                 # normal bound of the release branch
-                prerelease | patch)
+                prerelease | patch | "")
                         if [ "$(semver compare "${ROOT_MINOR_TAG}" "$previous_stable")" -eq "1" ]; then
                                 NEXT_TAG="${ROOT_MINOR_TAG}-beta.1"
                                 echo "Latest reachable tag from release branch ${CURRENT_BRANCH} is a stable release from a previous release (${previous_stable})"


### PR DESCRIPTION
I forgot to add the label to the main pr, so here's the manual backport for https://github.com/okteto/okteto/pull/3164
