### PR TITLE
Revert "fix: volumes not being deleted (#2955)"

### DIFF
--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -227,7 +227,6 @@ func (ph *proxyHandler) getProxyHandler(token string, clusterConfig *rest.Config
 
 		// Modify all resources updated or created to include the label.
 		if r.Method == "PUT" || r.Method == "POST" {
-			isCreation := r.Method == "POST"
 			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				oktetoLog.Infof("could not read the request body: %s", err)
@@ -240,7 +239,7 @@ func (ph *proxyHandler) getProxyHandler(token string, clusterConfig *rest.Config
 				return
 			}
 
-			b, err = ph.translateBody(b, isCreation)
+			b, err = ph.translateBody(b)
 			if err != nil {
 				oktetoLog.Info(err)
 				rw.WriteHeader(500)
@@ -268,7 +267,7 @@ func (ph *proxyHandler) SetDivert(divertedNamespace string) {
 	ph.DivertedNamespace = divertedNamespace
 }
 
-func (ph *proxyHandler) translateBody(b []byte, isCreation bool) ([]byte, error) {
+func (ph *proxyHandler) translateBody(b []byte) ([]byte, error) {
 	var body map[string]json.RawMessage
 	if err := json.Unmarshal(b, &body); err != nil {
 		oktetoLog.Infof("error unmarshalling resource body on proxy: %s", err.Error())
@@ -291,7 +290,7 @@ func (ph *proxyHandler) translateBody(b []byte, isCreation bool) ([]byte, error)
 			return nil, err
 		}
 	case "StatefulSet":
-		if err := ph.translateStatefulSetSpec(body, isCreation); err != nil {
+		if err := ph.translateStatefulSetSpec(body); err != nil {
 			return nil, err
 		}
 	case "Job":
@@ -366,18 +365,13 @@ func (ph *proxyHandler) translateDeploymentSpec(body map[string]json.RawMessage)
 	return nil
 }
 
-func (ph *proxyHandler) translateStatefulSetSpec(body map[string]json.RawMessage, isCreation bool) error {
+func (ph *proxyHandler) translateStatefulSetSpec(body map[string]json.RawMessage) error {
 	var spec appsv1.StatefulSetSpec
 	if err := json.Unmarshal(body["spec"], &spec); err != nil {
 		oktetoLog.Infof("error unmarshalling statefulset spec on proxy: %s", err.Error())
 		return nil
 	}
 	labels.SetInMetadata(&spec.Template.ObjectMeta, model.DeployedByLabel, ph.Name)
-	if isCreation {
-		for idx := range spec.VolumeClaimTemplates {
-			labels.SetInMetadata(&spec.VolumeClaimTemplates[idx].ObjectMeta, model.DeployedByLabel, ph.Name)
-		}
-	}
 	ph.applyDivert(&spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {

--- a/cmd/deploy/proxy_test.go
+++ b/cmd/deploy/proxy_test.go
@@ -13,39 +13,20 @@ var (
 
 func Test_TranslateInvalidResourceBody(t *testing.T) {
 	var tests = []struct {
-		name       string
-		body       []byte
-		isCreation bool
+		name string
+		body []byte
 	}{
 		{
-			name:       "null body json.RawMessage POST",
-			body:       []byte(``),
-			isCreation: true,
+			name: "null body json.RawMessage",
+			body: []byte(``),
 		},
 		{
-			name:       "correct body json.RawMessage POST",
-			body:       []byte(`{"kind":"Secret","apiVersion":"v1","metadata":{"name":"sh.helm.release.v1.movies.v6"},"type":"helm.sh/release.v1"}`),
-			isCreation: true,
+			name: "correct body json.RawMessage",
+			body: []byte(`{"kind":"Secret","apiVersion":"v1","metadata":{"name":"sh.helm.release.v1.movies.v6"},"type":"helm.sh/release.v1"}`),
 		},
 		{
-			name:       "incorrect body typemeta POST",
-			body:       []byte(`{"kind": {"key": "value"},"apiVersion":"v1","metadata":{"name":"sh.helm.release.v1.movies.v6"},"type":"helm.sh/release.v1"}`),
-			isCreation: true,
-		},
-		{
-			name:       "null body json.RawMessage PUT",
-			body:       []byte(``),
-			isCreation: false,
-		},
-		{
-			name:       "correct body json.RawMessage PUT",
-			body:       []byte(`{"kind":"Secret","apiVersion":"v1","metadata":{"name":"sh.helm.release.v1.movies.v6"},"type":"helm.sh/release.v1"}`),
-			isCreation: false,
-		},
-		{
-			name:       "incorrect body typemeta PUT",
-			body:       []byte(`{"kind": {"key": "value"},"apiVersion":"v1","metadata":{"name":"sh.helm.release.v1.movies.v6"},"type":"helm.sh/release.v1"}`),
-			isCreation: false,
+			name: "incorrect body typemeta",
+			body: []byte(`{"kind": {"key": "value"},"apiVersion":"v1","metadata":{"name":"sh.helm.release.v1.movies.v6"},"type":"helm.sh/release.v1"}`),
 		},
 	}
 
@@ -53,7 +34,7 @@ func Test_TranslateInvalidResourceBody(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := ph.translateBody(tt.body, tt.isCreation)
+			_, err := ph.translateBody(tt.body)
 			assert.NoError(t, err)
 		})
 	}
@@ -64,7 +45,7 @@ func Test_TranslateInvalidResourceSpec(t *testing.T) {
 		"spec": []byte(`{"selector": "invalid value"}`),
 	}
 	assert.NoError(t, ph.translateDeploymentSpec(invalidResourceSpec))
-	assert.NoError(t, ph.translateStatefulSetSpec(invalidResourceSpec, true))
+	assert.NoError(t, ph.translateStatefulSetSpec(invalidResourceSpec))
 	assert.NoError(t, ph.translateReplicationControllerSpec(invalidResourceSpec))
 	assert.NoError(t, ph.translateReplicaSetSpec(invalidResourceSpec))
 	assert.NoError(t, ph.translateDaemonSetSpec(invalidResourceSpec))


### PR DESCRIPTION
This reverts commit 5a232244d48f9484f8c43dd5d132f02e1bffffef.

Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #3175 

- Reverts #2955 PR to be able to redeploy statefulsets with volume mounts
- If a user has already deployed their statefulsets with 2.6/2.7/2.8 it will keep failing if they try to redeploy. For fixing it, the user must run `okteto destroy -v` and run `okteto deploy` again