### PR TITLE
fix: add error on init container volume full

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -373,6 +373,14 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
 					oktetoLog.Spinner("Insufficient cpu/memory in the cluster. Waiting for new nodes to come up...")
 					continue
 				}
+				if strings.Contains(e.Message, "failed to create subPath directory") {
+					return oktetoErrors.UserError{
+						E: fmt.Errorf("There is no space left in persistent volume"),
+						Hint: fmt.Sprintf(`Okteto volume is full.
+    Increase your persistent volume size, run '%s' and try 'okteto up' again.
+    More information about configuring your persistent volume at https://okteto.com/docs/reference/manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
+					}
+				}
 				return fmt.Errorf(e.Message)
 			case "SuccessfulAttachVolume":
 				oktetoLog.Success("Persistent volume successfully attached")


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #2214

- Check if fails to mount volume because is full and return the proper error

Testing `waitUntilDevelopmentContainerIsRunning` is very complex and can hide the changes done in this PR. It's a 150 lines function  that needs to inject updateFile/kubernetes interface and a go routine in the test that updates the pod and events. Should we do it as part of this PR or create a tech debt and schedule it for a following sprint since it will take a lot of time injecting all the dependencies needed? cc @jmacelroy @ifbyol 
