### PR TITLE
feat: add specific timeout to dependencies

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -248,7 +248,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")
 
 	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the development environment is deployed (defaults to false)")
-	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", (5 * time.Minute), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
+	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
 
 	return cmd
 }
@@ -349,7 +349,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			File:         dep.ManifestPath,
 			Variables:    model.SerializeEnvironmentVars(dep.Variables),
 			Wait:         dep.Wait,
-			Timeout:      deployOptions.Timeout,
+			Timeout:      dep.GetTimeout(deployOptions.Timeout),
 			SkipIfExists: !deployOptions.Dependencies,
 		}
 		pc, err := pipelineCMD.NewCommand()
@@ -682,4 +682,21 @@ func setDifference[T comparable](set1, set2 map[T]bool) map[T]bool {
 		}
 	}
 	return difference
+}
+
+func getDefaultTimeout() time.Duration {
+	defaultTimeout := 5 * time.Minute
+	t := os.Getenv(model.OktetoTimeoutEnvVar)
+	if t == "" {
+		return defaultTimeout
+	}
+
+	parsed, err := time.ParseDuration(t)
+	if err != nil {
+		oktetoLog.Infof("OKTETO_TIMEOUT is not a valid duration: %s", t)
+		oktetoLog.Infof("timeout fallback to defaultTimeout")
+		return defaultTimeout
+	}
+
+	return parsed
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/a8m/envsubst"
 	"github.com/okteto/okteto/pkg/discovery"
@@ -886,11 +887,19 @@ func (manifest *Manifest) ExpandEnvVars() error {
 
 // Dependency represents a dependency object at the manifest
 type Dependency struct {
-	Repository   string      `json:"repository" yaml:"repository"`
-	ManifestPath string      `json:"manifest,omitempty" yaml:"manifest,omitempty"`
-	Branch       string      `json:"branch,omitempty" yaml:"branch,omitempty"`
-	Variables    Environment `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Wait         bool        `json:"wait,omitempty" yaml:"wait,omitempty"`
+	Repository   string        `json:"repository" yaml:"repository"`
+	ManifestPath string        `json:"manifest,omitempty" yaml:"manifest,omitempty"`
+	Branch       string        `json:"branch,omitempty" yaml:"branch,omitempty"`
+	Variables    Environment   `json:"variables,omitempty" yaml:"variables,omitempty"`
+	Wait         bool          `json:"wait,omitempty" yaml:"wait,omitempty"`
+	Timeout      time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
+}
+
+func (d *Dependency) GetTimeout(defaultTimeout time.Duration) time.Duration {
+	if d.Timeout != 0 {
+		return d.Timeout
+	}
+	return defaultTimeout
 }
 
 // InferFromStack infers data from a stackfile

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -895,6 +895,7 @@ type Dependency struct {
 	Timeout      time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
+// GetTimeout returns dependency.Timeout if it's set or the one passed as arg if it's not
 func (d *Dependency) GetTimeout(defaultTimeout time.Duration) time.Duration {
 	if d.Timeout != 0 {
 		return d.Timeout

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1014,3 +1014,38 @@ func Test_SanitizeSvcNames(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetTimeout(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultTimeout time.Duration
+		dependency     *Dependency
+		expected       time.Duration
+	}{
+		{
+			name:           "default timeout set and specific not",
+			defaultTimeout: 5 * time.Minute,
+			dependency:     &Dependency{},
+			expected:       5 * time.Minute,
+		},
+		{
+			name: "default timeout unset and specific set",
+			dependency: &Dependency{
+				Timeout: 10 * time.Minute,
+			},
+			expected: 10 * time.Minute,
+		},
+		{
+			name:       "both unset",
+			dependency: &Dependency{},
+			expected:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dependency.GetTimeout(tt.defaultTimeout)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -746,14 +746,6 @@ type manifestRaw struct {
 	DeprecatedDevs []string `yaml:"devs"`
 }
 
-type dependenciesRaw struct {
-	Repository   string      `json:"repository,omitempty" yaml:"repository,omitempty"`
-	ManifestPath string      `json:"manifest,omitempty" yaml:"manifest,omitempty"`
-	Branch       string      `json:"branch,omitempty" yaml:"branch,omitempty"`
-	Variables    Environment `json:"variables,omitempty" yaml:"variables,omitempty"`
-	Wait         bool        `json:"wait,omitempty" yaml:"wait,omitempty"`
-}
-
 func getRepoNameFromGitURL(repo *url.URL) string {
 	repoPath := strings.Split(strings.TrimPrefix(repo.Path, "/"), "/")
 	return strings.ReplaceAll(repoPath[1], ".git", "")
@@ -790,25 +782,21 @@ func (md *ManifestDependencies) UnmarshalYAML(unmarshal func(interface{}) error)
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
-func (dependency *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var rawString string
 	err := unmarshal(&rawString)
 	if err == nil {
-		dependency.Repository = rawString
+		d.Repository = rawString
 		return nil
 	}
 
-	var rawDependency dependenciesRaw
-	err = unmarshal(&rawDependency)
+	type dependencyPreventRecursionType Dependency
+	var dependencyRaw dependencyPreventRecursionType
+	err = unmarshal(&dependencyRaw)
 	if err != nil {
 		return err
 	}
-
-	dependency.Repository = rawDependency.Repository
-	dependency.ManifestPath = rawDependency.ManifestPath
-	dependency.Branch = rawDependency.Branch
-	dependency.Variables = rawDependency.Variables
-	dependency.Wait = rawDependency.Wait
+	*d = Dependency(dependencyRaw)
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #3146

- Add `getDefaultTimeout` to check if the `OKTETO_TIMEOUT` environment variable is set. Set the timeout flag default value as follows: 1. User set flag 2. `OKTETO_TIMEOUT` environment variable 3. default value (5min)
- refactor dependency serializer: I added a new type and removed a copy paste of dependency struct called `dependencyRaw`. With this refactor If we update any dependency field we don't  have to update it in the `dependencyRaw` struct.
- Added tests for dependency unmarshaller.
- Added a new dependency field `timeout` and a new exported method `GetTimeout` that returns the dependency specific timeout if it's set or the one added as argument if not
- Called the new `dependency.GetTimeout` instead of directly the timeout flag when we are creating a dependency
