### PR TITLE
Updated error messaging when ctx use/update is used for vanilla clusters

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -128,7 +128,8 @@ func (c *ContextCommand) UseContext(ctx context.Context, ctxOptions *ContextOpti
 		} else {
 			if !isValidCluster(ctxOptions.Context) {
 				return oktetoErrors.UserError{E: fmt.Errorf("invalid okteto context '%s'", ctxOptions.Context),
-					Hint: "Please run 'okteto context' to select one context"}
+					Hint: fmt.Sprintf("Please run 'okteto context' to select one context. Please run 'kubectl config use-context %s' if attempting to use a Kubernetes context that is a not an Okteto context", ctxOptions.Context),
+				}
 			}
 			transformedCtx := okteto.K8sContextToOktetoUrl(ctx, ctxOptions.Context, ctxOptions.Namespace, c.K8sClientProvider)
 			if transformedCtx != ctxOptions.Context {

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -128,8 +128,7 @@ func (c *ContextCommand) UseContext(ctx context.Context, ctxOptions *ContextOpti
 		} else {
 			if !isValidCluster(ctxOptions.Context) {
 				return oktetoErrors.UserError{E: fmt.Errorf("invalid okteto context '%s'", ctxOptions.Context),
-					Hint: fmt.Sprintf("Please run 'okteto context' to select one context. Please run 'kubectl config use-context %s' if attempting to use a Kubernetes context that is a not an Okteto context", ctxOptions.Context),
-				}
+					Hint: "Please run 'okteto context' to select one context"}
 			}
 			transformedCtx := okteto.K8sContextToOktetoUrl(ctx, ctxOptions.Context, ctxOptions.Namespace, c.K8sClientProvider)
 			if transformedCtx != ctxOptions.Context {

--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -60,7 +60,7 @@ func Delete(okCtx string) error {
 		}
 		return oktetoErrors.UserError{
 			E:    fmt.Errorf("'%s' context doesn't exist. Valid options are: [%s]", okCtx, strings.Join(validOptions, ", ")),
-			Hint: fmt.Sprintf("Please run 'kubectl config delete-context %s' if attempting to delete a Kubernetes context that is a not an Okteto context", okCtx),
+			Hint: fmt.Sprintf("To delete a Kubernetes context run 'kubectl config delete-context %s'", okCtx),
 		}
 	}
 	return nil

--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
@@ -57,7 +58,10 @@ func Delete(okCtx string) error {
 				validOptions = append(validOptions, k)
 			}
 		}
-		return fmt.Errorf("'%s' context doesn't exist. Valid options are: [%s]", okCtx, strings.Join(validOptions, ", "))
+		return oktetoErrors.UserError{
+			E:    fmt.Errorf("'%s' context doesn't exist. Valid options are: [%s]", okCtx, strings.Join(validOptions, ", ")),
+			Hint: fmt.Sprintf("Please run 'kubectl config delete-context %s' if attempting to delete a Kubernetes context that is a not an Okteto context", okCtx),
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Vimal Patel <vimalpatel0611@gmail.com>

# Proposed changes

Fixes #2957

Added more descriptive error messaging for when a user attempts to run 'okteto ctx' to use/delete for a vanilla cluster.

