### PR TITLE
Make AskYesNo function support default answers

### DIFF
--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -180,7 +180,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 		isDeployed := pipeline.IsDeployed(ctx, manifest.Name, namespace, c)
 		deployAnswer := false
 		if !isDeployed && !opts.AutoDeploy {
-			deployAnswer, err = utils.AskYesNo("Do you want to launch your development environment? [y/n]: ")
+			deployAnswer, err = utils.AskYesNo("Do you want to launch your development environment?", utils.YesNoDefault_Yes)
 			if err != nil {
 				return nil, err
 			}
@@ -195,7 +195,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 		if isDeployed {
 			configureDevEnvsAnswer := false
 			if !opts.AutoConfigureDev {
-				configureDevEnvsAnswer, err = utils.AskYesNo("Do you want to configure your development containers? [y/n]: ")
+				configureDevEnvsAnswer, err = utils.AskYesNo("Do you want to configure your development containers?", utils.YesNoDefault_Yes)
 				if err != nil {
 					return nil, err
 				}
@@ -231,7 +231,7 @@ func (*ManifestCommand) configureManifestDeployAndBuild(cwd string) (*model.Mani
 			return nil, err
 		}
 		if composePath != "" {
-			answer, err := utils.AskYesNo("creating an okteto manifest is optional if you want to use a compose file. Do you want to continue? [y/n] ")
+			answer, err := utils.AskYesNo("creating an okteto manifest is optional if you want to use a compose file. Do you want to continue?", utils.YesNoDefault_Yes)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -163,7 +163,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 	}
 
 	oktetoLog.Information("Okteto requires a '.stignore' file to ignore file patterns that help optimize the synchronization service.")
-	stignoreDefaults, err := utils.AskYesNo("Do you want to infer defaults for the '.stignore' file? (otherwise, it will be left blank) [y/n] ")
+	stignoreDefaults, err := utils.AskYesNo("Do you want to infer defaults for the '.stignore' file? (otherwise, it will be left blank)", utils.YesNoDefault_Yes)
 	if err != nil {
 		return fmt.Errorf("failed to add '.stignore' to '%s': %s", folder, err.Error())
 	}
@@ -198,7 +198,7 @@ func askIfUpdatingStignore(stignorePath string) error {
 	}
 
 	oktetoLog.Information("The synchronization service performance is degraded if the '.git' folder is synchronized.")
-	ignoreGit, err := utils.AskYesNo("Do you want to ignore the '.git' folder in your '.stignore' file? [y/n] ")
+	ignoreGit, err := utils.AskYesNo("Do you want to ignore the '.git' folder in your '.stignore' file?", utils.YesNoDefault_Yes)
 	if err != nil {
 		return fmt.Errorf("failed to ask for adding '.git' to '%s': %s", stignorePath, err.Error())
 	}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -166,7 +166,7 @@ func Up() *cobra.Command {
 					return fmt.Errorf("your docker compose file is not currently supported: Okteto requires a 'host volume' to be defined. See %s", composeVolumesUrl)
 				}
 				oktetoLog.Warning("okteto manifest has no 'dev' section.")
-				answer, err := utils.AskYesNo("Do you want to configure okteto manifest now? [y/n]")
+				answer, err := utils.AskYesNo("Do you want to configure okteto manifest now?", utils.YesNoDefault_Yes)
 				if err != nil {
 					return err
 				}

--- a/cmd/utils/okteto.go
+++ b/cmd/utils/okteto.go
@@ -94,7 +94,7 @@ func ShouldCreateNamespace(ctx context.Context, ns string) (bool, error) {
 		if LoadBoolean(model.OktetoWithinDeployCommandContextEnvVar) {
 			return false, fmt.Errorf("cannot deploy on a namespace that doesn't exist. Please create %s and try again", ns)
 		}
-		create, err := AskYesNo(fmt.Sprintf("The namespace %s doesn't exist. Do you want to create it? [y/n] ", ns))
+		create, err := AskYesNo(fmt.Sprintf("The namespace %s doesn't exist. Do you want to create it?", ns), YesNoDefault_Yes)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
# Proposed changes

Fixes #2793

I added a new parameter to `utils.AskYesNo` function that enables the caller to set a default answer. That allows extra flexibility, as different questions could potentially have different defaults.

However, it seems that all the questions that exist today have the same sensible default of "yes". If you don't think there will ever be a question where the default could be "no", the defaults can be removed altogether to simplify the implementation.