### PR TITLE
Fix error logging crash on context load failure

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -227,7 +227,7 @@ func Up() *cobra.Command {
 			}
 			up.Client, up.RestConfig, err = okteto.GetK8sClient()
 			if err != nil {
-				return fmt.Errorf("failed to load okteto context '%s': %v", up.Dev.Context, err)
+				return fmt.Errorf("failed to load okteto context: %v", err)
 			}
 
 			// if manifest v1 - either set autocreate: true or pass --deploy (okteto forces autocreate: true)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -227,7 +227,7 @@ func Up() *cobra.Command {
 			}
 			up.Client, up.RestConfig, err = okteto.GetK8sClient()
 			if err != nil {
-				return fmt.Errorf("failed to load okteto context: %v", err)
+				return fmt.Errorf("failed to load k8s client: %v", err)
 			}
 
 			// if manifest v1 - either set autocreate: true or pass --deploy (okteto forces autocreate: true)


### PR DESCRIPTION
# Issue
For me running `okteto up` results in a the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x58 pc=0x1063f58b0]

goroutine 1 [running]:
github.com/okteto/okteto/cmd/up.Up.func1(0x14000a6d900?, {0x1400014ae60, 0x0, 0x2})
        github.com/okteto/okteto/cmd/up/up.go:230 +0x10e0

https://github.com/okteto/okteto/blob/da425cf06ae7e0877a263574ef78fe96e0f1ab3d/cmd/up/up.go#L230
```
Looks like the error reporting code at line 230 always tries to dereference a nil pointer. `up.Dev` is always nil at that line (set to nil on line 212), so `up.Dev.Context` is never referenceble.

# Fix

A basic fix is to omit the context from the error message.