### PR TITLE
Fix divert at scale

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -186,6 +186,11 @@ var (
 	ErrX509Hint = "Add the flag '--insecure-skip-tls-verify' to skip certificate verification.\n    Follow this link to know more about configuring your own certificates with Okteto:\n    https://www.okteto.com/docs/self-hosted/administration/certificates/"
 )
 
+// IsAlreadyExists raised if the Kubernetes API returns AlreadyExists
+func IsAlreadyExists(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already exists")
+}
+
 // IsForbidden raised if the Okteto API returns 401
 func IsForbidden(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "unauthorized")

--- a/pkg/k8s/diverts/translate.go
+++ b/pkg/k8s/diverts/translate.go
@@ -24,13 +24,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func translateIngress(m *model.Manifest, in *networkingv1.Ingress, resourceVersion string) *networkingv1.Ingress {
+func translateIngress(m *model.Manifest, in *networkingv1.Ingress) *networkingv1.Ingress {
 	result := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            in.Name,
-			Labels:          in.Labels,
-			Annotations:     in.Annotations,
-			ResourceVersion: resourceVersion,
+			Name:        in.Name,
+			Labels:      in.Labels,
+			Annotations: in.Annotations,
 		},
 		Spec: in.Spec,
 	}
@@ -50,18 +49,17 @@ func translateIngress(m *model.Manifest, in *networkingv1.Ingress, resourceVersi
 	return result
 }
 
-func translateService(m *model.Manifest, s *apiv1.Service, resourceVersion string) *apiv1.Service {
+func translateService(m *model.Manifest, s *apiv1.Service) *apiv1.Service {
 	result := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            s.Name,
-			Labels:          s.Labels,
-			Annotations:     s.Annotations,
-			ResourceVersion: resourceVersion,
+			Name:        s.Name,
+			Labels:      s.Labels,
+			Annotations: s.Annotations,
 		},
 		Spec: s.Spec,
 	}
 	labels.SetInMetadata(&result.ObjectMeta, model.DeployedByLabel, m.Name)
-	// create a headless service pointing to an endpoints object that resolves to pods in the diverted namespace
+	// create a headless service pointing to an endpoints object that resolves to service cluuster ip in the diverted namespace
 	result.Spec.ClusterIP = apiv1.ClusterIPNone
 	result.Spec.ClusterIPs = nil
 	result.Spec.Selector = nil
@@ -72,22 +70,48 @@ func translateService(m *model.Manifest, s *apiv1.Service, resourceVersion strin
 	return result
 }
 
-func translateEndpoints(m *model.Manifest, e *apiv1.Endpoints, resourceVersion string) *apiv1.Endpoints {
+func translateEndpoints(m *model.Manifest, s *apiv1.Service) *apiv1.Endpoints {
 	result := &apiv1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            e.Name,
-			Labels:          e.Labels,
-			Annotations:     e.Annotations,
-			ResourceVersion: resourceVersion,
+			Name: s.Name,
+			Labels: map[string]string{
+				model.DeployedByLabel: m.Name,
+			},
+			Annotations: map[string]string{
+				model.OktetoAutoCreateAnnotation: "true",
+			},
 		},
-		Subsets: e.Subsets,
+		Subsets: []apiv1.EndpointSubset{
+			{
+				Addresses: []apiv1.EndpointAddress{
+					{
+						IP: s.Spec.ClusterIP,
+						TargetRef: &apiv1.ObjectReference{
+							Kind:            "Service",
+							Namespace:       s.Namespace,
+							Name:            s.Name,
+							UID:             s.UID,
+							APIVersion:      "v1",
+							ResourceVersion: s.ResourceVersion,
+						},
+					},
+				},
+				Ports: []apiv1.EndpointPort{},
+			},
+		},
 	}
-	labels.SetInMetadata(&result.ObjectMeta, model.DeployedByLabel, m.Name)
-	labels.SetInMetadata(&result.ObjectMeta, model.OktetoDivertedFromLabel, string(e.UID))
-	if result.Annotations == nil {
-		result.Annotations = map[string]string{}
+	for _, p := range s.Spec.Ports {
+		result.Subsets[0].Ports = append(
+			result.Subsets[0].Ports,
+			apiv1.EndpointPort{
+				Name:        p.Name,
+				Port:        p.Port,
+				Protocol:    p.Protocol,
+				AppProtocol: p.AppProtocol,
+			},
+		)
 	}
-	result.Annotations[model.OktetoAutoCreateAnnotation] = "true"
+
 	return result
 }
 

--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -261,9 +261,11 @@ func Test_translateEndpoints(t *testing.T) {
 			Name: "name",
 			Labels: map[string]string{
 				model.DeployedByLabel: "test",
+				"l1":                  "v1",
 			},
 			Annotations: map[string]string{
 				model.OktetoAutoCreateAnnotation: "true",
+				"a1":                             "v1",
 			},
 		},
 		Subsets: []apiv1.EndpointSubset{

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -275,7 +275,4 @@ const (
 
 	// OktetoImageTagWithVolumes is the tag assigned to an image with volume mounts
 	OktetoImageTagWithVolumes = "okteto-with-volume-mounts"
-
-	// OktetoDivertedFromLabel represents an object is diverted from another one
-	OktetoDivertedFromLabel = "dev.okteto.com/divert-from"
 )


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

Divert is using a headless service to resolve a service `s1` in namespace `n1` to the endpoints of service `s1` in another namespace `n2`. We were using the `s1` in namespace `n2` pod endpoints to do this. When pods are recreated in `n2`, the okteto webhook is updating the headless service [here](https://github.com/okteto/app/blob/master/backend/cmd/webhook.go#L810).

In some environments, the webhook is timing out and failing to update all the headless services. 

In this PR, instead of using the pod ips in namespace `n2`, we are using the `s1` cluster ip, which doesn't change between upgrades. Using this approach, we will be able to delete the logic in our webhook to update the headless services