### PR TITLE
feat: add support for custom commands in `okteto up`

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -274,7 +274,7 @@ func Up() *cobra.Command {
 					return err
 				}
 			}
-			if upOptions.commandToExecute != nil {
+			if len(upOptions.commandToExecute) > 0 {
 				dev.Command.Values = upOptions.commandToExecute
 			}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -84,13 +84,12 @@ func Up() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "up [svc] <command>",
 		Short: "Launch your development environment",
-		//Args:  utils.MaximumNArgsAccepted(2, "https://okteto.com/docs/reference/cli/#up"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {
 				return oktetoErrors.ErrNotInDevContainer
 			}
 
-			if err := upOptions.AddArgs(cmd, args); err != nil {
+			if err := upOptions.AddArgs(args); err != nil {
 				return err
 			}
 
@@ -275,6 +274,9 @@ func Up() *cobra.Command {
 					return err
 				}
 			}
+			if upOptions.commandToExecute != nil {
+				dev.Command.Values = upOptions.commandToExecute
+			}
 
 			up.Dev = dev
 			if forceAutocreate {
@@ -362,7 +364,7 @@ func Up() *cobra.Command {
 }
 
 // AddArgs sets the args as options and return err if it's not compatible
-func (o *UpOptions) AddArgs(cmd *cobra.Command, args []string) error {
+func (o *UpOptions) AddArgs(args []string) error {
 
 	if len(args) == 1 {
 		o.DevName = args[0]
@@ -370,18 +372,6 @@ func (o *UpOptions) AddArgs(cmd *cobra.Command, args []string) error {
 		o.DevName = args[0]
 		o.commandToExecute = args[1:]
 	}
-
-	// maxV1Args := 2
-	// docsURL := "https://okteto.com/docs/reference/cli/#up"
-	// if len(args) > maxV1Args {
-	// 	cmd.Help()
-	// 	return oktetoErrors.UserError{
-	// 		E:    fmt.Errorf("%q accepts at most %d arg(s), but received %d", cmd.CommandPath(), maxV1Args, len(args)),
-	// 		Hint: fmt.Sprintf("Visit %s for more information.", docsURL),
-	// 	}
-	// } else if len(args) == maxV1Args {
-	// 	o.DevName = args[0]
-	// }
 
 	return nil
 }

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -65,25 +65,26 @@ type UpOptions struct {
 	ManifestPathFlag string
 	// ManifestPath is the patah to the manifest used though the command execution.
 	// This might change its value during execution
-	ManifestPath string
-	Namespace    string
-	K8sContext   string
-	DevName      string
-	Devs         []string
-	Envs         []string
-	Remote       int
-	Deploy       bool
-	ForcePull    bool
-	Reset        bool
+	ManifestPath     string
+	Namespace        string
+	K8sContext       string
+	DevName          string
+	Devs             []string
+	Envs             []string
+	Remote           int
+	Deploy           bool
+	ForcePull        bool
+	Reset            bool
+	commandToExecute []string
 }
 
 // Up starts a development container
 func Up() *cobra.Command {
 	upOptions := &UpOptions{}
 	cmd := &cobra.Command{
-		Use:   "up [svc]",
+		Use:   "up [svc] <command>",
 		Short: "Launch your development environment",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#up"),
+		//Args:  utils.MaximumNArgsAccepted(2, "https://okteto.com/docs/reference/cli/#up"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {
 				return oktetoErrors.ErrNotInDevContainer
@@ -363,17 +364,24 @@ func Up() *cobra.Command {
 // AddArgs sets the args as options and return err if it's not compatible
 func (o *UpOptions) AddArgs(cmd *cobra.Command, args []string) error {
 
-	maxV1Args := 1
-	docsURL := "https://okteto.com/docs/reference/cli/#up"
-	if len(args) > maxV1Args {
-		cmd.Help()
-		return oktetoErrors.UserError{
-			E:    fmt.Errorf("%q accepts at most %d arg(s), but received %d", cmd.CommandPath(), maxV1Args, len(args)),
-			Hint: fmt.Sprintf("Visit %s for more information.", docsURL),
-		}
-	} else if len(args) == 1 {
+	if len(args) == 1 {
 		o.DevName = args[0]
+	} else if len(args) > 1 {
+		o.DevName = args[0]
+		o.commandToExecute = args[1:]
 	}
+
+	// maxV1Args := 2
+	// docsURL := "https://okteto.com/docs/reference/cli/#up"
+	// if len(args) > maxV1Args {
+	// 	cmd.Help()
+	// 	return oktetoErrors.UserError{
+	// 		E:    fmt.Errorf("%q accepts at most %d arg(s), but received %d", cmd.CommandPath(), maxV1Args, len(args)),
+	// 		Hint: fmt.Sprintf("Visit %s for more information.", docsURL),
+	// 	}
+	// } else if len(args) == maxV1Args {
+	// 	o.DevName = args[0]
+	// }
 
 	return nil
 }

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -69,7 +69,6 @@ type UpOptions struct {
 	Namespace        string
 	K8sContext       string
 	DevName          string
-	Devs             []string
 	Envs             []string
 	Remote           int
 	Deploy           bool

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -63,7 +63,7 @@ type UpOptions struct {
 	// ManifestPathFlag is the option -f as introduced by the user when executing this command.
 	// This is stored at the configmap as filename to redeploy from the ui.
 	ManifestPathFlag string
-	// ManifestPath is the patah to the manifest used though the command execution.
+	// ManifestPath is the path to the manifest used though the command execution.
 	// This might change its value during execution
 	ManifestPath     string
 	Namespace        string
@@ -381,7 +381,7 @@ func (o *UpOptions) AddArgs(args []string, oktetoManifest *model.Manifest) error
 			o.commandToExecute = args
 		}
 	}
-
+	oktetoLog.Infof("dev name: %s / commandToExecute: %v", o.DevName, o.commandToExecute)
 	return nil
 }
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -89,10 +89,6 @@ func Up() *cobra.Command {
 				return oktetoErrors.ErrNotInDevContainer
 			}
 
-			if err := upOptions.AddArgs(args); err != nil {
-				return err
-			}
-
 			u := utils.UpgradeAvailable()
 			if len(u) > 0 {
 				warningFolder := filepath.Join(config.GetOktetoHome(), ".warnings")
@@ -153,6 +149,11 @@ func Up() *cobra.Command {
 					return err
 				}
 			}
+
+			if err := upOptions.AddArgs(args, oktetoManifest); err != nil {
+				return err
+			}
+
 			wd, err := os.Getwd()
 			if err != nil {
 				return err
@@ -364,13 +365,21 @@ func Up() *cobra.Command {
 }
 
 // AddArgs sets the args as options and return err if it's not compatible
-func (o *UpOptions) AddArgs(args []string) error {
+func (o *UpOptions) AddArgs(args []string, oktetoManifest *model.Manifest) error {
 
 	if len(args) == 1 {
-		o.DevName = args[0]
+		if _, ok := oktetoManifest.Dev[args[0]]; ok {
+			o.DevName = args[0]
+		} else {
+			o.commandToExecute = args
+		}
 	} else if len(args) > 1 {
-		o.DevName = args[0]
-		o.commandToExecute = args[1:]
+		if _, ok := oktetoManifest.Dev[args[0]]; ok {
+			o.DevName = args[0]
+			o.commandToExecute = args[1:]
+		} else {
+			o.commandToExecute = args
+		}
 	}
 
 	return nil

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -22,6 +22,7 @@ import (
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_waitUntilExitOrInterrupt(t *testing.T) {
@@ -304,6 +305,41 @@ func TestEnvVarIsNotAddedWhenHasBuiltInOktetoEnvVarsFormat(t *testing.T) {
 			if !errors.Is(err, oktetoErrors.ErrBuiltInOktetoEnvVarSetFromCMD) {
 				t.Fatalf("expected error in setEnvVarsFromCmd: %s due to try to set a built-in okteto environment variable", err)
 			}
+		})
+	}
+}
+
+func TestCommandAddedToUpOptionsWhenPassedAsFlag(t *testing.T) {
+	var tests = []struct {
+		name            string
+		command         []string
+		expectedCommand []string
+	}{
+		{
+			name:            "Passing no commands",
+			command:         []string{""},
+			expectedCommand: []string{},
+		},
+		{
+			name:            "Passing commands",
+			command:         []string{"echo", "hello"},
+			expectedCommand: []string{"echo", "hello"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			cmd := Up()
+			for _, val := range tt.command {
+				cmd.Flags().Set("command", val)
+			}
+
+			flagValue, err := cmd.Flags().GetStringArray("command")
+			if err != nil {
+				t.Fatalf("unexpected error in GetStringArray: %s", err)
+			}
+
+			assert.Equal(t, tt.expectedCommand, flagValue)
 		})
 	}
 }

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/model/forward"
@@ -305,58 +303,6 @@ func TestEnvVarIsNotAddedWhenHasBuiltInOktetoEnvVarsFormat(t *testing.T) {
 			_, err := getOverridedEnvVarsFromCmd(tt.dev.Environment, tt.upOptions.Envs)
 			if !errors.Is(err, oktetoErrors.ErrBuiltInOktetoEnvVarSetFromCMD) {
 				t.Fatalf("expected error in setEnvVarsFromCmd: %s due to try to set a built-in okteto environment variable", err)
-			}
-		})
-	}
-}
-
-func TestCommandAddedToUpOptionsWhenPassedAsArgument(t *testing.T) {
-	var tests = []struct {
-		name            string
-		upOptions       *UpOptions
-		args            []string
-		Manifest        *model.Manifest
-		expectedCommand []string
-		expectedDev     string
-	}{
-		{
-			name:            "Passing dev environment but no command",
-			upOptions:       &UpOptions{},
-			args:            []string{"frontend"},
-			Manifest:        &model.Manifest{Dev: map[string]*model.Dev{"frontend": {}}},
-			expectedCommand: nil,
-			expectedDev:     "frontend",
-		},
-		{
-			name:            "Passing command but no dev environment",
-			upOptions:       &UpOptions{},
-			args:            []string{"echo", "hello"},
-			Manifest:        &model.Manifest{Dev: map[string]*model.Dev{}},
-			expectedCommand: []string{"echo", "hello"},
-			expectedDev:     "",
-		},
-		{
-			name:            "Passing command and dev environment",
-			upOptions:       &UpOptions{},
-			args:            []string{"frontend", "echo", "hello"},
-			Manifest:        &model.Manifest{Dev: map[string]*model.Dev{"frontend": {}}},
-			expectedCommand: []string{"echo", "hello"},
-			expectedDev:     "frontend",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.upOptions.AddArgs(tt.args, tt.Manifest)
-			if !assert.NoError(t, err) {
-				t.Fatalf("unexpected error in  AddArgs: %s", err)
-			}
-
-			if !assert.Equal(t, tt.expectedCommand, tt.upOptions.commandToExecute) {
-				t.Fatalf("error in AddArgs; expected command %v but got %v", tt.expectedCommand, tt.upOptions.commandToExecute)
-			}
-
-			if !assert.Equal(t, tt.expectedDev, tt.upOptions.DevName) {
-				t.Fatalf("error in AddArgs; expected dev %s but got %s", tt.expectedDev, tt.upOptions.DevName)
 			}
 		})
 	}

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -152,7 +152,7 @@ func LoadManifestOrDefault(devPath, name string) (*model.Manifest, error) {
 	return nil, err
 }
 
-// GetDevFromManifest gets a dev from a manifest by
+// GetDevFromManifest gets a dev from a manifest by comparing the given dev name with the dev name in the manifest
 func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, error) {
 	if len(manifest.Dev) == 0 {
 		return nil, oktetoErrors.ErrManifestNoDevSection


### PR DESCRIPTION
Signed-off-by: Abhisman Sarkar <abhisman.sarkar@gmail.com>

# Proposed changes

Fixes #2300 

This allows for the option to run a command instead of the already defined command in the dev/command section of the okteto manifest file

Use case: my command is `yarn start`, but today I just want to run tests in my dev container. I can run `okteto up -- yarn test`
The extra `<command>` field will replace the `command` in the dev section:
https://www.okteto.com/docs/reference/manifest/#command-string-optional
