### PR TITLE
fix: private ingress annotations

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -396,10 +396,7 @@ func deployK8sEndpoint(ctx context.Context, ingressName, svcName string, port mo
 	if skipIngressDeployForStackNameLabel(ctx, c, ingress) {
 		return nil
 	}
-	if err := c.Deploy(ctx, ingress); err != nil {
-		return err
-	}
-	return nil
+	return c.Deploy(ctx, ingress)
 }
 
 func canSvcBeDeployed(ctx context.Context, stack *model.Stack, svcName string, client kubernetes.Interface, config *rest.Config) bool {

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -147,37 +147,7 @@ func deploy(ctx context.Context, s *model.Stack, c kubernetes.Interface, config 
 					ingressName = fmt.Sprintf("%s-%d", serviceName, ingressPort.ContainerPort)
 				}
 
-				// create a new endpoint for this port ingress deployment
-				endpoint := model.Endpoint{
-					Labels:      map[string]string{},
-					Annotations: map[string]string{},
-					Rules: []model.EndpointRule{
-						{
-							Path:    "/",
-							Service: serviceName,
-							Port:    ingressPort.ContainerPort,
-						},
-					},
-				}
-				// add specific stack labels
-				if _, ok := endpoint.Labels[model.StackNameLabel]; !ok {
-					endpoint.Labels[model.StackNameLabel] = s.Name
-				}
-				if _, ok := endpoint.Labels[model.StackEndpointNameLabel]; !ok {
-					endpoint.Labels[model.StackEndpointNameLabel] = ingressName
-				}
-
-				translateOptions := &ingresses.TranslateOptions{
-					Name:      s.Name,
-					Namespace: s.Namespace,
-				}
-				ingress := ingresses.Translate(ingressName, endpoint, translateOptions)
-
-				// check for labels collision in the case of a compose - before creation or update (deploy)
-				if skipIngressDeployForStackNameLabel(ctx, iClient, ingress) {
-					continue
-				}
-				if err := iClient.Deploy(ctx, ingress); err != nil {
+				if err := deployK8sEndpoint(ctx, ingressName, serviceName, ingressPort, s, iClient); err != nil {
 					exit <- err
 					return
 				}
@@ -391,6 +361,44 @@ func deploySvc(ctx context.Context, stack *model.Stack, svcName string, client k
 		oktetoLog.Success("Service '%s' updated", svcName)
 	}
 
+	return nil
+}
+
+func deployK8sEndpoint(ctx context.Context, ingressName, svcName string, port model.Port, s *model.Stack, c *ingresses.Client) error {
+
+	// create a new endpoint for this port ingress deployment
+	endpoint := model.Endpoint{
+		Labels:      translateLabels(svcName, s),
+		Annotations: translateAnnotations(s.Services[svcName]),
+		Rules: []model.EndpointRule{
+			{
+				Path:    "/",
+				Service: svcName,
+				Port:    port.ContainerPort,
+			},
+		},
+	}
+	// add specific stack labels
+	if _, ok := endpoint.Labels[model.StackNameLabel]; !ok {
+		endpoint.Labels[model.StackNameLabel] = s.Name
+	}
+	if _, ok := endpoint.Labels[model.StackEndpointNameLabel]; !ok {
+		endpoint.Labels[model.StackEndpointNameLabel] = ingressName
+	}
+
+	translateOptions := &ingresses.TranslateOptions{
+		Name:      s.Name,
+		Namespace: s.Namespace,
+	}
+	ingress := ingresses.Translate(ingressName, endpoint, translateOptions)
+
+	// check for labels collision in the case of a compose - before creation or update (deploy)
+	if skipIngressDeployForStackNameLabel(ctx, c, ingress) {
+		return nil
+	}
+	if err := c.Deploy(ctx, ingress); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/cmd/stack/deploy_test.go
+++ b/pkg/cmd/stack/deploy_test.go
@@ -969,7 +969,6 @@ func TestDeployK8sEndpoint(t *testing.T) {
 		name      string
 		stack     *model.Stack
 		ingresses []runtime.Object
-		err       error
 	}{
 		{
 			name: "deploy public endpoints",
@@ -1045,7 +1044,7 @@ func TestDeployK8sEndpoint(t *testing.T) {
 			fakeClient := fake.NewSimpleClientset(tt.ingresses...)
 			c := ingresses.NewIngressClient(fakeClient, true)
 			err := deployK8sEndpoint(context.Background(), "test", "test", model.Port{ContainerPort: 80}, tt.stack, c)
-			assert.Equal(t, tt.err, err)
+			assert.NoError(t, err)
 
 			obj, _ := c.Get(context.Background(), "test", "test")
 			assert.NotNil(t, obj)

--- a/pkg/cmd/stack/deploy_test.go
+++ b/pkg/cmd/stack/deploy_test.go
@@ -966,10 +966,10 @@ func TestGetErrorDueToRestartLimit(t *testing.T) {
 
 func TestDeployK8sEndpoint(t *testing.T) {
 	tests := []struct {
-		name   string
-		stack  *model.Stack
-		object []runtime.Object
-		err    error
+		name      string
+		stack     *model.Stack
+		ingresses []runtime.Object
+		err       error
 	}{
 		{
 			name: "deploy public endpoints",
@@ -1005,7 +1005,7 @@ func TestDeployK8sEndpoint(t *testing.T) {
 					},
 				},
 			},
-			object: []runtime.Object{
+			ingresses: []runtime.Object{
 				&networkingv1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
@@ -1028,7 +1028,7 @@ func TestDeployK8sEndpoint(t *testing.T) {
 					},
 				},
 			},
-			object: []runtime.Object{
+			ingresses: []runtime.Object{
 				&networkingv1.Ingress{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
@@ -1042,7 +1042,7 @@ func TestDeployK8sEndpoint(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewSimpleClientset(tt.object...)
+			fakeClient := fake.NewSimpleClientset(tt.ingresses...)
 			c := ingresses.NewIngressClient(fakeClient, true)
 			err := deployK8sEndpoint(context.Background(), "test", "test", model.Port{ContainerPort: 80}, tt.stack, c)
 			assert.Equal(t, tt.err, err)

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -54,6 +54,7 @@ type Stack struct {
 	Endpoints EndpointSpec           `yaml:"endpoints,omitempty"`
 }
 
+// ComposeServices represents the services declared in the compose
 type ComposeServices map[string]*Service
 
 // Service represents an okteto stack service

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -50,11 +50,11 @@ type Stack struct {
 	Volumes   map[string]*VolumeSpec `yaml:"volumes,omitempty"`
 	Namespace string                 `yaml:"namespace,omitempty"`
 	Context   string                 `yaml:"context,omitempty"`
-	Services  composeServices        `yaml:"services,omitempty"`
+	Services  ComposeServices        `yaml:"services,omitempty"`
 	Endpoints EndpointSpec           `yaml:"endpoints,omitempty"`
 }
 
-type composeServices map[string]*Service
+type ComposeServices map[string]*Service
 
 // Service represents an okteto stack service
 type Service struct {
@@ -849,7 +849,7 @@ func setEnvironmentFromFile(svc *Service, filename string) error {
 	return nil
 }
 
-func (s composeServices) toGraph() graph {
+func (s ComposeServices) toGraph() graph {
 	g := graph{}
 	for svcName, svcInfo := range s {
 		dependsOnList := []string{}

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -1240,12 +1240,12 @@ func Test_translateEnvVars(t *testing.T) {
 func TestServicesToGraph(t *testing.T) {
 	tests := []struct {
 		name          string
-		services      composeServices
+		services      ComposeServices
 		expectedGraph graph
 	}{
 		{
 			name: "no cycle - no connections",
-			services: composeServices{
+			services: ComposeServices{
 				"a": &Service{},
 				"b": &Service{},
 				"c": &Service{},
@@ -1258,7 +1258,7 @@ func TestServicesToGraph(t *testing.T) {
 		},
 		{
 			name: "no cycle - connections",
-			services: composeServices{
+			services: ComposeServices{
 				"a": &Service{
 					DependsOn: DependsOn{
 						"b": DependsOnConditionSpec{},
@@ -1279,7 +1279,7 @@ func TestServicesToGraph(t *testing.T) {
 		},
 		{
 			name: "cycle - direct cycle",
-			services: composeServices{
+			services: ComposeServices{
 				"a": &Service{
 					DependsOn: DependsOn{
 						"b": DependsOnConditionSpec{},
@@ -1300,7 +1300,7 @@ func TestServicesToGraph(t *testing.T) {
 		},
 		{
 			name: "cycle - indirect cycle",
-			services: composeServices{
+			services: ComposeServices{
 				"a": &Service{
 					DependsOn: DependsOn{
 						"b": DependsOnConditionSpec{},


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #3182

Add the annotations and labels from a compose/stack file into the kubernetes endpoints.
Create tests for deploying a kubernetes ingress
