### PR TITLE
Empty cfgmap repository if not valid repo schema

### DIFF
--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -109,7 +109,7 @@ func mergeServicesToDeployFromOptionsAndManifest(deployOptions *Options) {
 	}
 }
 
-func addEnvVars(ctx context.Context, cwd string) error {
+func addEnvVars(ctx context.Context, cwd string) {
 	if os.Getenv(model.OktetoGitBranchEnvVar) == "" {
 		branch, err := utils.GetBranch(cwd)
 		if err != nil {
@@ -125,17 +125,12 @@ func addEnvVars(ctx context.Context, cwd string) error {
 		}
 
 		if repo != "" {
-			repoHTTPS, err := switchRepoSchemaToHTTPS(repo)
-			if err != nil {
-				return err
-			}
-			if repoHTTPS != nil {
-				repo = repoHTTPS.String()
-			} else {
-				// ir repo was parsed but hasnt got a valid schema
+			repoHTTPS := switchRepoSchemaToHTTPS(repo)
+			if repoHTTPS == nil {
 				// fallback to empty repository
-				oktetoLog.Warning("retrieved local repository")
 				repo = ""
+			} else {
+				repo = repoHTTPS.String()
 			}
 		}
 		os.Setenv(model.GithubRepositoryEnvVar, repo)
@@ -165,23 +160,25 @@ func addEnvVars(ctx context.Context, cwd string) error {
 		os.Setenv(model.OktetoTokenEnvVar, okteto.Context().Token)
 	}
 	oktetoLog.AddMaskedWord(os.Getenv(model.OktetoTokenEnvVar))
-	return nil
 }
 
-func switchRepoSchemaToHTTPS(repo string) (*url.URL, error) {
+func switchRepoSchemaToHTTPS(repo string) *url.URL {
 	repoURL, err := giturls.Parse(repo)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 	switch repoURL.Scheme {
 	case sshScheme, httpScheme:
 		repoURL.Scheme = httpsScheme
 		repoURL.User = nil
-		return repoURL, nil
+		return repoURL
 	case httpsScheme:
-		return repoURL, nil
+		return repoURL
+	default:
+		// if repo was parsed but hasnt got a valid schema
+		oktetoLog.Info("retrieved local repository")
+		return nil
 	}
-	return nil, nil
 }
 
 func updateConfigMapStatusError(ctx context.Context, cfg *corev1.ConfigMap, c kubernetes.Interface, data *pipeline.CfgData, errMain error) error {

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -176,7 +176,7 @@ func switchRepoSchemaToHTTPS(repo string) *url.URL {
 		return repoURL
 	default:
 		// if repo was parsed but has not a valid schema
-		oktetoLog.Info("retrieved local repository")
+		oktetoLog.Infof("retrieved schema for %s - %s", repo, repoURL.Scheme)
 		return nil
 	}
 }

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -175,7 +175,7 @@ func switchRepoSchemaToHTTPS(repo string) *url.URL {
 	case httpsScheme:
 		return repoURL
 	default:
-		// if repo was parsed but hasnt got a valid schema
+		// if repo was parsed but has not a valid schema
 		oktetoLog.Info("retrieved local repository")
 		return nil
 	}

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -172,10 +172,9 @@ func Test_mergeServicesToDeployFromOptionsAndManifest(t *testing.T) {
 
 func Test_switchSSHRepoToHTTPS(t *testing.T) {
 	tests := []struct {
-		name        string
-		repo        string
-		expected    *url.URL
-		expectedErr error
+		name     string
+		repo     string
+		expected *url.URL
 	}{
 		{
 			name: "input-ssh",
@@ -203,18 +202,15 @@ func Test_switchSSHRepoToHTTPS(t *testing.T) {
 				Path:   "/okteto/go-getting-started.git",
 			}},
 		{
-			name:        "input-local",
-			repo:        "github.com/okteto/go-getting-started.git",
-			expected:    nil,
-			expectedErr: nil,
+			name:     "input-local",
+			repo:     "github.com/okteto/go-getting-started.git",
+			expected: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url, err := switchRepoSchemaToHTTPS(tt.repo)
-			assert.ErrorIs(t, err, tt.expectedErr)
-
+			url := switchRepoSchemaToHTTPS(tt.repo)
 			assert.Equal(t, tt.expected, url)
 		})
 	}

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -203,9 +203,10 @@ func Test_switchSSHRepoToHTTPS(t *testing.T) {
 				Path:   "/okteto/go-getting-started.git",
 			}},
 		{
-			name:        "input-not-allowed",
+			name:        "input-local",
 			repo:        "github.com/okteto/go-getting-started.git",
-			expectedErr: errUnsupportedScheme,
+			expected:    nil,
+			expectedErr: nil,
 		},
 	}
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -266,9 +266,8 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		return err
 	}
 
-	if err := addEnvVars(ctx, cwd); err != nil {
-		return err
-	}
+	addEnvVars(ctx, cwd)
+
 	oktetoLog.Debugf("creating temporal kubeconfig file '%s'", dc.TempKubeconfigFile)
 	if err := dc.Kubeconfig.Modify(dc.Proxy.GetPort(), dc.Proxy.GetToken(), dc.TempKubeconfigFile); err != nil {
 		oktetoLog.Infof("could not create temporal kubeconfig %s", err)

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -166,6 +166,10 @@ func translateOutput(output *bytes.Buffer) []byte {
 
 // translateConfigMapSandBox creates a configmap adding data from a config data
 func translateConfigMapSandBox(data *CfgData) *apiv1.ConfigMap {
+	// if repository is empty, force empty branch
+	if data.Repository == "" {
+		data.Branch = ""
+	}
 	cmap := &apiv1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: data.Namespace,
@@ -214,6 +218,11 @@ func updateCmap(cmap *apiv1.ConfigMap, data *CfgData) error {
 		// when repository is empty - the filename should not be saved and redeploys should be done from cli
 		cmap.Data[filenameField] = data.Filename
 		cmap.Data[repoField] = data.Repository
+	}
+
+	// if repository is empty, force empty branch
+	if data.Repository == "" {
+		data.Branch = ""
 	}
 
 	if data.Branch != "" {


### PR DESCRIPTION
# Proposed changes

Fixes #3228 

When parsing the `.git/config` url when cloned repo, if not recognised as `http`, https or ssh, we returned an error.
This fix allows not recognised schemas to work with okteto cli with local repositories.

Tested the scenario with repo go-gettting-started, changing the url param of the git config then run `okteto deploy`
UI output was showing a message not allowing redeploy and name for dev environment was last part of local repository url



