### PR TITLE
feat: add platform flag to build command

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -106,6 +106,7 @@ func Build(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.OutputMode, "progress", "", oktetoLog.TTYFormat, "show plain/tty build output")
 	cmd.Flags().StringArrayVar(&options.BuildArgs, "build-arg", nil, "set build-time variables")
 	cmd.Flags().StringArrayVar(&options.Secrets, "secret", nil, "secret files exposed to the build. Format: id=mysecret,src=/local/secret")
+	cmd.Flags().StringVar(&options.Platform, "platform", "", "set platform if server is multi-platform capable")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "namespace against which the image will be consumed. Default is the one defined at okteto context or okteto manifest")
 	cmd.Flags().BoolVarP(&options.BuildToGlobal, "global", "", false, "push the image to the global registry")
 	return cmd

--- a/pkg/cmd/build/build_docker.go
+++ b/pkg/cmd/build/build_docker.go
@@ -126,6 +126,7 @@ func buildWithDockerDaemonBuildkit(ctx context.Context, buildOptions *types.Buil
 			RemoteContext: remote,
 			SessionID:     s.ID(),
 			BuildArgs:     make(map[string]*string),
+			Platform:      buildOptions.Platform,
 		}
 		if buildOptions.Tag != "" {
 			dockerBuildOptions.Tags = append(dockerBuildOptions.Tags, buildOptions.Tag)

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -70,6 +70,9 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 		}
 	}
 
+	if buildOptions.Platform != "" {
+		frontendAttrs["platform"] = buildOptions.Platform
+	}
 	if buildOptions.Target != "" {
 		frontendAttrs["target"] = buildOptions.Target
 	}

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -24,6 +24,7 @@ type BuildOptions struct {
 	OutputMode    string
 	Path          string
 	Secrets       []string
+	Platform      string
 	Tag           string
 	Target        string
 	Namespace     string


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #2921 

## Proposed changes:

- Build with local docker: Only supports 1 platform. This is also happening with `docker build` commnand. The response from the server when we try to add more than one is `Error response from daemon: "amd64,linux" is an invalid component of "linux/amd64,linux/arm64": platform specifier component must match "^[A-Za-z0-9_-]+$": invalid argument`. which is the same thrown by docker. We could get rid off this error if we move to a `buildx` approach where we don't depend on docker cli

- build in Okteto: It accepts multiple platforms just like the `buildctl` or `buildx` commands. 

### Further improvement:

In order to allow multiple platforms in local docker, simplify the code (right now we have one for local buildkit and another one for remote buildkit in okteto) and make it testable we need to refactor the code related to calling the server. I created #3233 to improve the build with local docker and reduce the complexity of the code
