### PR TITLE
fix: show info if context is initialized by env vars

### DIFF
--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -58,21 +58,21 @@ func (o *ContextOptions) initFromContext() {
 }
 
 func (o *ContextOptions) initFromEnvVars() {
-	environmentVarialbes := []string{}
+	usedEnvVars := []string{}
 	if o.Token == "" && os.Getenv(model.OktetoTokenEnvVar) != "" {
 		o.Token = os.Getenv(model.OktetoTokenEnvVar)
-		environmentVarialbes = append(environmentVarialbes, model.OktetoTokenEnvVar)
+		usedEnvVars = append(usedEnvVars, model.OktetoTokenEnvVar)
 	}
 
 	if o.Context == "" && os.Getenv(model.OktetoURLEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoURLEnvVar)
 		o.IsOkteto = true
-		environmentVarialbes = append(environmentVarialbes, model.OktetoURLEnvVar)
+		usedEnvVars = append(usedEnvVars, model.OktetoURLEnvVar)
 	}
 
 	if o.Context == "" && os.Getenv(model.OktetoContextEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoContextEnvVar)
-		environmentVarialbes = append(environmentVarialbes, model.OktetoContextEnvVar)
+		usedEnvVars = append(usedEnvVars, model.OktetoContextEnvVar)
 	}
 
 	if o.Token != "" {
@@ -84,13 +84,13 @@ func (o *ContextOptions) initFromEnvVars() {
 
 	if o.Namespace == "" && os.Getenv(model.OktetoNamespaceEnvVar) != "" {
 		o.Namespace = os.Getenv(model.OktetoNamespaceEnvVar)
-		environmentVarialbes = append(environmentVarialbes, model.OktetoNamespaceEnvVar)
+		usedEnvVars = append(usedEnvVars, model.OktetoNamespaceEnvVar)
 	}
 
-	if len(environmentVarialbes) == 1 {
-		oktetoLog.Warning("Initializing context with the value of %s environment variable", environmentVarialbes[0])
-	} else if len(environmentVarialbes) > 1 {
-		oktetoLog.Warning("Initializing context with the value of %s and %s environment variables", strings.Join(environmentVarialbes[0:len(environmentVarialbes)-1], ", "), environmentVarialbes[len(environmentVarialbes)-1])
+	if len(usedEnvVars) == 1 {
+		oktetoLog.Warning("Initializing context with the value of %s environment variable", usedEnvVars[0])
+	} else if len(usedEnvVars) > 1 {
+		oktetoLog.Warning("Initializing context with the value of %s and %s environment variables", strings.Join(usedEnvVars[0:len(usedEnvVars)-1], ", "), usedEnvVars[len(usedEnvVars)-1])
 	}
 
 }

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -15,7 +15,9 @@ package context
 
 import (
 	"os"
+	"strings"
 
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 )
@@ -56,17 +58,21 @@ func (o *ContextOptions) initFromContext() {
 }
 
 func (o *ContextOptions) initFromEnvVars() {
-	if o.Token == "" {
+	environmentVarialbes := []string{}
+	if o.Token == "" && os.Getenv(model.OktetoTokenEnvVar) != "" {
 		o.Token = os.Getenv(model.OktetoTokenEnvVar)
+		environmentVarialbes = append(environmentVarialbes, model.OktetoTokenEnvVar)
 	}
 
 	if o.Context == "" && os.Getenv(model.OktetoURLEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoURLEnvVar)
 		o.IsOkteto = true
+		environmentVarialbes = append(environmentVarialbes, model.OktetoURLEnvVar)
 	}
 
 	if o.Context == "" && os.Getenv(model.OktetoContextEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoContextEnvVar)
+		environmentVarialbes = append(environmentVarialbes, model.OktetoContextEnvVar)
 	}
 
 	if o.Token != "" {
@@ -78,5 +84,13 @@ func (o *ContextOptions) initFromEnvVars() {
 
 	if o.Namespace == "" && os.Getenv(model.OktetoNamespaceEnvVar) != "" {
 		o.Namespace = os.Getenv(model.OktetoNamespaceEnvVar)
+		environmentVarialbes = append(environmentVarialbes, model.OktetoNamespaceEnvVar)
 	}
+
+	if len(environmentVarialbes) == 1 {
+		oktetoLog.Warning("Initializing context with the value of %s environment variable", environmentVarialbes[0])
+	} else if len(environmentVarialbes) > 1 {
+		oktetoLog.Warning("Initializing context with the value of %s and %s environment variables", strings.Join(environmentVarialbes[0:len(environmentVarialbes)-1], ", "), environmentVarialbes[len(environmentVarialbes)-1])
+	}
+
 }

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -90,8 +90,8 @@ Or a Kubernetes context:
 
 func (c *ContextCommand) Run(ctx context.Context, ctxOptions *ContextOptions) error {
 	ctxStore := okteto.ContextStore()
-	ctxOptions.initFromContext()
 	ctxOptions.initFromEnvVars()
+	ctxOptions.initFromContext()
 
 	if ctxOptions.Token == "" && kubeconfig.InCluster() && !isValidCluster(ctxOptions.Context) {
 		if ctxOptions.IsCtxCommand {


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #2378

This PR adds a warning message whenever the user is initialising the context from env vars