### PR TITLE
Check last stage instead of last line in the output tests to know if the log has finished

### DIFF
--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -116,10 +116,10 @@ func TestDeploySuccessOutput(t *testing.T) {
 
 	var text oktetoLog.JSONLogFormat
 	stageLines := map[string][]string{}
-	prevLine := ""
+	prevStage := ""
 	for _, l := range strings.Split(string(uiOutput), "\n") {
 		if err := json.Unmarshal([]byte(l), &text); err != nil {
-			if prevLine != "EOF" {
+			if prevStage != "done" {
 				t.Fatalf("not json format: %s", l)
 			}
 		}
@@ -128,7 +128,7 @@ func TestDeploySuccessOutput(t *testing.T) {
 		} else {
 			stageLines[text.Stage] = []string{text.Message}
 		}
-		prevLine = text.Message
+		prevStage = text.Stage
 	}
 
 	stagesToTest := []string{"Load manifest", "Building service app", "Deploying compose", "done"}
@@ -182,11 +182,11 @@ func TestCmdFailOutput(t *testing.T) {
 
 	var text oktetoLog.JSONLogFormat
 	stageLines := map[string][]string{}
-	prevLine := ""
+	prevStage := ""
 	numErrors := 0
 	for _, l := range strings.Split(string(uiOutput), "\n") {
 		if err := json.Unmarshal([]byte(l), &text); err != nil {
-			if prevLine != "EOF" {
+			if prevStage != "done" {
 				t.Fatalf("not json format: %s", l)
 			}
 		}
@@ -195,7 +195,7 @@ func TestCmdFailOutput(t *testing.T) {
 		} else {
 			stageLines[text.Stage] = []string{text.Message}
 		}
-		prevLine = text.Message
+		prevStage = text.Stage
 		if text.Level == "error" {
 			numErrors++
 		}
@@ -247,11 +247,11 @@ func TestComposeFailOutput(t *testing.T) {
 
 	var text oktetoLog.JSONLogFormat
 	stageLines := map[string][]string{}
-	prevLine := ""
+	prevStage := ""
 	numErrors := 0
 	for _, l := range strings.Split(string(uiOutput), "\n") {
 		if err := json.Unmarshal([]byte(l), &text); err != nil {
-			if prevLine != "EOF" {
+			if prevStage != "done" {
 				t.Fatalf("not json format: %s", l)
 			}
 		}
@@ -260,7 +260,7 @@ func TestComposeFailOutput(t *testing.T) {
 		} else {
 			stageLines[text.Stage] = []string{text.Message}
 		}
-		prevLine = text.Message
+		prevStage = text.Stage
 		if text.Level == "error" {
 			numErrors++
 		}


### PR DESCRIPTION
Signed-off-by: Ignacio Fuertes <nacho@okteto.com>

# Proposed changes

Probably the condition can change and the way we validate it, but this PR is a quick one to fix the tests. After the merge of this https://github.com/okteto/okteto/pull/3231, we assume that some log messages can be included as part of the `done` stage. So, instead of checking the last line, what we check is if the last stage is `done` or not. At the end, we only rely on the stage name to determine if the logs has ended or not.

In the case of the tests that were failing, these were the logs, so the check was failing as the `EOF` is not the last line.We should probably change that, but we assumed this scenario in the mentioned PR

```
{"level":"info","stage":"done","message":"EOF","timestamp":1669208339}
{"level":"info","stage":"done","message":"error executing command 'Failed command': exit status 1","timestamp":1669208339}
```
