### PR TITLE
Fix divert target port hwen target service is diverted

### DIFF
--- a/pkg/k8s/diverts/translate.go
+++ b/pkg/k8s/diverts/translate.go
@@ -108,7 +108,7 @@ func translateEndpoints(m *model.Manifest, s *apiv1.Service) *apiv1.Endpoints {
 			result.Subsets[0].Ports,
 			apiv1.EndpointPort{
 				Name:        p.Name,
-				Port:        p.Port,
+				Port:        p.TargetPort.IntVal,
 				Protocol:    p.Protocol,
 				AppProtocol: p.AppProtocol,
 			},

--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -24,6 +24,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 )
 
@@ -244,12 +245,14 @@ func Test_translateEndpoints(t *testing.T) {
 				{
 					Name:        "port1",
 					Port:        8080,
+					TargetPort:  intstr.IntOrString{IntVal: 9090},
 					Protocol:    apiv1.ProtocolTCP,
 					AppProtocol: pointer.StringPtr("tcp"),
 				},
 				{
 					Name:        "port2",
 					Port:        8081,
+					TargetPort:  intstr.IntOrString{IntVal: 9091},
 					Protocol:    apiv1.ProtocolTCP,
 					AppProtocol: pointer.StringPtr("tcp"),
 				},
@@ -286,13 +289,13 @@ func Test_translateEndpoints(t *testing.T) {
 				Ports: []apiv1.EndpointPort{
 					{
 						Name:        "port1",
-						Port:        8080,
+						Port:        9090,
 						Protocol:    apiv1.ProtocolTCP,
 						AppProtocol: pointer.StringPtr("tcp"),
 					},
 					{
 						Name:        "port2",
-						Port:        8081,
+						Port:        9091,
 						Protocol:    apiv1.ProtocolTCP,
 						AppProtocol: pointer.StringPtr("tcp"),
 					},


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

This solves a regression introduced by https://github.com/okteto/okteto/pull/3198

The problem is that when creating the headless service for an ingress, we use the `port` of the service for the endpoint. If the services get's diverted, the port is updated by weaver to be 1024. We should use the target port for the headless service, not the `port`