### PR TITLE
Include 'destroy-error' status as a failure in WaitForActionToFinish function. This was provoking that if the pipeline fails, we don't indicate the error in the CLI

### DIFF
--- a/pkg/okteto/action.go
+++ b/pkg/okteto/action.go
@@ -58,7 +58,7 @@ func (c *pipelineClient) WaitForActionToFinish(ctx context.Context, pipelineName
 			switch a.Status {
 			case "progressing", "queued":
 				continue
-			case "error":
+			case "error", "destroy-error":
 				oktetoLog.Infof("action '%s' failed", actionName)
 				return fmt.Errorf("pipeline '%s' failed", pipelineName)
 			default:


### PR DESCRIPTION
Signed-off-by: Ignacio Fuertes <nacho@okteto.com>

This affects/blocks the changes for the destroy all

# Proposed changes

* Include the case for `destroy-error` status when waiting a pipeline to be finished. This is the status used when the destroy operation fails. 


Check these screenshots, I executed `okteto pipeline destroy --wait` and the command specifies that the destroy was successfully

<img width="585" alt="Captura de Pantalla 2022-12-01 a las 11 49 35" src="https://user-images.githubusercontent.com/3510171/205034213-8ab29914-a6d3-411c-9405-f774a78c3662.png">

But if you go to the UI, you see that the destroy operation failed

<img width="1064" alt="Captura de Pantalla 2022-12-01 a las 11 49 29" src="https://user-images.githubusercontent.com/3510171/205034337-05e63dec-1b2e-41b1-9f01-fb5e469e28b7.png">

After this fix, the CLI output is

```
 x  Pipeline 'test-okteto' failed
```


