### PR TITLE
Fix inline export when image tag and cache tag are the same

### DIFF
--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -131,17 +131,17 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 	}
 
 	if buildOptions.ExportCache != "" {
-		mode := "min"
+		exportType := "inline"
 		if buildOptions.ExportCache != buildOptions.Tag {
-			mode = "max"
+			exportType = "registry"
 		}
 		opt.CacheExports = append(
 			opt.CacheExports,
 			client.CacheOptionsEntry{
-				Type: "registry",
+				Type: exportType,
 				Attrs: map[string]string{
 					"ref":  buildOptions.ExportCache,
-					"mode": mode,
+					"mode": "max",
 				},
 			},
 		)


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

Fix the `type` parameter based on the cache tag. If cache tag is the one we are pushing, `inline` must be used.
More info [here](https://github.com/moby/buildkit#inline-push-image-and-cache-together)