### PR TITLE
Fix infer name for "okteto logs"

### DIFF
--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -61,6 +61,13 @@ func Logs(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			if manifest.Name == "" {
+				manifest.Name = utils.InferName(wd)
+			}
 
 			if len(args) > 0 {
 				options.Include = args[0]


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

`okteto logs` is not inferring the name of the manifest properly. I think this logic should be part of the manifest deserialization, but that would require a larger refactor