### PR TITLE
Set "Ingress.Value" to properly initialize the HeaderID based on the …

### DIFF
--- a/pkg/cmd/stack/divert.go
+++ b/pkg/cmd/stack/divert.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"encoding/json"
+
+	"github.com/okteto/okteto/pkg/k8s/diverts"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func applyDivertToDeployment(d *appsv1.Deployment, old *appsv1.Deployment) {
+	if old.Spec.Template.Labels == nil {
+		return
+	}
+	if old.Spec.Template.Labels[model.OktetoDivertInjectSidecarLabel] == "" {
+		return
+	}
+	if d.Spec.Template.Labels == nil {
+		d.Spec.Template.Labels = map[string]string{}
+	}
+	d.Spec.Template.Labels[model.OktetoDivertInjectSidecarLabel] = old.Spec.Template.Labels[model.OktetoDivertInjectSidecarLabel]
+}
+
+func applyDivertToService(s *apiv1.Service, old *apiv1.Service) {
+	if old.Annotations[model.OktetoDivertServiceAnnotation] == "" {
+		return
+	}
+	if s.Annotations == nil {
+		s.Annotations = map[string]string{}
+	}
+	s.Annotations[model.OktetoDivertServiceAnnotation] = old.Annotations[model.OktetoDivertServiceAnnotation]
+	divertMapping := diverts.PortMapping{}
+	if err := json.Unmarshal([]byte(old.Annotations[model.OktetoDivertServiceAnnotation]), &divertMapping); err != nil {
+		oktetoLog.Warning("skipping apply divert to service '%s': %s", s.Name, err.Error())
+		return
+	}
+	for i := range s.Spec.Ports {
+		if s.Spec.Ports[i].Port == divertMapping.OriginalPort {
+			s.Spec.Ports[i].TargetPort = intstr.IntOrString{IntVal: divertMapping.ProxyPort}
+		}
+	}
+}

--- a/pkg/cmd/stack/divert_test.go
+++ b/pkg/cmd/stack/divert_test.go
@@ -1,0 +1,205 @@
+// Copyright 2022 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func Test_applyDivertToDeployment(t *testing.T) {
+	var tests = []struct {
+		name     string
+		d        *appsv1.Deployment
+		old      *appsv1.Deployment
+		expected map[string]string
+	}{
+		{
+			name: "no-divert",
+			d: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: apiv1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"key1": "value1",
+							},
+						},
+					},
+				},
+			},
+			old:      &appsv1.Deployment{},
+			expected: map[string]string{"key1": "value1"},
+		},
+		{
+			name: "divert",
+			d: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: apiv1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"key1": "value1",
+							},
+						},
+					},
+				},
+			},
+			old: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: apiv1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								model.OktetoDivertInjectSidecarLabel: "cindy",
+								"key2":                               "value2",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"key1":                               "value1",
+				model.OktetoDivertInjectSidecarLabel: "cindy",
+			},
+		},
+		{
+			name: "empty-divert",
+			d:    &appsv1.Deployment{},
+			old: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: apiv1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								model.OktetoDivertInjectSidecarLabel: "cindy",
+								"key2":                               "value2",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				model.OktetoDivertInjectSidecarLabel: "cindy",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyDivertToDeployment(tt.d, tt.old)
+			if !reflect.DeepEqual(tt.d.Spec.Template.Labels, tt.expected) {
+				t.Fatalf("Didn't updated template labels correctly")
+			}
+		})
+	}
+}
+
+func Test_applyDivertToService(t *testing.T) {
+	var tests = []struct {
+		name     string
+		s        *apiv1.Service
+		old      *apiv1.Service
+		expected []apiv1.ServicePort
+	}{
+		{
+			name: "no-divert",
+			s: &apiv1.Service{
+				Spec: apiv1.ServiceSpec{
+					Ports: []apiv1.ServicePort{
+						{
+							Name:       "web1",
+							Port:       8080,
+							TargetPort: intstr.IntOrString{IntVal: 80},
+						},
+						{
+							Name:       "web2",
+							Port:       8081,
+							TargetPort: intstr.IntOrString{IntVal: 81},
+						},
+					},
+				},
+			},
+			old: &apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"key1": "value1",
+					},
+				},
+			},
+			expected: []apiv1.ServicePort{
+				{
+					Name:       "web1",
+					Port:       8080,
+					TargetPort: intstr.IntOrString{IntVal: 80},
+				},
+				{
+					Name:       "web2",
+					Port:       8081,
+					TargetPort: intstr.IntOrString{IntVal: 81},
+				},
+			},
+		},
+		{
+			name: "divert",
+			s: &apiv1.Service{
+				Spec: apiv1.ServiceSpec{
+					Ports: []apiv1.ServicePort{
+						{
+							Name:       "web1",
+							Port:       8080,
+							TargetPort: intstr.IntOrString{IntVal: 80},
+						},
+						{
+							Name:       "web2",
+							Port:       8081,
+							TargetPort: intstr.IntOrString{IntVal: 81},
+						},
+					},
+				},
+			},
+			old: &apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						model.OktetoDivertServiceAnnotation: "{\"proxy_port\":1024,\"original_port\":8081,\"original_target_port\":81}",
+						"key1":                              "value1",
+					},
+				},
+			},
+			expected: []apiv1.ServicePort{
+				{
+					Name:       "web1",
+					Port:       8080,
+					TargetPort: intstr.IntOrString{IntVal: 80},
+				},
+				{
+					Name:       "web2",
+					Port:       8081,
+					TargetPort: intstr.IntOrString{IntVal: 1024},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyDivertToService(tt.s, tt.old)
+			if !reflect.DeepEqual(tt.s.Spec.Ports, tt.expected) {
+				t.Fatalf("Didn't updated ports correctly")
+			}
+		})
+	}
+}

--- a/pkg/k8s/diverts/translate.go
+++ b/pkg/k8s/diverts/translate.go
@@ -194,6 +194,9 @@ func translateDivertCRD(m *model.Manifest) *Divert {
 			Annotations: map[string]string{model.OktetoAutoCreateAnnotation: "true"},
 		},
 		Spec: DivertSpec{
+			Ingress: IngressDivertSpec{
+				Value: m.Namespace,
+			},
 			FromService: ServiceDivertSpec{
 				Name:      m.Deploy.Divert.Service,
 				Namespace: m.Deploy.Divert.Namespace,

--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -427,6 +427,9 @@ func Test_translateDivertCRD(t *testing.T) {
 			},
 		},
 		Spec: DivertSpec{
+			Ingress: IngressDivertSpec{
+				Value: "cindy",
+			},
 			FromService: ServiceDivertSpec{
 				Name:      "service",
 				Namespace: "staging",

--- a/pkg/k8s/diverts/translate_test.go
+++ b/pkg/k8s/diverts/translate_test.go
@@ -57,10 +57,10 @@ func Test_translateIngress(t *testing.T) {
 				"l1":                  "v1",
 			},
 			Annotations: map[string]string{
-				model.OktetoAutoCreateAnnotation:    "true",
-				"a1":                                "v1",
-				divertIngressInjectionAnnotation:    "cindy",
-				nginxConfigurationSnippetAnnotation: divertTextBlockParser.WriteBlock("proxy_set_header x-okteto-dvrt cindy;"),
+				model.OktetoAutoCreateAnnotation: "true",
+				"a1":                             "v1",
+				model.OktetoDivertIngressInjectionAnnotation:    "cindy",
+				model.OktetoNginxConfigurationSnippetAnnotation: divertTextBlockParser.WriteBlock("proxy_set_header x-okteto-dvrt cindy;"),
 			},
 		},
 		Spec: networkingv1.IngressSpec{
@@ -108,9 +108,9 @@ func Test_translateEmptyIngress(t *testing.T) {
 				model.DeployedByLabel: "test",
 			},
 			Annotations: map[string]string{
-				model.OktetoAutoCreateAnnotation:    "true",
-				divertIngressInjectionAnnotation:    "cindy",
-				nginxConfigurationSnippetAnnotation: divertTextBlockParser.WriteBlock("proxy_set_header x-okteto-dvrt cindy;"),
+				model.OktetoAutoCreateAnnotation:                "true",
+				model.OktetoDivertIngressInjectionAnnotation:    "cindy",
+				model.OktetoNginxConfigurationSnippetAnnotation: divertTextBlockParser.WriteBlock("proxy_set_header x-okteto-dvrt cindy;"),
 			},
 		},
 		Spec: networkingv1.IngressSpec{
@@ -198,8 +198,8 @@ func Test_translateDivertedService(t *testing.T) {
 			Namespace: "staging",
 			Labels:    map[string]string{"l1": "v1"},
 			Annotations: map[string]string{
-				"a1":                             "v1",
-				"divert.okteto.com/modification": "{\"proxy_port\":1024,\"original_port\":3000,\"original_target_port\":3000}",
+				"a1":                                "v1",
+				model.OktetoDivertServiceAnnotation: "{\"proxy_port\":1024,\"original_port\":3000,\"original_target_port\":3000}",
 			},
 		},
 		Spec: apiv1.ServiceSpec{

--- a/pkg/k8s/ingresses/crud_test.go
+++ b/pkg/k8s/ingresses/crud_test.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/model"
 	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -197,5 +199,109 @@ func TestDestroyWithError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), kubernetesError) {
 		t.Fatalf("Got '%s' error but expected '%s'", err.Error(), kubernetesError)
+	}
+}
+
+func Test_applyDivertChanges(t *testing.T) {
+	var tests = []struct {
+		name     string
+		iClient  *Client
+		ingress  *Ingress
+		old      *networkingv1.Ingress
+		expected map[string]string
+	}{
+		{
+			name:    "v1-no-divert",
+			iClient: &Client{isV1: true},
+			ingress: &Ingress{
+				V1: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{"key1": "value1"},
+					},
+				},
+			},
+			old: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"key2": "value2"},
+				},
+			},
+			expected: map[string]string{"key1": "value1"},
+		},
+		{
+			name:    "v1-divert",
+			iClient: &Client{isV1: true},
+			ingress: &Ingress{
+				V1: &networkingv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{"key1": "value1"},
+					},
+				},
+			},
+			old: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"key2": "value2",
+						model.OktetoDivertIngressInjectionAnnotation:    "cindy",
+						model.OktetoNginxConfigurationSnippetAnnotation: "start-divert-end",
+					},
+				},
+			},
+			expected: map[string]string{
+				"key1": "value1",
+				model.OktetoDivertIngressInjectionAnnotation:    "cindy",
+				model.OktetoNginxConfigurationSnippetAnnotation: "start-divert-end",
+			},
+		},
+		{
+			name:    "v1beta1-no-divert",
+			iClient: &Client{isV1: false},
+			ingress: &Ingress{
+				V1Beta1: &networkingv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{"key1": "value1"},
+					},
+				},
+			},
+			old: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"key2": "value2"},
+				},
+			},
+			expected: map[string]string{"key1": "value1"},
+		},
+		{
+			name:    "v1beta1-divert",
+			iClient: &Client{isV1: false},
+			ingress: &Ingress{
+				V1Beta1: &networkingv1beta1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{"key1": "value1"},
+					},
+				},
+			},
+			old: &networkingv1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"key2": "value2",
+						model.OktetoDivertIngressInjectionAnnotation:    "cindy",
+						model.OktetoNginxConfigurationSnippetAnnotation: "start-divert-end",
+					},
+				},
+			},
+			expected: map[string]string{
+				"key1": "value1",
+				model.OktetoDivertIngressInjectionAnnotation:    "cindy",
+				model.OktetoNginxConfigurationSnippetAnnotation: "start-divert-end",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.iClient.applyDivertChanges(tt.ingress, tt.old.GetObjectMeta())
+			if !reflect.DeepEqual(tt.ingress.GetAnnotations(), tt.expected) {
+				t.Fatalf("Didn't updated annotations correctly")
+			}
+		})
 	}
 }

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -281,4 +281,10 @@ const (
 
 	// OktetoDivertInjectSidecarLabel pod label used by divert to inject envoy sidecar
 	OktetoDivertInjectSidecarLabel = "divert.okteto.com/inject-sidecar"
+
+	// OktetoNginxConfigurationSnippetAnnotation annotation for nginx configuration snippet
+	OktetoNginxConfigurationSnippetAnnotation = "nginx.ingress.kubernetes.io/configuration-snippet"
+
+	// OktetoDivertIngressInjectionAnnotation annotation for nginx header injection
+	OktetoDivertIngressInjectionAnnotation = "divert.okteto.com/injection"
 )


### PR DESCRIPTION
…namespace name

# Proposed changes

Floww up of https://github.com/okteto/okteto/pull/3271, the `Ingress.Value` is needed to map the header injected in the nginx controller