### PR TITLE
Don't apply divert transformation if old service was autocreate/headless

### DIFF
--- a/pkg/cmd/stack/divert.go
+++ b/pkg/cmd/stack/divert.go
@@ -41,6 +41,9 @@ func applyDivertToService(s *apiv1.Service, old *apiv1.Service) {
 	if old.Annotations[model.OktetoDivertServiceAnnotation] == "" {
 		return
 	}
+	if old.Annotations[model.OktetoAutoCreateAnnotation] == "true" {
+		return
+	}
 	if s.Annotations == nil {
 		s.Annotations = map[string]string{}
 	}

--- a/pkg/cmd/stack/divert_test.go
+++ b/pkg/cmd/stack/divert_test.go
@@ -192,6 +192,46 @@ func Test_applyDivertToService(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "divert-with-autocreate",
+			s: &apiv1.Service{
+				Spec: apiv1.ServiceSpec{
+					Ports: []apiv1.ServicePort{
+						{
+							Name:       "web1",
+							Port:       8080,
+							TargetPort: intstr.IntOrString{IntVal: 80},
+						},
+						{
+							Name:       "web2",
+							Port:       8081,
+							TargetPort: intstr.IntOrString{IntVal: 81},
+						},
+					},
+				},
+			},
+			old: &apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						model.OktetoDivertServiceAnnotation: "{\"proxy_port\":1024,\"original_port\":8081,\"original_target_port\":81}",
+						"key1":                              "value1",
+						model.OktetoAutoCreateAnnotation:    "true",
+					},
+				},
+			},
+			expected: []apiv1.ServicePort{
+				{
+					Name:       "web1",
+					Port:       8080,
+					TargetPort: intstr.IntOrString{IntVal: 80},
+				},
+				{
+					Name:       "web2",
+					Port:       8081,
+					TargetPort: intstr.IntOrString{IntVal: 81},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

Follow uo to https://github.com/okteto/okteto/pull/3275. The divert service annotation must be kept only if previous service wasn't autocreated. If it was autocreated, it was a headless service and the stack deploy should create a new one
