### PR TITLE
Add "unable to upgrade connection" to retry logic

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -251,6 +251,7 @@ func IsTransient(err error) bool {
 		strings.Contains(err.Error(), "unexpected packet in response to channel open"),
 		strings.Contains(err.Error(), "closing remote connection: EOF"),
 		strings.Contains(err.Error(), "request for pseudo terminal failed: eof"),
+		strings.Contains(err.Error(), "unable to upgrade connection"),
 		strings.Contains(err.Error(), "command execution failed: eof"):
 		return true
 	default:


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

This error is raised when a spot instance is being recreated