### PR TITLE
Add parameter for pass thru of allowPrivilegeEscalation (#3291)

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -453,6 +453,10 @@ func TranslateContainerSecurityContext(c *apiv1.Container, s *model.SecurityCont
 	if s.RunAsNonRoot != nil {
 		c.SecurityContext.RunAsNonRoot = s.RunAsNonRoot
 	}
+    
+	if s.AllowPrivilegeEscalation != nil {
+		c.SecurityContext.AllowPrivilegeEscalation = s.AllowPrivilegeEscalation
+	}    
 
 	if s.Capabilities == nil {
 		return

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -275,11 +275,12 @@ type Duration time.Duration
 
 // SecurityContext represents a pod security context
 type SecurityContext struct {
-	RunAsUser    *int64        `json:"runAsUser,omitempty" yaml:"runAsUser,omitempty"`
-	RunAsGroup   *int64        `json:"runAsGroup,omitempty" yaml:"runAsGroup,omitempty"`
-	FSGroup      *int64        `json:"fsGroup,omitempty" yaml:"fsGroup,omitempty"`
-	Capabilities *Capabilities `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
-	RunAsNonRoot *bool         `json:"runAsNonRoot,omitempty" yaml:"runAsNonRoot,omitempty"`
+	RunAsUser    *int64              `json:"runAsUser,omitempty" yaml:"runAsUser,omitempty"`
+	RunAsGroup   *int64              `json:"runAsGroup,omitempty" yaml:"runAsGroup,omitempty"`
+	FSGroup      *int64              `json:"fsGroup,omitempty" yaml:"fsGroup,omitempty"`
+	Capabilities *Capabilities       `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
+	RunAsNonRoot *bool               `json:"runAsNonRoot,omitempty" yaml:"runAsNonRoot,omitempty"`
+        AllowPrivilegeEscalation *bool   `json:"allowPrivilegeEscalation,omitempty" yaml:"allowPrivilegeEscalation,omitempty"`
 }
 
 // Capabilities sets the linux capabilities of a container

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1280,6 +1280,7 @@ func Test_validateForExtraFields(t *testing.T) {
                runAsUser: 1000
                runAsGroup: 2000
                fsGroup: 3000
+               allowPrivilegeEscalation: false
                capabilities:
                  add:
                  - SYS_PTRACE`,


### PR DESCRIPTION
# Proposed changes

Fixes #3291

Added the ability to allow the parameter allowPrivilegeEscalation in the securityContext of the okteto.yaml file.
