### PR TITLE
Default to watch for logs

### DIFF
--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -40,7 +40,6 @@ type LogsOptions struct {
 	Namespace    string
 	Context      string
 	exclude      string
-	Watch        bool
 	Include      string
 	Since        time.Duration
 	Tail         int64
@@ -113,7 +112,6 @@ func Logs(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "the namespace to use to fetch the logs (defaults to the current okteto namespace)")
 	cmd.Flags().StringVarP(&options.Context, "context", "c", "", "the context to use to fetch the logs")
 	cmd.Flags().StringVarP(&options.exclude, "exclude", "e", "", "exclude by service name (regular expression)")
-	cmd.Flags().BoolVarP(&options.Watch, "watch", "w", true, "watch the log output")
 	cmd.Flags().DurationVarP(&options.Since, "since", "s", 48*time.Hour, "return logs newer than a relative duration like 5s, 2m, or 3h")
 	cmd.Flags().Int64Var(&options.Tail, "tail", 100, "the number of lines from the end of the logs to show")
 	cmd.Flags().BoolVarP(&options.Timestamps, "timestamps", "t", false, "print timestamps")

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -113,7 +113,7 @@ func Logs(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "the namespace to use to fetch the logs (defaults to the current okteto namespace)")
 	cmd.Flags().StringVarP(&options.Context, "context", "c", "", "the context to use to fetch the logs")
 	cmd.Flags().StringVarP(&options.exclude, "exclude", "e", "", "exclude by service name (regular expression)")
-	cmd.Flags().BoolVarP(&options.Watch, "watch", "w", false, "watch the log output")
+	cmd.Flags().BoolVarP(&options.Watch, "watch", "w", true, "watch the log output")
 	cmd.Flags().DurationVarP(&options.Since, "since", "s", 48*time.Hour, "return logs newer than a relative duration like 5s, 2m, or 3h")
 	cmd.Flags().Int64Var(&options.Tail, "tail", 100, "the number of lines from the end of the logs to show")
 	cmd.Flags().BoolVarP(&options.Timestamps, "timestamps", "t", false, "print timestamps")

--- a/cmd/logs/stern.go
+++ b/cmd/logs/stern.go
@@ -102,7 +102,7 @@ func getSternConfig(manifest *model.Manifest, o *LogsOptions, kubeconfigFile str
 		LabelSelector:       labelSelector,
 		FieldSelector:       fieldSelector,
 		TailLines:           pointer.Int64Ptr(o.Tail),
-		Follow:              o.Watch,
+		Follow:              true,
 		Timestamps:          o.Timestamps,
 		AllNamespaces:       false,
 		ErrOut:              os.Stderr,


### PR DESCRIPTION
Signed-off-by: Pablo Chico de Guzman <pchico83@gmail.com>

# Proposed changes

Switch to watch for logs by default in `okteto logs`