### PR TITLE
Okteto namespace delete use destroy all job

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -192,7 +192,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 			// when option --all the cmd will destroy everything at the namespace and return
 			if options.DestroyAll {
 				if !okteto.Context().IsOkteto {
-					return errors.New("option `--all` is not available for non-Okteto clusters. Learn more: https://www.okteto.com/docs/self-hosted/")
+					return oktetoErrors.ErrContextIsNotOktetoCluster
 				}
 				err = c.runDestroyAll(ctx, options)
 				if err == nil {

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -530,7 +530,9 @@ func (pc *destroyCommand) waitForNamespaceDestroyAllToComplete(ctx context.Conte
 
 			status, ok := ns.Labels["space.okteto.com/status"]
 			if !ok {
-				return errors.New("namespace does not have label for status")
+				// when status label is not present, continue polling the namespace until timeout
+				oktetoLog.Debugf("namespace %q does not have label for status", namespace)
+				continue
 			}
 
 			switch status {

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -156,6 +156,7 @@ func (nc *NamespaceCommand) waitForNamespaceDeleted(ctx context.Context, namespa
 			status, ok := ns.Labels["space.okteto.com/status"]
 			if !ok {
 				// when status label is not present, continue polling the namespace until timeout
+				oktetoLog.Debugf("namespace %q does not have label for status", namespace)
 				continue
 			}
 			if status == "DeleteFailed" {

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -37,6 +37,7 @@ func Delete(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a namespace",
+		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
@@ -55,7 +56,6 @@ func Delete(ctx context.Context) *cobra.Command {
 			analytics.TrackDeleteNamespace(err == nil)
 			return err
 		},
-		Args: utils.ExactArgsAccepted(1, ""),
 	}
 	return cmd
 }

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -39,7 +39,7 @@ func Delete(ctx context.Context) *cobra.Command {
 		Short: "Delete a namespace",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
+			nsToDelete := args[0]
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
 				return err
 			}
@@ -52,7 +52,7 @@ func Delete(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = nsCmd.ExecuteDeleteNamespace(ctx, args[0])
+			err = nsCmd.ExecuteDeleteNamespace(ctx, nsToDelete)
 			analytics.TrackDeleteNamespace(err == nil)
 			return err
 		},

--- a/cmd/namespace/delete_test.go
+++ b/cmd/namespace/delete_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func newFakeNamespaceCommand(okClient *client.FakeOktetoClient, k8sClient kubernetes.Interface, namespaces []types.Namespace, user *types.User) *NamespaceCommand {
+func newFakeNamespaceCommand(okClient *client.FakeOktetoClient, k8sClient kubernetes.Interface, user *types.User) *NamespaceCommand {
 	return &NamespaceCommand{
 		okClient:  okClient,
 		ctxCmd:    newFakeContextCommand(okClient, user),
@@ -153,7 +153,7 @@ func Test_deleteNamespace(t *testing.T) {
 				CurrentContext: "test-context",
 			}
 
-			nsFakeCommand := newFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, tt.initialNamespacesAtOktetoClient, usr)
+			nsFakeCommand := newFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr)
 			err := nsFakeCommand.ExecuteDeleteNamespace(ctx, tt.toDeleteNs)
 			assert.ErrorIs(t, err, tt.err)
 			assert.Equal(t, tt.finalNs, okteto.Context().Namespace)

--- a/cmd/namespace/delete_test.go
+++ b/cmd/namespace/delete_test.go
@@ -21,106 +21,112 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 )
+
+func newFakeNamespaceCommand(okClient *client.FakeOktetoClient, k8sClient kubernetes.Interface, namespaces []types.Namespace, user *types.User) *NamespaceCommand {
+	return &NamespaceCommand{
+		okClient:  okClient,
+		ctxCmd:    newFakeContextCommand(okClient, user),
+		k8sClient: k8sClient,
+	}
+}
 
 func Test_deleteNamespace(t *testing.T) {
 	ctx := context.Background()
-	personalNs := "personal"
-	currentNs := "test"
+	personalNamespace := "personal"
+	currentNamespace := "current"
+	usr := &types.User{
+		Token: "test-token",
+	}
+	initNamespaces := []types.Namespace{
+		{
+			ID: currentNamespace,
+		},
+		{
+			ID: personalNamespace,
+		},
+		{
+			ID: "test-1",
+		},
+	}
+
 	var tests = []struct {
-		name              string
-		toDeleteNs        string
-		currentNamespaces []types.Namespace
-		finalNs           string
-		err               bool
+		name string
+		// toDeleteNs the namespace to delete
+		toDeleteNs string
+		// finalNs the namespace user sould finaly be
+		finalNs                         string
+		initialNamespacesAtOktetoClient []types.Namespace
+		fakeOkClient                    *client.FakeOktetoClient
+		fakeK8sClient                   *fake.Clientset
+		err                             error
 	}{
 		{
-			name:       "delete existing ns, the current one",
-			toDeleteNs: currentNs,
-			currentNamespaces: []types.Namespace{
-				{
-					ID: "test-1",
-				},
-				{
-					ID: currentNs,
-				},
-				{
-					ID: personalNs,
-				},
+			name:                            "delete existing ns, the current one",
+			toDeleteNs:                      currentNamespace,
+			initialNamespacesAtOktetoClient: initNamespaces,
+			finalNs:                         personalNamespace,
+			fakeOkClient: &client.FakeOktetoClient{
+				Namespace:    client.NewFakeNamespaceClient(initNamespaces, nil),
+				Users:        client.NewFakeUsersClient(usr),
+				StreamClient: client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 			},
-			finalNs: personalNs,
+			fakeK8sClient: fake.NewSimpleClientset(),
 		},
 		{
-			name:       "delete existing ns but not the current one",
-			toDeleteNs: "test-1",
-			currentNamespaces: []types.Namespace{
-				{
-					ID: "test-1",
-				},
-				{
-					ID: currentNs,
-				},
-				{
-					ID: personalNs,
-				},
+			name:                            "delete existing ns, not the current one",
+			toDeleteNs:                      "test-1",
+			initialNamespacesAtOktetoClient: initNamespaces,
+			finalNs:                         currentNamespace,
+			fakeOkClient: &client.FakeOktetoClient{
+				Namespace:    client.NewFakeNamespaceClient(initNamespaces, nil),
+				Users:        client.NewFakeUsersClient(usr),
+				StreamClient: client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 			},
-			finalNs: currentNs,
+			fakeK8sClient: fake.NewSimpleClientset(),
 		},
 		{
-			name:       "delete non-existing ns",
-			toDeleteNs: "test-1",
-			currentNamespaces: []types.Namespace{
-				{
-					ID: "test",
-				},
-				{
-					ID: currentNs,
-				},
-				{
-					ID: personalNs,
-				},
+			name:                            "delete non-existing ns",
+			toDeleteNs:                      "test-non-existing",
+			initialNamespacesAtOktetoClient: initNamespaces,
+			finalNs:                         currentNamespace,
+			err:                             errFailedDeleteNamespace,
+			fakeOkClient: &client.FakeOktetoClient{
+				Namespace:    client.NewFakeNamespaceClient(initNamespaces, nil),
+				Users:        client.NewFakeUsersClient(usr),
+				StreamClient: client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 			},
-			finalNs: currentNs,
-			err:     true,
+			fakeK8sClient: fake.NewSimpleClientset(),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// init ctx current store with initial values
 			okteto.CurrentStore = &okteto.OktetoContextStore{
 				Contexts: map[string]*okteto.OktetoContext{
-					"test": {
-						Name:              "test",
-						Token:             "test",
-						PersonalNamespace: personalNs,
+					"test-context": {
+						Name:              "test-context",
+						Token:             "test-token",
+						PersonalNamespace: personalNamespace,
 						IsOkteto:          true,
-						Namespace:         currentNs,
+						Namespace:         currentNamespace,
 						UserID:            "1",
 					},
 				},
-				CurrentContext: "test",
-			}
-			usr := &types.User{
-				Token: "test",
-			}
-			fakeOktetoClient := &client.FakeOktetoClient{
-				Namespace: client.NewFakeNamespaceClient(tt.currentNamespaces, nil),
-				Users:     client.NewFakeUsersClient(usr),
-			}
-			nsCmd := &NamespaceCommand{
-				okClient: fakeOktetoClient,
-				ctxCmd:   newFakeContextCommand(fakeOktetoClient, usr),
-			}
-			err := nsCmd.ExecuteDeleteNamespace(ctx, tt.toDeleteNs)
-			if tt.err {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
+				CurrentContext: "test-context",
 			}
 
+			nsFakeCommand := newFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, tt.initialNamespacesAtOktetoClient, usr)
+			err := nsFakeCommand.ExecuteDeleteNamespace(ctx, tt.toDeleteNs)
+			assert.ErrorIs(t, err, tt.err)
 			assert.Equal(t, tt.finalNs, okteto.Context().Namespace)
 
-			ns, err := fakeOktetoClient.Namespaces().List(ctx)
+			// check namespace has been deleted from list
+			ns, err := tt.fakeOkClient.Namespaces().List(ctx)
+			// no error for this namespace list
 			assert.Equal(t, nil, err)
 			for _, n := range ns {
 				assert.NotEqual(t, n.ID, tt.toDeleteNs)

--- a/cmd/namespace/errors.go
+++ b/cmd/namespace/errors.go
@@ -6,6 +6,4 @@ import (
 
 var errFailedDeleteNamespace = errors.New("failed to delete namespace")
 
-var errNoStatusLabel = errors.New("namespace does not have label for status")
-
 var errDeleteNamespaceTimeout = errors.New("namespace delete didn't finish")

--- a/cmd/namespace/errors.go
+++ b/cmd/namespace/errors.go
@@ -1,0 +1,11 @@
+package namespace
+
+import (
+	"errors"
+)
+
+var errFailedDeleteNamespace = errors.New("failed to delete namespace")
+
+var errNoStatusLabel = errors.New("namespace does not have label for status")
+
+var errDeleteNamespaceTimeout = errors.New("namespace delete didn't finish")

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -21,12 +21,14 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 )
 
 // NamespaceCommand has all the namespaces subcommands
 type NamespaceCommand struct {
-	ctxCmd   *contextCMD.ContextCommand
-	okClient types.OktetoInterface
+	ctxCmd    *contextCMD.ContextCommand
+	okClient  types.OktetoInterface
+	k8sClient kubernetes.Interface
 }
 
 // NewCommand creates a namespace command to
@@ -35,9 +37,15 @@ func NewCommand() (*NamespaceCommand, error) {
 	if err != nil {
 		return nil, err
 	}
+	k8sClient, _, err := okteto.GetK8sClient()
+	if err != nil {
+		return nil, err
+	}
+
 	return &NamespaceCommand{
-		ctxCmd:   contextCMD.NewContextCommand(),
-		okClient: c,
+		ctxCmd:    contextCMD.NewContextCommand(),
+		okClient:  c,
+		k8sClient: k8sClient,
 	}, nil
 }
 

--- a/internal/test/client/namespace.go
+++ b/internal/test/client/namespace.go
@@ -46,17 +46,21 @@ func (c *FakeNamespaceClient) AddMembers(_ context.Context, _ string, _ []string
 
 // Delete deletes a namespace
 func (c *FakeNamespaceClient) Delete(_ context.Context, namespace string) error {
-	toRemove := -1
 	for idx, ns := range c.namespaces {
 		if ns.ID == namespace {
-			toRemove = idx
-			break
+			var left, right []types.Namespace
+			switch idx {
+			case 0:
+				right = c.namespaces[idx+1:]
+			case len(c.namespaces) - 1:
+				left = c.namespaces[:len(c.namespaces)-1]
+			default:
+				left = c.namespaces[:idx-1]
+				right = c.namespaces[idx+1:]
+			}
+			c.namespaces = append(left, right...)
+			return nil
 		}
-	}
-	if toRemove != -1 {
-		c.namespaces[toRemove] = c.namespaces[len(c.namespaces)-1]
-		c.namespaces = c.namespaces[:len(c.namespaces)-1]
-		return nil
 	}
 	return fmt.Errorf("not found")
 }

--- a/internal/test/client/namespace.go
+++ b/internal/test/client/namespace.go
@@ -46,23 +46,19 @@ func (c *FakeNamespaceClient) AddMembers(_ context.Context, _ string, _ []string
 
 // Delete deletes a namespace
 func (c *FakeNamespaceClient) Delete(_ context.Context, namespace string) error {
-	for idx, ns := range c.namespaces {
-		if ns.ID == namespace {
-			var left, right []types.Namespace
-			switch idx {
-			case 0:
-				right = c.namespaces[idx+1:]
-			case len(c.namespaces) - 1:
-				left = c.namespaces[:len(c.namespaces)-1]
-			default:
-				left = c.namespaces[:idx-1]
-				right = c.namespaces[idx+1:]
-			}
-			c.namespaces = append(left, right...)
-			return nil
+	var updatedNamespaces []types.Namespace
+	for _, ns := range c.namespaces {
+		if ns.ID != namespace {
+			updatedNamespaces = append(updatedNamespaces, ns)
 		}
 	}
-	return fmt.Errorf("not found")
+	// if updated are same as current, namespace was not found
+	if len(updatedNamespaces) == len(c.namespaces) {
+		return fmt.Errorf("not found")
+	}
+	// override with updated
+	c.namespaces = updatedNamespaces
+	return nil
 }
 
 // SleepNamespace deletes a namespace

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -105,7 +105,7 @@ var (
 	ErrDivertNotSupported = fmt.Errorf("the 'divert' field is only supported in clusters that have Okteto installed")
 
 	// ContextIsNotOktetoCluster raised if the cluster connected is not managed by okteto
-	ErrContextIsNotOktetoCluster = fmt.Errorf("this command is only available on Okteto Cloud or Okteto Enterprise")
+	ErrContextIsNotOktetoCluster = fmt.Errorf("this command is only available in clusters where Okteto is installed.\n Follow this link to know more about configuring Okteto at your cluster: https://www.okteto.com/docs/self-hosted/")
 
 	// ErrTokenFlagNeeded is raised when the command is executed from inside a pod from a ctx command
 	ErrTokenFlagNeeded = fmt.Errorf("this command is not supported without the '--token' flag from inside a container")

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -121,10 +121,12 @@ func (c *namespaceClient) Delete(ctx context.Context, namespace string) error {
 	var mutation struct {
 		Space struct {
 			Id graphql.String
-		} `graphql:"deleteSpace(id: $id)"`
+		} `graphql:"deleteSpace(id: $id, force: $force)"`
 	}
 	variables := map[string]interface{}{
 		"id": graphql.String(namespace),
+		// force is disabled to delete namespace using destroy-all-namespace job
+		"force": graphql.Boolean(false),
 	}
 	err := mutate(ctx, &mutation, variables, c.client)
 	if err != nil {


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/5177

Proposed changes:
- include force param as false to the delete space mutation call
- add to the namespace delete cmd the logs streamed by the destroy-all job triggered
- check namespace status while deleting, to check is not DeleteFailed
