### PR TITLE
Fix endpoints name in compose

### DIFF
--- a/integration/deploy/endpoints_test.go
+++ b/integration/deploy/endpoints_test.go
@@ -425,3 +425,101 @@ func Test_EndpointsFromStackAndManifest(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 }
+
+// Test_EndpointsFromOktetoManifest_NameOption tests the following scenario:
+// - Deploying a okteto manifest locally
+// - K8s Service manifest has auto-ingress, endpoints are automatically created when kubectl apply
+// - The endpoints declared at the manifest deploy section are accessible and have name of deploy option
+func Test_EndpointsFromOktetoManifest_NameOption(t *testing.T) {
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, createEndpointsFromOktetoManifestInferredName(dir))
+	require.NoError(t, createAppDockerfile(dir))
+	require.NoError(t, createK8sManifest(dir))
+
+	testNamespace := integration.GetTestNamespace("EndpointManifestNameOp", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		Name:       "my test",
+	}
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+
+	// Test that endpoint works - created by auto-ingress at k8s manifest
+	autoIngressURL := fmt.Sprintf("https://e2etest-%s.%s", testNamespace, appsSubdomain)
+	require.NotEmpty(t, integration.GetContentFromURL(autoIngressURL, timeout))
+
+	// Test that endpoint works - created by okteto manifest
+	manifestEndpointURL := fmt.Sprintf("https://my-test-%s.%s", testNamespace, appsSubdomain)
+	require.NotEmpty(t, integration.GetContentFromURL(manifestEndpointURL, timeout))
+
+	destroyOptions := &commands.DestroyOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Name: 		"my test",
+	}
+	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
+	require.True(t, k8sErrors.IsNotFound(err))
+}
+
+// Test_EndpointsFromStackWithEndpoints_InferredName tests the following scenario:
+// - Deploying a stack manifest locally from a compose file with endpoints section
+// - The endpoints generated are accessible and name from deploy option
+func Test_EndpointsFromStackWith_NameOption(t *testing.T) {
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, createStackWithEndpointsInferredNameScenario(dir))
+
+	testNamespace := integration.GetTestNamespace("TEndpointsStackNameOp", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		Name:       "my test",
+	}
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+
+	// Test endpoints are accessible
+	nginxURL := fmt.Sprintf("https://my-test-%s.%s", testNamespace, appsSubdomain)
+	require.NotEmpty(t, integration.GetContentFromURL(nginxURL, timeout))
+
+	destroyOptions := &commands.DestroyOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Name:       "my test",
+	}
+	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+}

--- a/pkg/k8s/ingresses/translate.go
+++ b/pkg/k8s/ingresses/translate.go
@@ -19,6 +19,7 @@ type TranslateOptions struct {
 
 // Translate translates the endpoints spec at compose or okteto manifest and returns an ingress
 func Translate(endpointName string, endpoint model.Endpoint, opts *TranslateOptions) *Ingress {
+	// endpointName could not be sanitized 
 	if endpointName == "" {
 		// opts.Name is already sanitized- this should be clean version of name
 		endpointName = opts.Name
@@ -32,7 +33,7 @@ func Translate(endpointName string, endpoint model.Endpoint, opts *TranslateOpti
 func translateV1(ingressName string, endpoint model.Endpoint, opts *TranslateOptions) *networkingv1.Ingress {
 	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        ingressName,
+			Name:        format.ResourceK8sMetaString(ingressName),
 			Namespace:   opts.Namespace,
 			Labels:      setLabels(endpoint, opts),
 			Annotations: setAnnotations(endpoint),
@@ -54,7 +55,7 @@ func translateV1(ingressName string, endpoint model.Endpoint, opts *TranslateOpt
 func translateV1Beta1(ingressName string, endpoint model.Endpoint, opts *TranslateOptions) *networkingv1beta1.Ingress {
 	return &networkingv1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        ingressName,
+			Name:        format.ResourceK8sMetaString(ingressName),
 			Namespace:   opts.Namespace,
 			Labels:      setLabels(endpoint, opts),
 			Annotations: setAnnotations(endpoint),

--- a/pkg/k8s/ingresses/translate.go
+++ b/pkg/k8s/ingresses/translate.go
@@ -20,6 +20,7 @@ type TranslateOptions struct {
 // Translate translates the endpoints spec at compose or okteto manifest and returns an ingress
 func Translate(endpointName string, endpoint model.Endpoint, opts *TranslateOptions) *Ingress {
 	if endpointName == "" {
+		// opts.Name is already sanitized- this should be clean version of name
 		endpointName = opts.Name
 	}
 	return &Ingress{

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -238,7 +238,8 @@ func GetStackFromPath(name, stackPath string, isCompose bool) (*Stack, error) {
 	}
 
 	if endpoint, ok := s.Endpoints[""]; ok {
-		s.Endpoints[s.Name] = endpoint
+		// s.Name should be sanitize and compliant with url format
+		s.Endpoints[format.ResourceK8sMetaString(s.Name)] = endpoint
 		delete(s.Endpoints, "")
 	}
 


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

The bug appears when trying to deploy a compose with endpoints and custom name. The name used for the endpoints is not being sanitised.

<img width="1403" alt="Captura de Pantalla 2022-12-20 a las 16 07 43" src="https://user-images.githubusercontent.com/40767058/208717302-5c0546f4-bbdc-4bd0-9862-e56045649c4c.png">


This does not appear when the endpoints are declared at the okteto manifest deploy endpoints section, this was already being sanitised.
Also, when endpoints are created from the service port mapping, the name used is the service name, which is already sanitised.

How to repro:
- clone https://github.com/okteto/node-compose-getting-started
- okteto deploy --name "Use any custom name"
- an error appears when deploying the endpoints at the compose

# Proposed changes

- added comment for tracing the name sanitisation at okteto manifest deploy endpoints section
- sanitise endpoints name when stack serialisation
