### PR TITLE
Remove force param from delete mutation

### DIFF
--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -121,12 +121,10 @@ func (c *namespaceClient) Delete(ctx context.Context, namespace string) error {
 	var mutation struct {
 		Space struct {
 			Id graphql.String
-		} `graphql:"deleteSpace(id: $id, force: $force)"`
+		} `graphql:"deleteSpace(id: $id)"`
 	}
 	variables := map[string]interface{}{
 		"id": graphql.String(namespace),
-		// force is disabled to delete namespace using destroy-all-namespace job
-		"force": graphql.Boolean(false),
 	}
 	err := mutate(ctx, &mutation, variables, c.client)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

# Proposed changes

Remove force option from mutation to keep compatibility. Api has default value false. Client will be implemented in upcomming issue.

context https://github.com/okteto/okteto/pull/3308/files#r1055255206
