### PR TITLE
refactor: use client provider instead of get client

### DIFF
--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -137,12 +137,18 @@ func (nc *NamespaceCommand) waitForNamespaceDeleted(ctx context.Context, namespa
 	ticker := time.NewTicker(1 * time.Second)
 	to := time.NewTicker(timeout)
 
+	// provide k8s
+	c, _, err := nc.k8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-to.C:
 			return fmt.Errorf("%w: namespace %s, time %s", errDeleteNamespaceTimeout, namespace, timeout.String())
 		case <-ticker.C:
-			ns, err := nc.k8sClient.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+			ns, err := c.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 			if err != nil {
 				// not found error is expected when the namespace is deleted.
 				// adding also IsForbidden as in some versions kubernetes returns this status when the namespace is deleted

--- a/cmd/namespace/delete_test.go
+++ b/cmd/namespace/delete_test.go
@@ -38,7 +38,7 @@ func (p *fakeK8sProvider) Provide(_ *clientcmdapi.Config) (kubernetes.Interface,
 	return p.k8sClient, nil, nil
 }
 
-func (p *fakeK8sProvider) GetIngressClient() (*ingresses.Client, error) {
+func (*fakeK8sProvider) GetIngressClient() (*ingresses.Client, error) {
 	return nil, nil
 }
 

--- a/cmd/namespace/delete_test.go
+++ b/cmd/namespace/delete_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/internal/test/client"
+	"github.com/okteto/okteto/pkg/k8s/ingresses"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -25,13 +26,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
+
+type fakeK8sProvider struct {
+	k8sClient kubernetes.Interface
+}
+
+func (p *fakeK8sProvider) Provide(_ *clientcmdapi.Config) (kubernetes.Interface, *rest.Config, error) {
+	return p.k8sClient, nil, nil
+}
+
+func (p *fakeK8sProvider) GetIngressClient() (*ingresses.Client, error) {
+	return nil, nil
+}
 
 func newFakeNamespaceCommand(okClient *client.FakeOktetoClient, k8sClient kubernetes.Interface, user *types.User) *NamespaceCommand {
 	return &NamespaceCommand{
-		okClient:  okClient,
-		ctxCmd:    newFakeContextCommand(okClient, user),
-		k8sClient: k8sClient,
+		okClient: okClient,
+		ctxCmd:   newFakeContextCommand(okClient, user),
+		k8sClientProvider: &fakeK8sProvider{
+			k8sClient: k8sClient,
+		},
 	}
 }
 

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -21,14 +21,13 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
 )
 
 // NamespaceCommand has all the namespaces subcommands
 type NamespaceCommand struct {
-	ctxCmd    *contextCMD.ContextCommand
-	okClient  types.OktetoInterface
-	k8sClient kubernetes.Interface
+	ctxCmd            *contextCMD.ContextCommand
+	okClient          types.OktetoInterface
+	k8sClientProvider okteto.K8sClientProvider
 }
 
 // NewCommand creates a namespace command to
@@ -37,15 +36,11 @@ func NewCommand() (*NamespaceCommand, error) {
 	if err != nil {
 		return nil, err
 	}
-	k8sClient, _, err := okteto.GetK8sClient()
-	if err != nil {
-		return nil, err
-	}
 
 	return &NamespaceCommand{
-		ctxCmd:    contextCMD.NewContextCommand(),
-		okClient:  c,
-		k8sClient: k8sClient,
+		ctxCmd:            contextCMD.NewContextCommand(),
+		okClient:          c,
+		k8sClientProvider: okteto.NewK8sClientProvider(),
 	}, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Teresa Romero <teresa@okteto.com>

# Proposed changes

When using `okteto namespace use <namespace>` the context was not initiated so when getting kubernetes client context was missing.
This was introduce in recent change of the `okteto namespace delete` https://github.com/okteto/okteto/pull/3301