### PR TITLE
Added labelSelector to configmap lists at waitForNamespaceD…

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -539,7 +539,10 @@ func (pc *destroyCommand) waitForNamespaceDestroyAllToComplete(ctx context.Conte
 			case "Active":
 				if hasBeenDestroyingAll {
 					// when status is active again check if all resources have been correctly destroyed
-					cfgList, err := c.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
+					// list configmaps that belong okteto deployments
+					cfgList, err := c.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{
+						LabelSelector: fmt.Sprintf("%s=%s", model.GitDeployLabel, "true"),
+					})
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION

# Proposed changes

Introduced at https://github.com/okteto/okteto/pull/3256 

When checking all configmaps are deleted, there was no labelselector to filter by the configmaps created by okteto.
I spotted this bug as i had one configmap that was not from okteto deployments but was at my namespace.

