### PR TITLE
fix deploy when field notes not given to external

### DIFF
--- a/pkg/externalresource/external_resource.go
+++ b/pkg/externalresource/external_resource.go
@@ -55,6 +55,11 @@ func sanitizeForEnv(name string) string {
 
 // LoadMarkdownContent loads and store markdown content related to external resource
 func (ef *ERFilesystemManager) LoadMarkdownContent(manifestPath string) error {
+
+	if ef.ExternalResource.Notes == nil {
+		return nil
+	}
+
 	markdownAbsPath := filepath.Join(filepath.Dir(manifestPath), ef.ExternalResource.Notes.Path)
 	b, err := afero.ReadFile(ef.Fs, markdownAbsPath)
 	if err != nil {

--- a/pkg/externalresource/external_resource_test.go
+++ b/pkg/externalresource/external_resource_test.go
@@ -1,7 +1,6 @@
 package externalresource
 
 import (
-	b64 "encoding/base64"
 	"fmt"
 	"os"
 	"testing"
@@ -58,6 +57,7 @@ func TestExternalResource_LoadMarkdownContent(t *testing.T) {
 		name                string
 		externalResourceFSM ERFilesystemManager
 		expectErr           bool
+		expectedResult      ExternalResource
 	}{
 		{
 			name: "markdown not found",
@@ -86,6 +86,14 @@ func TestExternalResource_LoadMarkdownContent(t *testing.T) {
 				Fs: fs,
 			},
 			expectErr: false,
+			expectedResult: ExternalResource{
+				Icon: "myIcon",
+				Notes: &Notes{
+					Path:     "/external/readme.md",
+					Markdown: "IyMgTWFya2Rvd24gY29udGVudA==",
+				},
+				Endpoints: []ExternalEndpoint{},
+			},
 		},
 		{
 			name: "notes info not present in external. No markdown loaded",
@@ -101,6 +109,14 @@ func TestExternalResource_LoadMarkdownContent(t *testing.T) {
 				Fs: fs,
 			},
 			expectErr: false,
+			expectedResult: ExternalResource{
+				Endpoints: []ExternalEndpoint{
+					{
+						Name: "name1",
+						Url:  "/some/url",
+					},
+				},
+			},
 		},
 	}
 
@@ -110,15 +126,7 @@ func TestExternalResource_LoadMarkdownContent(t *testing.T) {
 				assert.Error(t, tt.externalResourceFSM.LoadMarkdownContent(manifestPath))
 			} else {
 				assert.NoError(t, tt.externalResourceFSM.LoadMarkdownContent(manifestPath))
-				if tt.externalResourceFSM.ExternalResource.Notes != nil {
-					sDec, err := b64.StdEncoding.DecodeString(tt.externalResourceFSM.ExternalResource.Notes.Markdown)
-					if err != nil {
-						t.Fatal(err)
-					}
-
-					assert.Equal(t, string(sDec), markdownContent)
-				}
-
+				assert.Equal(t, tt.externalResourceFSM.ExternalResource, tt.expectedResult)
 			}
 		})
 	}

--- a/pkg/externalresource/external_resource_test.go
+++ b/pkg/externalresource/external_resource_test.go
@@ -87,6 +87,21 @@ func TestExternalResource_LoadMarkdownContent(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		{
+			name: "notes info not present in external. No markdown loaded",
+			externalResourceFSM: ERFilesystemManager{
+				ExternalResource: ExternalResource{
+					Endpoints: []ExternalEndpoint{
+						{
+							Name: "name1",
+							Url:  "/some/url",
+						},
+					},
+				},
+				Fs: fs,
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -95,12 +110,15 @@ func TestExternalResource_LoadMarkdownContent(t *testing.T) {
 				assert.Error(t, tt.externalResourceFSM.LoadMarkdownContent(manifestPath))
 			} else {
 				assert.NoError(t, tt.externalResourceFSM.LoadMarkdownContent(manifestPath))
-				sDec, err := b64.StdEncoding.DecodeString(tt.externalResourceFSM.ExternalResource.Notes.Markdown)
-				if err != nil {
-					t.Fatal(err)
+				if tt.externalResourceFSM.ExternalResource.Notes != nil {
+					sDec, err := b64.StdEncoding.DecodeString(tt.externalResourceFSM.ExternalResource.Notes.Markdown)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					assert.Equal(t, string(sDec), markdownContent)
 				}
 
-				assert.Equal(t, string(sDec), markdownContent)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: adripedriza <adripedriza@gmail.com>

# Proposed changes
- check that `notes` is not nil (has not been included in the manifest) before try to read its value
- add test covering scenario

Fixes #3342
