### PR TITLE
switch to personal namespace if previous namespace is missing

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -172,21 +172,23 @@ func (c *ContextCommand) UseContext(ctx context.Context, ctxOptions *ContextOpti
 			return err
 		}
 
-		// if using a new context, our cached namespace may have been removed
-		// so swap over to the personal namespace instead of erroring
-		if !hasAccess && !ctxOptions.FromNamespace {
-			oktetoLog.Success(
+		if !hasAccess {
+			if ctxOptions.CheckNamespaceAccess {
+				return oktetoErrors.UserError{
+					E:    fmt.Errorf("namespace '%s' not found on context '%s'", ctxOptions.Namespace, ctxOptions.Context),
+					Hint: "Please verify that the namespace exists and that you have access to it.",
+				}
+			}
+
+			// if using a new context, our cached namespace may have been removed
+			// so swap over to the personal namespace instead of erroring
+			oktetoLog.Warning(
 				"No access to namespace '%s' switching to personal namespace '%s'",
 				ctxOptions.Namespace,
 				okteto.Context().PersonalNamespace,
 			)
 			currentCtx := ctxStore.Contexts[ctxOptions.Context]
-            currentCtx.Namespace = currentCtx.PersonalNamespace
-		} else if !hasAccess {
-			return oktetoErrors.UserError{
-				E:    fmt.Errorf("namespace '%s' not found on context '%s'", ctxOptions.Namespace, ctxOptions.Context),
-				Hint: "Please verify that the namespace exists and that you have access to it.",
-			}
+			currentCtx.Namespace = currentCtx.PersonalNamespace
 		}
 
 		if err := c.OktetoContextWriter.Write(); err != nil {

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -85,6 +85,31 @@ func Test_createContext(t *testing.T) {
 				CurrentContext: "https://okteto.cloud.com",
 			},
 			ctxOptions: &ContextOptions{
+				IsOkteto:      true,
+				Save:          true,
+				Context:       "https://okteto.cloud.com",
+				Namespace:     "not-found",
+				FromNamespace: true,
+			},
+			user: &types.User{
+				Token: "test",
+			},
+			kubeconfigCtx: test.KubeconfigFields{
+				Name:           []string{"cloud_okteto_com"},
+				Namespace:      []string{"test"},
+				CurrentContext: "",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "change to personal namespace if namespace is not found",
+			ctxStore: &okteto.OktetoContextStore{
+				Contexts: map[string]*okteto.OktetoContext{
+					"https://okteto.cloud.com": {},
+				},
+				CurrentContext: "https://okteto.cloud.com",
+			},
+			ctxOptions: &ContextOptions{
 				IsOkteto:  true,
 				Save:      true,
 				Context:   "https://okteto.cloud.com",
@@ -98,7 +123,7 @@ func Test_createContext(t *testing.T) {
 				Namespace:      []string{"test"},
 				CurrentContext: "",
 			},
-			expectedErr: true,
+			expectedErr: false,
 		},
 		{
 			name: "transform k8s to url and create okteto context -> namespace with label",
@@ -368,6 +393,8 @@ func TestAutoAuthWhenNotValidTokenOnlyWhenOktetoContextIsRun(t *testing.T) {
 }
 
 func TestCheckAccessToNamespace(t *testing.T) {
+    t.Parallel()
+
 	ctx := context.Background()
 	user := &types.User{
 		Token: "test",

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -85,11 +85,11 @@ func Test_createContext(t *testing.T) {
 				CurrentContext: "https://okteto.cloud.com",
 			},
 			ctxOptions: &ContextOptions{
-				IsOkteto:      true,
-				Save:          true,
-				Context:       "https://okteto.cloud.com",
-				Namespace:     "not-found",
-				FromNamespace: true,
+				IsOkteto:             true,
+				Save:                 true,
+				Context:              "https://okteto.cloud.com",
+				Namespace:            "not-found",
+				CheckNamespaceAccess: true,
 			},
 			user: &types.User{
 				Token: "test",
@@ -393,7 +393,7 @@ func TestAutoAuthWhenNotValidTokenOnlyWhenOktetoContextIsRun(t *testing.T) {
 }
 
 func TestCheckAccessToNamespace(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
 	ctx := context.Background()
 	user := &types.User{

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -31,6 +31,7 @@ type ContextOptions struct {
 	Show                  bool
 	Save                  bool
 	IsCtxCommand          bool
+	FromNamespace         bool
 	IsOkteto              bool
 	raiseNotCtxError      bool
 	InsecureSkipTlsVerify bool

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -31,7 +31,7 @@ type ContextOptions struct {
 	Show                  bool
 	Save                  bool
 	IsCtxCommand          bool
-	FromNamespace         bool
+	CheckNamespaceAccess  bool
 	IsOkteto              bool
 	raiseNotCtxError      bool
 	InsecureSkipTlsVerify bool

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -68,6 +68,7 @@ Or a Kubernetes context:
 
 			ctxOptions.IsCtxCommand = true
 			ctxOptions.Save = true
+			ctxOptions.CheckNamespaceAccess = ctxOptions.Namespace != ""
 
 			err := NewContextCommand().Run(ctx, ctxOptions)
 			analytics.TrackContext(err == nil)

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -84,11 +84,12 @@ func (nc *NamespaceCommand) Use(ctx context.Context, namespace string) error {
 	return nc.ctxCmd.Run(
 		ctx,
 		&contextCMD.ContextOptions{
-			Context:      okteto.Context().Name,
-			Namespace:    namespace,
-			Save:         true,
-			Show:         false,
-			IsCtxCommand: true,
+			Context:       okteto.Context().Name,
+			Namespace:     namespace,
+			Save:          true,
+			Show:          false,
+			IsCtxCommand:  true,
+			FromNamespace: true,
 		},
 	)
 

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -84,12 +84,12 @@ func (nc *NamespaceCommand) Use(ctx context.Context, namespace string) error {
 	return nc.ctxCmd.Run(
 		ctx,
 		&contextCMD.ContextOptions{
-			Context:       okteto.Context().Name,
-			Namespace:     namespace,
-			Save:          true,
-			Show:          false,
-			IsCtxCommand:  true,
-			FromNamespace: true,
+			Context:              okteto.Context().Name,
+			Namespace:            namespace,
+			Save:                 true,
+			Show:                 false,
+			IsCtxCommand:         true,
+			CheckNamespaceAccess: true,
 		},
 	)
 


### PR DESCRIPTION
# Proposed changes

Fixes #3334

Add a new value to context options indicating if the command originated from `ctx` or `ns`.
If switching context, and we do not have access to the previous namespace, switch to our personal one instead of crashing.
