### PR TITLE
Make okteto up wait until original resource is awaken before starting dev container

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -36,6 +36,8 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	"github.com/okteto/okteto/pkg/discovery"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/config"
@@ -293,6 +295,22 @@ func Up() *cobra.Command {
 				// update autocreate property if needed to be forced
 				oktetoLog.Info("Setting Autocreate to true because manifest v1 and flag --deploy")
 				up.Dev.Autocreate = true
+			}
+
+			// only if the context is an okteto one, we should verify if the namespace has to be woken up
+			if okteto.Context().IsOkteto {
+				k8sClient, _, err := okteto.NewK8sClientProvider().Provide(okteto.Context().Cfg)
+				if err != nil {
+					return err
+				}
+				okClient, err := okteto.NewOktetoClient()
+				if err != nil {
+					return err
+				}
+				if err := wakeNamespaceIfApplies(ctx, up.Dev.Namespace, k8sClient, okClient); err != nil {
+					// If there is an error waking up namespace, we don't want to fail the up command
+					oktetoLog.Infof("failed to wake up the namespace: %s", err.Error())
+				}
 			}
 
 			if err := setBuildEnvVars(ctx, oktetoManifest); err != nil {
@@ -902,4 +920,20 @@ func setBuildEnvVars(ctx context.Context, m *model.Manifest) error {
 		Manifest:    m,
 	}
 	return builder.Build(ctx, buildOptions)
+}
+
+// wakeNamespaceIfApplies wakes the namespace if it is sleeping
+func wakeNamespaceIfApplies(ctx context.Context, ns string, k8sClient kubernetes.Interface, okClient types.OktetoInterface) error {
+	n, err := k8sClient.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// If the namespace is not sleeping, do nothing
+	if n.Labels["space.okteto.com/status"] != "Sleeping" {
+		return nil
+	}
+
+	oktetoLog.Information("Namespace '%s' is sleeping, waking it up...", ns)
+	return okClient.Namespaces().Wake(ctx, ns)
 }

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -19,10 +19,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/okteto/okteto/internal/test/client"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_waitUntilExitOrInterrupt(t *testing.T) {
@@ -340,6 +346,55 @@ func TestCommandAddedToUpOptionsWhenPassedAsFlag(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedCommand, flagValue)
+		})
+	}
+}
+
+func TestWakeNamespaceIfAppliesWithoutErrors(t *testing.T) {
+	tests := []struct {
+		name              string
+		ns                v1.Namespace
+		expectedWakeCalls int
+	}{
+		{
+			name: "wake namespace if it is not sleeping",
+			ns: v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"space.okteto.com/status": "Active",
+					},
+				},
+			},
+			expectedWakeCalls: 0,
+		},
+		{
+			name: "wake namespace if it is sleeping",
+			ns: v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Labels: map[string]string{
+						"space.okteto.com/status": "Sleeping",
+					},
+				},
+			},
+			expectedWakeCalls: 1,
+		},
+	}
+	ctx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset(&tt.ns)
+			nsClient := client.NewFakeNamespaceClient([]types.Namespace{}, nil)
+			oktetoClient := &client.FakeOktetoClient{
+				Namespace: nsClient,
+			}
+
+			err := wakeNamespaceIfApplies(ctx, tt.ns.Name, k8sClient, oktetoClient)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedWakeCalls, nsClient.WakeCalls)
 		})
 	}
 }

--- a/internal/test/client/namespace.go
+++ b/internal/test/client/namespace.go
@@ -22,6 +22,9 @@ import (
 type FakeNamespaceClient struct {
 	namespaces []types.Namespace
 	err        error
+
+	// WakeCalls is the number of times Wake was called
+	WakeCalls int
 }
 
 func NewFakeNamespaceClient(ns []types.Namespace, err error) *FakeNamespaceClient {
@@ -68,5 +71,15 @@ func (*FakeNamespaceClient) SleepNamespace(_ context.Context, _ string) error {
 
 // DestroyAll deletes a namespace
 func (*FakeNamespaceClient) DestroyAll(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+
+// Wake wakes up a namespace
+func (c *FakeNamespaceClient) Wake(_ context.Context, _ string) error {
+	if c.err != nil {
+		return c.err
+	}
+
+	c.WakeCalls++
 	return nil
 }

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -188,3 +188,21 @@ func (c *namespaceClient) DestroyAll(ctx context.Context, namespace string, dest
 
 	return nil
 }
+
+// Wake wakes a namespace
+func (c *namespaceClient) Wake(ctx context.Context, namespace string) error {
+	var mutation struct {
+		Space struct {
+			Id graphql.String
+		} `graphql:"wakeSpace(space: $space)"`
+	}
+	variables := map[string]interface{}{
+		"space": graphql.String(namespace),
+	}
+	err := mutate(ctx, &mutation, variables, c.client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -40,6 +40,7 @@ type NamespaceInterface interface {
 	AddMembers(ctx context.Context, namespace string, members []string) error
 	SleepNamespace(ctx context.Context, namespace string) error
 	DestroyAll(ctx context.Context, namespace string, destroyVolumes bool) error
+	Wake(ctx context.Context, namespace string) error
 }
 
 // PreviewInterface represents the client that connects to the preview functions


### PR DESCRIPTION
Signed-off-by: Ignacio Fuertes <nacho@okteto.com>

# Proposed changes

Fixes https://github.com/okteto/app/issues/5520

Changes in the up command to wake the namespace up (if it is sleeping and it is an okteto context) and wait until the annotation dev.okteto.com/state-before-sleeping is not present in the original deployment before deploying the dev container. The main changes are:
* If the context is an Okteto one, we call to the `wakeSpace` mutation as one of the first steps of the command
* Before cloning the original sfs/deployment, check if it is already awaken or not. The reason is because that resource could depend on other service which is not already awaken. As the wake function will awake resources in order taking into account the dependencies, if the original resource don't have the annotation it means that all their dependencies are already up
