### PR TITLE
Add HasReverse to metadata sent to metrics for `okteto up` command

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -560,6 +560,7 @@ func (up *upContext) start() error {
 		HasDeploySection: (up.Manifest.IsV2 &&
 			up.Manifest.Deploy != nil &&
 			(len(up.Manifest.Deploy.Commands) > 0 || up.Manifest.Deploy.ComposeSection.ComposesInfo != nil)),
+		HasReverse: len(up.Dev.Reverse) > 0,
 	})
 
 	go up.activateLoop()

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -175,6 +175,7 @@ type TrackUpMetadata struct {
 	HasBuildSection        bool
 	HasDeploySection       bool
 	Success                bool
+	HasReverse             bool
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
@@ -187,6 +188,7 @@ func TrackUp(m TrackUpMetadata) {
 		"hasDependenciesSection": m.HasDependenciesSection,
 		"hasBuildSection":        m.HasBuildSection,
 		"hasDeploySection":       m.HasDeploySection,
+		"hasReverse":             m.HasReverse,
 	}
 	track(upEvent, m.Success, props)
 }


### PR DESCRIPTION
Signed-off-by: Ignacio Fuertes <nacho@okteto.com>

# Proposed changes

Added HasRevese property on the metadata we send to metrics on okteto up command

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
