### PR TITLE
log a warning instead of prompting to ignore .git

### DIFF
--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -137,7 +137,7 @@ func checkStignoreConfiguration(dev *model.Dev) error {
 			continue
 		}
 
-		if err := askIfUpdatingStignore(stignorePath); err != nil {
+		if err := checkIfStignoreHasGitFolder(stignorePath); err != nil {
 			return err
 		}
 	}
@@ -187,7 +187,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 	return nil
 }
 
-func askIfUpdatingStignore(stignorePath string) error {
+func checkIfStignoreHasGitFolder(stignorePath string) error {
 	stignoreBytes, err := os.ReadFile(stignorePath)
 	if err != nil {
 		return fmt.Errorf("failed to read '%s': %s", stignorePath, err.Error())
@@ -197,19 +197,6 @@ func askIfUpdatingStignore(stignorePath string) error {
 		return nil
 	}
 
-	oktetoLog.Information("The synchronization service performance is degraded if the '.git' folder is synchronized.")
-	ignoreGit, err := utils.AskYesNo("Do you want to ignore the '.git' folder in your '.stignore' file?", utils.YesNoDefault_Yes)
-	if err != nil {
-		return fmt.Errorf("failed to ask for adding '.git' to '%s': %s", stignorePath, err.Error())
-	}
-	oktetoLog.Infof("adding '.git' to '%s'", stignorePath)
-	if ignoreGit {
-		stignoreContent = fmt.Sprintf(".git\n%s", stignoreContent)
-	} else {
-		stignoreContent = fmt.Sprintf("// .git\n%s", stignoreContent)
-	}
-	if err := os.WriteFile(stignorePath, []byte(stignoreContent), 0600); err != nil {
-		return fmt.Errorf("failed to update '%s': %s", stignorePath, err.Error())
-	}
+	oktetoLog.Warning("The synchronization service performance could be degraded if the '.git' folder is synchronized. Please add '.git' to the '.stignore' file.")
 	return nil
 }


### PR DESCRIPTION
# Proposed changes

Fixes #2250 

Instead of prompting for an option to ignore the .git, just output a warning instead.
Might be worth adding a second warning of something like "It is recommended to add '.git' to '.stignore'"