### PR TITLE
chore: rename NamespaceInterface SleepNamespace

### DIFF
--- a/integration/okteto/autowake_test.go
+++ b/integration/okteto/autowake_test.go
@@ -342,7 +342,7 @@ func sleepNamespace(namespace string) error {
 	if err != nil {
 		return err
 	}
-	if err := client.Namespaces().SleepNamespace(context.Background(), namespace); err != nil {
+	if err := client.Namespaces().Sleep(context.Background(), namespace); err != nil {
 		return err
 	}
 	return nil

--- a/internal/test/client/namespace.go
+++ b/internal/test/client/namespace.go
@@ -61,8 +61,8 @@ func (c *FakeNamespaceClient) Delete(_ context.Context, namespace string) error 
 	return nil
 }
 
-// SleepNamespace deletes a namespace
-func (*FakeNamespaceClient) SleepNamespace(_ context.Context, _ string) error {
+// Sleep deletes a namespace
+func (*FakeNamespaceClient) Sleep(_ context.Context, _ string) error {
 	return nil
 }
 

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -151,8 +151,8 @@ func validateNamespace(namespace, object string) error {
 	return nil
 }
 
-// SleepNamespace sleeps a namespace
-func (c *namespaceClient) SleepNamespace(ctx context.Context, namespace string) error {
+// Sleep sleeps a namespace
+func (c *namespaceClient) Sleep(ctx context.Context, namespace string) error {
 	var mutation struct {
 		Space struct {
 			Id graphql.String

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -38,7 +38,7 @@ type NamespaceInterface interface {
 	List(ctx context.Context) ([]Namespace, error)
 	Delete(ctx context.Context, namespace string) error
 	AddMembers(ctx context.Context, namespace string, members []string) error
-	SleepNamespace(ctx context.Context, namespace string) error
+	Sleep(ctx context.Context, namespace string) error
 	DestroyAll(ctx context.Context, namespace string, destroyVolumes bool) error
 }
 


### PR DESCRIPTION
This PR removes resource type from `SleepNamespace` function name in
`NamespaceInterface`, becoming just `Sleep`.

Signed-off-by: Javier Provecho Fernández (Okteto) jpf@okteto.com