### PR TITLE
improve spinner for remote deploy

### DIFF
--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -130,9 +130,13 @@ func (t *trace) display() {
 			default:
 				continue
 			}
+
+			if v.completed {
+				oktetoLog.StopSpinner()
+			}
 		}
 		if t.hasCommandLogs(v) {
-			oktetoLog.StopSpinner()
+			oktetoLog.Spinner("Deploying your development environment...")
 			for _, log := range v.logs {
 				var text oktetoLog.JSONLogFormat
 				if err := json.Unmarshal([]byte(log), &text); err != nil {


### PR DESCRIPTION
# Proposed changes

Fixes #3359 
- Display current context loaded.
- When a deployment load a context greater than 50MB, an info log is displayed.


https://user-images.githubusercontent.com/22500940/216581840-977e1c9b-0b16-412e-8a4c-1d2a9e172c8f.mp4

cc @rlamana @pchico83 



