### PR TITLE
fix: omit auth error on build

### DIFF
--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/cli/cli/config/types"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -84,7 +85,8 @@ func (ap *authProvider) Credentials(_ context.Context, req *auth.CredentialsRequ
 	}
 	ac, err := ap.config.GetAuthConfig(req.Host)
 	if err != nil {
-		return nil, err
+		oktetoLog.Infof("could not access %s defined in %s", ap.config.CredentialsStore, ap.config.Filename)
+		return res, nil
 	}
 	if ac.IdentityToken != "" {
 		res.Secret = ac.IdentityToken

--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -16,6 +16,7 @@ package build
 import (
 	"context"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/docker/cli/cli/config"
@@ -85,8 +86,12 @@ func (ap *authProvider) Credentials(_ context.Context, req *auth.CredentialsRequ
 	}
 	ac, err := ap.config.GetAuthConfig(req.Host)
 	if err != nil {
-		oktetoLog.Infof("could not access %s defined in %s", ap.config.CredentialsStore, ap.config.Filename)
-		return res, nil
+		if strings.HasPrefix(err.Error(), "error getting credentials") {
+			oktetoLog.Infof("could not access %s defined in %s", ap.config.CredentialsStore, ap.config.Filename)
+			return res, nil
+		}
+
+		return nil, err
 	}
 	if ac.IdentityToken != "" {
 		res.Secret = ac.IdentityToken

--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -112,7 +112,7 @@ func isErrCredentialsHelperNotAccessible(err error) bool {
 		return true
 	}
 
-	if strings.Contains(err.Error(), "executable file not found in $PATH") {
+	if strings.Contains(err.Error(), "executable file not found") {
 		return true
 	}
 

--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -86,7 +86,7 @@ func (ap *authProvider) Credentials(_ context.Context, req *auth.CredentialsRequ
 	}
 	ac, err := ap.config.GetAuthConfig(req.Host)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "error getting credentials") {
+		if isErrCredentialsHelperNotAccessible(err) {
 			oktetoLog.Infof("could not access %s defined in %s", ap.config.CredentialsStore, ap.config.Filename)
 			return res, nil
 		}
@@ -100,4 +100,21 @@ func (ap *authProvider) Credentials(_ context.Context, req *auth.CredentialsRequ
 		res.Secret = ac.Password
 	}
 	return res, nil
+}
+
+func isErrCredentialsHelperNotAccessible(err error) bool {
+
+	if !strings.HasPrefix(err.Error(), "error getting credentials") {
+		return false
+	}
+
+	if strings.Contains(err.Error(), "resolves to executable in current directory") {
+		return true
+	}
+
+	if strings.Contains(err.Error(), "executable file not found in $PATH") {
+		return true
+	}
+
+	return false
 }

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,4 +46,15 @@ func Test_isErrCredentialsHelperNotAccessiblee(t *testing.T) {
 			require.Equal(t, isErrCredentialsHelperNotAccessible(tt.err), tt.expected)
 		})
 	}
+}
+
+func Test_GetAuthConfig_OmisionIfNeeded(t *testing.T) {
+	config := &configfile.ConfigFile{
+		AuthConfigs: map[string]types.AuthConfig{
+			"https://index.docker.io/v1/": {},
+		},
+		CredentialsStore: "desktop",
+	}
+	_, err := config.GetAuthConfig("https://index.docker.io/v1/")
+	require.True(t, isErrCredentialsHelperNotAccessible(err))
 }

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -1,0 +1,47 @@
+package build
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isErrCredentialsHelperNotAccessiblee(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "credential not accessible error ",
+			err:      errors.New("error getting credentials: something resolves to executable in current directory (whatever)"),
+			expected: true,
+		},
+		{
+			name:     "credential not accessible error",
+			err:      errors.New("error getting credentials: foo executable file not found in $PATH (bar)"),
+			expected: true,
+		},
+		{
+			name:     "not a credential not accessible error",
+			err:      errors.New("error getting credentials: other error message"),
+			expected: false,
+		},
+		{
+			name:     "not a credential not accessible error",
+			err:      errors.New("error: resolves to executable in current directory"),
+			expected: false,
+		},
+		{
+			name:     "not a credential not accessible error",
+			err:      errors.New("a totally different error message"),
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, isErrCredentialsHelperNotAccessible(tt.err), tt.expected)
+		})
+	}
+}

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -53,8 +53,10 @@ func Test_GetAuthConfig_OmisionIfNeeded(t *testing.T) {
 		AuthConfigs: map[string]types.AuthConfig{
 			"https://index.docker.io/v1/": {},
 		},
-		CredentialsStore: "desktop",
+		CredentialsStore: "okteto-fake", // resolves to binary named docker-credential-okteto-fake, which shouldn't be present at $PATH
 	}
 	_, err := config.GetAuthConfig("https://index.docker.io/v1/")
+	require.Error(t, err)
+	t.Logf("error is: %q", err)
 	require.True(t, isErrCredentialsHelperNotAccessible(err))
 }


### PR DESCRIPTION
Signed-off-by: Javier López Barba <javier@okteto.com>

# Proposed changes

Fixes #3353

If the user has an corrupted credentials store, we should not login the user into the registry but we should not fail either.
If the user needs authentication permission to create the image it will fail later.