### PR TITLE
Don't delete volume snapshot on DestroyWithLabel if -v flag is not set

### DIFF
--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -43,6 +43,7 @@ import (
 const (
 	parallelism              int64 = 10
 	volumeKind                     = "PersistentVolumeClaim"
+	volumeSnapshotKind             = "VolumeSnapshot"
 	jobKind                        = "Job"
 	resourcePolicyAnnotation       = "dev.okteto.com/policy"
 	keepPolicy                     = "keep"
@@ -146,7 +147,7 @@ func (n *Namespaces) DestroyWithLabel(ctx context.Context, ns string, opts Delet
 			return err
 		}
 		gvk := obj.GetObjectKind().GroupVersionKind()
-		if gvk.Kind == volumeKind && !opts.IncludeVolumes {
+		if isStorage(gvk.Kind) && !opts.IncludeVolumes {
 			oktetoLog.Debugf("skipping deletion of pvc '%s' because of volume flag", m.GetName())
 			return nil
 		}
@@ -348,4 +349,15 @@ func (t *Trip) listAll(ctx context.Context, traveler Traveler, client dynamic.Re
 		}
 		return nil
 	})
+}
+
+// isStorage returns if the kind is some of storage kind
+func isStorage(kind string) bool {
+	switch kind {
+	case volumeKind:
+		return true
+	case volumeSnapshotKind:
+		return true
+	}
+	return false
 }

--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -148,7 +148,7 @@ func (n *Namespaces) DestroyWithLabel(ctx context.Context, ns string, opts Delet
 		}
 		gvk := obj.GetObjectKind().GroupVersionKind()
 		if isStorage(gvk.Kind) && !opts.IncludeVolumes {
-			oktetoLog.Debugf("skipping deletion of pvc '%s' because of volume flag", m.GetName())
+			oktetoLog.Debugf("skipping deletion of '%s' '%s' because of volume flag", gvk.Kind, m.GetName())
 			return nil
 		}
 
@@ -191,7 +191,7 @@ func (n *Namespaces) DestroySFSVolumes(ctx context.Context, ns string, opts Dele
 	if !opts.IncludeVolumes {
 		return nil
 	}
-	pvcNames := []string{}
+	var pvcNames []string
 
 	ssList, err := statefulsets.List(ctx, ns, opts.LabelSelector, n.k8sClient)
 	if err != nil {
@@ -354,9 +354,7 @@ func (t *Trip) listAll(ctx context.Context, traveler Traveler, client dynamic.Re
 // isStorage returns if the kind is some of storage kind
 func isStorage(kind string) bool {
 	switch kind {
-	case volumeKind:
-		return true
-	case volumeSnapshotKind:
+	case volumeKind, volumeSnapshotKind:
 		return true
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: Ignacio Fuertes <nacho@okteto.com>

# Proposed changes

Don't include volume snapshots when the flag `-v` is not set. Volume snapshots don't include `deployed-by` label, so this function won't delete it but it could happen that volume snapshots start having that label and we should make sure they are not deleted if `-v` flag is not set
