### PR TITLE
add destroy in remote

### DIFF
--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -174,9 +174,10 @@ dependencies:
 						CacheFrom: []string{"cache-image-1", "cache-image-2"},
 					},
 				},
-				Icon: "",
-				Dev:  model.ManifestDevs{},
-				Type: model.OktetoManifestType,
+				Icon:    "",
+				Dev:     model.ManifestDevs{},
+				Type:    model.OktetoManifestType,
+				Destroy: &model.DestroyInfo{},
 				Dependencies: model.ManifestDependencies{
 					"one": &model.Dependency{
 						Repository: "https://repo.url",

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/stack"
+	"github.com/okteto/okteto/pkg/constants"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -35,6 +36,14 @@ const (
 )
 
 func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Options, cwd string, c kubernetes.Interface) error {
+	if deployOptions.RunInRemote {
+		if deployOptions.Manifest.Deploy != nil {
+			if deployOptions.Manifest.Deploy.Image == "" {
+				deployOptions.Manifest.Deploy.Image = constants.OktetoPipelineRunnerImage
+			}
+		}
+	}
+
 	if deployOptions.Manifest.Context == "" {
 		deployOptions.Manifest.Context = okteto.Context().Name
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -59,6 +59,7 @@ type Options struct {
 	Build            bool
 	Dependencies     bool
 	RunWithoutBash   bool
+	RunInRemote      bool
 	servicesToDeploy []string
 
 	Repository string
@@ -238,6 +239,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolVarP(&options.Build, "build", "", false, "force build of images when deploying the development environment")
 	cmd.Flags().BoolVarP(&options.Dependencies, "dependencies", "", false, "deploy the dependencies from manifest")
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")
+	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "force run deploy commands in remote")
 
 	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the development environment is deployed (defaults to false)")
 	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
@@ -482,7 +484,7 @@ func getDeployer(manifest *model.Manifest, opts *Options, cwd string, builder *b
 
 	isRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
 
-	if isRemote {
+	if isRemote || manifest.Deploy.Image == "" {
 		deployer, err = newLocalDeployer(opts.Name, cwd, opts.RunWithoutBash)
 		if err != nil {
 			return nil, fmt.Errorf("could not initialize local deploy command: %w", err)

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -62,8 +62,6 @@ WORKDIR /okteto/src
 ENV OKTETO_INVALIDATE_CACHE {{ .RandomInt }}
 RUN okteto deploy --log-output=json {{ .DeployFlags }}
 `
-	dockerignoreName = "deploy.dockerignore"
-	buildOutput      = "deploy"
 )
 
 type dockerfileTemplateProperties struct {
@@ -153,7 +151,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	// undo modification of CWD for Build command
 	os.Chdir(cwd)
 
-	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: buildOutput})
+	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"})
 	buildOptions.Tag = ""
 
 	// we need to call Build() method using a remote builder. This Builder will have
@@ -176,7 +174,7 @@ func (rd *remoteDeployCommand) cleanUp(ctx context.Context, err error) {
 }
 
 func (rd *remoteDeployCommand) createDockerignoreIfNeeded(cwd, tmpDir string) error {
-	dockerignoreFilePath := fmt.Sprintf("%s/%s", cwd, dockerignoreName)
+	dockerignoreFilePath := fmt.Sprintf("%s/%s", cwd, ".oktetodeployignore")
 	if _, err := rd.fs.Stat(dockerignoreFilePath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
@@ -187,7 +185,7 @@ func (rd *remoteDeployCommand) createDockerignoreIfNeeded(cwd, tmpDir string) er
 			return err
 		}
 
-		err = afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, dockerignoreName), dockerignoreContent, 0600)
+		err = afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
 		if err != nil {
 			return err
 		}

--- a/cmd/destroy/all.go
+++ b/cmd/destroy/all.go
@@ -1,0 +1,148 @@
+package destroy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+
+	"github.com/okteto/okteto/cmd/utils/executor"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/secrets"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/okteto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type localDestroyAllCommand struct {
+	configMapHandler  configMapHandler
+	nsDestroyer       destroyer
+	executor          executor.ManifestExecutor
+	oktetoClient      *okteto.OktetoClient
+	secrets           secretHandler
+	k8sClientProvider okteto.K8sClientProvider
+}
+
+func newLocalDestroyerAll(
+	k8sClient *kubernetes.Clientset,
+	k8sClientProvider okteto.K8sClientProvider,
+	executor executor.ManifestExecutor,
+	nsDestroyer destroyer,
+	oktetoClient *okteto.OktetoClient,
+) *localDestroyAllCommand {
+	return &localDestroyAllCommand{
+		configMapHandler:  newConfigmapHandler(k8sClient),
+		secrets:           secrets.NewSecrets(k8sClient),
+		k8sClientProvider: k8sClientProvider,
+		oktetoClient:      oktetoClient,
+		nsDestroyer:       nsDestroyer,
+		executor:          executor,
+	}
+}
+
+func (dc *localDestroyAllCommand) destroy(ctx context.Context, opts *Options) error {
+	oktetoLog.Spinner(fmt.Sprintf("Deleting all in %s namespace", opts.Namespace))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
+
+	if err := dc.oktetoClient.Namespaces().DestroyAll(ctx, opts.Namespace, opts.DestroyVolumes); err != nil {
+		return err
+	}
+
+	waitCtx, ctxCancel := context.WithCancel(ctx)
+	defer ctxCancel()
+
+	stop := make(chan os.Signal, 1)
+	defer close(stop)
+
+	signal.Notify(stop, os.Interrupt)
+	exit := make(chan error, 1)
+	defer close(exit)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		exit <- dc.waitForNamespaceDestroyAllToComplete(waitCtx, opts.Namespace)
+	}(&wg)
+
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		err := dc.oktetoClient.Stream().DestroyAllLogs(waitCtx, opts.Namespace)
+		if err != nil {
+			oktetoLog.Warning("destroy all logs cannot be streamed due to connectivity issues")
+			oktetoLog.Infof("destroy all logs cannot be streamed due to connectivity issues: %v", err)
+		}
+	}(&wg)
+
+	select {
+	case <-stop:
+		ctxCancel()
+		oktetoLog.Infof("CTRL+C received, exit")
+		return oktetoErrors.ErrIntSig
+	case err := <-exit:
+		// wait until streaming logs have finished
+		wg.Wait()
+		return err
+	}
+}
+
+func (ld *localDestroyAllCommand) waitForNamespaceDestroyAllToComplete(ctx context.Context, namespace string) error {
+	timeout := 5 * time.Minute
+	ticker := time.NewTicker(1 * time.Second)
+	to := time.NewTicker(timeout)
+
+	c, _, err := ld.k8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		return err
+	}
+	hasBeenDestroyingAll := false
+
+	for {
+		select {
+		case <-to.C:
+			return fmt.Errorf("'%s' deploy didn't finish after %s", namespace, timeout.String())
+		case <-ticker.C:
+			ns, err := c.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			status, ok := ns.Labels["space.okteto.com/status"]
+			if !ok {
+				// when status label is not present, continue polling the namespace until timeout
+				oktetoLog.Debugf("namespace %q does not have label for status", namespace)
+				continue
+			}
+
+			switch status {
+			case "Active":
+				if hasBeenDestroyingAll {
+					// when status is active again check if all resources have been correctly destroyed
+					cfgList, err := c.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
+					if err != nil {
+						return err
+					}
+
+					// no configmap for the given namespace should exist
+					if len(cfgList.Items) > 0 {
+						return fmt.Errorf("namespace destroy all failed: some resources where not destroyed")
+					}
+					// exit the waiting loop when status is active again
+					return nil
+				}
+			case "DestroyingAll":
+				// initial state would be active, check if this changes to assure namespace has been in destroying all status
+				hasBeenDestroyingAll = true
+			case "DestroyAllFailed":
+				return errors.New("namespace destroy all failed")
+			}
+		}
+	}
+}

--- a/cmd/destroy/all.go
+++ b/cmd/destroy/all.go
@@ -28,7 +28,7 @@ type localDestroyAllCommand struct {
 }
 
 func newLocalDestroyerAll(
-	k8sClient *kubernetes.Clientset,
+	k8sClient kubernetes.Interface,
 	k8sClientProvider okteto.K8sClientProvider,
 	executor executor.ManifestExecutor,
 	nsDestroyer destroyer,

--- a/cmd/destroy/all.go
+++ b/cmd/destroy/all.go
@@ -15,7 +15,6 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 type localDestroyAllCommand struct {
@@ -28,12 +27,15 @@ type localDestroyAllCommand struct {
 }
 
 func newLocalDestroyerAll(
-	k8sClient kubernetes.Interface,
 	k8sClientProvider okteto.K8sClientProvider,
 	executor executor.ManifestExecutor,
 	nsDestroyer destroyer,
 	oktetoClient *okteto.OktetoClient,
-) *localDestroyAllCommand {
+) (*localDestroyAllCommand, error) {
+	k8sClient, _, err := k8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		return nil, err
+	}
 	return &localDestroyAllCommand{
 		configMapHandler:  newConfigmapHandler(k8sClient),
 		secrets:           secrets.NewSecrets(k8sClient),
@@ -41,7 +43,7 @@ func newLocalDestroyerAll(
 		oktetoClient:      oktetoClient,
 		nsDestroyer:       nsDestroyer,
 		executor:          executor,
-	}
+	}, nil
 }
 
 func (dc *localDestroyAllCommand) destroy(ctx context.Context, opts *Options) error {

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -211,16 +211,14 @@ func getTempKubeConfigFile(name string) string {
 }
 
 func getDestroyer(k8sClient *kubernetes.Clientset, okK8sClient okteto.K8sClientProvider, nsDestroyer destroyer, executor executor.ManifestExecutor, okClient *okteto.OktetoClient, opts *Options) (destroyInterface, error) {
-	var (
-		deployer destroyInterface
-	)
+	var deployer destroyInterface
 
 	if opts.DestroyAll {
 		if !okteto.Context().IsOkteto {
 			return nil, oktetoErrors.ErrContextIsNotOktetoCluster
 		}
 		deployer = newLocalDestroyerAll(k8sClient, okK8sClient, executor, nsDestroyer, okClient)
-		oktetoLog.Info("Destroying locally...")
+		oktetoLog.Info("Destroying all...")
 	} else {
 
 		manifest, err := model.GetManifestV2(opts.ManifestPath)

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -15,27 +15,18 @@ package destroy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"sync"
 	"time"
 
-	"strings"
-
 	contextCMD "github.com/okteto/okteto/cmd/context"
-	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/cmd/utils/executor"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/format"
 
-	"github.com/okteto/okteto/pkg/analytics"
-	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/k8s/namespaces"
 	"github.com/okteto/okteto/pkg/k8s/secrets"
@@ -45,9 +36,7 @@ import (
 	oktetoPath "github.com/okteto/okteto/pkg/path"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -85,6 +74,9 @@ type Options struct {
 	DestroyAll          bool
 }
 
+type destroyInterface interface {
+	destroy(context.Context, *Options) error
+}
 type destroyCommand struct {
 	getManifest func(path string) (*model.Manifest, error)
 
@@ -94,6 +86,7 @@ type destroyCommand struct {
 	k8sClientProvider okteto.K8sClientProvider
 	configMapHandler  configMapHandler
 	oktetoClient      *okteto.OktetoClient
+	getDestroyer      func(*model.Manifest, *kubernetes.Clientset, okteto.K8sClientProvider, destroyer, executor.ManifestExecutor, *okteto.OktetoClient) (destroyInterface, error)
 }
 
 // Destroy destroys the dev application defined by the manifest
@@ -172,7 +165,6 @@ func Destroy(ctx context.Context) *cobra.Command {
 			}
 
 			c := &destroyCommand{
-				getManifest: model.GetManifestV2,
 
 				executor:          executor.NewExecutor(oktetoLog.GetOutputFormat(), options.RunWithoutBash),
 				configMapHandler:  newConfigmapHandler(k8sClient),
@@ -180,6 +172,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 				secrets:           secrets.NewSecrets(k8sClient),
 				k8sClientProvider: okteto.NewK8sClientProvider(),
 				oktetoClient:      okClient,
+				getDestroyer:      getDestroyer,
 			}
 
 			kubeconfigPath := getTempKubeConfigFile(name)
@@ -189,23 +182,21 @@ func Destroy(ctx context.Context) *cobra.Command {
 			os.Setenv("KUBECONFIG", kubeconfigPath)
 			defer os.Remove(kubeconfigPath)
 
-			// when option --all the cmd will destroy everything at the namespace and return
-			if options.DestroyAll {
-				if !okteto.Context().IsOkteto {
-					return oktetoErrors.ErrContextIsNotOktetoCluster
-				}
-				err = c.runDestroyAll(ctx, options)
-				if err == nil {
-					oktetoLog.Success("All resources at namespace '%s' where successfully destroyed", options.Namespace)
-				}
-			} else {
-				err = c.runDestroy(ctx, options)
-				if err == nil {
-					oktetoLog.Success("Development environment '%s' successfully destroyed", options.Name)
+			manifest, err := model.GetManifestV2(options.ManifestPath)
+			if err != nil {
+				// Log error message but application can still be deleted
+				oktetoLog.Infof("could not find manifest file to be executed: %s", err)
+				manifest = &model.Manifest{
+					Destroy: &model.DestroyInfo{},
 				}
 			}
-			analytics.TrackDestroy(err == nil, options.DestroyAll)
-			return err
+
+			destroyer, err := c.getDestroyer(manifest, k8sClient, c.k8sClientProvider, c.nsDestroyer, c.executor, c.oktetoClient)
+			if err != nil {
+				return err
+			}
+
+			return destroyer.destroy(ctx, options)
 		},
 	}
 
@@ -222,341 +213,24 @@ func Destroy(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-func (dc *destroyCommand) runDestroy(ctx context.Context, opts *Options) error {
-	// Read manifest file with the commands to be executed
-	manifest, err := dc.getManifest(opts.ManifestPath)
-	if err != nil {
-		// Log error message but application can still be deleted
-		oktetoLog.Infof("could not find manifest file to be executed: %s", err)
-		manifest = &model.Manifest{
-			Destroy: []model.DeployCommand{},
-		}
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get the current working directory: %w", err)
-	}
-	if opts.Name == "" {
-		if manifest.Name != "" {
-			opts.Name = manifest.Name
-		} else {
-			opts.Name = utils.InferName(cwd)
-		}
-
-	}
-	err = manifest.ExpandEnvVars()
-	if err != nil {
-		return err
-	}
-
-	for _, variable := range opts.Variables {
-		value := strings.SplitN(variable, "=", 2)[1]
-		if strings.TrimSpace(value) != "" {
-			oktetoLog.AddMaskedWord(value)
-		}
-	}
-	oktetoLog.EnableMasking()
-
-	namespace := opts.Namespace
-	if namespace == "" {
-		namespace = okteto.Context().Namespace
-	}
-
-	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Destroying...")
-
-	data := &pipeline.CfgData{
-		Name:      opts.Name,
-		Namespace: namespace,
-		Status:    pipeline.DestroyingStatus,
-		Filename:  opts.ManifestPathFlag,
-	}
-
-	cfg, err := dc.configMapHandler.translateConfigMapAndDeploy(ctx, data)
-	if err != nil {
-		return err
-	}
-
-	if manifest.Context == "" {
-		manifest.Context = okteto.Context().Name
-	}
-	if manifest.Namespace == okteto.Context().Namespace {
-		manifest.Namespace = okteto.Context().Namespace
-	}
-	os.Setenv(constants.OktetoNameEnvVar, opts.Name)
-
-	if opts.DestroyDependencies {
-		for depName, depInfo := range manifest.Dependencies {
-			oktetoLog.SetStage(fmt.Sprintf("Destroying dependency '%s'", depName))
-
-			namespace := okteto.Context().Namespace
-			if depInfo.Namespace != "" {
-				namespace = depInfo.Namespace
-			}
-
-			destOpts := &pipelineCMD.DestroyOptions{
-				Name:           depName,
-				DestroyVolumes: opts.DestroyVolumes,
-				Namespace:      namespace,
-			}
-			pipelineCmd, err := pipelineCMD.NewCommand()
-			if err != nil {
-				if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
-					return err
-				}
-				return err
-			}
-			if err := pipelineCmd.ExecuteDestroyPipeline(ctx, destOpts); err != nil {
-				if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
-					return err
-				}
-				return err
-			}
-		}
-		oktetoLog.SetStage("")
-	}
-
-	var commandErr error
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, os.Interrupt)
-	exit := make(chan error, 1)
-
-	go func() {
-		for _, command := range manifest.Destroy {
-			oktetoLog.Information("Running '%s'", command.Name)
-			oktetoLog.SetStage(command.Name)
-			if err := dc.executor.Execute(command, opts.Variables); err != nil {
-				err = fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
-				if !opts.ForceDestroy {
-					if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
-						exit <- err
-						return
-					}
-					exit <- err
-					return
-				}
-
-				// Store the error to return if the force destroy option is set
-				commandErr = err
-			}
-		}
-		exit <- nil
-	}()
-	select {
-	case <-stop:
-		oktetoLog.Infof("CTRL+C received, starting shutdown sequence")
-		errStop := "interrupt signal received"
-		dc.executor.CleanUp(errors.New(errStop))
-		if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, fmt.Errorf(errStop)); err != nil {
-			return err
-		}
-		return oktetoErrors.ErrIntSig
-	case err := <-exit:
-		if err != nil {
-			oktetoLog.Infof("exit signal received due to error: %s", err)
-			return err
-		}
-	}
-	oktetoLog.SetStage("")
-	oktetoLog.DisableMasking()
-
-	oktetoLog.Spinner(fmt.Sprintf("Destroying development environment '%s'...", opts.Name))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
-	deployedByLs, err := labels.NewRequirement(
-		model.DeployedByLabel,
-		selection.Equals,
-		[]string{format.ResourceK8sMetaString(opts.Name)},
-	)
-	if err != nil {
-		if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
-			return err
-		}
-		return err
-	}
-	deployedBySelector := labels.NewSelector().Add(*deployedByLs).String()
-	deleteOpts := namespaces.DeleteAllOptions{
-		LabelSelector:  deployedBySelector,
-		IncludeVolumes: opts.DestroyVolumes,
-	}
-
-	oktetoLog.SetStage("Destroying volumes")
-	if err := dc.nsDestroyer.DestroySFSVolumes(ctx, opts.Namespace, deleteOpts); err != nil {
-		if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
-			return err
-		}
-		return err
-	}
-
-	oktetoLog.SetStage("Destroying Helm release")
-	if err := dc.destroyHelmReleasesIfPresent(ctx, opts, deployedBySelector); err != nil {
-		if !opts.ForceDestroy {
-			if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
-				return err
-			}
-			return err
-		}
-	}
-
-	oktetoLog.Debugf("destroying resources with deployed-by label '%s'", deployedBySelector)
-	oktetoLog.SetStage(fmt.Sprintf("Destroying by label '%s'", deployedBySelector))
-	if err := dc.nsDestroyer.DestroyWithLabel(ctx, opts.Namespace, deleteOpts); err != nil {
-		oktetoLog.Infof("could not delete all the resources: %s", err)
-		if err := dc.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
-			return err
-		}
-		return err
-	}
-
-	oktetoLog.SetStage("Destroying configmap")
-
-	if err := dc.configMapHandler.destroyConfigMap(ctx, cfg, namespace); err != nil {
-		return err
-	}
-
-	return commandErr
-}
-
-func (dc *destroyCommand) destroyHelmReleasesIfPresent(ctx context.Context, opts *Options, labelSelector string) error {
-	sList, err := dc.secrets.List(ctx, opts.Namespace, labelSelector)
-	if err != nil {
-		return err
-	}
-
-	oktetoLog.Debugf("checking if application installed something with helm")
-	helmReleases := map[string]bool{}
-	for _, s := range sList {
-		if s.Type == model.HelmSecretType && s.Labels[ownerLabel] == helmOwner {
-			helmReleaseName, ok := s.Labels[nameLabel]
-			if !ok {
-				continue
-			}
-
-			helmReleases[helmReleaseName] = true
-		}
-	}
-
-	// If the application to be destroyed was deployed with helm, we try to uninstall it to avoid to leave orphan release resources
-	for releaseName := range helmReleases {
-		oktetoLog.Debugf("uninstalling helm release '%s'", releaseName)
-		cmd := fmt.Sprintf(helmUninstallCommand, releaseName)
-		cmdInfo := model.DeployCommand{Command: cmd, Name: cmd}
-		oktetoLog.Information("Running '%s'", cmdInfo.Name)
-		if err := dc.executor.Execute(cmdInfo, opts.Variables); err != nil {
-			oktetoLog.Infof("could not uninstall helm release '%s': %s", releaseName, err)
-			if !opts.ForceDestroy {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 func getTempKubeConfigFile(name string) string {
 	tempKubeconfigFileName := fmt.Sprintf("kubeconfig-destroy-%s-%d", name, time.Now().UnixMilli())
 	return filepath.Join(config.GetOktetoHome(), tempKubeconfigFileName)
 }
 
-func (dc *destroyCommand) runDestroyAll(ctx context.Context, opts *Options) error {
-	oktetoLog.Spinner(fmt.Sprintf("Deleting all in %s namespace", opts.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
+func getDestroyer(manifest *model.Manifest, k8sClient *kubernetes.Clientset, okK8sClient okteto.K8sClientProvider, nsDestroyer destroyer, executor executor.ManifestExecutor, okClient *okteto.OktetoClient) (destroyInterface, error) {
+	var (
+		deployer destroyInterface
+	)
 
-	if err := dc.oktetoClient.Namespaces().DestroyAll(ctx, opts.Namespace, opts.DestroyVolumes); err != nil {
-		return err
+	isRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
+
+	if isRemote || manifest.Destroy.Image == "" {
+		deployer = newLocalDestroyer(manifest, k8sClient, okK8sClient, executor, nsDestroyer, okClient)
+		oktetoLog.Info("Destroying locally...")
+	} else {
+		deployer = newRemoteDestroyer(manifest)
+		oktetoLog.Info("Destroying remotely...")
 	}
-
-	waitCtx, ctxCancel := context.WithCancel(ctx)
-	defer ctxCancel()
-
-	stop := make(chan os.Signal, 1)
-	defer close(stop)
-
-	signal.Notify(stop, os.Interrupt)
-	exit := make(chan error, 1)
-	defer close(exit)
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		exit <- dc.waitForNamespaceDestroyAllToComplete(waitCtx, opts.Namespace)
-	}(&wg)
-
-	wg.Add(1)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		err := dc.oktetoClient.Stream().DestroyAllLogs(waitCtx, opts.Namespace)
-		if err != nil {
-			oktetoLog.Warning("destroy all logs cannot be streamed due to connectivity issues")
-			oktetoLog.Infof("destroy all logs cannot be streamed due to connectivity issues: %v", err)
-		}
-	}(&wg)
-
-	select {
-	case <-stop:
-		ctxCancel()
-		oktetoLog.Infof("CTRL+C received, exit")
-		return oktetoErrors.ErrIntSig
-	case err := <-exit:
-		// wait until streaming logs have finished
-		wg.Wait()
-		return err
-	}
-}
-
-func (pc *destroyCommand) waitForNamespaceDestroyAllToComplete(ctx context.Context, namespace string) error {
-	timeout := 5 * time.Minute
-	ticker := time.NewTicker(1 * time.Second)
-	to := time.NewTicker(timeout)
-
-	c, _, err := pc.k8sClientProvider.Provide(okteto.Context().Cfg)
-	if err != nil {
-		return err
-	}
-	hasBeenDestroyingAll := false
-
-	for {
-		select {
-		case <-to.C:
-			return fmt.Errorf("'%s' deploy didn't finish after %s", namespace, timeout.String())
-		case <-ticker.C:
-			ns, err := c.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-
-			status, ok := ns.Labels["space.okteto.com/status"]
-			if !ok {
-				// when status label is not present, continue polling the namespace until timeout
-				oktetoLog.Debugf("namespace %q does not have label for status", namespace)
-				continue
-			}
-
-			switch status {
-			case "Active":
-				if hasBeenDestroyingAll {
-					// when status is active again check if all resources have been correctly destroyed
-					cfgList, err := c.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
-					if err != nil {
-						return err
-					}
-
-					// no configmap for the given namespace should exist
-					if len(cfgList.Items) > 0 {
-						return fmt.Errorf("namespace destroy all failed: some resources where not destroyed")
-					}
-					// exit the waiting loop when status is active again
-					return nil
-				}
-			case "DestroyingAll":
-				// initial state would be active, check if this changes to assure namespace has been in destroying all status
-				hasBeenDestroyingAll = true
-			case "DestroyAllFailed":
-				return errors.New("namespace destroy all failed")
-			}
-		}
-	}
+	return deployer, nil
 }

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -72,6 +72,7 @@ type Options struct {
 	K8sContext          string
 	RunWithoutBash      bool
 	DestroyAll          bool
+	RunInRemote         bool
 }
 
 type destroyInterface interface {
@@ -165,7 +166,6 @@ func Destroy(ctx context.Context) *cobra.Command {
 			}
 
 			c := &destroyCommand{
-
 				executor:          executor.NewExecutor(oktetoLog.GetOutputFormat(), options.RunWithoutBash),
 				configMapHandler:  newConfigmapHandler(k8sClient),
 				nsDestroyer:       namespaces.NewNamespace(dynClient, discClient, cfg, k8sClient),
@@ -209,6 +209,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment was deployed")
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")
 	cmd.Flags().BoolVarP(&options.DestroyAll, "all", "", false, "destroy everything in the namespace")
+	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "force run destroy commands in remote")
 
 	return cmd
 }

--- a/cmd/destroy/destroy_test.go
+++ b/cmd/destroy/destroy_test.go
@@ -151,11 +151,13 @@ func TestDestroyWithErrorDeletingVolumes(t *testing.T) {
 	}
 
 	ld := localDestroyCommand{
-		manifest:          fakeManifest,
-		configMapHandler:  newConfigmapHandler(fakeClient),
-		nsDestroyer:       destroyer,
-		executor:          executor,
-		k8sClientProvider: k8sClientProvider,
+		&localDestroyAllCommand{
+			configMapHandler:  newConfigmapHandler(fakeClient),
+			nsDestroyer:       destroyer,
+			executor:          executor,
+			k8sClientProvider: k8sClientProvider,
+		},
+		fakeManifest,
 	}
 
 	err = ld.runDestroy(ctx, opts)
@@ -215,12 +217,14 @@ func TestDestroyWithErrorListingSecrets(t *testing.T) {
 			}
 
 			ld := localDestroyCommand{
-				manifest:          tt.manifest,
-				configMapHandler:  newConfigmapHandler(fakeClient),
-				nsDestroyer:       &fakeDestroyer{},
-				executor:          executor,
-				k8sClientProvider: k8sClientProvider,
-				secrets:           &secretHandler,
+				&localDestroyAllCommand{
+					configMapHandler:  newConfigmapHandler(fakeClient),
+					nsDestroyer:       &fakeDestroyer{},
+					executor:          executor,
+					k8sClientProvider: k8sClientProvider,
+					secrets:           &secretHandler,
+				},
+				tt.manifest,
 			}
 
 			err = ld.runDestroy(ctx, opts)
@@ -356,12 +360,14 @@ func TestDestroyWithError(t *testing.T) {
 			}
 
 			ld := localDestroyCommand{
-				manifest:          tt.manifest,
-				secrets:           &secretHandler,
-				executor:          executor,
-				nsDestroyer:       destroyer,
-				k8sClientProvider: k8sClientProvider,
-				configMapHandler:  newConfigmapHandler(fakeClient),
+				&localDestroyAllCommand{
+					configMapHandler:  newConfigmapHandler(fakeClient),
+					nsDestroyer:       destroyer,
+					executor:          executor,
+					k8sClientProvider: k8sClientProvider,
+					secrets:           &secretHandler,
+				},
+				tt.manifest,
 			}
 
 			err = ld.runDestroy(ctx, opts)
@@ -595,13 +601,16 @@ func TestDestroyWithoutError(t *testing.T) {
 			if err != nil {
 				t.Fatal("could not create fake k8s client")
 			}
-			ld := &localDestroyCommand{
-				manifest:          tt.manifest,
-				secrets:           &secretHandler,
-				executor:          executor,
-				nsDestroyer:       destroyer,
-				k8sClientProvider: k8sClientProvider,
-				configMapHandler:  newConfigmapHandler(fakeClient),
+
+			ld := localDestroyCommand{
+				&localDestroyAllCommand{
+					configMapHandler:  newConfigmapHandler(fakeClient),
+					nsDestroyer:       destroyer,
+					executor:          executor,
+					k8sClientProvider: k8sClientProvider,
+					secrets:           &secretHandler,
+				},
+				tt.manifest,
 			}
 
 			err = ld.runDestroy(ctx, opts)
@@ -840,13 +849,16 @@ func TestDestroyWithoutErrorInsideOktetoDeploy(t *testing.T) {
 			}
 			// Set env var destroy inside deploy
 			t.Setenv(constants.OktetoWithinDeployCommandContextEnvVar, "true")
-			ld := &localDestroyCommand{
-				manifest:          tt.manifest,
-				secrets:           &secretHandler,
-				executor:          executor,
-				nsDestroyer:       destroyer,
-				k8sClientProvider: test.NewFakeK8sProvider(),
-				configMapHandler:  newConfigmapHandler(nil),
+
+			ld := localDestroyCommand{
+				&localDestroyAllCommand{
+					configMapHandler:  newConfigmapHandler(nil),
+					nsDestroyer:       destroyer,
+					executor:          executor,
+					k8sClientProvider: test.NewFakeK8sProvider(),
+					secrets:           &secretHandler,
+				},
+				tt.manifest,
 			}
 
 			err := ld.runDestroy(ctx, opts)
@@ -894,13 +906,15 @@ func TestDestroyWithoutForceOptionAndFailedCommands(t *testing.T) {
 		t.Fatal("could not create fake k8s client")
 	}
 
-	ld := &localDestroyCommand{
-		manifest:          fakeManifest,
-		secrets:           &secretHandler,
-		executor:          executor,
-		nsDestroyer:       destroyer,
-		k8sClientProvider: k8sClientProvider,
-		configMapHandler:  newConfigmapHandler(fakeClient),
+	ld := localDestroyCommand{
+		&localDestroyAllCommand{
+			configMapHandler:  newConfigmapHandler(fakeClient),
+			nsDestroyer:       destroyer,
+			executor:          executor,
+			k8sClientProvider: k8sClientProvider,
+			secrets:           &secretHandler,
+		},
+		fakeManifest,
 	}
 
 	err = ld.runDestroy(ctx, opts)
@@ -943,12 +957,14 @@ func TestDestroyWithForceOptionAndFailedCommands(t *testing.T) {
 	}
 
 	ld := localDestroyCommand{
-		manifest:          fakeManifest,
-		secrets:           &secretHandler,
-		executor:          executor,
-		nsDestroyer:       destroyer,
-		k8sClientProvider: k8sClientProvider,
-		configMapHandler:  newConfigmapHandler(fakeClient),
+		&localDestroyAllCommand{
+			configMapHandler:  newConfigmapHandler(fakeClient),
+			nsDestroyer:       destroyer,
+			executor:          executor,
+			k8sClientProvider: k8sClientProvider,
+			secrets:           &secretHandler,
+		},
+		fakeManifest,
 	}
 
 	err = ld.runDestroy(ctx, opts)

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -1,0 +1,407 @@
+package destroy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"time"
+
+	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
+	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/cmd/utils/executor"
+	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/cmd/pipeline"
+	"github.com/okteto/okteto/pkg/constants"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/format"
+	"github.com/okteto/okteto/pkg/k8s/namespaces"
+	"github.com/okteto/okteto/pkg/k8s/secrets"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
+)
+
+type localDestroyCommand struct {
+	manifest          *model.Manifest
+	configMapHandler  configMapHandler
+	nsDestroyer       destroyer
+	executor          executor.ManifestExecutor
+	oktetoClient      *okteto.OktetoClient
+	secrets           *secrets.Secrets
+	k8sClientProvider okteto.K8sClientProvider
+}
+
+func newLocalDestroyer(
+	manifest *model.Manifest,
+	k8sClient *kubernetes.Clientset,
+	k8sClientProvider okteto.K8sClientProvider,
+	executor executor.ManifestExecutor,
+	nsDestroyer destroyer,
+	oktetoClient *okteto.OktetoClient,
+) *localDestroyCommand {
+	return &localDestroyCommand{
+		configMapHandler:  newConfigmapHandler(k8sClient),
+		secrets:           secrets.NewSecrets(k8sClient),
+		k8sClientProvider: k8sClientProvider,
+		manifest:          manifest,
+		oktetoClient:      oktetoClient,
+		nsDestroyer:       nsDestroyer,
+		executor:          executor,
+	}
+}
+
+func (ld *localDestroyCommand) destroy(ctx context.Context, opts *Options) error {
+
+	var err error
+	// when option --all the cmd will destroy everything at the namespace and return
+	if opts.DestroyAll {
+		if !okteto.Context().IsOkteto {
+			return oktetoErrors.ErrContextIsNotOktetoCluster
+		}
+		err = ld.runDestroyAll(ctx, opts)
+		if err == nil {
+			oktetoLog.Success("All resources at namespace '%s' where successfully destroyed", opts.Namespace)
+		}
+	} else {
+		err = ld.runDestroy(ctx, opts)
+		if err == nil {
+			oktetoLog.Success("Development environment '%s' successfully destroyed", opts.Name)
+		}
+	}
+	analytics.TrackDestroy(err == nil, opts.DestroyAll)
+
+	return err
+}
+
+func (dc *localDestroyCommand) runDestroyAll(ctx context.Context, opts *Options) error {
+	oktetoLog.Spinner(fmt.Sprintf("Deleting all in %s namespace", opts.Namespace))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
+
+	if err := dc.oktetoClient.Namespaces().DestroyAll(ctx, opts.Namespace, opts.DestroyVolumes); err != nil {
+		return err
+	}
+
+	waitCtx, ctxCancel := context.WithCancel(ctx)
+	defer ctxCancel()
+
+	stop := make(chan os.Signal, 1)
+	defer close(stop)
+
+	signal.Notify(stop, os.Interrupt)
+	exit := make(chan error, 1)
+	defer close(exit)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		exit <- dc.waitForNamespaceDestroyAllToComplete(waitCtx, opts.Namespace)
+	}(&wg)
+
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		err := dc.oktetoClient.Stream().DestroyAllLogs(waitCtx, opts.Namespace)
+		if err != nil {
+			oktetoLog.Warning("destroy all logs cannot be streamed due to connectivity issues")
+			oktetoLog.Infof("destroy all logs cannot be streamed due to connectivity issues: %v", err)
+		}
+	}(&wg)
+
+	select {
+	case <-stop:
+		ctxCancel()
+		oktetoLog.Infof("CTRL+C received, exit")
+		return oktetoErrors.ErrIntSig
+	case err := <-exit:
+		// wait until streaming logs have finished
+		wg.Wait()
+		return err
+	}
+}
+
+func (ld *localDestroyCommand) runDestroy(ctx context.Context, opts *Options) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %w", err)
+	}
+	if opts.Name == "" {
+		if ld.manifest.Name != "" {
+			opts.Name = ld.manifest.Name
+		} else {
+			opts.Name = utils.InferName(cwd)
+		}
+
+	}
+	err = ld.manifest.ExpandEnvVars()
+	if err != nil {
+		return err
+	}
+
+	for _, variable := range opts.Variables {
+		value := strings.SplitN(variable, "=", 2)[1]
+		if strings.TrimSpace(value) != "" {
+			oktetoLog.AddMaskedWord(value)
+		}
+	}
+	oktetoLog.EnableMasking()
+
+	namespace := opts.Namespace
+	if namespace == "" {
+		namespace = okteto.Context().Namespace
+	}
+
+	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Destroying...")
+
+	data := &pipeline.CfgData{
+		Name:      opts.Name,
+		Namespace: namespace,
+		Status:    pipeline.DestroyingStatus,
+		Filename:  opts.ManifestPathFlag,
+	}
+
+	cfg, err := ld.configMapHandler.translateConfigMapAndDeploy(ctx, data)
+	if err != nil {
+		return err
+	}
+
+	if ld.manifest.Context == "" {
+		ld.manifest.Context = okteto.Context().Name
+	}
+	if ld.manifest.Namespace == okteto.Context().Namespace {
+		ld.manifest.Namespace = okteto.Context().Namespace
+	}
+	os.Setenv(constants.OktetoNameEnvVar, opts.Name)
+
+	if opts.DestroyDependencies {
+		for depName, depInfo := range ld.manifest.Dependencies {
+			oktetoLog.SetStage(fmt.Sprintf("Destroying dependency '%s'", depName))
+
+			namespace := okteto.Context().Namespace
+			if depInfo.Namespace != "" {
+				namespace = depInfo.Namespace
+			}
+
+			destOpts := &pipelineCMD.DestroyOptions{
+				Name:           depName,
+				DestroyVolumes: opts.DestroyVolumes,
+				Namespace:      namespace,
+			}
+			pipelineCmd, err := pipelineCMD.NewCommand()
+			if err != nil {
+				if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
+					return err
+				}
+				return err
+			}
+			if err := pipelineCmd.ExecuteDestroyPipeline(ctx, destOpts); err != nil {
+				if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
+					return err
+				}
+				return err
+			}
+		}
+		oktetoLog.SetStage("")
+	}
+
+	var commandErr error
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+	exit := make(chan error, 1)
+
+	go func() {
+		for _, command := range ld.manifest.Destroy.Commands {
+			oktetoLog.Information("Running '%s'", command.Name)
+			oktetoLog.SetStage(command.Name)
+			if err := ld.executor.Execute(command, opts.Variables); err != nil {
+				err = fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
+				if !opts.ForceDestroy {
+					if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
+						exit <- err
+						return
+					}
+					exit <- err
+					return
+				}
+
+				// Store the error to return if the force destroy option is set
+				commandErr = err
+			}
+		}
+		exit <- nil
+	}()
+	select {
+	case <-stop:
+		oktetoLog.Infof("CTRL+C received, starting shutdown sequence")
+		errStop := "interrupt signal received"
+		ld.executor.CleanUp(errors.New(errStop))
+		if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, fmt.Errorf(errStop)); err != nil {
+			return err
+		}
+		return oktetoErrors.ErrIntSig
+	case err := <-exit:
+		if err != nil {
+			oktetoLog.Infof("exit signal received due to error: %s", err)
+			return err
+		}
+	}
+	oktetoLog.SetStage("")
+	oktetoLog.DisableMasking()
+
+	oktetoLog.Spinner(fmt.Sprintf("Destroying development environment '%s'...", opts.Name))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
+
+	deployedByLs, err := labels.NewRequirement(
+		model.DeployedByLabel,
+		selection.Equals,
+		[]string{format.ResourceK8sMetaString(opts.Name)},
+	)
+	if err != nil {
+		if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
+			return err
+		}
+		return err
+	}
+	deployedBySelector := labels.NewSelector().Add(*deployedByLs).String()
+	deleteOpts := namespaces.DeleteAllOptions{
+		LabelSelector:  deployedBySelector,
+		IncludeVolumes: opts.DestroyVolumes,
+	}
+
+	oktetoLog.SetStage("Destroying volumes")
+	if err := ld.nsDestroyer.DestroySFSVolumes(ctx, opts.Namespace, deleteOpts); err != nil {
+		if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
+			return err
+		}
+		return err
+	}
+
+	oktetoLog.SetStage("Destroying Helm release")
+	if err := ld.destroyHelmReleasesIfPresent(ctx, opts, deployedBySelector); err != nil {
+		if !opts.ForceDestroy {
+			if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
+				return err
+			}
+			return err
+		}
+	}
+
+	oktetoLog.Debugf("destroying resources with deployed-by label '%s'", deployedBySelector)
+	oktetoLog.SetStage(fmt.Sprintf("Destroying by label '%s'", deployedBySelector))
+	if err := ld.nsDestroyer.DestroyWithLabel(ctx, opts.Namespace, deleteOpts); err != nil {
+		oktetoLog.Infof("could not delete all the resources: %s", err)
+		if err := ld.configMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
+			return err
+		}
+		return err
+	}
+
+	oktetoLog.SetStage("Destroying configmap")
+
+	if err := ld.configMapHandler.destroyConfigMap(ctx, cfg, namespace); err != nil {
+		return err
+	}
+
+	return commandErr
+}
+
+func (ld *localDestroyCommand) waitForNamespaceDestroyAllToComplete(ctx context.Context, namespace string) error {
+	timeout := 5 * time.Minute
+	ticker := time.NewTicker(1 * time.Second)
+	to := time.NewTicker(timeout)
+
+	c, _, err := ld.k8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		return err
+	}
+	hasBeenDestroyingAll := false
+
+	for {
+		select {
+		case <-to.C:
+			return fmt.Errorf("'%s' deploy didn't finish after %s", namespace, timeout.String())
+		case <-ticker.C:
+			ns, err := c.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			status, ok := ns.Labels["space.okteto.com/status"]
+			if !ok {
+				// when status label is not present, continue polling the namespace until timeout
+				oktetoLog.Debugf("namespace %q does not have label for status", namespace)
+				continue
+			}
+
+			switch status {
+			case "Active":
+				if hasBeenDestroyingAll {
+					// when status is active again check if all resources have been correctly destroyed
+					cfgList, err := c.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
+					if err != nil {
+						return err
+					}
+
+					// no configmap for the given namespace should exist
+					if len(cfgList.Items) > 0 {
+						return fmt.Errorf("namespace destroy all failed: some resources where not destroyed")
+					}
+					// exit the waiting loop when status is active again
+					return nil
+				}
+			case "DestroyingAll":
+				// initial state would be active, check if this changes to assure namespace has been in destroying all status
+				hasBeenDestroyingAll = true
+			case "DestroyAllFailed":
+				return errors.New("namespace destroy all failed")
+			}
+		}
+	}
+}
+
+func (dc *localDestroyCommand) destroyHelmReleasesIfPresent(ctx context.Context, opts *Options, labelSelector string) error {
+	sList, err := dc.secrets.List(ctx, opts.Namespace, labelSelector)
+	if err != nil {
+		return err
+	}
+
+	oktetoLog.Debugf("checking if application installed something with helm")
+	helmReleases := map[string]bool{}
+	for _, s := range sList {
+		if s.Type == model.HelmSecretType && s.Labels[ownerLabel] == helmOwner {
+			helmReleaseName, ok := s.Labels[nameLabel]
+			if !ok {
+				continue
+			}
+
+			helmReleases[helmReleaseName] = true
+		}
+	}
+
+	// If the application to be destroyed was deployed with helm, we try to uninstall it to avoid to leave orphan release resources
+	for releaseName := range helmReleases {
+		oktetoLog.Debugf("uninstalling helm release '%s'", releaseName)
+		cmd := fmt.Sprintf(helmUninstallCommand, releaseName)
+		cmdInfo := model.DeployCommand{Command: cmd, Name: cmd}
+		oktetoLog.Information("Running '%s'", cmdInfo.Name)
+		if err := dc.executor.Execute(cmdInfo, opts.Variables); err != nil {
+			oktetoLog.Infof("could not uninstall helm release '%s': %s", releaseName, err)
+			if !opts.ForceDestroy {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -35,7 +35,7 @@ type localDestroyCommand struct {
 	nsDestroyer       destroyer
 	executor          executor.ManifestExecutor
 	oktetoClient      *okteto.OktetoClient
-	secrets           *secrets.Secrets
+	secrets           secretHandler
 	k8sClientProvider okteto.K8sClientProvider
 }
 
@@ -59,6 +59,14 @@ func newLocalDestroyer(
 }
 
 func (ld *localDestroyCommand) destroy(ctx context.Context, opts *Options) error {
+
+	if opts.RunInRemote {
+		if ld.manifest.Deploy != nil {
+			if ld.manifest.Deploy.Image == "" {
+				ld.manifest.Deploy.Image = constants.OktetoPipelineRunnerImage
+			}
+		}
+	}
 
 	var err error
 	// when option --all the cmd will destroy everything at the namespace and return

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -7,40 +7,25 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
-	"time"
 
 	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
-	"github.com/okteto/okteto/cmd/utils/executor"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/format"
 	"github.com/okteto/okteto/pkg/k8s/namespaces"
-	"github.com/okteto/okteto/pkg/k8s/secrets"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/kubernetes"
 )
 
 type localDestroyCommand struct {
 	*localDestroyAllCommand
 	manifest *model.Manifest
-}
-
-type localDestroyAllCommand struct {
-	configMapHandler  configMapHandler
-	nsDestroyer       destroyer
-	executor          executor.ManifestExecutor
-	oktetoClient      *okteto.OktetoClient
-	secrets           secretHandler
-	k8sClientProvider okteto.K8sClientProvider
 }
 
 func newLocalDestroyer(
@@ -53,30 +38,11 @@ func newLocalDestroyer(
 	}
 }
 
-func newLocalDestroyerAll(
-	k8sClient *kubernetes.Clientset,
-	k8sClientProvider okteto.K8sClientProvider,
-	executor executor.ManifestExecutor,
-	nsDestroyer destroyer,
-	oktetoClient *okteto.OktetoClient,
-) *localDestroyAllCommand {
-	return &localDestroyAllCommand{
-		configMapHandler:  newConfigmapHandler(k8sClient),
-		secrets:           secrets.NewSecrets(k8sClient),
-		k8sClientProvider: k8sClientProvider,
-		oktetoClient:      oktetoClient,
-		nsDestroyer:       nsDestroyer,
-		executor:          executor,
-	}
-}
-
 func (ld *localDestroyCommand) destroy(ctx context.Context, opts *Options) error {
 
 	if opts.RunInRemote {
-		if ld.manifest.Deploy != nil {
-			if ld.manifest.Deploy.Image == "" {
-				ld.manifest.Deploy.Image = constants.OktetoPipelineRunnerImage
-			}
+		if ld.manifest.Destroy != nil && ld.manifest.Destroy.Image == "" {
+			ld.manifest.Destroy.Image = constants.OktetoPipelineRunnerImage
 		}
 	}
 
@@ -87,55 +53,6 @@ func (ld *localDestroyCommand) destroy(ctx context.Context, opts *Options) error
 	analytics.TrackDestroy(err == nil, opts.DestroyAll)
 
 	return err
-}
-
-func (dc *localDestroyAllCommand) destroy(ctx context.Context, opts *Options) error {
-	oktetoLog.Spinner(fmt.Sprintf("Deleting all in %s namespace", opts.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
-	if err := dc.oktetoClient.Namespaces().DestroyAll(ctx, opts.Namespace, opts.DestroyVolumes); err != nil {
-		return err
-	}
-
-	waitCtx, ctxCancel := context.WithCancel(ctx)
-	defer ctxCancel()
-
-	stop := make(chan os.Signal, 1)
-	defer close(stop)
-
-	signal.Notify(stop, os.Interrupt)
-	exit := make(chan error, 1)
-	defer close(exit)
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		exit <- dc.waitForNamespaceDestroyAllToComplete(waitCtx, opts.Namespace)
-	}(&wg)
-
-	wg.Add(1)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-		err := dc.oktetoClient.Stream().DestroyAllLogs(waitCtx, opts.Namespace)
-		if err != nil {
-			oktetoLog.Warning("destroy all logs cannot be streamed due to connectivity issues")
-			oktetoLog.Infof("destroy all logs cannot be streamed due to connectivity issues: %v", err)
-		}
-	}(&wg)
-
-	select {
-	case <-stop:
-		ctxCancel()
-		oktetoLog.Infof("CTRL+C received, exit")
-		return oktetoErrors.ErrIntSig
-	case err := <-exit:
-		// wait until streaming logs have finished
-		wg.Wait()
-		return err
-	}
 }
 
 func (ld *localDestroyCommand) runDestroy(ctx context.Context, opts *Options) error {
@@ -322,60 +239,6 @@ func (ld *localDestroyCommand) runDestroy(ctx context.Context, opts *Options) er
 	}
 
 	return commandErr
-}
-
-func (ld *localDestroyAllCommand) waitForNamespaceDestroyAllToComplete(ctx context.Context, namespace string) error {
-	timeout := 5 * time.Minute
-	ticker := time.NewTicker(1 * time.Second)
-	to := time.NewTicker(timeout)
-
-	c, _, err := ld.k8sClientProvider.Provide(okteto.Context().Cfg)
-	if err != nil {
-		return err
-	}
-	hasBeenDestroyingAll := false
-
-	for {
-		select {
-		case <-to.C:
-			return fmt.Errorf("'%s' deploy didn't finish after %s", namespace, timeout.String())
-		case <-ticker.C:
-			ns, err := c.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
-			if err != nil {
-				return err
-			}
-
-			status, ok := ns.Labels["space.okteto.com/status"]
-			if !ok {
-				// when status label is not present, continue polling the namespace until timeout
-				oktetoLog.Debugf("namespace %q does not have label for status", namespace)
-				continue
-			}
-
-			switch status {
-			case "Active":
-				if hasBeenDestroyingAll {
-					// when status is active again check if all resources have been correctly destroyed
-					cfgList, err := c.CoreV1().ConfigMaps(namespace).List(ctx, metav1.ListOptions{})
-					if err != nil {
-						return err
-					}
-
-					// no configmap for the given namespace should exist
-					if len(cfgList.Items) > 0 {
-						return fmt.Errorf("namespace destroy all failed: some resources where not destroyed")
-					}
-					// exit the waiting loop when status is active again
-					return nil
-				}
-			case "DestroyingAll":
-				// initial state would be active, check if this changes to assure namespace has been in destroying all status
-				hasBeenDestroyingAll = true
-			case "DestroyAllFailed":
-				return errors.New("namespace destroy all failed")
-			}
-		}
-	}
 }
 
 func (dc *localDestroyCommand) destroyHelmReleasesIfPresent(ctx context.Context, opts *Options, labelSelector string) error {

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -31,6 +31,7 @@ RUN apk update && apk add ca-certificates
 FROM {{ .UserDestroyImage }} as deploy
 
 ENV PATH="${PATH}:/okteto/bin"
+COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 {{range $key, $val := .OktetoBuildEnvVars }}

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -98,9 +98,8 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	}
 
 	dockerfileSyntax := dockerfileTemplateProperties{
-		OktetoCLIImage:   constants.OktetoCLIImageForRemote,
-		UserDestroyImage: rd.manifest.Destroy.Image,
-		//OktetoBuildEnvVars: rd.builder.GetBuildEnvVars(),
+		OktetoCLIImage:     constants.OktetoCLIImageForRemote,
+		UserDestroyImage:   rd.manifest.Destroy.Image,
 		ContextEnvVar:      model.OktetoContextEnvVar,
 		ContextValue:       okteto.Context().Name,
 		NamespaceEnvVar:    model.OktetoNamespaceEnvVar,

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -79,6 +79,11 @@ func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
 }
 
 func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) error {
+
+	if rd.manifest.Destroy.Image == "" {
+		rd.manifest.Destroy.Image = constants.OktetoPipelineRunnerImage
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -1,0 +1,175 @@
+package destroy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	remoteBuild "github.com/okteto/okteto/cmd/build/remote"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+
+	"github.com/okteto/okteto/pkg/cmd/build"
+	"github.com/okteto/okteto/pkg/constants"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/afero"
+)
+
+const (
+	dockerfileTemplate = `
+FROM {{ .OktetoCLIImage }} as okteto-cli
+
+FROM alpine as certs
+RUN apk update && apk add ca-certificates
+
+FROM {{ .UserDestroyImage }} as deploy
+
+ENV PATH="${PATH}:/okteto/bin"
+COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
+
+{{range $key, $val := .OktetoBuildEnvVars }}
+ENV {{$key}} {{$val}}
+{{end}}
+ENV {{ .NamespaceEnvVar }} {{ .NamespaceValue }}
+ENV {{ .ContextEnvVar }} {{ .ContextValue }}
+ENV {{ .TokenEnvVar }} {{ .TokenValue }}
+ENV {{ .RemoteDeployEnvVar }} true
+
+COPY . /okteto/src
+WORKDIR /okteto/src
+
+ENV OKTETO_INVALIDATE_CACHE {{ .RandomInt }}
+RUN okteto destroy
+`
+	dockerignoreName = "deploy.dockerignore"
+	buildOutput      = "deploy"
+)
+
+type dockerfileTemplateProperties struct {
+	OktetoCLIImage     string
+	UserDestroyImage   string
+	OktetoBuildEnvVars map[string]string
+	ContextEnvVar      string
+	ContextValue       string
+	NamespaceEnvVar    string
+	NamespaceValue     string
+	TokenEnvVar        string
+	TokenValue         string
+	RemoteDeployEnvVar string
+	DeployFlags        string
+	RandomInt          int
+}
+
+type remoteDestroyCommand struct {
+	manifest *model.Manifest
+	fs       afero.Fs
+}
+
+func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
+	return &remoteDestroyCommand{
+		manifest: manifest,
+		fs:       afero.NewOsFs(),
+	}
+}
+
+func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("dockerfile").Parse(dockerfileTemplate)
+	if err != nil {
+		return err
+	}
+
+	dockerfileSyntax := dockerfileTemplateProperties{
+		OktetoCLIImage:   constants.OktetoCLIImageForRemote,
+		UserDestroyImage: rd.manifest.Destroy.Image,
+		//OktetoBuildEnvVars: rd.builder.GetBuildEnvVars(),
+		ContextEnvVar:      model.OktetoContextEnvVar,
+		ContextValue:       okteto.Context().Name,
+		NamespaceEnvVar:    model.OktetoNamespaceEnvVar,
+		NamespaceValue:     okteto.Context().Namespace,
+		TokenEnvVar:        model.OktetoTokenEnvVar,
+		TokenValue:         okteto.Context().Token,
+		RemoteDeployEnvVar: constants.OKtetoDeployRemote,
+		RandomInt:          rand.Intn(1000),
+	}
+
+	tmpDir, err := afero.TempDir(rd.fs, "", "")
+	if err != nil {
+		return err
+	}
+
+	dockerfile, err := rd.fs.Create(filepath.Join(tmpDir, "deploy"))
+	if err != nil {
+		return err
+	}
+
+	err = rd.createDockerignoreIfNeeded(cwd, tmpDir)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := rd.fs.Remove(dockerfile.Name()); err != nil {
+			oktetoLog.Infof("error removing dockerfile: %w", err)
+		}
+	}()
+	if err := tmpl.Execute(dockerfile, dockerfileSyntax); err != nil {
+		return err
+	}
+
+	buildInfo := &model.BuildInfo{
+		Dockerfile: dockerfile.Name(),
+	}
+
+	// undo modification of CWD for Build command
+	os.Chdir(cwd)
+
+	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: buildOutput})
+	buildOptions.Tag = ""
+
+	// we need to call Build() method using a remote builder. This Builder will have
+	// the same behavior as the V1 builder but with a different output taking into
+	// account that we must not confuse the user with build messages since this logic is
+	// executed in the deploy command.
+	if err := remoteBuild.NewBuilderFromScratch().Build(ctx, buildOptions); err != nil {
+		fmt.Println(err)
+		return oktetoErrors.UserError{
+			E: fmt.Errorf("Error during development environment deployment."),
+		}
+	}
+	oktetoLog.SetStage("done")
+	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
+
+	return nil
+}
+
+func (rd *remoteDestroyCommand) createDockerignoreIfNeeded(cwd, tmpDir string) error {
+	dockerignoreFilePath := fmt.Sprintf("%s/%s", cwd, dockerignoreName)
+	if _, err := rd.fs.Stat(dockerignoreFilePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	} else {
+		dockerignoreContent, err := afero.ReadFile(rd.fs, dockerignoreFilePath)
+		if err != nil {
+			return err
+		}
+
+		err = afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, dockerignoreName), dockerignoreContent, 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -47,7 +47,7 @@ COPY . /okteto/src
 WORKDIR /okteto/src
 
 ENV OKTETO_INVALIDATE_CACHE {{ .RandomInt }}
-RUN okteto destroy {{ .DestroyFlags }}
+RUN okteto destroy --log-output=json {{ .DestroyFlags }}
 `
 )
 
@@ -148,7 +148,6 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	// account that we must not confuse the user with build messages since this logic is
 	// executed in the deploy command.
 	if err := remoteBuild.NewBuilderFromScratch().Build(ctx, buildOptions); err != nil {
-		fmt.Println(err)
 		return oktetoErrors.UserError{
 			E: fmt.Errorf("Error during development environment deployment."),
 		}
@@ -201,10 +200,6 @@ func getDestroyFlags(opts *Options) []string {
 
 	if opts.ForceDestroy {
 		deployFlags = append(deployFlags, "--force-destroy")
-	}
-
-	if opts.DestroyAll {
-		deployFlags = append(deployFlags, "--all")
 	}
 
 	return deployFlags

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -49,8 +49,6 @@ WORKDIR /okteto/src
 ENV OKTETO_INVALIDATE_CACHE {{ .RandomInt }}
 RUN okteto destroy {{ .DestroyFlags }}
 `
-	dockerignoreName = "deploy.dockerignore"
-	buildOutput      = "deploy"
 )
 
 type dockerfileTemplateProperties struct {
@@ -142,7 +140,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	// undo modification of CWD for Build command
 	os.Chdir(cwd)
 
-	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: buildOutput})
+	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"})
 	buildOptions.Tag = ""
 
 	// we need to call Build() method using a remote builder. This Builder will have
@@ -162,7 +160,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 }
 
 func (rd *remoteDestroyCommand) createDockerignoreIfNeeded(cwd, tmpDir string) error {
-	dockerignoreFilePath := fmt.Sprintf("%s/%s", cwd, dockerignoreName)
+	dockerignoreFilePath := fmt.Sprintf("%s/%s", cwd, ".oktetodeployignore")
 	if _, err := rd.fs.Stat(dockerignoreFilePath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
@@ -173,7 +171,7 @@ func (rd *remoteDestroyCommand) createDockerignoreIfNeeded(cwd, tmpDir string) e
 			return err
 		}
 
-		err = afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, dockerignoreName), dockerignoreContent, 0600)
+		err = afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
 		if err != nil {
 			return err
 		}

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -108,6 +108,43 @@ func RunOktetoDestroy(oktetoPath string, destroyOptions *DestroyOptions) error {
 	return nil
 }
 
+// RunOktetoDestroyRemote runs an okteto destroy command in remote
+func RunOktetoDestroyRemote(oktetoPath string, destroyOptions *DestroyOptions) error {
+	log.Printf("okteto destroy %s", oktetoPath)
+	cmd := exec.Command(oktetoPath, "destroy")
+	cmd.Args = append(cmd.Args, "--remote")
+
+	if destroyOptions.Workdir != "" {
+		cmd.Dir = destroyOptions.Workdir
+	}
+	if destroyOptions.Name != "" {
+		cmd.Args = append(cmd.Args, "--name", destroyOptions.Name)
+	}
+	if destroyOptions.ManifestPath != "" {
+		cmd.Args = append(cmd.Args, "-f", destroyOptions.ManifestPath)
+	}
+	if destroyOptions.Namespace != "" {
+		cmd.Args = append(cmd.Args, "--namespace", destroyOptions.Namespace)
+	}
+	cmd.Env = os.Environ()
+	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))
+	}
+
+	if destroyOptions.OktetoHome != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, destroyOptions.OktetoHome))
+	}
+	if destroyOptions.Token != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, destroyOptions.Token))
+	}
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("okteto deploy --remote failed: %s - %s", string(o), err)
+	}
+	log.Printf("okteto destroy success")
+	return nil
+}
+
 func getDeployCmd(oktetoPath string, deployOptions *DeployOptions) *exec.Cmd {
 	cmd := exec.Command(oktetoPath, "deploy")
 	if deployOptions.Workdir != "" {

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -386,7 +386,7 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 		Namespace:  testNamespace,
 		OktetoHome: dir,
 	}
-	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDestroyRemote(oktetoPath, destroyOptions))
 
 	_, err = integration.GetDeployment(context.Background(), testNamespace, "my-dep", c)
 	require.NoError(t, err)

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -130,11 +130,6 @@ func (t *trace) display() {
 			}
 		}
 		if t.hasCommandLogs(v) {
-			oktetoLog.StopSpinner()
-			logs := strings.Join(v.logs, "")
-			if !strings.HasPrefix(logs, "{") {
-				oktetoLog.Println(logs)
-			}
 			oktetoLog.Spinner("Deploying your development environment...")
 			for _, log := range v.logs {
 				var text oktetoLog.JSONLogFormat

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -115,6 +115,7 @@ func (t trace) display() {
 	for _, v := range t.ongoing {
 		if t.hasCommandLogs(v) {
 			oktetoLog.StopSpinner()
+			oktetoLog.Println(strings.Join(v.logs, ""))
 			for _, log := range v.logs {
 				var text oktetoLog.JSONLogFormat
 				if err := json.Unmarshal([]byte(log), &text); err != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -97,7 +97,7 @@ type Manifest struct {
 	Icon          string                                   `json:"icon,omitempty" yaml:"icon,omitempty"`
 	Deploy        *DeployInfo                              `json:"deploy,omitempty" yaml:"deploy,omitempty"`
 	Dev           ManifestDevs                             `json:"dev,omitempty" yaml:"dev,omitempty"`
-	Destroy       []DeployCommand                          `json:"destroy,omitempty" yaml:"destroy,omitempty"`
+	Destroy       *DestroyInfo                             `json:"destroy,omitempty" yaml:"destroy,omitempty"`
 	Build         ManifestBuild                            `json:"build,omitempty" yaml:"build,omitempty"`
 	Dependencies  ManifestDependencies                     `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 	GlobalForward []forward.GlobalForward                  `json:"forward,omitempty" yaml:"forward,omitempty"`
@@ -183,6 +183,12 @@ type DeployInfo struct {
 	ComposeSection *ComposeSectionInfo `json:"compose,omitempty" yaml:"compose,omitempty"`
 	Endpoints      EndpointSpec        `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
 	Divert         *DivertDeploy       `json:"divert,omitempty" yaml:"divert,omitempty"`
+}
+
+// DestroyInfo represents what must be destroyed for the app
+type DestroyInfo struct {
+	Image    string          `json:"image,omitempty" yaml:"image,omitempty"`
+	Commands []DeployCommand `json:"commands,omitempty" yaml:"commands,omitempty"`
 }
 
 // DivertDeploy represents information about the deploy divert configuration
@@ -864,12 +870,12 @@ func (manifest *Manifest) ExpandEnvVars() error {
 		}
 	}
 	if manifest.Destroy != nil {
-		for idx, cmd := range manifest.Destroy {
+		for idx, cmd := range manifest.Destroy.Commands {
 			cmd.Command, err = envsubst.String(cmd.Command)
 			if err != nil {
 				return errors.New("could not parse env vars")
 			}
-			manifest.Destroy[idx] = cmd
+			manifest.Destroy.Commands[idx] = cmd
 		}
 	}
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -814,6 +814,10 @@ func (m *Manifest) setDefaults() error {
 		}
 	}
 
+	if m.Destroy == nil {
+		m.Destroy = &DestroyInfo{}
+	}
+
 	return nil
 }
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -807,11 +807,6 @@ func (m *Manifest) setDefaults() error {
 			b.setBuildDefaults()
 		}
 	}
-	if m.Deploy != nil {
-		if m.Deploy.Image == "" {
-			m.Deploy.Image = constants.OktetoPipelineRunnerImage
-		}
-	}
 
 	return nil
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -831,6 +831,12 @@ func (m *Manifest) mergeWithOktetoManifest(other *Manifest) {
 func (manifest *Manifest) ExpandEnvVars() error {
 	var err error
 	if manifest.Deploy != nil {
+		if manifest.Deploy.Image != "" {
+			manifest.Deploy.Image, err = envsubst.String(manifest.Deploy.Image)
+			if err != nil {
+				return errors.New("could not parse env vars for an image used for remote deploy")
+			}
+		}
 		if manifest.Deploy.ComposeSection != nil && manifest.Deploy.ComposeSection.Stack != nil {
 			var stackFiles []string
 			for _, composeInfo := range manifest.Deploy.ComposeSection.ComposesInfo {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -137,6 +137,22 @@ func TestManifestExpandDevEnvs(t *testing.T) {
 			manifest:         &Manifest{},
 			expectedManifest: &Manifest{},
 		},
+		{
+			name: "expand image for remote deploy",
+			envs: map[string]string{
+				"myImage": "test",
+			},
+			manifest: &Manifest{
+				Deploy: &DeployInfo{
+					Image: "${myImage}",
+				},
+			},
+			expectedManifest: &Manifest{
+				Deploy: &DeployInfo{
+					Image: "test",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -428,6 +428,7 @@ func TestInferFromStack(t *testing.T) {
 						Stack: stack,
 					},
 				},
+				Destroy: &DestroyInfo{},
 			},
 		},
 		{
@@ -470,7 +471,8 @@ func TestInferFromStack(t *testing.T) {
 						Dockerfile: filepath.Join("test-1", "Dockerfile"),
 					},
 				},
-				Dev: ManifestDevs{},
+				Dev:     ManifestDevs{},
+				Destroy: &DestroyInfo{},
 				Deploy: &DeployInfo{
 					Image: constants.OktetoPipelineRunnerImage,
 					ComposeSection: &ComposeSectionInfo{
@@ -534,6 +536,7 @@ func TestInferFromStack(t *testing.T) {
 						Dockerfile: "Dockerfile",
 					},
 				},
+				Destroy: &DestroyInfo{},
 				Dev: ManifestDevs{
 					"test": &Dev{
 						Name:      "one",
@@ -584,7 +587,6 @@ func TestInferFromStack(t *testing.T) {
 					},
 				},
 				Deploy: &DeployInfo{
-					Image: constants.OktetoPipelineRunnerImage,
 					ComposeSection: &ComposeSectionInfo{
 						Stack: stack,
 					},

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -894,6 +894,10 @@ func (d *DeployCommand) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+func (d *DestroyInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	return nil
+}
+
 func (d *DeployInfo) MarshalYAML() (interface{}, error) {
 	if d.ComposeSection != nil && len(d.ComposeSection.ComposesInfo) != 0 {
 		return d, nil

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -894,10 +894,6 @@ func (d *DeployCommand) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (d *DestroyInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	return nil
-}
-
 func (d *DeployInfo) MarshalYAML() (interface{}, error) {
 	if d.ComposeSection != nil && len(d.ComposeSection.ComposesInfo) != 0 {
 		return d, nil

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -768,7 +768,7 @@ type manifestRaw struct {
 	Icon          string                                   `json:"icon,omitempty" yaml:"icon,omitempty"`
 	Deploy        *DeployInfo                              `json:"deploy,omitempty" yaml:"deploy,omitempty"`
 	Dev           ManifestDevs                             `json:"dev,omitempty" yaml:"dev,omitempty"`
-	Destroy       []DeployCommand                          `json:"destroy,omitempty" yaml:"destroy,omitempty"`
+	Destroy       *DestroyInfo                             `json:"destroy,omitempty" yaml:"destroy,omitempty"`
 	Build         ManifestBuild                            `json:"build,omitempty" yaml:"build,omitempty"`
 	Dependencies  ManifestDependencies                     `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 	GlobalForward []forward.GlobalForward                  `json:"forward,omitempty" yaml:"forward,omitempty"`

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -942,10 +942,6 @@ func (d *DeployInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if deploy.Image == "" {
-		deploy.Image = constants.OktetoPipelineRunnerImage
-	}
-
 	*d = DeployInfo(deploy)
 	return nil
 }

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/kballard/go-shellquote"
-	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/externalresource"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model/forward"
@@ -925,14 +924,12 @@ func (d *DeployInfo) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				Command: cmdString,
 			})
 		}
-		d.Image = constants.OktetoPipelineRunnerImage
 		return nil
 	}
 	var commands []DeployCommand
 	err = unmarshal(&commands)
 	if err == nil {
 		d.Commands = commands
-		d.Image = constants.OktetoPipelineRunnerImage
 		return nil
 	}
 	type deployInfoRaw DeployInfo

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1074,6 +1074,7 @@ deploy:
 						},
 					},
 				},
+				Destroy:      &DestroyInfo{},
 				Dev:          map[string]*Dev{},
 				Dependencies: map[string]*Dependency{},
 				External:     externalresource.ExternalResourceSection{},
@@ -1109,6 +1110,7 @@ dev:
 						},
 					},
 				},
+				Destroy:      &DestroyInfo{},
 				Dependencies: map[string]*Dependency{},
 				External:     externalresource.ExternalResourceSection{},
 				Dev: map[string]*Dev{
@@ -1253,11 +1255,10 @@ dev:
 sync:
   - app:/app`),
 			expected: &Manifest{
-				Type:  OktetoManifestType,
-				Build: map[string]*BuildInfo{},
-				Deploy: &DeployInfo{
-					Image: constants.OktetoPipelineRunnerImage,
-				},
+				Type:          OktetoManifestType,
+				Build:         map[string]*BuildInfo{},
+				Deploy:        &DeployInfo{},
+				Destroy:       &DestroyInfo{},
 				Dependencies:  map[string]*Dependency{},
 				External:      externalresource.ExternalResourceSection{},
 				GlobalForward: []forward.GlobalForward{},
@@ -1339,11 +1340,10 @@ sync:
 services:
   - name: svc`),
 			expected: &Manifest{
-				Type:  OktetoManifestType,
-				Build: map[string]*BuildInfo{},
-				Deploy: &DeployInfo{
-					Image: constants.OktetoPipelineRunnerImage,
-				},
+				Type:          OktetoManifestType,
+				Build:         map[string]*BuildInfo{},
+				Deploy:        &DeployInfo{},
+				Destroy:       &DestroyInfo{},
 				Dependencies:  map[string]*Dependency{},
 				GlobalForward: []forward.GlobalForward{},
 				External:      externalresource.ExternalResourceSection{},
@@ -1478,6 +1478,7 @@ dev:
 				Build:        map[string]*BuildInfo{},
 				Dependencies: map[string]*Dependency{},
 				External:     externalresource.ExternalResourceSection{},
+				Destroy:      &DestroyInfo{},
 				Dev: map[string]*Dev{
 					"test": {
 						Name: "test",
@@ -1565,6 +1566,7 @@ dev:
 				Build:        map[string]*BuildInfo{},
 				Dependencies: map[string]*Dependency{},
 				External:     externalresource.ExternalResourceSection{},
+				Destroy:      &DestroyInfo{},
 				Dev: map[string]*Dev{
 					"test-1": {
 						Name: "test-1",
@@ -1733,6 +1735,7 @@ deploy:
 				Build:        map[string]*BuildInfo{},
 				Dependencies: map[string]*Dependency{},
 				External:     externalresource.ExternalResourceSection{},
+				Destroy:      &DestroyInfo{},
 				Deploy: &DeployInfo{
 					Image: constants.OktetoPipelineRunnerImage,
 					Commands: []DeployCommand{
@@ -1761,6 +1764,7 @@ devs:
 				Build:        map[string]*BuildInfo{},
 				Dependencies: map[string]*Dependency{},
 				External:     externalresource.ExternalResourceSection{},
+				Destroy:      &DestroyInfo{},
 				Deploy: &DeployInfo{
 					Image: constants.OktetoPipelineRunnerImage,
 					Commands: []DeployCommand{
@@ -1848,7 +1852,6 @@ func TestDeployInfoUnmarshalling(t *testing.T) {
 						Command: "okteto stack deploy",
 					},
 				},
-				Image: constants.OktetoPipelineRunnerImage,
 			},
 		},
 		{

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model/forward"
 	"github.com/stretchr/testify/assert"
@@ -1066,7 +1065,6 @@ deploy:
 				Namespace: "test",
 				Build:     map[string]*BuildInfo{},
 				Deploy: &DeployInfo{
-					Image: constants.OktetoPipelineRunnerImage,
 					Commands: []DeployCommand{
 						{
 							Name:    "okteto stack deploy",
@@ -1102,7 +1100,6 @@ dev:
 				Type:  OktetoManifestType,
 				Build: map[string]*BuildInfo{},
 				Deploy: &DeployInfo{
-					Image: constants.OktetoPipelineRunnerImage,
 					Commands: []DeployCommand{
 						{
 							Name:    "okteto stack deploy",
@@ -1737,7 +1734,6 @@ deploy:
 				External:     externalresource.ExternalResourceSection{},
 				Destroy:      &DestroyInfo{},
 				Deploy: &DeployInfo{
-					Image: constants.OktetoPipelineRunnerImage,
 					Commands: []DeployCommand{
 						{
 							Name:    "okteto stack deploy",
@@ -1766,7 +1762,6 @@ devs:
 				External:     externalresource.ExternalResourceSection{},
 				Destroy:      &DestroyInfo{},
 				Deploy: &DeployInfo{
-					Image: constants.OktetoPipelineRunnerImage,
 					Commands: []DeployCommand{
 						{
 							Name:    "okteto stack deploy",
@@ -1817,7 +1812,6 @@ func TestDeployInfoUnmarshalling(t *testing.T) {
 			deployInfoManifest: []byte(`
 - okteto stack deploy`),
 			expected: &DeployInfo{
-				Image: constants.OktetoPipelineRunnerImage,
 				Commands: []DeployCommand{
 					{
 						Name:    "okteto stack deploy",
@@ -1832,7 +1826,6 @@ func TestDeployInfoUnmarshalling(t *testing.T) {
 - name: deploy stack
   command: okteto stack deploy`),
 			expected: &DeployInfo{
-				Image: constants.OktetoPipelineRunnerImage,
 				Commands: []DeployCommand{
 					{
 						Name:    "deploy stack",


### PR DESCRIPTION
# Proposed changes

Fixes # (issue)

- added `destroy` command working in remote if `--remote` flag is added or `destroy.Image` is set
- only run in remote if `--remote` flag or `deploy/destroy.image` are set in manifest
