### PR TITLE
Fixed bug of memory requests/reservations

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -667,8 +667,8 @@ func translateResources(svc *model.Service) apiv1.ResourceRequirements {
 		if svc.Resources.Requests.Memory.Value.Cmp(resource.MustParse("0")) > 0 {
 			if result.Requests == nil {
 				result.Requests = apiv1.ResourceList{}
-				result.Requests[apiv1.ResourceMemory] = svc.Resources.Requests.Memory.Value
 			}
+			result.Requests[apiv1.ResourceMemory] = svc.Resources.Requests.Memory.Value
 		}
 	}
 	return result

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1236,6 +1236,151 @@ func Test_translateServiceEnvironment(t *testing.T) {
 	}
 }
 
+func Test_translateResources(t *testing.T) {
+	tests := []struct {
+		name      string
+		svc       *model.Service
+		resources apiv1.ResourceRequirements
+	}{
+		{
+			name: "svc not defined",
+			svc: &model.Service{
+				Resources: nil,
+			},
+			resources: apiv1.ResourceRequirements{},
+		},
+		{
+			name: "svc Limits CPU defined",
+			svc: &model.Service{
+				Resources: &model.StackResources{
+					Limits: model.ServiceResources{
+						CPU: model.Quantity{Value: resource.MustParse("2")},
+					},
+				},
+			},
+			resources: apiv1.ResourceRequirements{
+				Limits: apiv1.ResourceList{
+					apiv1.ResourceCPU: resource.MustParse("2"),
+				},
+			},
+		},
+		{
+			name: "svc Limits Memory defined",
+			svc: &model.Service{
+				Resources: &model.StackResources{
+					Limits: model.ServiceResources{
+						Memory: model.Quantity{Value: resource.MustParse("5Gi")},
+					},
+				},
+			},
+			resources: apiv1.ResourceRequirements{
+				Limits: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+			},
+		},
+		{
+			name: "svc Limits ALL defined",
+			svc: &model.Service{
+				Resources: &model.StackResources{
+					Limits: model.ServiceResources{
+						CPU:    model.Quantity{Value: resource.MustParse("2")},
+						Memory: model.Quantity{Value: resource.MustParse("5Gi")},
+					},
+				},
+			},
+			resources: apiv1.ResourceRequirements{
+				Limits: apiv1.ResourceList{
+					apiv1.ResourceCPU:    resource.MustParse("2"),
+					apiv1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+			},
+		},
+
+		{
+			name: "svc Requests CPU defined",
+			svc: &model.Service{
+				Resources: &model.StackResources{
+					Requests: model.ServiceResources{
+						CPU: model.Quantity{Value: resource.MustParse("11m")},
+					},
+				},
+			},
+			resources: apiv1.ResourceRequirements{
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceCPU: resource.MustParse("11m"),
+				},
+			},
+		},
+		{
+			name: "svc Requests Memory defined",
+			svc: &model.Service{
+				Resources: &model.StackResources{
+					Requests: model.ServiceResources{
+						Memory: model.Quantity{Value: resource.MustParse("60Mi")},
+					},
+				},
+			},
+			resources: apiv1.ResourceRequirements{
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceMemory: resource.MustParse("60Mi"),
+				},
+			},
+		},
+		{
+			name: "svc Requests ALL defined",
+			svc: &model.Service{
+				Resources: &model.StackResources{
+					Requests: model.ServiceResources{
+						CPU:    model.Quantity{Value: resource.MustParse("11m")},
+						Memory: model.Quantity{Value: resource.MustParse("60Mi")},
+					},
+				},
+			},
+			resources: apiv1.ResourceRequirements{
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceCPU:    resource.MustParse("11m"),
+					apiv1.ResourceMemory: resource.MustParse("60Mi"),
+				},
+			},
+		},
+		{
+			name: "svc ALL defined",
+			svc: &model.Service{
+				Resources: &model.StackResources{
+					Limits: model.ServiceResources{
+						CPU:    model.Quantity{Value: resource.MustParse("2")},
+						Memory: model.Quantity{Value: resource.MustParse("5Gi")},
+					},
+					Requests: model.ServiceResources{
+						CPU:    model.Quantity{Value: resource.MustParse("11m")},
+						Memory: model.Quantity{Value: resource.MustParse("60Mi")},
+					},
+				},
+			},
+			resources: apiv1.ResourceRequirements{
+				Limits: apiv1.ResourceList{
+					apiv1.ResourceCPU:    resource.MustParse("2"),
+					apiv1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+				Requests: apiv1.ResourceList{
+					apiv1.ResourceCPU:    resource.MustParse("11m"),
+					apiv1.ResourceMemory: resource.MustParse("60Mi"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := translateResources(tt.svc)
+			if !reflect.DeepEqual(tt.resources, res) {
+				t.Fatalf("Wrong translation expected %v, got %v", tt.resources, res)
+			}
+		})
+	}
+}
+
 func Test_translateAffinity(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes #3383 

Tested with the two `resources` options allowed: 

```
deploy: 
      resources:
          limits:
            cpus: "2"
            memory: "5Gi"
          reservations:
            cpus: 11m
            memory: 60Mi
```


and 

```
resources:
    limits:
      cpu: "2"
      memory: "5Gi"
    requests:
      cpu: 11m
      memory: 60Mi
```

We should add to the docs the two options, since we just have the second one and docker-compose allows the first one too: 

https://www.okteto.com/docs/reference/compose/#resources-object-optional