### PR TITLE
feat: update to golang to 1.19.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.2.0
+      - image: okteto/golang-ci:2.1.0
 
 jobs:
   build-binaries:
@@ -104,7 +104,7 @@ jobs:
       - checkout
       - run:
           name: Upgrade Golang
-          command: choco upgrade golang --version 1.20
+          command: choco upgrade golang --version 1.19
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -182,7 +182,7 @@ jobs:
       - checkout
       - run:
           name: Upgrade Golang
-          command: choco upgrade golang --version 1.20
+          command: choco upgrade golang --version 1.19
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:1.18.0
+      - image: okteto/golang-ci:2.2.0
 
 jobs:
   build-binaries:
@@ -104,7 +104,7 @@ jobs:
       - checkout
       - run:
           name: Upgrade Golang
-          command: choco upgrade golang --version 1.18
+          command: choco upgrade golang --version 1.20
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -182,7 +182,7 @@ jobs:
       - checkout
       - run:
           name: Upgrade Golang
-          command: choco upgrade golang --version 1.18
+          command: choco upgrade golang --version 1.20
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: 1.20
+  go: 1.19
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
   errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: 1.18
+  go: 1.20
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
   errcheck:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM bitnami/kubectl:1.21.0 as kubectl
 FROM alpine/helm:3.8.0 as helm
 
-FROM golang:1.20-bullseye as builder
+FROM golang:1.19-bullseye as builder
 WORKDIR /okteto
 
 ENV CGO_ENABLED=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM bitnami/kubectl:1.21.0 as kubectl
 FROM alpine/helm:3.8.0 as helm
 
-FROM golang:1.18-buster as builder
+FROM golang:1.20-bullseye as builder
 WORKDIR /okteto
 
 ENV CGO_ENABLED=0

--- a/contributing.md
+++ b/contributing.md
@@ -94,7 +94,7 @@ If a pull request does not have one of these labels checks will fail and PR merg
 
 ## Development Guide
 
-Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.18](https://go.dev/doc/go1.18). It uses go modules for dependency management.
+Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.20](https://go.dev/doc/go1.20). It uses go modules for dependency management.
 
 ### Building
 

--- a/contributing.md
+++ b/contributing.md
@@ -94,7 +94,7 @@ If a pull request does not have one of these labels checks will fail and PR merg
 
 ## Development Guide
 
-Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.20](https://go.dev/doc/go1.20). It uses go modules for dependency management.
+Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.19](https://go.dev/doc/go1.19). It uses go modules for dependency management.
 
 ### Building
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/okteto/okteto
 
-go 1.20
+go 1.19
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/okteto/okteto
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1


### PR DESCRIPTION
Okteto was using 1.18 but it was deprecated 15 days ago. This PR focus on using the latest Go version.

## Proposed changes
- Use Go 1.19.5 as the go version for CLI project

