### PR TITLE
Revert "feat: update to golang to 1.19.5 (#3397)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.1.0
+      - image: okteto/golang-ci:1.18.0
 
 jobs:
   build-binaries:
@@ -104,7 +104,7 @@ jobs:
       - checkout
       - run:
           name: Upgrade Golang
-          command: choco upgrade golang --version 1.19
+          command: choco upgrade golang --version 1.18
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -182,7 +182,7 @@ jobs:
       - checkout
       - run:
           name: Upgrade Golang
-          command: choco upgrade golang --version 1.19
+          command: choco upgrade golang --version 1.18
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: 1.19
+  go: 1.18
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
   errcheck:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add curl && \
     apk add --no-cache openssl && \
     bash <( curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 ) "--version" "v${HELM_VERSION}"
 
-FROM golang:1.19-bullseye as builder
+FROM golang:1.18-buster as builder
 WORKDIR /okteto
 
 ENV CGO_ENABLED=0

--- a/contributing.md
+++ b/contributing.md
@@ -94,7 +94,7 @@ If a pull request does not have one of these labels checks will fail and PR merg
 
 ## Development Guide
 
-Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.19](https://go.dev/doc/go1.19). It uses go modules for dependency management.
+Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.18](https://go.dev/doc/go1.18). It uses go modules for dependency management.
 
 ### Building
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/okteto/okteto
 
-go 1.19
+go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1


### PR DESCRIPTION
This reverts commit 37dcce6f8f9725ab19ad5355d3e73d8f2427867e (#3397).

# Proposed changes

- Reverts changes that are causing [failures on windows e2e test trying to find a port](https://app.circleci.com/pipelines/github/okteto/okteto/9490/workflows/ed286ff0-e214-485d-9ff5-87bfcd3eeb4e/jobs/27624) 

