### PR TITLE
Implement `kubetoken` command for k8s client authentication

### DIFF
--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -50,7 +50,7 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return errors.ErrContextIsNotOktetoCluster
 		}
 
-		c, err := okteto.NewKubeTokenClient()
+		c, err := okteto.NewKubeTokenClient(okteto.Context().Name, okteto.Context().Token)
 		if err != nil {
 			return fmt.Errorf("failed to initialize the kubetoken client: %w", err)
 		}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -19,8 +19,6 @@ import (
 	"os"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
-	"github.com/okteto/okteto/pkg/config"
-	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -29,23 +27,20 @@ import (
 
 func KubeToken() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kubetoken",
+		Use:   "kubetoken [context]",
 		Short: "Print Kubernetes cluster credentials in ExecCredential format.",
 		Long: `Print Kubernetes cluster credentials in ExecCredential format.
 You can find more information on 'ExecCredential' and 'client side authentication' at (https://kubernetes.io/docs/reference/config-api/client-authentication.v1/) and  https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins`,
 		Hidden: true,
+		Args:   cobra.ExactArgs(1),
 	}
 
-	cmd.RunE = func(*cobra.Command, []string) error {
+	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		ctx := context.Background()
-
-		cfg := kubeconfig.Get(config.GetKubeconfigPath())
-		if cfg == nil {
-			return fmt.Errorf("failed to get the kubeconfig file. Please, check that your kubeconfig file is valid and in path")
-		}
+		context := args[0]
 
 		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{
-			Context: cfg.CurrentContext,
+			Context: context,
 		})
 		if err != nil {
 			return err

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -29,8 +29,10 @@ import (
 
 func KubeToken() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "kubetoken",
-		Short:  "Gets a token to access the Kubernetes API with client authentication",
+		Use:   "kubetoken",
+		Short: "Print Kubernetes cluster credentials in ExecCredential format.",
+		Long: `Print Kubernetes cluster credentials in ExecCredential format.
+You can find more information on 'ExecCredential' and 'client side authentication' at (https://kubernetes.io/docs/reference/config-api/client-authentication.v1/) and  https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins`,
 		Hidden: true,
 	}
 

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -22,8 +22,9 @@ import (
 
 func KubeToken() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kubetoken",
-		Short: "Gets a token to access the Kubernetes API with client authentication",
+		Use:    "kubetoken",
+		Short:  "Gets a token to access the Kubernetes API with client authentication",
+		Hidden: true,
 	}
 
 	cmd.RunE = func(*cobra.Command, []string) error {

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -14,7 +14,10 @@
 package kubetoken
 
 import (
+	"context"
 	"fmt"
+
+	contextCMD "github.com/okteto/okteto/cmd/context"
 
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
@@ -28,6 +31,13 @@ func KubeToken() *cobra.Command {
 	}
 
 	cmd.RunE = func(*cobra.Command, []string) error {
+		ctx := context.Background()
+
+		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{})
+		if err != nil {
+			return err
+		}
+
 		c, err := okteto.NewKubeTokenClient()
 		if err != nil {
 			return fmt.Errorf("failed to initialize the kubetoken client: %w", err)

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -1,0 +1,32 @@
+package kubetoken
+
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/cobra"
+)
+
+func KubeToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kubetoken",
+		Short: "Gets a token to access the Kubernetes API with client authentication",
+	}
+
+	cmd.RunE = func(*cobra.Command, []string) error {
+		c, err := okteto.NewKubeTokenClient()
+		if err != nil {
+			return fmt.Errorf("failed to initialize the kubetoken client: %w", err)
+		}
+
+		out, err := c.GetKubeToken()
+		if err != nil {
+			return fmt.Errorf("failed to get the kubetoken: %w", err)
+		}
+
+		cmd.Print(out)
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kubetoken
 
 import (

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -27,20 +27,22 @@ import (
 
 func KubeToken() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kubetoken [context]",
+		Use:   "kubetoken <context> <namespace>",
 		Short: "Print Kubernetes cluster credentials in ExecCredential format.",
 		Long: `Print Kubernetes cluster credentials in ExecCredential format.
 You can find more information on 'ExecCredential' and 'client side authentication' at (https://kubernetes.io/docs/reference/config-api/client-authentication.v1/) and  https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins`,
 		Hidden: true,
-		Args:   cobra.ExactArgs(1),
+		Args:   cobra.ExactArgs(2),
 	}
 
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		ctx := context.Background()
 		context := args[0]
+		namespace := args[1]
 
 		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{
-			Context: context,
+			Context:   context,
+			Namespace: namespace,
 		})
 		if err != nil {
 			return err
@@ -50,7 +52,7 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return errors.ErrContextIsNotOktetoCluster
 		}
 
-		c, err := okteto.NewKubeTokenClient(okteto.Context().Name, okteto.Context().Token)
+		c, err := okteto.NewKubeTokenClient(okteto.Context().Name, okteto.Context().Token, namespace)
 		if err != nil {
 			return fmt.Errorf("failed to initialize the kubetoken client: %w", err)
 		}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -19,6 +19,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 
+	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +37,10 @@ func KubeToken() *cobra.Command {
 		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{})
 		if err != nil {
 			return err
+		}
+
+		if !okteto.Context().IsOkteto {
+			return errors.ErrContextIsNotOktetoCluster
 		}
 
 		c, err := okteto.NewKubeTokenClient()

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -19,6 +19,8 @@ import (
 	"os"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
+	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -35,7 +37,14 @@ func KubeToken() *cobra.Command {
 	cmd.RunE = func(*cobra.Command, []string) error {
 		ctx := context.Background()
 
-		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{})
+		cfg := kubeconfig.Get(config.GetKubeconfigPath())
+		if cfg == nil {
+			return fmt.Errorf("failed to get the kubeconfig file. Please, check that your kubeconfig file is valid and in path")
+		}
+
+		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{
+			Context: cfg.CurrentContext,
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -16,6 +16,7 @@ package kubetoken
 import (
 	"context"
 	"fmt"
+	"os"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 
@@ -56,6 +57,8 @@ func KubeToken() *cobra.Command {
 		cmd.Print(out)
 		return nil
 	}
+
+	cmd.SetOut(os.Stdout)
 
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
 	"github.com/okteto/okteto/cmd/destroy"
+	"github.com/okteto/okteto/cmd/kubetoken"
 	"github.com/okteto/okteto/cmd/logs"
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/pipeline"
@@ -117,6 +118,7 @@ func main() {
 	root.AddCommand(cmd.Login())
 	root.AddCommand(contextCMD.Context())
 	root.AddCommand(cmd.Kubeconfig())
+	root.AddCommand(kubetoken.KubeToken())
 	root.AddCommand(build.Build(ctx))
 
 	root.AddCommand(namespace.Namespace(ctx))

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -161,6 +161,10 @@ func newOktetoClientFromGraphqlClient(url string, httpClient *http.Client) (*Okt
 }
 
 func parseOktetoURL(u string) (string, error) {
+	return parseOktetoURLWithPath(u, "graphql")
+}
+
+func parseOktetoURLWithPath(u, path string) (string, error) {
 	if u == "" {
 		return "", fmt.Errorf("the okteto URL is not set")
 	}
@@ -175,7 +179,7 @@ func parseOktetoURL(u string) (string, error) {
 		parsed.Host = parsed.Path
 	}
 
-	parsed.Path = "graphql"
+	parsed.Path = path
 	return parsed.String(), nil
 }
 

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -61,13 +61,21 @@ func (*OktetoClientProvider) Provide() (types.OktetoInterface, error) {
 
 // NewOktetoClient creates a new client to connect with Okteto API
 func NewOktetoClient() (*OktetoClient, error) {
-	token := Context().Token
-	if token == "" {
-		return nil, fmt.Errorf(oktetoErrors.ErrNotLogged, Context().Name)
-	}
-	u, err := parseOktetoURL(Context().Name)
+	httpClient, u, err := newOktetoHttpClient(Context().Name, Context().Token, "graphql")
 	if err != nil {
 		return nil, err
+	}
+
+	return newOktetoClientFromGraphqlClient(u, httpClient)
+}
+
+func newOktetoHttpClient(contextName, token, oktetoUrlPath string) (*http.Client, string, error) {
+	if token == "" {
+		return nil, "", fmt.Errorf(oktetoErrors.ErrNotLogged, contextName)
+	}
+	u, err := parseOktetoURLWithPath(contextName, oktetoUrlPath)
+	if err != nil {
+		return nil, "", err
 	}
 
 	src := oauth2.StaticTokenSource(
@@ -87,7 +95,7 @@ func NewOktetoClient() (*OktetoClient, error) {
 
 	httpClient := oauth2.NewClient(ctx, src)
 
-	return newOktetoClientFromGraphqlClient(u, httpClient)
+	return httpClient, u, err
 }
 
 // NewOktetoClientFromUrlAndToken creates a new client to connect with Okteto API provided url and token

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package okteto
 
 import (

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -75,6 +75,10 @@ func (c *kubeTokenClient) GetKubeToken() (string, error) {
 		return "", fmt.Errorf("failed GET request: %w", err)
 	}
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", fmt.Errorf(oktetoErrors.ErrNotLogged, Context().Name)
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("GET request returned status %s", resp.Status)
 	}

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -1,0 +1,75 @@
+package okteto
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoHttp "github.com/okteto/okteto/pkg/http"
+	"golang.org/x/oauth2"
+)
+
+const kubetokenPath = "auth/kubetoken"
+
+type kubeTokenClient struct {
+	httpClient *http.Client
+	url        string
+}
+
+func NewKubeTokenClient() (*kubeTokenClient, error) {
+	token := Context().Token
+	if token == "" {
+		return nil, fmt.Errorf(oktetoErrors.ErrNotLogged, Context().Name)
+	}
+	u := Context().Name
+	if u == "" {
+		return nil, fmt.Errorf("the okteto URL is not set")
+	}
+
+	parsed, err := parseOktetoURLWithPath(u, kubetokenPath)
+	if err != nil {
+		return nil, err
+	}
+
+	src := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token,
+			TokenType: "Bearer"},
+	)
+
+	ctxHttpClient := http.DefaultClient
+
+	if insecureSkipTLSVerify {
+		ctxHttpClient = oktetoHttp.InsecureHTTPClient()
+	} else if cert, err := GetContextCertificate(); err == nil {
+		ctxHttpClient = oktetoHttp.StrictSSLHTTPClient(cert)
+	}
+
+	ctx := contextWithOauth2HttpClient(context.Background(), ctxHttpClient)
+
+	httpClient := oauth2.NewClient(ctx, src)
+
+	return &kubeTokenClient{
+		httpClient: httpClient,
+		url:        parsed,
+	}, nil
+}
+
+func (c *kubeTokenClient) GetKubeToken() (string, error) {
+	resp, err := c.httpClient.Get(c.url)
+	if err != nil {
+		return "", fmt.Errorf("failed GET request: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GET request returned status %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read kubetoken response: %w", err)
+	}
+
+	return string(body), nil
+}

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -29,12 +29,12 @@ type KubeTokenClient struct {
 	contextName string
 }
 
-func NewKubeTokenClient(contextName, token string) (*KubeTokenClient, error) {
+func NewKubeTokenClient(contextName, token, namespace string) (*KubeTokenClient, error) {
 	if contextName == "" {
 		return nil, oktetoErrors.ErrCtxNotSet
 	}
 
-	httpClient, url, err := newOktetoHttpClient(contextName, token, kubetokenPath)
+	httpClient, url, err := newOktetoHttpClient(contextName, token, fmt.Sprintf("%s/%s", kubetokenPath, namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -26,12 +26,12 @@ import (
 
 const kubetokenPath = "auth/kubetoken"
 
-type kubeTokenClient struct {
+type KubeTokenClient struct {
 	httpClient *http.Client
 	url        string
 }
 
-func NewKubeTokenClient() (*kubeTokenClient, error) {
+func NewKubeTokenClient() (*KubeTokenClient, error) {
 	token := Context().Token
 	if token == "" {
 		return nil, fmt.Errorf(oktetoErrors.ErrNotLogged, Context().Name)
@@ -63,13 +63,13 @@ func NewKubeTokenClient() (*kubeTokenClient, error) {
 
 	httpClient := oauth2.NewClient(ctx, src)
 
-	return &kubeTokenClient{
+	return &KubeTokenClient{
 		httpClient: httpClient,
 		url:        parsed,
 	}, nil
 }
 
-func (c *kubeTokenClient) GetKubeToken() (string, error) {
+func (c *KubeTokenClient) GetKubeToken() (string, error) {
 	resp, err := c.httpClient.Get(c.url)
 	if err != nil {
 		return "", fmt.Errorf("failed GET request: %w", err)

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -37,7 +37,7 @@ func NewKubeTokenClient(contextName, token string) (*KubeTokenClient, error) {
 		return nil, fmt.Errorf(oktetoErrors.ErrNotLogged, contextName)
 	}
 	if contextName == "" {
-		return nil, fmt.Errorf("the okteto URL is not set")
+		return nil, oktetoErrors.ErrCtxNotSet
 	}
 
 	parsed, err := parseOktetoURLWithPath(contextName, kubetokenPath)

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -72,12 +72,30 @@ func TestGetKubeToken(t *testing.T) {
 	defer s.Close()
 
 	c := &KubeTokenClient{
-		httpClient:  s.Client(),
-		url:         s.URL,
-		contextName: "test",
+		httpClient: s.Client(),
+		url:        s.URL,
 	}
 
 	token, err := c.GetKubeToken()
 	require.NoError(t, err)
 	require.Equal(t, expectedToken, token)
+}
+
+func TestGetKubeTokenUnauthorizedErr(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+
+	defer s.Close()
+
+	context := "testctx"
+
+	c := &KubeTokenClient{
+		httpClient:  s.Client(),
+		url:         s.URL,
+		contextName: context,
+	}
+
+	_, err := c.GetKubeToken()
+	require.Equal(t, fmt.Errorf(oktetoErrors.ErrNotLogged, context), err)
 }

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -42,7 +42,7 @@ func TestNewKubeTokenClient(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
-			client, err := NewKubeTokenClient(tc.contextName, tc.token)
+			client, err := NewKubeTokenClient(tc.contextName, tc.token, "test")
 
 			require.Equal(t, tc.expectedError, err)
 			require.Equal(t, tc.expectedClient, client)
@@ -52,17 +52,17 @@ func TestNewKubeTokenClient(t *testing.T) {
 	t.Run("Parse error", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewKubeTokenClient("not!!://a.url", "mytoken")
+		_, err := NewKubeTokenClient("not!!://a.url", "mytoken", "test")
 		require.Error(t, err)
 	})
 
 	t.Run("No error", func(t *testing.T) {
 		t.Parallel()
 
-		client, err := NewKubeTokenClient("cloud.okteto.com", "mytoken")
+		client, err := NewKubeTokenClient("cloud.okteto.com", "mytoken", "testns")
 		require.NoError(t, err)
 
-		require.Equal(t, "https://cloud.okteto.com/auth/kubetoken", client.url)
+		require.Equal(t, "https://cloud.okteto.com/auth/kubetoken/testns", client.url)
 		require.Equal(t, "cloud.okteto.com", client.contextName)
 	})
 }

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNewKubeTokenClient(t *testing.T) {
+	t.Parallel()
+
 	tt := []struct {
 		testName       string
 		contextName    string
@@ -36,7 +38,10 @@ func TestNewKubeTokenClient(t *testing.T) {
 	}
 
 	for _, tc := range tt {
+		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+
 			client, err := NewKubeTokenClient(tc.contextName, tc.token)
 
 			require.Equal(t, tc.expectedError, err)
@@ -45,24 +50,26 @@ func TestNewKubeTokenClient(t *testing.T) {
 	}
 
 	t.Run("Parse error", func(t *testing.T) {
+		t.Parallel()
 
 		_, err := NewKubeTokenClient("not!!://a.url", "mytoken")
 		require.Error(t, err)
-	},
-	)
+	})
 
 	t.Run("No error", func(t *testing.T) {
+		t.Parallel()
 
 		client, err := NewKubeTokenClient("cloud.okteto.com", "mytoken")
 		require.NoError(t, err)
 
 		require.Equal(t, "https://cloud.okteto.com/auth/kubetoken", client.url)
 		require.Equal(t, "cloud.okteto.com", client.contextName)
-	},
-	)
+	})
 }
 
 func TestGetKubeToken(t *testing.T) {
+	t.Parallel()
+
 	expectedToken := "token"
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -82,6 +89,8 @@ func TestGetKubeToken(t *testing.T) {
 }
 
 func TestGetKubeTokenUnauthorizedErr(t *testing.T) {
+	t.Parallel()
+
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -2,6 +2,8 @@ package okteto
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -58,4 +60,24 @@ func TestNewKubeTokenClient(t *testing.T) {
 		require.Equal(t, "cloud.okteto.com", client.contextName)
 	},
 	)
+}
+
+func TestGetKubeToken(t *testing.T) {
+	expectedToken := "token"
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(expectedToken))
+	}))
+
+	defer s.Close()
+
+	c := &KubeTokenClient{
+		httpClient:  s.Client(),
+		url:         s.URL,
+		contextName: "test",
+	}
+
+	token, err := c.GetKubeToken()
+	require.NoError(t, err)
+	require.Equal(t, expectedToken, token)
 }

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -1,0 +1,61 @@
+package okteto
+
+import (
+	"fmt"
+	"testing"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKubeTokenClient(t *testing.T) {
+	tt := []struct {
+		testName       string
+		contextName    string
+		token          string
+		expectedError  error
+		expectedClient *KubeTokenClient
+	}{
+		{
+
+			testName:       "No token",
+			contextName:    "test",
+			token:          "",
+			expectedError:  fmt.Errorf(oktetoErrors.ErrNotLogged, "test"),
+			expectedClient: nil,
+		},
+		{
+			testName:       "No context",
+			contextName:    "",
+			token:          "test",
+			expectedError:  oktetoErrors.ErrCtxNotSet,
+			expectedClient: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.testName, func(t *testing.T) {
+			client, err := NewKubeTokenClient(tc.contextName, tc.token)
+
+			require.Equal(t, tc.expectedError, err)
+			require.Equal(t, tc.expectedClient, client)
+		})
+	}
+
+	t.Run("Parse error", func(t *testing.T) {
+
+		_, err := NewKubeTokenClient("not!!://a.url", "mytoken")
+		require.Error(t, err)
+	},
+	)
+
+	t.Run("No error", func(t *testing.T) {
+
+		client, err := NewKubeTokenClient("cloud.okteto.com", "mytoken")
+		require.NoError(t, err)
+
+		require.Equal(t, "https://cloud.okteto.com/auth/kubetoken", client.url)
+		require.Equal(t, "cloud.okteto.com", client.contextName)
+	},
+	)
+}


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/5793

Added a `kubetoken` command that uses a new client for getting the `/auth/kubeconfig` endpoint

I didn't want to make too much noise, but `pkg/okteto/client.go` could be refactored a bit. 
Also, I've found unit testing hard due to the dependency of okteto context. If you find that it's valuable, I could add a bit of unit testing in the cobra command for the `RunE` function and the kubetoken client