### PR TITLE
Run okteto init v1 for vanilla clusters

### DIFF
--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -24,8 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/okteto/okteto/cmd/manifest"
 	"github.com/okteto/okteto/cmd/utils"
+	initCMD "github.com/okteto/okteto/pkg/cmd/init"
 	"github.com/okteto/okteto/pkg/config"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/filesystem"
@@ -176,7 +176,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 		return nil
 	}
 
-	language, err := manifest.GetLanguage("", folder)
+	language, err := initCMD.GetLanguage("", folder)
 	if err != nil {
 		return fmt.Errorf("failed to get language for '%s': %s", folder, err.Error())
 	}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -29,9 +29,9 @@ import (
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
-	"github.com/okteto/okteto/cmd/manifest"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	initCMD "github.com/okteto/okteto/pkg/cmd/init"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	"github.com/okteto/okteto/pkg/discovery"
@@ -183,13 +183,13 @@ func Up() *cobra.Command {
 					return err
 				}
 				if answer {
-					mc := &manifest.ManifestCommand{
+					mc := &initCMD.ManifestCommand{
 						K8sClientProvider: okteto.NewK8sClientProvider(),
 					}
 					if upOptions.ManifestPath == "" {
 						upOptions.ManifestPath = utils.DefaultManifest
 					}
-					oktetoManifest, err = mc.RunInitV2(ctx, &manifest.InitOpts{
+					oktetoManifest, err = mc.RunInitV2(ctx, &initCMD.InitOpts{
 						DevPath:          upOptions.ManifestPath,
 						Namespace:        upOptions.Namespace,
 						Context:          upOptions.K8sContext,
@@ -425,10 +425,10 @@ func LoadManifestWithInit(ctx context.Context, k8sContext, namespace, devPath st
 		return nil, err
 	}
 
-	mc := &manifest.ManifestCommand{
+	mc := &initCMD.ManifestCommand{
 		K8sClientProvider: okteto.NewK8sClientProvider(),
 	}
-	manifest, err := mc.RunInitV2(ctx, &manifest.InitOpts{DevPath: devPath, ShowCTA: false, Workdir: dir})
+	manifest, err := mc.RunInitV2(ctx, &initCMD.InitOpts{DevPath: devPath, ShowCTA: false, Workdir: dir})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -32,8 +32,9 @@ const (
 // UpdateDeprecated checks if there is a new version available and updates it
 func UpdateDeprecated() *cobra.Command {
 	return &cobra.Command{
-		Use:   "update",
-		Short: "Update Okteto CLI version",
+		Use:    "update",
+		Short:  "Update Okteto CLI version",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto update' is deprecated in favor of 'okteto version update', and will be removed in a future version")
 			currentVersion, err := semver.NewVersion(config.VersionString)

--- a/main.go
+++ b/main.go
@@ -95,8 +95,8 @@ func main() {
 
 	root := &cobra.Command{
 		Use:           fmt.Sprintf("%s COMMAND [ARG...]", config.GetBinaryName()),
-		Short:         "Okteto - Remote Development Environments powered by Kubernetes",
-		Long:          "Okteto - Remote Development Environments powered by Kubernetes",
+		Short:         "Okteto - Remote Development Environments on Kubernetes",
+		Long:          "Okteto - Remote Development Environments on Kubernetes",
 		SilenceErrors: true,
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			ccmd.SilenceUsage = true

--- a/pkg/cmd/init/init-v1.go
+++ b/pkg/cmd/init/init-v1.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manifest
+package init
 
 import (
 	"context"
@@ -23,7 +23,6 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
-	initCMD "github.com/okteto/okteto/pkg/cmd/init"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/k8s/apps"
@@ -131,7 +130,7 @@ func (*ManifestCommand) RunInitV1(ctx context.Context, opts *InitOpts) error {
 			suffix := fmt.Sprintf("Analyzing %s '%s'...", strings.ToLower(app.Kind()), app.ObjectMeta().Name)
 			oktetoLog.Spinner(suffix)
 			oktetoLog.StartSpinner()
-			err = initCMD.SetDevDefaultsFromApp(ctx, dev, app, container, opts.Language, path)
+			err = SetDevDefaultsFromApp(ctx, dev, app, container, opts.Language, path)
 			if err == nil {
 				oktetoLog.Success(fmt.Sprintf("%s '%s' successfully analyzed", strings.ToLower(app.Kind()), app.ObjectMeta().Name))
 			} else {

--- a/pkg/cmd/init/init-v1_test.go
+++ b/pkg/cmd/init/init-v1_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manifest
+package init
 
 import (
 	"context"

--- a/pkg/cmd/init/selector.go
+++ b/pkg/cmd/init/selector.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manifest
+package init
 
 import (
 	"fmt"

--- a/pkg/cmd/init/selector_test.go
+++ b/pkg/cmd/init/selector_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manifest
+package init
 
 import (
 	"testing"


### PR DESCRIPTION
# Proposed changes

This PR does the following things:

- Run `okteto init --v1` automatically for clusters without the server-side component of okteto. This is because `build` and `deploy` don't work well in vanilla clusters and they are going to be deprecated in Okteto CLI 3.0
- Remove unused code from the `cmd/manifest` package
- Set some options as `hidden`