### PR TITLE
fixes remote feature

### DIFF
--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -260,7 +260,7 @@ func (ld *localDeployer) runDeploySection(ctx context.Context, opts *Options) er
 	}
 
 	// deploy externals if any
-	if opts.Manifest.External != nil {
+	if len(opts.Manifest.External) > 0 {
 		oktetoLog.SetStage("External configuration")
 		if !okteto.IsOkteto() {
 			oktetoLog.Warning("external resources cannot be deployed on a cluster not managed by okteto")

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -108,7 +108,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	}
 
 	dockerfileSyntax := dockerfileTemplateProperties{
-		OktetoCLIImage:     getOktetoCLIVersion(),
+		OktetoCLIImage:     getOktetoCLIVersion(config.VersionString),
 		UserDeployImage:    deployOptions.Manifest.Deploy.Image,
 		OktetoBuildEnvVars: rd.builder.GetBuildEnvVars(),
 		ContextEnvVar:      model.OktetoContextEnvVar,
@@ -227,10 +227,10 @@ func getOriginalCWD(cwd, manifestPath string) string {
 	return strings.TrimSuffix(cwd, manifestPathDir)
 }
 
-func getOktetoCLIVersion() string {
+func getOktetoCLIVersion(versionString string) string {
 	var version string
-	if match, _ := regexp.MatchString(`\d+\.\d+\.\d+`, config.VersionString); match {
-		version = fmt.Sprintf(constants.OktetoCLIImageForRemoteTemplate, config.VersionString)
+	if match, _ := regexp.MatchString(`\d+\.\d+\.\d+`, versionString); match {
+		version = fmt.Sprintf(constants.OktetoCLIImageForRemoteTemplate, versionString)
 	} else {
 		remoteOktetoImage := os.Getenv(constants.OKtetoDeployRemoteImage)
 		if remoteOktetoImage != "" {

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -229,7 +229,7 @@ func getOriginalCWD(cwd, manifestPath string) string {
 
 func getOktetoCLIVersion() string {
 	var version string
-	if match, _ := regexp.MatchString("\\d+\\.\\d+\\.\\d+", config.VersionString); match {
+	if match, _ := regexp.MatchString(`\d+\.\d+\.\d+`, config.VersionString); match {
 		version = fmt.Sprintf(constants.OktetoCLIImageForRemoteTemplate, config.VersionString)
 	} else {
 		remoteOktetoImage := os.Getenv(constants.OKtetoDeployRemoteImage)

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -1,0 +1,51 @@
+package deploy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getOktetoCLIVersion(t *testing.T) {
+	var tests = []struct {
+		name                                 string
+		versionString, expected, cliImageEnv string
+	}{
+		{
+			name:          "no version string and no env return latest",
+			versionString: "",
+			expected:      "okteto/okteto:latest",
+		},
+		{
+			name:          "no version string return env value",
+			versionString: "",
+			cliImageEnv:   "okteto/remote:test",
+			expected:      "okteto/remote:test",
+		},
+		{
+			name:          "found version string",
+			versionString: "2.2.2",
+			expected:      "okteto/okteto:2.2.2",
+		},
+		{
+			name:          "found incorrect version string return latest ",
+			versionString: "2.a.2",
+			expected:      "okteto/okteto:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cliImageEnv != "" {
+				os.Setenv(constants.OKtetoDeployRemoteImage, tt.cliImageEnv)
+				defer os.Unsetenv(constants.OKtetoDeployRemoteImage)
+			}
+
+			version := getOktetoCLIVersion(tt.versionString)
+			require.Equal(t, version, tt.expected)
+		})
+	}
+}

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -98,7 +98,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	}
 
 	dockerfileSyntax := dockerfileTemplateProperties{
-		OktetoCLIImage:     getOktetoCLIVersion(),
+		OktetoCLIImage:     getOktetoCLIVersion(config.VersionString),
 		UserDestroyImage:   rd.manifest.Destroy.Image,
 		ContextEnvVar:      model.OktetoContextEnvVar,
 		ContextValue:       okteto.Context().Name,
@@ -207,10 +207,10 @@ func getDestroyFlags(opts *Options) []string {
 	return deployFlags
 }
 
-func getOktetoCLIVersion() string {
+func getOktetoCLIVersion(versionString string) string {
 	var version string
-	if match, _ := regexp.MatchString(`\d+\.\d+\.\d+`, config.VersionString); match {
-		version = fmt.Sprintf(constants.OktetoCLIImageForRemoteTemplate, config.VersionString)
+	if match, _ := regexp.MatchString(`\d+\.\d+\.\d+`, versionString); match {
+		version = fmt.Sprintf(constants.OktetoCLIImageForRemoteTemplate, versionString)
 	} else {
 		remoteOktetoImage := os.Getenv(constants.OKtetoDeployRemoteImage)
 		if remoteOktetoImage != "" {

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -209,7 +209,7 @@ func getDestroyFlags(opts *Options) []string {
 
 func getOktetoCLIVersion() string {
 	var version string
-	if match, _ := regexp.MatchString("\\d+\\.\\d+\\.\\d+", config.VersionString); match {
+	if match, _ := regexp.MatchString(`\d+\.\d+\.\d+`, config.VersionString); match {
 		version = fmt.Sprintf(constants.OktetoCLIImageForRemoteTemplate, config.VersionString)
 	} else {
 		remoteOktetoImage := os.Getenv(constants.OKtetoDeployRemoteImage)

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -1,0 +1,51 @@
+package destroy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getOktetoCLIVersion(t *testing.T) {
+	var tests = []struct {
+		name                                 string
+		versionString, expected, cliImageEnv string
+	}{
+		{
+			name:          "no version string and no env return latest",
+			versionString: "",
+			expected:      "okteto/okteto:latest",
+		},
+		{
+			name:          "no version string return env value",
+			versionString: "",
+			cliImageEnv:   "okteto/remote:test",
+			expected:      "okteto/remote:test",
+		},
+		{
+			name:          "found version string",
+			versionString: "2.2.2",
+			expected:      "okteto/okteto:2.2.2",
+		},
+		{
+			name:          "found incorrect version string return latest ",
+			versionString: "2.a.2",
+			expected:      "okteto/okteto:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.cliImageEnv != "" {
+				os.Setenv(constants.OKtetoDeployRemoteImage, tt.cliImageEnv)
+				defer os.Unsetenv(constants.OKtetoDeployRemoteImage)
+			}
+
+			version := getOktetoCLIVersion(tt.versionString)
+			require.Equal(t, version, tt.expected)
+		})
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,8 +53,11 @@ const (
 	// OKtetoDeployRemote defines if deployment is executed remotely
 	OKtetoDeployRemote = "OKTETO_DEPLOY_REMOTE"
 
-	// OktetoCLIImageForRemote defines okteto CLI image to use for remote deployments
-	OktetoCLIImageForRemote = "okteto/okteto:remote-deploy"
+	// OKtetoDeployRemoteImage defines okteto cli image used for deploy an evironment remotely
+	OKtetoDeployRemoteImage = "OKTETO_REMOTE_CLI_IMAGE"
+
+	// OktetoCLIImageForRemoteTemplate defines okteto CLI image template to use for remote deployments
+	OktetoCLIImageForRemoteTemplate = "okteto/okteto:%s"
 
 	// OktetoPipelineRunnerImage defines image to use for remote deployments if empty
 	OktetoPipelineRunnerImage = "okteto/installer:1.7.6"


### PR DESCRIPTION
## Proposed changes
- e4913dfb08ea07272a6e8f7be5f062db37402134: check if there is any external using `len(external) > 0` instead `external != nil`, this will allow us to now display `external resources cannot be deployed on a cluster not managed by okteto` when is not needed 
- b3b70666c6e3f1b4ba4c2391b23c141a3c8b611d: automate cli version used in remote deploy/destroy