### PR TITLE
fix(cli): broken docs urls

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -31,7 +31,7 @@ func Login() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "login [url]",
-		Args:   utils.MaximumNArgsAccepted(1, "https://www.okteto.com/docs/0.10/reference/cli/#login"),
+		Args:   utils.MaximumNArgsAccepted(1, "https://www.okteto.com/docs/reference/cli/#context"),
 		Short:  "Log into Okteto",
 		Long: `Log into Okteto
 

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -116,7 +116,7 @@ func Init() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Context, "context", "c", "", "context target for generating the okteto manifest")
 	cmd.Flags().StringVarP(&opts.DevPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
 	cmd.Flags().BoolVarP(&opts.Overwrite, "replace", "r", false, "overwrite existing manifest file")
-	cmd.Flags().BoolVarP(&opts.Version1, "v1", "", false, "create a v1 okteto manifest: https://www.okteto.com/docs/0.10/reference/manifest/")
+	cmd.Flags().BoolVarP(&opts.Version1, "v1", "", false, "create a v1 okteto manifest: https://www.okteto.com/docs/reference/manifest/")
 	cmd.Flags().BoolVarP(&opts.AutoDeploy, "deploy", "", false, "deploy the application after generate the okteto manifest if it's not running already")
 	cmd.Flags().BoolVarP(&opts.AutoConfigureDev, "configure-devs", "", false, "configure devs after deploying the application")
 	return cmd

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -25,7 +25,7 @@ func Stack(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "stack",
 		Short:  "Stack management commands",
-		Args:   utils.NoArgsAccepted("https://www.okteto.com/docs/0.10/reference/cli/#stack"),
+		Args:   utils.NoArgsAccepted("https://www.okteto.com/docs/reference/cli/#deploy"),
 		Hidden: true,
 	}
 	cmd.AddCommand(deploy(ctx))

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -85,7 +85,7 @@ func WithBrowser(ctx context.Context, oktetoURL string) (*types.User, error) {
 		if strings.Contains(err.Error(), "executable file not found in $PATH") {
 			return nil, oktetoErrors.UserError{
 				E:    fmt.Errorf("no browser could be found"),
-				Hint: "Use the '--token' flag to run this command in server mode. More information can be found here: https://www.okteto.com/docs/0.10/reference/cli/#login",
+				Hint: "Use the '--token' flag to run this command in server mode. More information can be found here: https://www.okteto.com/docs/reference/cli/#context",
 			}
 		}
 		oktetoLog.Errorf("Something went wrong opening your browser: %s\n", err)

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1273,7 +1273,7 @@ func (dev *Dev) translateDeprecatedMetadataFields() {
 }
 
 func (service *Dev) validateForExtraFields() error {
-	errorMessage := "%q is not supported in Services. Please visit https://www.okteto.com/docs/0.10/reference/manifest/#services-object-optional for documentation"
+	errorMessage := "%q is not supported in Services. Please visit https://www.okteto.com/docs/reference/manifest/#services-object-optional for documentation"
 	if service.Username != "" {
 		return fmt.Errorf(errorMessage, "username")
 	}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1399,7 +1399,7 @@ services:
         cpu: "500m"
     workdir: /app
     %s`, tt.value))
-			expected := fmt.Sprintf("Error on dev 'deployment': %q is not supported in Services. Please visit https://www.okteto.com/docs/0.10/reference/manifest/#services-object-optional for documentation", tt.name)
+			expected := fmt.Sprintf("Error on dev 'deployment': %q is not supported in Services. Please visit https://www.okteto.com/docs/reference/manifest/#services-object-optional for documentation", tt.name)
 
 			_, err := Read(manifest)
 			if err == nil {


### PR DESCRIPTION
# Proposed changes

Fixes #3415

Pointing to the latest docs. The entire `/0.1` doesn't exist anymore on the website, or I wasn't able to find it, so I propose to point to the latest (omitting a speicfic version) to avoid manually bumping up all the time.

Links such as `#login` and `#stacks` are no longer available in any docs so I propose we just link to the newer related cmd (ie. `#context` and `#deploy`).

I am open to other suggestions 👂 🙏 