### PR TITLE
Jlopezbarb/add remote deploy unit test

### DIFF
--- a/cmd/build/remote/build.go
+++ b/cmd/build/remote/build.go
@@ -66,3 +66,7 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 	analytics.TrackBuild(okteto.Context().Builder, true)
 	return nil
 }
+
+func (bc *OktetoBuilder) IsV1() bool {
+	return true
+}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -177,7 +177,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 			k8sClientProvider := okteto.NewK8sClientProvider()
 			pc, err := pipelineCMD.NewCommand()
 			if err != nil {
-				return err
+				return fmt.Errorf("could not create pipeline command: %w", err)
 			}
 			c := &DeployCommand{
 				GetManifest: model.GetManifestV2,

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -18,8 +18,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
+	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
@@ -923,6 +925,82 @@ func TestValidateK8sResources(t *testing.T) {
 			} else {
 				assert.NoError(t, ld.validateK8sResources(ctx, tc.manifest))
 			}
+		})
+	}
+}
+
+func TestGetDefaultTimeout(t *testing.T) {
+	tt := []struct {
+		name       string
+		envarValue string
+		expected   time.Duration
+	}{
+		{
+			name:       "env var not set",
+			envarValue: "",
+			expected:   5 * time.Minute,
+		},
+		{
+			name:       "env var set with not the proper syntax",
+			envarValue: "hello world",
+			expected:   5 * time.Minute,
+		},
+		{
+			name:       "env var set",
+			envarValue: "10m",
+			expected:   10 * time.Minute,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(model.OktetoTimeoutEnvVar, tc.envarValue)
+			assert.Equal(t, tc.expected, getDefaultTimeout())
+		})
+	}
+}
+
+type fakePipelineDeployer struct {
+	err error
+}
+
+func (fd fakePipelineDeployer) ExecuteDeployPipeline(_ context.Context, _ *pipelineCMD.DeployOptions) error {
+	return fd.err
+}
+
+func TestDeployDependencies(t *testing.T) {
+	fakeManifest := &model.Manifest{
+		Dependencies: model.ManifestDependencies{
+			"a": &model.Dependency{
+				Namespace: "b",
+			},
+			"b": &model.Dependency{},
+		},
+	}
+	type config struct {
+		pipelineErr error
+	}
+	tt := []struct {
+		name     string
+		config   config
+		expected error
+	}{
+		{
+			name:     "error deploying dependency",
+			config:   config{pipelineErr: assert.AnError},
+			expected: assert.AnError,
+		},
+		{
+			name: "successful",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := &DeployCommand{
+				PipelineCMD: fakePipelineDeployer{tc.config.pipelineErr},
+			}
+			assert.ErrorIs(t, tc.expected, dc.deployDependencies(context.Background(), &Options{Manifest: fakeManifest}))
 		})
 	}
 }

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -15,9 +15,10 @@ package deploy
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -165,6 +166,11 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 
 	tmpl := template.Must(template.New(templateName).Parse(dockerfileTemplate))
 
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000))
+	if err != nil {
+		return "", err
+	}
+
 	dockerfileSyntax := dockerfileTemplateProperties{
 		OktetoCLIImage:     getOktetoCLIVersion(config.VersionString),
 		UserDeployImage:    opts.Manifest.Deploy.Image,
@@ -176,7 +182,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		TokenEnvVar:        model.OktetoTokenEnvVar,
 		TokenValue:         okteto.Context().Token,
 		RemoteDeployEnvVar: constants.OKtetoDeployRemote,
-		RandomInt:          rand.Intn(1000),
+		RandomInt:          int(randomNumber.Int64()),
 		DeployFlags:        strings.Join(getDeployFlags(opts), " "),
 	}
 

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -203,7 +203,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 }
 
 func (rd *remoteDeployCommand) createDockerignoreIfNeeded(cwd, tmpDir string) error {
-	dockerignoreFilePath := fmt.Sprintf("%s/%s", cwd, oktetoDockerignoreName)
+	dockerignoreFilePath := filepath.Join(cwd, oktetoDockerignoreName)
 	if _, err := rd.fs.Stat(dockerignoreFilePath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -34,7 +34,7 @@ type fakeBuilder struct {
 	err error
 }
 
-func (f fakeBuilder) Build(ctx context.Context, options *types.BuildOptions) error {
+func (f fakeBuilder) Build(_ context.Context, _ *types.BuildOptions) error {
 	return f.err
 }
 

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/okteto/okteto/cmd/build/v2"
+	filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteTest(t *testing.T) {
+	ctx := context.Background()
+	fakeManifest := &model.Manifest{
+		Deploy: &model.DeployInfo{
+			Image: "test-image",
+		},
+	}
+	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+
+	type config struct {
+		wd      filesystem.FakeWorkingDirectoryCtrlErrors
+		options *Options
+	}
+	var tests = []struct {
+		name     string
+		config   config
+		expected error
+	}{
+		{
+			name: "OS can't access to the working directory",
+			config: config{
+				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+					Getter: assert.AnError,
+				},
+				options: &Options{},
+			},
+			expected: assert.AnError,
+		},
+		{
+			name: "OS can't change to the previous working directory",
+			config: config{
+				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+					Setter: assert.AnError,
+				},
+				options: &Options{
+					Manifest: fakeManifest,
+				},
+			},
+			expected: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wdCtrl.SetErrors(tt.config.wd)
+			rdc := remoteDeployCommand{
+				builder:          &v2.OktetoBuilder{},
+				fs:               afero.NewMemMapFs(),
+				workingDirectory: wdCtrl,
+			}
+			err := rdc.deploy(ctx, tt.config.options)
+			assert.ErrorIs(t, err, tt.expected)
+		})
+	}
+
+}

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -236,7 +236,7 @@ func TestCreateDockerfile(t *testing.T) {
 				},
 			},
 			expected: expected{
-				dockerfileName: "/test/deploy",
+				dockerfileName: filepath.Clean("/test/deploy"),
 			},
 		},
 	}

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -2,9 +2,10 @@ package destroy
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -153,6 +154,11 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 		return "", err
 	}
 
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000))
+	if err != nil {
+		return "", err
+	}
+
 	tmpl := template.Must(template.New(templateName).Parse(dockerfileTemplate))
 	dockerfileSyntax := dockerfileTemplateProperties{
 		OktetoCLIImage:     getOktetoCLIVersion(config.VersionString),
@@ -164,7 +170,7 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 		TokenEnvVar:        model.OktetoTokenEnvVar,
 		TokenValue:         okteto.Context().Token,
 		RemoteDeployEnvVar: constants.OKtetoDeployRemote,
-		RandomInt:          rand.Intn(1000),
+		RandomInt:          int(randomNumber.Int64()),
 		DestroyFlags:       strings.Join(getDestroyFlags(opts), " "),
 	}
 

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -231,7 +231,7 @@ func TestCreateDockerfile(t *testing.T) {
 				opts: &Options{},
 			},
 			expected: expected{
-				dockerfileName: "/test/deploy",
+				dockerfileName: filepath.Clean("/test/deploy"),
 			},
 		},
 	}

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -33,7 +33,7 @@ type fakeBuilder struct {
 	err error
 }
 
-func (f fakeBuilder) Build(ctx context.Context, options *types.BuildOptions) error {
+func (f fakeBuilder) Build(_ context.Context, _ *types.BuildOptions) error {
 	return f.err
 }
 

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -1,0 +1,292 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package destroy
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeBuilder struct {
+	err error
+}
+
+func (f fakeBuilder) Build(ctx context.Context, options *types.BuildOptions) error {
+	return f.err
+}
+
+func (f fakeBuilder) IsV1() bool { return true }
+
+func TestRemoteTest(t *testing.T) {
+	ctx := context.Background()
+	fakeManifest := &model.Manifest{
+		Destroy: &model.DestroyInfo{},
+	}
+	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+	fs := afero.NewMemMapFs()
+	tempCreator := filesystem.NewTemporalDirectoryCtrl(fs)
+
+	type config struct {
+		wd            filesystem.FakeWorkingDirectoryCtrlErrors
+		tempFsCreator error
+		options       *Options
+		builderErr    error
+	}
+	var tests = []struct {
+		name     string
+		config   config
+		expected error
+	}{
+		{
+			name: "OS can't access to the working directory",
+			config: config{
+				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+					Getter: assert.AnError,
+				},
+				options: &Options{},
+			},
+			expected: assert.AnError,
+		},
+		{
+			name: "OS can't create temporal directory",
+			config: config{
+				options:       &Options{},
+				tempFsCreator: assert.AnError,
+			},
+			expected: assert.AnError,
+		},
+		{
+			name: "OS can't change to the previous working directory",
+			config: config{
+				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+					Setter: assert.AnError,
+				},
+				options: &Options{},
+			},
+			expected: assert.AnError,
+		},
+		{
+			name: "build incorrect",
+			config: config{
+				options:    &Options{},
+				builderErr: assert.AnError,
+			},
+			expected: oktetoErrors.UserError{
+				E: fmt.Errorf("error during development environment deployment"),
+			},
+		},
+		{
+			name: "everything correct",
+			config: config{
+				options: &Options{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wdCtrl.SetErrors(tt.config.wd)
+			tempCreator.SetError(tt.config.tempFsCreator)
+			rdc := remoteDestroyCommand{
+				builder:              fakeBuilder{tt.config.builderErr},
+				fs:                   fs,
+				workingDirectoryCtrl: wdCtrl,
+				temporalCtrl:         tempCreator,
+				manifest:             fakeManifest,
+			}
+			err := rdc.destroy(ctx, tt.config.options)
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}
+
+func TestGetDestroyFlags(t *testing.T) {
+	type config struct {
+		opts *Options
+	}
+	var tests = []struct {
+		name     string
+		config   config
+		expected []string
+	}{
+		{
+			name: "no extra options",
+			config: config{
+				opts: &Options{},
+			},
+		},
+		{
+			name: "name set",
+			config: config{
+				opts: &Options{
+					Name: "test",
+				},
+			},
+			expected: []string{"--name test"},
+		},
+		{
+			name: "namespace set",
+			config: config{
+				opts: &Options{
+					Namespace: "test",
+				},
+			},
+			expected: []string{"--namespace test"},
+		},
+		{
+			name: "manifest path set",
+			config: config{
+				opts: &Options{
+					ManifestPathFlag: "/hello/this/is/a/test",
+				},
+			},
+			expected: []string{"--file /hello/this/is/a/test"},
+		},
+		{
+			name: "destroy volumes set",
+			config: config{
+				opts: &Options{
+					DestroyVolumes: true,
+				},
+			},
+			expected: []string{"--volumes"},
+		},
+		{
+			name: "force destroy set",
+			config: config{
+				opts: &Options{
+					ForceDestroy: true,
+				},
+			},
+			expected: []string{"--force-destroy"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := getDestroyFlags(tt.config.opts)
+			assert.Equal(t, tt.expected, flags)
+		})
+	}
+}
+
+func TestCreateDockerfile(t *testing.T) {
+	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+	fs := afero.NewMemMapFs()
+	fakeManifest := &model.Manifest{
+		Destroy: &model.DestroyInfo{
+			Image: "test-image",
+		},
+	}
+	type config struct {
+		wd   filesystem.FakeWorkingDirectoryCtrlErrors
+		opts *Options
+	}
+	type expected struct {
+		dockerfileName string
+		err            error
+	}
+	var tests = []struct {
+		name     string
+		config   config
+		expected expected
+	}{
+		{
+			name: "OS can't access working directory",
+			config: config{
+				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+					Getter: assert.AnError,
+				},
+			},
+			expected: expected{
+				dockerfileName: "",
+				err:            assert.AnError,
+			},
+		},
+		{
+			name: "with dockerignore",
+			config: config{
+				opts: &Options{},
+			},
+			expected: expected{
+				dockerfileName: "/test/deploy",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wdCtrl.SetErrors(tt.config.wd)
+			rdc := remoteDestroyCommand{
+				fs:                   fs,
+				manifest:             fakeManifest,
+				workingDirectoryCtrl: wdCtrl,
+			}
+			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts)
+			assert.ErrorIs(t, err, tt.expected.err)
+			assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
+
+			if tt.expected.err == nil {
+				_, err = rdc.fs.Stat(filepath.Join("/test", dockerfileTemporalNane))
+				assert.NoError(t, err)
+			}
+
+		})
+	}
+}
+
+func TestCreateDockerignoreIfNeeded(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	dockerignoreWd := "/test/"
+	assert.NoError(t, fs.MkdirAll(dockerignoreWd, 0755))
+	assert.NoError(t, afero.WriteFile(fs, "/test/.oktetodeployignore", []byte("FROM alpine"), 0644))
+	type config struct {
+		wd string
+	}
+	var tests = []struct {
+		name   string
+		config config
+	}{
+		{
+			name: "dockerignore present",
+			config: config{
+				wd: dockerignoreWd,
+			},
+		},
+		{
+			name:   "without dockerignore",
+			config: config{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rdc := remoteDestroyCommand{
+				fs: fs,
+			}
+			err := rdc.createDockerignoreIfNeeded(tt.config.wd, "/temp")
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -25,6 +25,7 @@ import (
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
+	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	initCMD "github.com/okteto/okteto/pkg/cmd/init"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
@@ -268,6 +269,10 @@ func (*ManifestCommand) configureManifestDeployAndBuild(cwd string) (*model.Mani
 }
 
 func (mc *ManifestCommand) deploy(ctx context.Context, opts *InitOpts) error {
+	pc, err := pipelineCMD.NewCommand()
+	if err != nil {
+		return err
+	}
 	c := &deploy.DeployCommand{
 		GetManifest:        mc.getManifest,
 		TempKubeconfigFile: deploy.GetTempKubeConfigFile(mc.manifest.Name),
@@ -276,9 +281,10 @@ func (mc *ManifestCommand) deploy(ctx context.Context, opts *InitOpts) error {
 		GetExternalControl: deploy.GetExternalControl,
 		Fs:                 afero.NewOsFs(),
 		CfgMapHandler:      deploy.NewConfigmapHandler(mc.K8sClientProvider),
+		PipelineCMD:        pc,
 	}
 
-	err := c.RunDeploy(ctx, &deploy.Options{
+	err = c.RunDeploy(ctx, &deploy.Options{
 		Name:         mc.manifest.Name,
 		ManifestPath: opts.DevPath,
 		Timeout:      5 * time.Minute,

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -22,6 +22,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type PipelineDeployerInterface interface {
+	ExecuteDeployPipeline(ctx context.Context, opts *DeployOptions) error
+}
+type PipelineInterface interface {
+	PipelineDeployerInterface
+}
+
 // Command has all the pipeline subcommands
 type Command struct {
 	okClient types.OktetoInterface

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/config"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -522,6 +523,10 @@ func getOverridedEnvVarsFromCmd(manifestEnvVars model.Environment, commandEnvVar
 
 func (up *upContext) deployApp(ctx context.Context) error {
 	k8sProvider := okteto.NewK8sClientProvider()
+	pc, err := pipelineCMD.NewCommand()
+	if err != nil {
+		return err
+	}
 	c := &deploy.DeployCommand{
 		GetManifest:        up.getManifest,
 		GetDeployer:        deploy.GetDeployer,
@@ -531,6 +536,7 @@ func (up *upContext) deployApp(ctx context.Context) error {
 		GetExternalControl: deploy.GetExternalControl,
 		Fs:                 afero.NewOsFs(),
 		CfgMapHandler:      deploy.NewConfigmapHandler(k8sProvider),
+		PipelineCMD:        pc,
 	}
 
 	return c.RunDeploy(ctx, &deploy.Options{

--- a/pkg/filesystem/fake/temporal.go
+++ b/pkg/filesystem/fake/temporal.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import "github.com/spf13/afero"
+
+type FakeTemporalDirectoryCtrl struct {
+	fs  afero.Fs
+	err error
+}
+
+func NewTemporalDirectoryCtrl(fs afero.Fs) *FakeTemporalDirectoryCtrl {
+	return &FakeTemporalDirectoryCtrl{
+		fs:  fs,
+		err: nil,
+	}
+}
+
+func (fwd *FakeTemporalDirectoryCtrl) SetError(err error) {
+	fwd.err = err
+}
+
+func (fwd FakeTemporalDirectoryCtrl) Create() (string, error) {
+	dir, err := afero.TempDir(fwd.fs, "", "")
+	if err != nil {
+		return "", err
+	}
+	return dir, fwd.err
+}

--- a/pkg/filesystem/fake/temporal_test.go
+++ b/pkg/filesystem/fake/temporal_test.go
@@ -1,0 +1,46 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFakeTemporalDirectoryCtrl(t *testing.T) {
+	tempDirCtrl := NewTemporalDirectoryCtrl(afero.NewMemMapFs())
+	var tests = []struct {
+		name   string
+		errors error
+	}{
+		{
+			name:   "create with error",
+			errors: assert.AnError,
+		},
+		{
+			name:   "create with no error",
+			errors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDirCtrl.SetError(tt.errors)
+			_, err := tempDirCtrl.Create()
+			assert.Equal(t, tt.errors, err)
+		})
+	}
+}

--- a/pkg/filesystem/fake/wd.go
+++ b/pkg/filesystem/fake/wd.go
@@ -1,0 +1,44 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+type FakeWorkingDirectoryCtrl struct {
+	wd     string
+	errors FakeWorkingDirectoryCtrlErrors
+}
+
+type FakeWorkingDirectoryCtrlErrors struct {
+	Getter error
+	Setter error
+}
+
+func NewFakeWorkingDirectoryCtrl(dir string) *FakeWorkingDirectoryCtrl {
+	return &FakeWorkingDirectoryCtrl{
+		wd:     dir,
+		errors: FakeWorkingDirectoryCtrlErrors{},
+	}
+}
+
+func (fwd *FakeWorkingDirectoryCtrl) SetErrors(errors FakeWorkingDirectoryCtrlErrors) {
+	fwd.errors = errors
+}
+
+func (fwd FakeWorkingDirectoryCtrl) Get() (string, error) {
+	return fwd.wd, fwd.errors.Getter
+}
+
+func (fwd *FakeWorkingDirectoryCtrl) Change(dir string) error {
+	fwd.wd = dir
+	return fwd.errors.Setter
+}

--- a/pkg/filesystem/fake/wd_test.go
+++ b/pkg/filesystem/fake/wd_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFakeWorkingDirectoryCtrl(t *testing.T) {
+	wdCtrl := NewFakeWorkingDirectoryCtrl("/hola")
+	cwd, err := wdCtrl.Get()
+	assert.NoError(t, err)
+
+	err = wdCtrl.Change(filepath.Clean("/"))
+	assert.NoError(t, err)
+	newWd, err := wdCtrl.Get()
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, cwd, newWd)
+}
+
+func TestFakeWorkingDirectoryCtrlSetErrors(t *testing.T) {
+	wdCtrl := NewFakeWorkingDirectoryCtrl("/hola")
+
+	var tests = []struct {
+		name   string
+		errors FakeWorkingDirectoryCtrlErrors
+	}{
+		{
+			name: "getter error set",
+			errors: FakeWorkingDirectoryCtrlErrors{
+				Getter: assert.AnError,
+			},
+		},
+		{
+			name: "setter error set",
+			errors: FakeWorkingDirectoryCtrlErrors{
+				Setter: assert.AnError,
+			},
+		},
+		{
+			name: "getter and setter error set",
+			errors: FakeWorkingDirectoryCtrlErrors{
+				Getter: assert.AnError,
+				Setter: assert.AnError,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wdCtrl.SetErrors(tt.errors)
+			_, err := wdCtrl.Get()
+			assert.Equal(t, tt.errors.Getter, err)
+
+			err = wdCtrl.Change("")
+			assert.Equal(t, tt.errors.Setter, err)
+		})
+	}
+}

--- a/pkg/filesystem/temporal.go
+++ b/pkg/filesystem/temporal.go
@@ -1,0 +1,36 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"github.com/spf13/afero"
+)
+
+type TemporalDirectoryInterface interface {
+	Create() (string, error)
+}
+
+type TemporalDirectoryCtrl struct {
+	fs afero.Fs
+}
+
+func NewTemporalDirectoryCtrl(fs afero.Fs) TemporalDirectoryCtrl {
+	return TemporalDirectoryCtrl{
+		fs: fs,
+	}
+}
+
+func (os TemporalDirectoryCtrl) Create() (string, error) {
+	return afero.TempDir(os.fs, "", "")
+}

--- a/pkg/filesystem/temporal_test.go
+++ b/pkg/filesystem/temporal_test.go
@@ -1,0 +1,32 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemporalDirectoryCtrl(t *testing.T) {
+	temporalCtrl := NewTemporalDirectoryCtrl(afero.NewMemMapFs())
+	dir, err := temporalCtrl.Create()
+	assert.NoError(t, err)
+
+	fileInfo, err := temporalCtrl.fs.Stat(dir)
+	assert.NoError(t, err)
+
+	assert.True(t, fileInfo.IsDir())
+}

--- a/pkg/filesystem/wd.go
+++ b/pkg/filesystem/wd.go
@@ -1,0 +1,35 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import "os"
+
+type WorkingDirectoryInterface interface {
+	Get() (string, error)
+	Change(string) error
+}
+
+type OsWorkingDirectoryCtrl struct{}
+
+func NewOsWorkingDirectoryCtrl() OsWorkingDirectoryCtrl {
+	return OsWorkingDirectoryCtrl{}
+}
+
+func (OsWorkingDirectoryCtrl) Get() (string, error) {
+	return os.Getwd()
+}
+
+func (OsWorkingDirectoryCtrl) Change(dir string) error {
+	return os.Chdir(dir)
+}

--- a/pkg/filesystem/wd_test.go
+++ b/pkg/filesystem/wd_test.go
@@ -1,0 +1,34 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOsWorkingDirectoryCtrl(t *testing.T) {
+	wdCtrl := NewOsWorkingDirectoryCtrl()
+	cwd, err := wdCtrl.Get()
+	assert.NoError(t, err)
+
+	err = wdCtrl.Change(filepath.Clean("/"))
+	assert.NoError(t, err)
+	newWd, err := wdCtrl.Get()
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, cwd, newWd)
+}


### PR DESCRIPTION
# Proposed changes

Fixes #3407 

This PR is a follow up adding unit tests for remote deploy and destroy commands.

Changes the structs to inject dependencies and be able to test properly mocking the fully the operative system calls
