### PR TITLE
e2e: fix naming convention

### DIFF
--- a/integration/actions/apply_test.go
+++ b/integration/actions/apply_test.go
@@ -73,7 +73,7 @@ type deployment struct {
 func TestApplyPipeline(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("applyaction", user)
 	oktetoPath, err := integration.GetOktetoPath()
 	assert.NoError(t, err)
 

--- a/integration/actions/build_test.go
+++ b/integration/actions/build_test.go
@@ -34,7 +34,7 @@ const buildPath = "okteto/build"
 func TestBuildActionPipeline(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("buildaction", user)
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 

--- a/integration/actions/namespace_test.go
+++ b/integration/actions/namespace_test.go
@@ -21,10 +21,8 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -40,7 +38,7 @@ const (
 func TestNamespaceActionsPipeline(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("namespaceaction", user)
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, executeChangeNamespaceAction(namespace))
@@ -138,11 +136,4 @@ func executeDeleteNamespaceAction(namespace string) error {
 
 	log.Printf("deleting namespace output: \n%s\n", string(o))
 	return nil
-}
-
-func getTestNamespace() string {
-	tName := fmt.Sprintf("TestAction-%s", runtime.GOOS)
-	name := strings.ToLower(fmt.Sprintf("%s-%d", tName, time.Now().Unix()))
-	namespace := fmt.Sprintf("%s-%s", name, user)
-	return namespace
 }

--- a/integration/actions/pipeline_test.go
+++ b/integration/actions/pipeline_test.go
@@ -45,7 +45,7 @@ const (
 func TestPipelineActions(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("PipelineActions", user)
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, executeDeployPipelineAction(t, namespace))
@@ -56,7 +56,7 @@ func TestPipelineActions(t *testing.T) {
 func TestPipelineActionsWithCompose(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("pipelinecomposeaction", user)
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, executeDeployWithComposePipelineAction(namespace))
 	assert.NoError(t, executeDestroyPipelineAction(namespace))

--- a/integration/actions/preview_test.go
+++ b/integration/actions/preview_test.go
@@ -35,8 +35,7 @@ const (
 
 func TestPreviewActions(t *testing.T) {
 	integration.SkipIfWindows(t)
-
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("PreviewActions", user)
 
 	assert.NoError(t, executeDeployPreviewAction(namespace))
 	assert.NoError(t, executeDestroyPreviewAction(namespace))

--- a/integration/actions/push_test.go
+++ b/integration/actions/push_test.go
@@ -39,7 +39,7 @@ const pushPath = "okteto/push"
 func TestPushAction(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("pushactions", user)
 	oktetoPath, err := integration.GetOktetoPath()
 	if err != nil {
 		t.Fatal(err)

--- a/integration/actions/stacks_test.go
+++ b/integration/actions/stacks_test.go
@@ -46,7 +46,7 @@ services:
 func TestStacksActions(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := getTestNamespace()
+	namespace := integration.GetTestNamespace("stackaction", user)
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 


### PR DESCRIPTION
# Proposed changes

Fixes e2e tests failing due to having the same name

Actions were using a different name from the rest of e2e tests. Since we run the tests in parallel it may happen that two different tests have the same name and fail because of this