### PR TITLE
feat: add env vars on external resources

### DIFF
--- a/pkg/externalresource/serializer.go
+++ b/pkg/externalresource/serializer.go
@@ -2,6 +2,8 @@ package externalresource
 
 import (
 	"fmt"
+
+	"github.com/a8m/envsubst"
 )
 
 type externalResourceUnmarshaller struct {
@@ -44,9 +46,17 @@ func (er *ExternalResource) UnmarshalYAML(unmarshal func(interface{}) error) err
 	}
 
 	for _, endpoint := range result.Endpoints {
+		name, err := envsubst.String(endpoint.Name)
+		if err != nil {
+			return fmt.Errorf("error expanding environment on '%s': %w", endpoint.Name, err)
+		}
+		url, err := envsubst.String(endpoint.Url)
+		if err != nil {
+			return fmt.Errorf("error expanding environment on '%s': %w", endpoint.Name, err)
+		}
 		er.Endpoints = append(er.Endpoints, &ExternalEndpoint{
-			Name: endpoint.Name,
-			Url:  endpoint.Url,
+			Name: name,
+			Url:  url,
 		})
 	}
 

--- a/pkg/externalresource/serializer_test.go
+++ b/pkg/externalresource/serializer_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestExternalResource_UnmarshalYAML(t *testing.T) {
+	t.Setenv("NAME", "test")
+	t.Setenv("URL_PATH", "test")
 	tests := []struct {
 		name        string
 		data        []byte
@@ -78,6 +80,27 @@ endpoints:
 					{
 						Name: "endpoint1",
 						Url:  "/some/url/1",
+					},
+				},
+			},
+		},
+		{
+			name: "valid external resource expanding variables",
+			data: []byte(`
+icon: default
+notes: /path/to/file
+endpoints:
+- name: ${NAME}
+  url: /some/url/${URL_PATH}`),
+			expected: ExternalResource{
+				Icon: "default",
+				Notes: &Notes{
+					Path: "/path/to/file",
+				},
+				Endpoints: []*ExternalEndpoint{
+					{
+						Name: "test",
+						Url:  "/some/url/test",
 					},
 				},
 			},


### PR DESCRIPTION
# Proposed changes

Fixes Env vars where not being expanded on external resources

- Add the expand env vars for the name and url in endpoints field

## Tests

Tested with the following scenario:
```yaml
deploy:
- echo hola
external:
  bucket:
    notes: docs/bucket.md
    icon: dashboard
    endpoints:
    - name: console
      url: https://test-${OKTETO_NAMESPACE}
```
