### PR TITLE
fix destroy image envsub

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -240,6 +240,10 @@ func (dc *destroyCommand) getDestroyer(opts *Options) (destroyInterface, error) 
 			}
 		}
 
+		if err := manifest.ExpandEnvVars(); err != nil {
+			oktetoLog.Infof("could not expand manifest envs: %v", err)
+		}
+
 		isRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
 
 		destroyImage := ""

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -77,17 +77,17 @@ type dockerfileTemplateProperties struct {
 
 type remoteDestroyCommand struct {
 	builder              builder.Builder
-	manifest             *model.Manifest
+	destroyImage         string
 	fs                   afero.Fs
 	workingDirectoryCtrl filesystem.WorkingDirectoryInterface
 	temporalCtrl         filesystem.TemporalDirectoryInterface
 }
 
-func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
+func newRemoteDestroyer(destroyImage string) *remoteDestroyCommand {
 	fs := afero.NewOsFs()
 	return &remoteDestroyCommand{
 		builder:              remoteBuild.NewBuilderFromScratch(),
-		manifest:             manifest,
+		destroyImage:         destroyImage,
 		fs:                   fs,
 		workingDirectoryCtrl: filesystem.NewOsWorkingDirectoryCtrl(),
 		temporalCtrl:         filesystem.NewTemporalDirectoryCtrl(fs),
@@ -96,8 +96,8 @@ func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
 
 func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) error {
 
-	if rd.manifest.Destroy.Image == "" {
-		rd.manifest.Destroy.Image = constants.OktetoPipelineRunnerImage
+	if rd.destroyImage == "" {
+		rd.destroyImage = constants.OktetoPipelineRunnerImage
 	}
 
 	cwd, err := rd.workingDirectoryCtrl.Get()
@@ -162,7 +162,7 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 	tmpl := template.Must(template.New(templateName).Parse(dockerfileTemplate))
 	dockerfileSyntax := dockerfileTemplateProperties{
 		OktetoCLIImage:     getOktetoCLIVersion(config.VersionString),
-		UserDestroyImage:   rd.manifest.Destroy.Image,
+		UserDestroyImage:   rd.destroyImage,
 		ContextEnvVar:      model.OktetoContextEnvVar,
 		ContextValue:       okteto.Context().Name,
 		NamespaceEnvVar:    model.OktetoNamespaceEnvVar,

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
-	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -41,9 +40,6 @@ func (f fakeBuilder) IsV1() bool { return true }
 
 func TestRemoteTest(t *testing.T) {
 	ctx := context.Background()
-	fakeManifest := &model.Manifest{
-		Destroy: &model.DestroyInfo{},
-	}
 	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
 	fs := afero.NewMemMapFs()
 	tempCreator := filesystem.NewTemporalDirectoryCtrl(fs)
@@ -114,7 +110,7 @@ func TestRemoteTest(t *testing.T) {
 				fs:                   fs,
 				workingDirectoryCtrl: wdCtrl,
 				temporalCtrl:         tempCreator,
-				manifest:             fakeManifest,
+				destroyImage:         "",
 			}
 			err := rdc.destroy(ctx, tt.config.options)
 			assert.Equal(t, tt.expected, err)
@@ -195,11 +191,6 @@ func TestGetDestroyFlags(t *testing.T) {
 func TestCreateDockerfile(t *testing.T) {
 	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
 	fs := afero.NewMemMapFs()
-	fakeManifest := &model.Manifest{
-		Destroy: &model.DestroyInfo{
-			Image: "test-image",
-		},
-	}
 	type config struct {
 		wd   filesystem.FakeWorkingDirectoryCtrlErrors
 		opts *Options
@@ -241,7 +232,7 @@ func TestCreateDockerfile(t *testing.T) {
 			wdCtrl.SetErrors(tt.config.wd)
 			rdc := remoteDestroyCommand{
 				fs:                   fs,
-				manifest:             fakeManifest,
+				destroyImage:         "test-image",
 				workingDirectoryCtrl: wdCtrl,
 			}
 			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts)

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -944,6 +944,12 @@ func (manifest *Manifest) ExpandEnvVars() error {
 		}
 	}
 	if manifest.Destroy != nil {
+		if manifest.Destroy.Image != "" {
+			manifest.Destroy.Image, err = envsubst.String(manifest.Destroy.Image)
+			if err != nil {
+				return errors.New("could not parse env vars for an image used for remote destroy")
+			}
+		}
 		for idx, cmd := range manifest.Destroy.Commands {
 			cmd.Command, err = envsubst.String(cmd.Command)
 			if err != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -945,9 +945,9 @@ func (manifest *Manifest) ExpandEnvVars() error {
 	}
 	if manifest.Destroy != nil {
 		if manifest.Destroy.Image != "" {
-			manifest.Destroy.Image, err = envsubst.String(manifest.Destroy.Image)
+			manifest.Destroy.Image, err = ExpandEnv(manifest.Destroy.Image, true)
 			if err != nil {
-				return errors.New("could not parse env vars for an image used for remote destroy")
+				return err
 			}
 		}
 		for idx, cmd := range manifest.Destroy.Commands {


### PR DESCRIPTION
Fixes env var substitution for destroy image.

## TEST
Having an env OK_IMG_DESTROY_TEST=alpine and using this manifest:
````yaml
destroy:
  image: ${OK_IMG_DESTROY_TEST}
  commands:
  - name: First step
    command: echo hello-world

````
you should be able to execute destroy remotely.