### PR TITLE
fix: avoid panic when removing a deployment that does not exist…

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -175,7 +175,7 @@ func GetDevFromManifest(manifest *model.Manifest, devName string) (*model.Dev, e
 		return nil, ErrNoDevSelected
 	}
 
-	options := []string{}
+	var options []string
 	for name, dev := range manifest.Dev {
 		if name == devName {
 			return dev, nil
@@ -197,7 +197,7 @@ func SelectDevFromManifest(manifest *model.Manifest, selector OktetoSelectorInte
 		}
 		return devs[i] < devs[j]
 	})
-	items := []SelectorItem{}
+	var items []SelectorItem
 	for _, dev := range devs {
 		items = append(items, SelectorItem{
 			Name:   dev,
@@ -396,7 +396,7 @@ func GetApp(ctx context.Context, dev *model.Dev, c kubernetes.Interface, isRetry
 			return apps.NewDeploymentApp(deployments.Sandbox(dev)), true, nil
 		}
 		if len(dev.Selector) > 0 {
-			if err == oktetoErrors.ErrNotFound {
+			if oktetoErrors.IsNotFound(err) {
 				err = oktetoErrors.UserError{
 					E:    fmt.Errorf("didn't find an application in namespace %s that matches the labels in your Okteto manifest", dev.Namespace),
 					Hint: "Update the labels or point your context to a different namespace and try again"}

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -132,6 +132,9 @@ func GetByDev(ctx context.Context, dev *model.Dev, namespace string, c kubernete
 			validDeployments = append(validDeployments, &dList.Items[i])
 		}
 	}
+	if len(validDeployments) == 0 {
+		return nil, oktetoErrors.ErrNotFound
+	}
 	if len(validDeployments) > 1 {
 		return nil, fmt.Errorf("found '%d' deployments for labels '%s' instead of 1", len(validDeployments), dev.LabelsSelector())
 	}

--- a/pkg/k8s/deployments/crud_test.go
+++ b/pkg/k8s/deployments/crud_test.go
@@ -28,28 +28,190 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	ctx := context.Background()
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "fake",
-			Namespace: "test",
+	tests := []struct {
+		name               string
+		deployments        *appsv1.DeploymentList
+		dev                *model.Dev
+		namespace          string
+		expectedErr        error
+		expectedFoundCount int
+	}{
+		{
+			name: "Get by Name: no deployments",
+			dev: &model.Dev{
+				Name: "fake",
+			},
+			namespace: "test",
+			deployments: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{},
+			},
+			expectedErr:        fmt.Errorf("deployments.apps \"%s\" not found", "fake"),
+			expectedFoundCount: 0,
+		},
+		{
+			name: "Get by Name: found 1 deployment",
+			dev: &model.Dev{
+				Name: "fake",
+			},
+			namespace: "test",
+			deployments: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedErr:        nil,
+			expectedFoundCount: 1,
+		},
+		{
+			name: "Search by Label: no deployments found",
+			dev: &model.Dev{
+				Selector: map[string]string{
+					"deployed-by": "fake",
+				},
+			},
+			namespace: "test",
+			deployments: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{},
+			},
+			expectedErr:        oktetoErrors.ErrNotFound,
+			expectedFoundCount: 0,
+		},
+		{
+			name: "Search by Label: cloned deployments are filtered out successfully",
+			dev: &model.Dev{
+				Selector: map[string]string{
+					"deployed-by": "fake",
+				},
+			},
+			namespace: "test",
+			deployments: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake1-clone",
+							Namespace: "test",
+							Labels: map[string]string{
+								model.DevCloneLabel: "id-123",
+								"deployed-by":       "fake",
+							},
+						},
+					},
+				},
+			},
+			expectedErr:        oktetoErrors.ErrNotFound,
+			expectedFoundCount: 0,
+		},
+		{
+			name: "Search by Label: no matching deployments found",
+			dev: &model.Dev{
+				Selector: map[string]string{
+					"deployed-by": "fake",
+				},
+			},
+			namespace: "test",
+			deployments: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "another-fake",
+							Namespace: "test",
+						},
+					},
+				},
+			},
+			expectedErr:        oktetoErrors.ErrNotFound,
+			expectedFoundCount: 0,
+		},
+		{
+			name: "Search by Label: 1 deployment found",
+			dev: &model.Dev{
+				Selector: map[string]string{
+					"deployed-by": "fake",
+				},
+			},
+			namespace: "test",
+			deployments: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "another-fake",
+							Namespace: "test",
+							Labels: map[string]string{
+								"deployed-by": "fake",
+							},
+						},
+					},
+				},
+			},
+			expectedErr:        nil,
+			expectedFoundCount: 1,
+		},
+		{
+			name: "Search by Label: Unexpectedly found 2 deployments",
+			dev: &model.Dev{
+				Selector: map[string]string{
+					"deployed-by": "fake",
+				},
+			},
+			namespace: "test",
+			deployments: &appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake1",
+							Namespace: "test",
+							Labels: map[string]string{
+								"deployed-by": "fake",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "fake2",
+							Namespace: "test",
+							Labels: map[string]string{
+								"deployed-by": "fake",
+							},
+						},
+					},
+				},
+			},
+			expectedErr:        fmt.Errorf("found '%d' deployments for labels '%s' instead of 1", 2, "deployed-by=fake"),
+			expectedFoundCount: 0,
 		},
 	}
 
-	dev := &model.Dev{Name: "fake"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
 
-	clientset := fake.NewSimpleClientset(deployment)
-	d, err := GetByDev(ctx, dev, deployment.GetNamespace(), clientset)
-	if err != nil {
-		t.Fatal(err)
-	}
+			clientset := fake.NewSimpleClientset(tt.deployments)
+			d, err := GetByDev(ctx, tt.dev, tt.namespace, clientset)
 
-	if d == nil {
-		t.Fatal("empty deployment")
-	}
-
-	if d.Name != deployment.GetName() {
-		t.Fatalf("wrong deployment. Got %s, expected %s", d.Name, deployment.GetName())
+			if err == nil && tt.expectedErr != nil {
+				t.Fatalf("wrong error. Got nil, expected %s", tt.expectedErr.Error())
+			}
+			if err != nil && tt.expectedErr == nil {
+				t.Fatalf("wrong error. Got nil, expected %s", err.Error())
+			}
+			if err != nil && tt.expectedErr != nil && err.Error() != tt.expectedErr.Error() {
+				t.Fatalf("wrong error. Got %s, expected %s", err, tt.expectedErr)
+			}
+			if err == nil && d == nil {
+				t.Fatal("deployment is nil found but no errors were returned")
+			}
+			if tt.expectedFoundCount > 0 && d == nil {
+				t.Fatalf("expected %d deployments, instead found none", tt.expectedFoundCount)
+			}
+			if tt.expectedFoundCount == 0 && d != nil {
+				t.Fatal("expected no deployments, instead found one")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# Proposed changes

Fixes #3388


Fix a `panic` occurring in `okteto down` when a deployment cannot be found by label. I've added a bunch of test cases which hopefully cover most scenarios.

Here is an example of before/after when the scrnario described in #3388 would occur:

| Before | After |
|--------|-------|
|  <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/223878649-9b15df91-214e-4feb-83c1-80d4b8c17af5.png" />      |       <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/224121349-67e4011f-1f7b-4aae-b5fe-331405196880.png" /> |

This is instead the message that it outputs without using a label selector:

<img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/224121353-40ba889a-554f-4d3e-a963-3d7ddb85bbec.png" />
