### PR TITLE
Ignore OKTETO_TOKEN warning if OKTETO_TOKEN is the one in the current…

### DIFF
--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -60,8 +60,10 @@ func (o *ContextOptions) initFromContext() {
 
 func (o *ContextOptions) initFromEnvVars() {
 	usedEnvVars := []string{}
-	if o.Token == "" && os.Getenv(model.OktetoTokenEnvVar) != "" {
-		o.Token = os.Getenv(model.OktetoTokenEnvVar)
+
+	envToken := os.Getenv(model.OktetoTokenEnvVar)
+	if o.Token == "" && envToken != "" && okteto.Context().Token != envToken {
+		o.Token = envToken
 		usedEnvVars = append(usedEnvVars, model.OktetoTokenEnvVar)
 	}
 


### PR DESCRIPTION
# Proposed changes

Fixes #3434 

This PR will ignore logging warning when env token `OKTETO_TOKEN` is the same with token inside storage
