### PR TITLE
interface defaults to localhost

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1346,13 +1345,6 @@ func (service *Dev) validateForExtraFields() error {
 // DevCloneName returns the name of the mirrored version of a given resource
 func DevCloneName(name string) string {
 	return fmt.Sprintf("%s-okteto", name)
-}
-
-func getLocalhost() string {
-	if runtime.GOOS != "windows" {
-		return PrivilegedLocalhost
-	}
-	return Localhost
 }
 
 // Copy clones the buildInfo without the pointers

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -577,9 +577,6 @@ func (dev *Dev) SetDefaults() error {
 	}
 	if dev.Interface == "" {
 		dev.Interface = Localhost
-		if runtime.GOOS != "windows" {
-			dev.Interface = PrivilegedLocalhost
-		}
 	}
 	if dev.SSHServerPort == 0 {
 		dev.SSHServerPort = oktetoDefaultSSHServerPort

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -381,10 +380,7 @@ func Test_validateManifestBuild(t *testing.T) {
 
 func TestInferFromStack(t *testing.T) {
 	dirtest := filepath.Clean("/stack/dir/")
-	devInterface := PrivilegedLocalhost
-	if runtime.GOOS == "windows" {
-		devInterface = Localhost
-	}
+	devInterface := Localhost
 	stack := &Stack{
 		Services: map[string]*Service{
 			"test": {

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1133,7 +1133,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: getLocalhost(),
+						Interface: Localhost,
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1198,7 +1198,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: getLocalhost(),
+						Interface: Localhost,
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1282,7 +1282,7 @@ sync:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: getLocalhost(),
+						Interface: Localhost,
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1367,7 +1367,7 @@ services:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: getLocalhost(),
+						Interface: Localhost,
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1499,7 +1499,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: getLocalhost(),
+						Interface: Localhost,
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1587,7 +1587,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: getLocalhost(),
+						Interface: Localhost,
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},
@@ -1652,7 +1652,7 @@ dev:
 							Dockerfile: "Dockerfile",
 							Target:     "",
 						},
-						Interface: getLocalhost(),
+						Interface: Localhost,
 						PersistentVolumeInfo: &PersistentVolumeInfo{
 							Enabled: true,
 						},


### PR DESCRIPTION
Fixes https://github.com/okteto/app/issues/5854

## Context

We were setting the default value of `interface` to `0.0.0.0` instead of `localhost`. This is causing `okteto up` command not work with certain IntelliJ versions.

## Proposed Changes

- Change the default value to **always** point to localhost unless the user explicity declares it as localhost
- Fix tests that were using old values
- Running e2e tests  to check that everything is correct

## Tests done
1.Run okteto up on this okteto manifest:
```yaml
name: aaaa
image: busybox
command: bash
forward:
- 2222:2222
sync:
- .:/usr/src/app
autocreate: true
```
2. Check that the ssh config created hostname is localhost(`tail ~/.ssh/config`):
```
Host aaaa.okteto
  ForwardAgent yes
  PubkeyAcceptedKeyTypes +ssh-rsa
  HostKeyAlgorithms +ssh-rsa
  HostName localhost
  Port 12345
  StrictHostKeyChecking no
  UserKnownHostsFile /dev/null
  IdentityFile "myPath"
  IdentitiesOnly yes
```

