### PR TITLE
fix(deploy): wait if dependency is being deployed

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -15,6 +15,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -126,14 +127,60 @@ func (pc *Command) ExecuteDeployPipeline(ctx context.Context, opts *DeployOption
 			return fmt.Errorf("failed to load okteto context '%s': %v", okteto.Context().Name, err)
 		}
 
-		_, err = configmaps.Get(ctx, pipeline.TranslatePipelineName(opts.Name), opts.Namespace, c)
-		if err == nil {
-			oktetoLog.Success("Skipping repository '%s' because it's already deployed", opts.Name)
-			return nil
-		}
+		cfgName := pipeline.TranslatePipelineName(opts.Name)
 
-		if !oktetoErrors.IsNotFound(err) {
+		cfg, err := configmaps.Get(ctx, cfgName, opts.Namespace, c)
+		if err != nil && !oktetoErrors.IsNotFound(err) {
 			return err
+		}
+		if err == nil {
+			if cfg != nil && cfg.Data != nil {
+				if cfg.Data["status"] == pipeline.DeployedStatus {
+					oktetoLog.Success("Skipping repository '%s' because it's already deployed", opts.Name)
+					return nil
+				}
+
+				if !opts.Wait && cfg.Data["status"] == pipeline.ProgressingStatus {
+					oktetoLog.Success("Repository '%s' already scheduled for deployment", opts.Name)
+					return nil
+				}
+
+				canStreamPrevLogs := cfg.Data["actionLock"] != "" && cfg.Data["actionName"] != "cli"
+
+				if opts.Wait && canStreamPrevLogs {
+					oktetoLog.Spinner(fmt.Sprintf("Repository '%s' is already being deployed, waiting for it to finish...", opts.Name))
+					oktetoLog.StartSpinner()
+					defer oktetoLog.StopSpinner()
+
+					existingAction := &types.Action{
+						ID:   cfg.Data["actionLock"],
+						Name: cfg.Data["actionName"],
+					}
+					if err := pc.waitUntilRunning(ctx, opts.Name, opts.Namespace, existingAction, opts.Timeout); err != nil {
+						return err
+					}
+					oktetoLog.Success("Repository '%s' successfully deployed", opts.Name)
+					return nil
+				}
+
+				if opts.Wait && !canStreamPrevLogs && cfg.Data["status"] == pipeline.ProgressingStatus {
+					oktetoLog.Spinner(fmt.Sprintf("Repository '%s' is already being deployed, waiting for it to finish...", opts.Name))
+					oktetoLog.StartSpinner()
+					defer oktetoLog.StopSpinner()
+
+					ticker := time.NewTicker(1 * time.Second)
+					err := configmaps.WaitForStatus(ctx, cfgName, opts.Namespace, pipeline.DeployedStatus, ticker, opts.Timeout, c)
+					if err != nil {
+						if errors.Is(err, oktetoErrors.ErrTimeout) {
+							return fmt.Errorf("timed out waiting for repository '%s' to be deployed", opts.Name)
+						}
+						return fmt.Errorf("failed to wait for repository '%s' to be deployed: %w", opts.Name, err)
+					}
+
+					oktetoLog.Success("Repository '%s' successfully deployed", opts.Name)
+					return nil
+				}
+			}
 		}
 	}
 
@@ -146,6 +193,10 @@ func (pc *Command) ExecuteDeployPipeline(ctx context.Context, opts *DeployOption
 		oktetoLog.Success("Repository '%s' scheduled for deployment", opts.Name)
 		return nil
 	}
+
+	oktetoLog.Spinner(fmt.Sprintf("Waiting for repository '%s' to be deployed...", opts.Name))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
 
 	if err := pc.waitUntilRunning(ctx, opts.Name, opts.Namespace, resp.Action, opts.Timeout); err != nil {
 		return err
@@ -204,10 +255,6 @@ func (pc *Command) streamPipelineLogs(ctx context.Context, name, namespace, acti
 func (pc *Command) waitUntilRunning(ctx context.Context, name, namespace string, action *types.Action, timeout time.Duration) error {
 	waitCtx, ctxCancel := context.WithCancel(ctx)
 	defer ctxCancel()
-
-	oktetoLog.Spinner(fmt.Sprintf("Waiting for repository '%s' to be deployed...", name))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)
@@ -375,7 +422,7 @@ func (o *DeployOptions) setDefaults() error {
 }
 
 func (o *DeployOptions) toPipelineDeployClientOptions() (types.PipelineDeployOptions, error) {
-	varList := []types.Variable{}
+	var varList []types.Variable
 	for _, v := range o.Variables {
 		kv := strings.SplitN(v, "=", 2)
 		if len(kv) != 2 {

--- a/cmd/pipeline/destroy_test.go
+++ b/cmd/pipeline/destroy_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDestroyPipelineSuccesful(t *testing.T) {
+func TestDestroyPipelineSuccessful(t *testing.T) {
 	ctx := context.Background()
 	response := &client.FakePipelineResponses{
 		DestroyResponse: &types.GitDeployResponse{
@@ -47,7 +47,7 @@ func TestDestroyPipelineSuccesful(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDestroyPipelineSuccesfulWithWait(t *testing.T) {
+func TestDestroyPipelineSuccessfulWithWait(t *testing.T) {
 	ctx := context.Background()
 	response := &client.FakePipelineResponses{
 		DestroyResponse: &types.GitDeployResponse{
@@ -71,7 +71,7 @@ func TestDestroyPipelineSuccesfulWithWait(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDestroyPipelineSuccesfulWithWaitStreamErr(t *testing.T) {
+func TestDestroyPipelineSuccessfulWithWaitStreamErr(t *testing.T) {
 	ctx := context.Background()
 	response := &client.FakePipelineResponses{
 		DestroyResponse: &types.GitDeployResponse{
@@ -95,7 +95,7 @@ func TestDestroyPipelineSuccesfulWithWaitStreamErr(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDestroyNonExistantPipeline(t *testing.T) {
+func TestDestroyNonExistentPipeline(t *testing.T) {
 	ctx := context.Background()
 	response := &client.FakePipelineResponses{
 		DestroyErr: fmt.Errorf("not found"),
@@ -112,7 +112,7 @@ func TestDestroyNonExistantPipeline(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDestroyNonExistantPipelineWithWait(t *testing.T) {
+func TestDestroyNonExistentPipelineWithWait(t *testing.T) {
 	ctx := context.Background()
 	response := &client.FakePipelineResponses{
 		DestroyErr: fmt.Errorf("not found"),
@@ -135,7 +135,7 @@ func TestDestroyNonExistantPipelineWithWait(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestDestroyExistantPipelineWithError(t *testing.T) {
+func TestDestroyExistentPipelineWithError(t *testing.T) {
 	ctx := context.Background()
 	pipelineErr := fmt.Errorf("test error")
 	response := &client.FakePipelineResponses{
@@ -154,7 +154,7 @@ func TestDestroyExistantPipelineWithError(t *testing.T) {
 	assert.ErrorIs(t, err, pipelineErr)
 }
 
-func TestDestroyExistantPipelineTimeoutError(t *testing.T) {
+func TestDestroyExistentPipelineTimeoutError(t *testing.T) {
 	ctx := context.Background()
 	pipelineErr := fmt.Errorf("test error")
 	response := &client.FakePipelineResponses{

--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	github.com/tklauser/numcpus v0.3.0 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20210609172227-d72af97c0eaf // indirect
-	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
+	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea
 	github.com/tonistiigi/vt100 v0.0.0-20210615222946-8066bb97264f // indirect
 	github.com/toqueteos/trie v1.0.0 // indirect
 	github.com/ulikunitz/xz v0.5.9 // indirect

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -184,6 +184,9 @@ var (
 
 	// ErrX509Hint should be included within a UserError.Hint when IsX509() return true
 	ErrX509Hint = "Add the flag '--insecure-skip-tls-verify' to skip certificate verification.\n    Follow this link to know more about configuring your own certificates with Okteto:\n    https://www.okteto.com/docs/self-hosted/administration/certificates/"
+
+	// ErrTimeout is raised when an operation has timed out
+	ErrTimeout = fmt.Errorf("operation timed out")
 )
 
 // IsAlreadyExists raised if the Kubernetes API returns AlreadyExists

--- a/pkg/k8s/configmaps/crud_test.go
+++ b/pkg/k8s/configmaps/crud_test.go
@@ -1,0 +1,136 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package configmaps_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/configmaps"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8sTesting "k8s.io/client-go/testing"
+)
+
+func TestGet(t *testing.T) {
+	ctx := context.Background()
+	ns := "fake-ns"
+	mockCfgName := "fake-cfg"
+	mockCfgStatus := "fake-status"
+	mockCfg := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mockCfgName,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			"status": mockCfgStatus,
+		},
+	}
+	clientset := fake.NewSimpleClientset(mockCfg)
+
+	cfg, err := configmaps.Get(ctx, mockCfgName, ns, clientset)
+
+	require.NoError(t, err)
+	assert.Equal(t, mockCfg, cfg)
+}
+
+func TestGet_Err(t *testing.T) {
+	ctx := context.Background()
+
+	mockErr := errors.New("unexpected error")
+
+	clientset := fake.NewSimpleClientset()
+	clientset.Fake.PrependReactor("get", "configmaps", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, mockErr
+	})
+
+	cfg, err := configmaps.Get(ctx, "fake-cfg-name", "fake-ns", clientset)
+
+	assert.Nil(t, cfg)
+	assert.ErrorIs(t, err, mockErr)
+}
+
+func TestWaitForStatus(t *testing.T) {
+	ctx := context.Background()
+
+	ticker := time.NewTicker(1 * time.Millisecond)
+
+	mockCfgName := "fake-cfg"
+	ns := "fake-ns"
+
+	mockCfg := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mockCfgName,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			"status": "fake-initial-status",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(mockCfg)
+
+	go func() {
+		mockCfg.Data["status"] = "fake-final-status"
+		clientset.CoreV1().ConfigMaps(ns).Update(ctx, mockCfg, metav1.UpdateOptions{})
+	}()
+
+	err := configmaps.WaitForStatus(ctx, mockCfgName, ns, "fake-final-status", ticker, 5*time.Millisecond, clientset)
+	assert.Nil(t, err)
+}
+
+func TestWaitForStatus_Timeout(t *testing.T) {
+	ctx := context.Background()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+
+	mockCfgName := "fake-cfg"
+	ns := "fake-ns"
+
+	mockCfg := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mockCfgName,
+			Namespace: ns,
+		},
+		Data: map[string]string{
+			"status": "fake-initial-status",
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(mockCfg)
+	err := configmaps.WaitForStatus(ctx, mockCfgName, ns, "fake-final-status", ticker, 1*time.Microsecond, clientset)
+	assert.ErrorIs(t, err, oktetoErrors.ErrTimeout)
+}
+
+func TestWaitForStatus_NotFound(t *testing.T) {
+	ctx := context.Background()
+
+	ticker := time.NewTicker(1 * time.Millisecond)
+
+	clientset := fake.NewSimpleClientset()
+	clientset.Fake.PrependReactor("get", "configmaps", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, k8sErrors.NewNotFound(apiv1.Resource("configmaps"), "fake-cfg")
+	})
+
+	err := configmaps.WaitForStatus(ctx, "fake-cfg", "fake-ns", "fake-final-status", ticker, 5*time.Second, clientset)
+	assert.ErrorIs(t, err, oktetoErrors.ErrNotFound)
+}


### PR DESCRIPTION
# Proposed changes

Fixes #3281 

Loom video demo: https://www.loom.com/share/8d7c2482a1c54f318b3f712b31c3f0a2

Follow up demo (covers scenario 4): https://www.loom.com/share/1dca9392bce049268ff97b8e44499588

Context: Currently, using `okteto deploy` on a manifest that has dependencies already being deployed, despite having `wait: true` on the dependency, does not wait for the deployment to be completed.

Proposed change: Extending the `deploy` cmd to wait when a repository is found in a "deploying" state. To achieve that, we can rely on an existing Configmap being found and its `Status` value.

Additionally, if we found that a previous job is running, we can also stream the logs. Unfortunately this is only possible for "pipeline deployments". If the deploy occurs locally, the logs won't be available for retrvial.

## How to test

There are 2 scenarios to test.

Scenario 1: **Deploy of the movies-multi-repo twice
Steps:
- Checkout this branch and build the CLI
- Clone movies-multi-repo: `git clone git@github.com:okteto/movies-multi-repo.git`
- Open two terminal sessions and run `okteto deploy` on each one
- Notice how the second one will stream the logs of the first one

Scenario 2: **Deploy `movies-frontend` and `movies-multi-repo`
Steps:
- Checkout this branch and build the CLI
- Clone movies-frontend: `git clone git@github.com:okteto/movies-frontend.git`
- Change the `okteto.yml` of `movies-frontend` removing the `depencencies` block
- Clone movies-multi-repo: `git clone git@github.com:okteto/movies-multi-repo.git`
- Change the `okteto.yml` of `movies-multi-repo` with:
```yaml
dependencies:
  movies-frontend:
    repository: https://github.com/okteto/movies-frontend
    wait: true
deploy:
  - name: Deploy MongoDB
    command: helm upgrade --install mongodb mongodb-12.1.30.tgz -f values.yml
 ```
- Open a terminal sessions for each repo and run `okteto deploy` on each one
- Notice how the second one will say that movies-frontend is already being deployed and waits until it ends.

Scenario 3: **Don't wait for the dependency**
Steps:
- Checkout this branch and build the CLI
- Clone movies-frontend: `git clone git@github.com:okteto/movies-frontend.git`
- Clone movies-multi-repo: `git clone git@github.com:okteto/movies-multi-repo.git`
- Modify the `okteto.yml` manifest of `movies-multi-repo`, set "wait: false`
- Open a terminal sessions for each repo and run `okteto deploy` on each one
- Notice how the second one will say that movies-frontend is already being scheduled for deploy and continue without waiting

Scenario 4: **Recover from `error` state**
Steps:
- Checkout this branch and build the CLI
- Clone movies-frontend: `git clone git@github.com:okteto/movies-frontend.git`
- Clone movies-multi-repo: `git clone git@github.com:okteto/movies-multi-repo.git`
- Modify the `okteto.yml` manifest of `movies-frontend`, adding a non-existing command in the deploy (so that it will break)
- Open a terminal sessions for each repo and run `okteto deploy` on each one
- Notice how the first will go into error state, but when you deploy the second one will recover to progressing and eventually to deployed
