### PR TITLE
Add support for sharing a preview with other members

### DIFF
--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -49,6 +49,7 @@ type DeployOptions struct {
 	timeout            time.Duration
 	variables          []string
 	wait               bool
+	members            *[]string
 }
 
 // Deploy Deploy a preview environment
@@ -94,6 +95,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a preview environment variable (can be set more than once)")
 	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", false, "wait until the preview environment deployment finishes (defaults to false)")
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "relative path within the repository to the okteto manifest (default to okteto.yaml or .okteto/okteto.yaml)")
+	cmd.Flags().StringArrayVarP(opts.members, "members", "m", []string{}, "members of the namespace, it can the username or email")
 
 	cmd.Flags().StringVarP(&opts.deprecatedFilename, "filename", "", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
 	if err := cmd.Flags().MarkHidden("filename"); err != nil {
@@ -113,6 +115,12 @@ func (pw *Command) ExecuteDeployPreview(ctx context.Context, opts *DeployOptions
 	if !opts.wait {
 		oktetoLog.Success("Preview environment '%s' scheduled for deployment", opts.name)
 		return nil
+	}
+
+	if opts.members != nil && len(*opts.members) > 0 {
+		if err := pw.okClient.Previews().AddMembers(ctx, opts.name, *opts.members); err != nil {
+			return fmt.Errorf("failed to invite %s to the preview deploy: %s", strings.Join(*opts.members, ", "), err)
+		}
 	}
 
 	if err := pw.waitUntilRunning(ctx, opts.name, okteto.Context().Namespace, resp.Action, opts.timeout); err != nil {

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -65,3 +65,7 @@ func (c *FakePreviewsClient) Destroy(_ context.Context, _ string) error {
 	c.response.DestroySuccessCount++
 	return nil
 }
+
+func (c *FakePreviewsClient) AddMembers(_ context.Context, _ string, _ []string) error {
+	return nil
+}

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -337,6 +337,30 @@ func (c *previewClient) GetResourcesStatusFromPreview(ctx context.Context, previ
 	return status, nil
 }
 
+// AddMembers adds members to a preview deploy
+func (c *previewClient) AddMembers(ctx context.Context, previewName string, members []string) error {
+	var mutation struct {
+		Space struct {
+			Id graphql.String
+		} `graphql:"updatePreview(id: $id, members: $members)"`
+	}
+
+	membersVariable := make([]graphql.String, 0)
+	for _, m := range members {
+		membersVariable = append(membersVariable, graphql.String(m))
+	}
+	variables := map[string]interface{}{
+		"id":      graphql.String(previewName),
+		"members": membersVariable,
+	}
+	err := mutate(ctx, &mutation, variables, c.client)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func translatePreviewAPIErr(err error, name string) error {
 	if err.Error() == "conflict" {
 		return fmt.Errorf("preview '%s' already exists with a different scope. Please use a different name", name)

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -49,6 +49,7 @@ type PreviewInterface interface {
 	DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []Variable) (*PreviewResponse, error)
 	GetResourcesStatusFromPreview(ctx context.Context, previewName, devName string) (map[string]string, error)
 	Destroy(ctx context.Context, previewName string) error
+	AddMembers(ctx context.Context, namespace string, members []string) error
 }
 
 // PipelineInterface represents the client that connects to the pipeline functions


### PR DESCRIPTION
# Proposed changes

This PR adds support for the `--members` flag in the `okteto preview deploy` command. This allows users to share a preview environment with a specified set of members.

The implementation of this feature replicates the functionality of the existing `okteto ns create --members` command.


# Motivation

This feature was added to address the problem of wanting to share preview environments with specific team members. By allowing users to specify members when deploying a preview environment, it makes collaboration easier and more streamlined.

Fixes #3453 

