### PR TITLE
Remove Token from credentials query

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -55,7 +55,9 @@ func NewContextCommand() *ContextCommand {
 		OktetoClientProvider: okteto.NewOktetoClientProvider(),
 		OktetoContextWriter:  okteto.NewContextConfigWriter(),
 		IsOktetoKubeTokenPresent: func(oktetoURL string) (bool, error) {
-			kubeTokenURL, err := okteto.ParseOktetoURLWithPath(oktetoURL, "auth/kubetoken")
+			// this is a hack to check if the server was upgraded to a version that supports the /auth/kubetoken/{namespace} endpoint
+			// if the endpoint is not present, the server will return a 401 unauthorized error
+			kubeTokenURL, err := okteto.ParseOktetoURLWithPath(oktetoURL, "auth/kubetoken/default")
 			if err != nil {
 				return false, fmt.Errorf("failed to parse kubetoken url: %w", err)
 			}

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -44,7 +44,7 @@ type ContextCommand struct {
 	OktetoClientProvider types.OktetoClientProvider
 
 	OktetoContextWriter    okteto.ContextConfigWriterInterface
-	oktetoKubeTokenPresent func(url string) (bool, error)
+	OktetoKubeTokenPresent func(url string) (bool, error)
 }
 
 // NewContextCommand creates a new ContextCommand
@@ -54,7 +54,7 @@ func NewContextCommand() *ContextCommand {
 		LoginController:      login.NewLoginController(),
 		OktetoClientProvider: okteto.NewOktetoClientProvider(),
 		OktetoContextWriter:  okteto.NewContextConfigWriter(),
-		oktetoKubeTokenPresent: func(oktetoURL string) (bool, error) {
+		OktetoKubeTokenPresent: func(oktetoURL string) (bool, error) {
 			kubeTokenURL, err := okteto.ParseOktetoURLWithPath(oktetoURL, "auth/kubetoken")
 			if err != nil {
 				return false, fmt.Errorf("failed to parse kubetoken url: %w", err)
@@ -279,7 +279,7 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	if cfg == nil {
 		cfg = kubeconfig.Create()
 	}
-	err = okteto.AddOktetoCredentialsToCfg(cfg, &userContext.Credentials, ctxOptions.Namespace, userContext.User.ID, okteto.Context().Name, c.oktetoKubeTokenPresent)
+	err = okteto.AddOktetoCredentialsToCfg(cfg, &userContext.Credentials, ctxOptions.Namespace, userContext.User.ID, okteto.Context().Name, c.OktetoKubeTokenPresent)
 	if err != nil {
 		return err
 	}

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -43,8 +43,8 @@ type ContextCommand struct {
 	LoginController      login.LoginInterface
 	OktetoClientProvider types.OktetoClientProvider
 
-	OktetoContextWriter    okteto.ContextConfigWriterInterface
-	OktetoKubeTokenPresent func(url string) (bool, error)
+	OktetoContextWriter      okteto.ContextConfigWriterInterface
+	IsOktetoKubeTokenPresent func(url string) (bool, error)
 }
 
 // NewContextCommand creates a new ContextCommand
@@ -54,7 +54,7 @@ func NewContextCommand() *ContextCommand {
 		LoginController:      login.NewLoginController(),
 		OktetoClientProvider: okteto.NewOktetoClientProvider(),
 		OktetoContextWriter:  okteto.NewContextConfigWriter(),
-		OktetoKubeTokenPresent: func(oktetoURL string) (bool, error) {
+		IsOktetoKubeTokenPresent: func(oktetoURL string) (bool, error) {
 			kubeTokenURL, err := okteto.ParseOktetoURLWithPath(oktetoURL, "auth/kubetoken")
 			if err != nil {
 				return false, fmt.Errorf("failed to parse kubetoken url: %w", err)
@@ -279,7 +279,7 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	if cfg == nil {
 		cfg = kubeconfig.Create()
 	}
-	err = okteto.AddOktetoCredentialsToCfg(cfg, &userContext.Credentials, ctxOptions.Namespace, userContext.User.ID, okteto.Context().Name, c.OktetoKubeTokenPresent)
+	err = okteto.AddOktetoCredentialsToCfg(cfg, &userContext.Credentials, ctxOptions.Namespace, userContext.User.ID, okteto.Context().Name, c.IsOktetoKubeTokenPresent)
 	if err != nil {
 		return err
 	}

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -38,7 +38,7 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User, fakeObj
 		LoginController:      test.NewFakeLoginController(user, nil),
 		OktetoClientProvider: client.NewFakeOktetoClientProvider(c),
 		OktetoContextWriter:  test.NewFakeOktetoContextWriter(),
-		OktetoKubeTokenPresent: func(url string) (bool, error) {
+		IsOktetoKubeTokenPresent: func(url string) (bool, error) {
 			return false, nil
 		},
 	}

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -38,6 +38,9 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User, fakeObj
 		LoginController:      test.NewFakeLoginController(user, nil),
 		OktetoClientProvider: client.NewFakeOktetoClientProvider(c),
 		OktetoContextWriter:  test.NewFakeOktetoContextWriter(),
+		OktetoKubeTokenPresent: func(url string) (bool, error) {
+			return false, nil
+		},
 	}
 }
 

--- a/cmd/namespace/create_test.go
+++ b/cmd/namespace/create_test.go
@@ -32,6 +32,9 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User) *contex
 		K8sClientProvider:    test.NewFakeK8sProvider(nil),
 		LoginController:      test.NewFakeLoginController(user, nil),
 		OktetoContextWriter:  test.NewFakeOktetoContextWriter(),
+		OktetoKubeTokenPresent: func(url string) (bool, error) {
+			return false, nil
+		},
 	}
 }
 

--- a/cmd/namespace/create_test.go
+++ b/cmd/namespace/create_test.go
@@ -32,7 +32,7 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User) *contex
 		K8sClientProvider:    test.NewFakeK8sProvider(nil),
 		LoginController:      test.NewFakeLoginController(user, nil),
 		OktetoContextWriter:  test.NewFakeOktetoContextWriter(),
-		OktetoKubeTokenPresent: func(url string) (bool, error) {
+		IsOktetoKubeTokenPresent: func(url string) (bool, error) {
 			return false, nil
 		},
 	}

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -161,6 +161,10 @@ func newOktetoClientFromGraphqlClient(url string, httpClient *http.Client) (*Okt
 }
 
 func parseOktetoURL(u string) (string, error) {
+	return ParseOktetoURLWithPath(u, "graphql")
+}
+
+func ParseOktetoURLWithPath(u, path string) (string, error) {
 	if u == "" {
 		return "", fmt.Errorf("the okteto URL is not set")
 	}
@@ -175,7 +179,7 @@ func parseOktetoURL(u string) (string, error) {
 		parsed.Host = parsed.Path
 	}
 
-	parsed.Path = "graphql"
+	parsed.Path = path
 	return parsed.String(), nil
 }
 

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -352,7 +352,7 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 		user.Token = ""
 		user.Exec = &clientcmdapi.ExecConfig{
 			Command:            "okteto",
-			Args:               []string{"kubetoken"},
+			Args:               []string{"kubetoken", clusterName},
 			APIVersion:         "client.authentication.k8s.io/v1",
 			InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
 			ProvideClusterInfo: true,

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -360,7 +360,7 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 		}
 	} else {
 		// fallback for okteto API before client authentication support
-		// TODO: remove once we stop supporting token based authentication
+		// TODO: remove once we stop supporting token based authentication https://github.com/okteto/okteto/pull/3409
 		user.Token = cred.Token
 		user.Exec = nil
 	}

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -327,6 +327,11 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 		return nil
 	}
 
+	hasKubeToken, err := hasKubeTokenCapabily(oktetoURL)
+	if err != nil {
+		return err
+	}
+
 	clusterName := UrlToKubernetesContext(oktetoURL)
 	// create cluster
 	cluster, ok := cfg.Clusters[clusterName]
@@ -344,10 +349,6 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 		user = clientcmdapi.NewAuthInfo()
 	}
 
-	hasKubeToken, err := hasKubeTokenCapabily(oktetoURL)
-	if err != nil {
-		return err
-	}
 	if hasKubeToken {
 		user.Token = ""
 		user.Exec = &clientcmdapi.ExecConfig{

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -360,9 +360,7 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 			InteractiveMode:    "IfAvailable",
 		}
 	} else {
-		// fallback for okteto API before client authentication support
-		// TODO: remove once we stop supporting token based authentication https://github.com/okteto/okteto/pull/3409
-		user.Token = cred.Token
+		// TODO: return error
 		user.Exec = nil
 	}
 	cfg.AuthInfos[userName] = user

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -353,7 +353,7 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 		user.Token = ""
 		user.Exec = &clientcmdapi.ExecConfig{
 			Command:            "okteto",
-			Args:               []string{"kubetoken", clusterName},
+			Args:               []string{"kubetoken", oktetoURL, namespace},
 			APIVersion:         "client.authentication.k8s.io/v1",
 			InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
 			ProvideClusterInfo: true,

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -343,7 +343,21 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 	if !ok {
 		user = clientcmdapi.NewAuthInfo()
 	}
-	user.Token = cred.Token
+	serverHasKubeTokenCapabilities := true // YODO: check if server has client authentication support
+	if serverHasKubeTokenCapabilities {
+		user.Token = ""
+		user.Exec = &clientcmdapi.ExecConfig{
+			Command:            "okteto",
+			Args:               []string{"kubetoken"},
+			APIVersion:         "client.authentication.k8s.io/v1",
+			InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
+			ProvideClusterInfo: true,
+			InteractiveMode:    "IfAvailable",
+		}
+	} else {
+		// fallback for okteto API before client authentication support
+		user.Token = cred.Token
+	}
 	cfg.AuthInfos[userName] = user
 
 	// create context

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -360,6 +360,7 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 		}
 	} else {
 		// fallback for okteto API before client authentication support
+		// TODO: remove once we stop supporting token based authentication
 		user.Token = cred.Token
 		user.Exec = nil
 	}

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -178,7 +178,7 @@ func Test_AddOktetoCredentialsToCfg(t *testing.T) {
 					username: {
 						Exec: &clientcmdapi.ExecConfig{
 							Command:            "okteto",
-							Args:               []string{"kubetoken", clusterAndContextName},
+							Args:               []string{"kubetoken", oktetoURL, namespace},
 							APIVersion:         "client.authentication.k8s.io/v1",
 							InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
 							ProvideClusterInfo: true,

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -15,6 +15,7 @@ package okteto
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -136,53 +137,116 @@ func Test_AddOktetoCredentialsToCfg(t *testing.T) {
 	cred := &types.Credential{
 		Server:      "https://ip.ip.ip.ip",
 		Certificate: "cred-cert",
+		Token:       "cred-token",
 	}
 
-	hasKubeTokenCapabily := func(oktetoURL string) (bool, error) {
-		return true, nil
-	}
 	oktetoURL := "https://cloud.okteto.com"
 	clusterAndContextName := "cloud_okteto_com"
-	AddOktetoCredentialsToCfg(cfg, cred, namespace, username, oktetoURL, hasKubeTokenCapabily)
 
-	expectedCfg := &clientcmdapi.Config{
-		Extensions: map[string]runtime.Object{},
-		Clusters: map[string]*clientcmdapi.Cluster{
-			clusterAndContextName: {
-				Server:                   cred.Server,
-				CertificateAuthorityData: []byte(cred.Certificate),
-				Extensions:               map[string]runtime.Object{},
-			},
-		},
-		Contexts: map[string]*clientcmdapi.Context{
-			clusterAndContextName: {
-				Cluster:   clusterAndContextName,
-				AuthInfo:  username,
-				Namespace: namespace,
-				Extensions: map[string]runtime.Object{
-					constants.OktetoExtension: nil,
+	tt := []struct {
+		name          string
+		hasKubeToken  bool
+		expectedCfg   *clientcmdapi.Config
+		err           error
+		expectedError error
+	}{
+		{
+			name:         "has-kube-token",
+			hasKubeToken: true,
+			expectedCfg: &clientcmdapi.Config{
+				Extensions: map[string]runtime.Object{},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					clusterAndContextName: {
+						Server:                   cred.Server,
+						CertificateAuthorityData: []byte(cred.Certificate),
+						Extensions:               map[string]runtime.Object{},
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					clusterAndContextName: {
+						Cluster:   clusterAndContextName,
+						AuthInfo:  username,
+						Namespace: namespace,
+						Extensions: map[string]runtime.Object{
+							constants.OktetoExtension: nil,
+						},
+					},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					username: {
+						Exec: &clientcmdapi.ExecConfig{
+							Command:            "okteto",
+							Args:               []string{"kubetoken", clusterAndContextName},
+							APIVersion:         "client.authentication.k8s.io/v1",
+							InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
+							ProvideClusterInfo: true,
+							InteractiveMode:    "IfAvailable",
+						},
+						Extensions:           map[string]runtime.Object{},
+						ImpersonateUserExtra: map[string][]string{},
+					},
+				},
+				CurrentContext: clusterAndContextName,
+				Preferences: clientcmdapi.Preferences{
+					Extensions: map[string]runtime.Object{},
 				},
 			},
 		},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			username: {
-				Exec: &clientcmdapi.ExecConfig{
-					Command:            "okteto",
-					Args:               []string{"kubetoken", clusterAndContextName},
-					APIVersion:         "client.authentication.k8s.io/v1",
-					InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
-					ProvideClusterInfo: true,
-					InteractiveMode:    "IfAvailable",
+		{
+			name:         "no-kube-token",
+			hasKubeToken: false,
+			expectedCfg: &clientcmdapi.Config{
+				Extensions: map[string]runtime.Object{},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					clusterAndContextName: {
+						Server:                   cred.Server,
+						CertificateAuthorityData: []byte(cred.Certificate),
+						Extensions:               map[string]runtime.Object{},
+					},
 				},
-				Extensions:           map[string]runtime.Object{},
-				ImpersonateUserExtra: map[string][]string{},
+				Contexts: map[string]*clientcmdapi.Context{
+					clusterAndContextName: {
+						Cluster:   clusterAndContextName,
+						AuthInfo:  username,
+						Namespace: namespace,
+						Extensions: map[string]runtime.Object{
+							constants.OktetoExtension: nil,
+						},
+					},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					username: {
+						Token:                cred.Token,
+						Extensions:           map[string]runtime.Object{},
+						ImpersonateUserExtra: map[string][]string{},
+					},
+				},
+				CurrentContext: clusterAndContextName,
+				Preferences: clientcmdapi.Preferences{
+					Extensions: map[string]runtime.Object{},
+				},
 			},
 		},
-		CurrentContext: clusterAndContextName,
-		Preferences: clientcmdapi.Preferences{
-			Extensions: map[string]runtime.Object{},
+		{
+			name:          "error",
+			err:           fmt.Errorf("error"),
+			expectedError: fmt.Errorf("error"),
+			expectedCfg:   clientcmdapi.NewConfig(),
 		},
 	}
 
-	require.Equal(t, expectedCfg, cfg)
+	for _, testCase := range tt {
+		cfg := cfg.DeepCopy()
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			hasKubeTokenCapabily := func(oktetoURL string) (bool, error) {
+				return testCase.hasKubeToken, testCase.err
+			}
+			err := AddOktetoCredentialsToCfg(cfg, cred, namespace, username, oktetoURL, hasKubeTokenCapabily)
+			require.Equal(t, testCase.expectedCfg, cfg)
+			require.Equal(t, testCase.expectedError, err)
+		})
+	}
+
 }

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -139,7 +139,6 @@ func Test_AddOktetoCredentialsToCfg(t *testing.T) {
 	cred := &types.Credential{
 		Server:      "https://ip.ip.ip.ip",
 		Certificate: "cred-cert",
-		Token:       "cred-token",
 	}
 
 	oktetoURL := "https://cloud.okteto.com"
@@ -195,39 +194,10 @@ func Test_AddOktetoCredentialsToCfg(t *testing.T) {
 			},
 		},
 		{
-			name:         "no-kube-token",
-			hasKubeToken: false,
-			expectedCfg: &clientcmdapi.Config{
-				Extensions: map[string]runtime.Object{},
-				Clusters: map[string]*clientcmdapi.Cluster{
-					clusterAndContextName: {
-						Server:                   cred.Server,
-						CertificateAuthorityData: []byte(cred.Certificate),
-						Extensions:               map[string]runtime.Object{},
-					},
-				},
-				Contexts: map[string]*clientcmdapi.Context{
-					clusterAndContextName: {
-						Cluster:   clusterAndContextName,
-						AuthInfo:  username,
-						Namespace: namespace,
-						Extensions: map[string]runtime.Object{
-							constants.OktetoExtension: nil,
-						},
-					},
-				},
-				AuthInfos: map[string]*clientcmdapi.AuthInfo{
-					username: {
-						Token:                cred.Token,
-						Extensions:           map[string]runtime.Object{},
-						ImpersonateUserExtra: map[string][]string{},
-					},
-				},
-				CurrentContext: clusterAndContextName,
-				Preferences: clientcmdapi.Preferences{
-					Extensions: map[string]runtime.Object{},
-				},
-			},
+			name:          "no-kube-token",
+			hasKubeToken:  false,
+			expectedCfg:   clientcmdapi.NewConfig(),
+			expectedError: fmt.Errorf(noKubetokenCapabilityError),
 		},
 		{
 			name:          "error",

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -17,7 +17,13 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
 	"github.com/okteto/okteto/internal/test"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_UrlToKubernetesContext(t *testing.T) {
@@ -121,4 +127,62 @@ func Test_RemoveSchema(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_AddOktetoCredentialsToCfg(t *testing.T) {
+	cfg := clientcmdapi.NewConfig()
+	namespace := "namespace"
+	username := "cindy"
+	cred := &types.Credential{
+		Server:      "https://ip.ip.ip.ip",
+		Certificate: "cred-cert",
+	}
+
+	hasKubeTokenCapabily := func(oktetoURL string) (bool, error) {
+		return true, nil
+	}
+	oktetoURL := "https://cloud.okteto.com"
+	clusterAndContextName := "cloud_okteto_com"
+	AddOktetoCredentialsToCfg(cfg, cred, namespace, username, oktetoURL, hasKubeTokenCapabily)
+
+	expectedCfg := &clientcmdapi.Config{
+		Extensions: map[string]runtime.Object{},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			clusterAndContextName: {
+				Server:                   cred.Server,
+				CertificateAuthorityData: []byte(cred.Certificate),
+				Extensions:               map[string]runtime.Object{},
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			clusterAndContextName: {
+				Cluster:   clusterAndContextName,
+				AuthInfo:  username,
+				Namespace: namespace,
+				Extensions: map[string]runtime.Object{
+					constants.OktetoExtension: nil,
+				},
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			username: {
+				Exec: &clientcmdapi.ExecConfig{
+					Command:            "okteto",
+					Args:               []string{"kubetoken", clusterAndContextName},
+					APIVersion:         "client.authentication.k8s.io/v1",
+					InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
+					ProvideClusterInfo: true,
+					InteractiveMode:    "IfAvailable",
+				},
+				Extensions:           map[string]runtime.Object{},
+				ImpersonateUserExtra: map[string][]string{},
+			},
+		},
+		CurrentContext: clusterAndContextName,
+		Preferences: clientcmdapi.Preferences{
+			Extensions: map[string]runtime.Object{},
+		},
+	}
+
+	require.Equal(t, expectedCfg, cfg)
 }

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -131,6 +131,8 @@ func Test_RemoveSchema(t *testing.T) {
 }
 
 func Test_AddOktetoCredentialsToCfg(t *testing.T) {
+	t.Parallel()
+
 	cfg := clientcmdapi.NewConfig()
 	namespace := "namespace"
 	username := "cindy"

--- a/pkg/okteto/credential.go
+++ b/pkg/okteto/credential.go
@@ -27,7 +27,6 @@ func (c *OktetoClient) GetCredentials(ctx context.Context) (*types.Credential, e
 		Space struct {
 			Server      graphql.String
 			Certificate graphql.String
-			Token       graphql.String
 			Namespace   graphql.String
 		} `graphql:"credentials(space: $cred)"`
 	}
@@ -43,7 +42,6 @@ func (c *OktetoClient) GetCredentials(ctx context.Context) (*types.Credential, e
 	cred := &types.Credential{
 		Server:      string(queryStruct.Space.Server),
 		Certificate: string(queryStruct.Space.Certificate),
-		Token:       string(queryStruct.Space.Token),
 		Namespace:   string(queryStruct.Space.Namespace),
 	}
 

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -79,7 +79,6 @@ func (c *userClient) GetContext(ctx context.Context) (*types.UserContext, error)
 		Cred struct {
 			Server      graphql.String
 			Certificate graphql.String
-			Token       graphql.String // TODO: Deprecate once we move to kubetoken auth https://github.com/okteto/okteto/pull/3409
 			Namespace   graphql.String
 		} `graphql:"credentials(space: $cred)"`
 	}
@@ -129,7 +128,6 @@ func (c *userClient) GetContext(ctx context.Context) (*types.UserContext, error)
 		Credentials: types.Credential{
 			Server:      string(queryStruct.Cred.Server),
 			Certificate: string(queryStruct.Cred.Certificate),
-			Token:       string(queryStruct.Cred.Token),
 			Namespace:   string(queryStruct.Cred.Namespace),
 		},
 	}
@@ -157,7 +155,6 @@ func (c *userClient) deprecatedGetUserContext(ctx context.Context) (*types.UserC
 		Cred struct {
 			Server      graphql.String
 			Certificate graphql.String
-			Token       graphql.String
 			Namespace   graphql.String
 		} `graphql:"credentials(space: $cred)"`
 	}
@@ -197,7 +194,6 @@ func (c *userClient) deprecatedGetUserContext(ctx context.Context) (*types.UserC
 		Credentials: types.Credential{
 			Server:      string(queryStruct.Cred.Server),
 			Certificate: string(queryStruct.Cred.Certificate),
-			Token:       string(queryStruct.Cred.Token),
 			Namespace:   string(queryStruct.Cred.Namespace),
 		},
 	}

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -79,7 +79,7 @@ func (c *userClient) GetContext(ctx context.Context) (*types.UserContext, error)
 		Cred struct {
 			Server      graphql.String
 			Certificate graphql.String
-			Token       graphql.String
+			Token       graphql.String // TODO: Deprecate once we move to kubetoken auth
 			Namespace   graphql.String
 		} `graphql:"credentials(space: $cred)"`
 	}

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -79,7 +79,7 @@ func (c *userClient) GetContext(ctx context.Context) (*types.UserContext, error)
 		Cred struct {
 			Server      graphql.String
 			Certificate graphql.String
-			Token       graphql.String // TODO: Deprecate once we move to kubetoken auth
+			Token       graphql.String // TODO: Deprecate once we move to kubetoken auth https://github.com/okteto/okteto/pull/3409
 			Namespace   graphql.String
 		} `graphql:"credentials(space: $cred)"`
 	}

--- a/pkg/types/credential.go
+++ b/pkg/types/credential.go
@@ -17,6 +17,6 @@ package types
 type Credential struct {
 	Server      string `json:"server" yaml:"server"`
 	Certificate string `json:"certificate" yaml:"certificate"`
-	Token       string `json:"token" yaml:"token"`
+	Token       string `json:"token" yaml:"token"` // TODO: Deprecate once we move to kubetoken auth
 	Namespace   string `json:"namespace" yaml:"namespace"`
 }

--- a/pkg/types/credential.go
+++ b/pkg/types/credential.go
@@ -17,6 +17,5 @@ package types
 type Credential struct {
 	Server      string `json:"server" yaml:"server"`
 	Certificate string `json:"certificate" yaml:"certificate"`
-	Token       string `json:"token" yaml:"token"` // TODO: Deprecate once we move to kubetoken auth
 	Namespace   string `json:"namespace" yaml:"namespace"`
 }


### PR DESCRIPTION
# Proposed changes

This PR should get merged in some time, I'm leaving it here to not lose context and have the work in place

Fixes https://github.com/okteto/okteto/issues/3410

Removes the usage of Token from the backend Credentials (used for authentication to the k8s cluster). Builds on top of https://github.com/okteto/okteto/pull/3409

Should be merged after the clusters have been upgraded to have the kubetoken capability

Open discussion: Should we not handle the case when the okteto cluster version is old and doesn't handle the kubetoken (i.e. retrocompatibility)? Maybe it's something to be done later, so we can remove the "legacy" code around checking for the capability