### PR TITLE
fix: remote deploy with name multiple words

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -227,7 +227,7 @@ func getDeployFlags(opts *Options) []string {
 	var deployFlags []string
 
 	if opts.Name != "" {
-		deployFlags = append(deployFlags, fmt.Sprintf("--name %s", opts.Name))
+		deployFlags = append(deployFlags, fmt.Sprintf("--name \"%s\"", opts.Name))
 	}
 
 	if opts.Namespace != "" {

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -153,7 +153,16 @@ func TestGetDeployFlags(t *testing.T) {
 					Name: "test",
 				},
 			},
-			expected: []string{"--name test"},
+			expected: []string{"--name \"test\""},
+		},
+		{
+			name: "name multiple words",
+			config: config{
+				opts: &Options{
+					Name: "this is a test",
+				},
+			},
+			expected: []string{"--name \"this is a test\""},
 		},
 		{
 			name: "namespace set",


### PR DESCRIPTION
# Problem description

When we run an okteto deploy that contains a name with multiple words, i.e: `okteto deploy --name "this is a test"` we didn't surround the name with quotes which causes a failure while reading the manifest during the remote execution.

# Proposed changes

- Surround the name with quotes on the remote command. This will run the command with the correct name and will run the commands in the remote



