### PR TITLE
fix: destroy command should expand env vars

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -948,13 +948,6 @@ func (manifest *Manifest) ExpandEnvVars() error {
 				return err
 			}
 		}
-		for idx, cmd := range manifest.Destroy.Commands {
-			cmd.Command, err = envsubst.String(cmd.Command)
-			if err != nil {
-				return errors.New("could not parse env vars")
-			}
-			manifest.Destroy.Commands[idx] = cmd
-		}
 	}
 
 	for devName, devInfo := range manifest.Dev {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -152,6 +152,36 @@ func TestManifestExpandDevEnvs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "does not expand vars in destroy command",
+			envs: map[string]string{
+				"TEST_VAR": "test",
+			},
+			manifest: &Manifest{
+				Destroy: &DestroyInfo{
+					Image: "",
+					Commands: []DeployCommand{
+						{
+							Name: "test",
+							Command: `TEST_VAR="do-not-expand-me"
+echo $TEST_VAR`,
+						},
+					},
+				},
+			},
+			expectedManifest: &Manifest{
+				Destroy: &DestroyInfo{
+					Image: "",
+					Commands: []DeployCommand{
+						{
+							Name: "test",
+							Command: `TEST_VAR="do-not-expand-me"
+echo $TEST_VAR`,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/6100

- Remove command variable expansion (is already done in the executor)
- Couldn't add unit test since the command executor opens a new connection

## Tested scenarios
1. Create the following manifest:
```yaml
name: test-pipeline

#build:
#  context: .

#dependencies:
#  test:
#    repository: http://nonexistentrepo/okteto/test.git
#    wait: true

deploy:
  commands:
    - name: test variable scripting
      command: |
        HELLO_WORLD="hi!"
        echo $HELLO_WORLD

destroy:
  commands:
    - name: test variable scripting
      command: |
        ANOTHER_VAR="this is another variable"
        echo $ANOTHER_VAR
```
2. Run `okteto destroy`
3. See that variable is actually expanded

