### PR TITLE
Always pull & export default cache when building an image

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -51,6 +51,10 @@ type registryInterface interface {
 	IsOktetoRegistry(image string) bool
 	GetImageReference(image string) (registry.OktetoImageReference, error)
 	HasGlobalPushAccess() (bool, error)
+	IsGlobalRegistry(image string) bool
+
+	GetRegistryAndRepo(image string) (string, string)
+	GetRepoNameAndTag(repo string) (string, string)
 }
 
 // NewBuildCommand creates a struct to run all build methods
@@ -109,7 +113,7 @@ func Build(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Target, "target", "", "", "set the target build stage to build")
 	cmd.Flags().BoolVarP(&options.NoCache, "no-cache", "", false, "do not use cache when building the image")
 	cmd.Flags().StringArrayVar(&options.CacheFrom, "cache-from", nil, "cache source images")
-	cmd.Flags().StringVarP(&options.ExportCache, "export-cache", "", "", "export cache image")
+	cmd.Flags().StringArrayVar(&options.ExportCache, "export-cache", nil, "export cache images")
 	cmd.Flags().StringVarP(&options.OutputMode, "progress", "", oktetoLog.TTYFormat, "show plain/tty build output")
 	cmd.Flags().StringArrayVar(&options.BuildArgs, "build-arg", nil, "set build-time variables")
 	cmd.Flags().StringArrayVar(&options.Secrets, "secret", nil, "secret files exposed to the build. Format: id=mysecret,src=/local/secret")

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -84,6 +84,11 @@ func (fr fakeRegistry) GetImageReference(image string) (registry.OktetoImageRefe
 	}, nil
 }
 
+func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
+
+func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
+func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
+
 var fakeManifestV2 *model.Manifest = &model.Manifest{
 	Build: model.ManifestBuild{
 		"test-1": &model.BuildInfo{

--- a/cmd/build/remote/build.go
+++ b/cmd/build/remote/build.go
@@ -19,14 +19,20 @@ type oktetoBuilderInterface interface {
 	Run(ctx context.Context, buildOptions *types.BuildOptions) error
 }
 
-type oktetoRegistryInterface interface {
+type OktetoRegistryInterface interface {
 	GetImageTagWithDigest(imageTag string) (string, error)
+	IsOktetoRegistry(image string) bool
+	HasGlobalPushAccess() (bool, error)
+	IsGlobalRegistry(image string) bool
+
+	GetRegistryAndRepo(image string) (string, string)
+	GetRepoNameAndTag(repo string) (string, string)
 }
 
 // OktetoBuilder builds the images
 type OktetoBuilder struct {
 	Builder  oktetoBuilderInterface
-	Registry oktetoRegistryInterface
+	Registry OktetoRegistryInterface
 }
 
 // NewBuilderFromScratch creates a new okteto builder

--- a/cmd/build/remote/build_test.go
+++ b/cmd/build/remote/build_test.go
@@ -46,6 +46,13 @@ func (fr fakeRegistry) AddImageByOpts(opts *types.BuildOptions) error {
 	return nil
 }
 
+func (fr fakeRegistry) IsOktetoRegistry(image string) bool { return false }
+func (fr fakeRegistry) HasGlobalPushAccess() (bool, error) { return false, nil }
+func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
+
+func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
+func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
+
 func TestBuildWithErrorFromDockerfile(t *testing.T) {
 	ctx := context.Background()
 	okteto.CurrentStore = &okteto.OktetoContextStore{

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -44,6 +44,10 @@ type oktetoRegistryInterface interface {
 	IsOktetoRegistry(image string) bool
 	GetImageReference(image string) (registry.OktetoImageReference, error)
 	HasGlobalPushAccess() (bool, error)
+	IsGlobalRegistry(image string) bool
+
+	GetRegistryAndRepo(image string) (string, string)
+	GetRepoNameAndTag(repo string) (string, string)
 }
 
 // oktetoBuilderConfigInterface returns the configuration that the builder has for the registry and project
@@ -226,7 +230,7 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 	tagToBuild := bc.getTagToBuild(manifest.Name, svcName, buildSvcInfo)
 	buildSvcInfo.Image = tagToBuild
 
-	buildOptions := build.OptsFromBuildInfo(manifest.Name, svcName, buildSvcInfo, options)
+	buildOptions := build.OptsFromBuildInfo(manifest.Name, svcName, buildSvcInfo, options, bc.Registry)
 
 	if err := bc.V1Builder.Build(ctx, buildOptions); err != nil {
 		return "", err
@@ -256,7 +260,7 @@ func (bc *OktetoBuilder) addVolumeMounts(ctx context.Context, manifest *model.Ma
 		buildSvcInfo.Image = tagToBuild[0]
 	}
 
-	buildOptions := build.OptsFromBuildInfo(manifest.Name, svcName, svcBuild, options)
+	buildOptions := build.OptsFromBuildInfo(manifest.Name, svcName, svcBuild, options, bc.Registry)
 
 	if err := bc.V1Builder.Build(ctx, buildOptions); err != nil {
 		return "", err

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -103,6 +103,11 @@ func (fr fakeRegistry) GetImageReference(image string) (registry.OktetoImageRefe
 	}, nil
 }
 
+func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
+
+func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
+func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
+
 func NewFakeBuilder(builder OktetoBuilderInterface, registry oktetoRegistryInterface) *OktetoBuilder {
 	return &OktetoBuilder{
 		Registry:          registry,

--- a/cmd/build/v2/environment.go
+++ b/cmd/build/v2/environment.go
@@ -72,7 +72,7 @@ func (bc *OktetoBuilder) SetServiceEnvVars(service, reference string) {
 	oktetoLog.Debug("manifest env vars set")
 }
 
-// SetServiceEnvVars set okteto build env vars
+// GetBuildEnvVars gets okteto build env vars
 func (bc *OktetoBuilder) GetBuildEnvVars() map[string]string {
 	return bc.buildEnvironments
 }

--- a/cmd/context/use-namespace.go
+++ b/cmd/context/use-namespace.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Namespace changes your current context namespace.
+// UseNamespace changes your current context namespace.
 func UseNamespace() *cobra.Command {
 	ctxOptions := &ContextOptions{}
 	cmd := &cobra.Command{

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -262,12 +262,12 @@ func Deploy(ctx context.Context) *cobra.Command {
 
 // RunDeploy runs the deploy sequence
 func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) error {
-	var err error
 	oktetoLog.SetStage("Load manifest")
-	deployOptions.Manifest, err = dc.GetManifest(deployOptions.ManifestPath)
+	manifest, err := dc.GetManifest(deployOptions.ManifestPath)
 	if err != nil {
 		return err
 	}
+	deployOptions.Manifest = manifest
 	oktetoLog.Debug("found okteto manifest")
 	dc.PipelineType = deployOptions.Manifest.Type
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -112,6 +112,11 @@ func (fr fakeRegistry) AddImageByOpts(opts *types.BuildOptions) error {
 	return nil
 }
 
+func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
+
+func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
+func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
+
 var fakeManifest *model.Manifest = &model.Manifest{
 	Deploy: &model.DeployInfo{
 		Commands: []model.DeployCommand{

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -148,7 +148,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		return err
 	}
 
-	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"})
+	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"}, rd.builderV2.Registry)
 	buildOptions.Tag = ""
 	buildOptions.Manifest = deployOptions.Manifest
 

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -135,7 +135,9 @@ func TestRemoteTest(t *testing.T) {
 			wdCtrl.SetErrors(tt.config.wd)
 			tempCreator.SetError(tt.config.tempFsCreator)
 			rdc := remoteDeployCommand{
-				builderV2:            &v2.OktetoBuilder{},
+				builderV2: &v2.OktetoBuilder{
+					Registry: newFakeRegistry(),
+				},
 				builderV1:            fakeBuilder{tt.config.builderErr},
 				fs:                   fs,
 				workingDirectoryCtrl: wdCtrl,

--- a/cmd/preview/deploy_test.go
+++ b/cmd/preview/deploy_test.go
@@ -23,7 +23,7 @@ func Test_ExecuteDeployPreview(t *testing.T) {
 		username          string
 		pipelineResponses *client.FakePipelineResponses
 		previewResponses  *client.FakePreviewResponse
-		streamResponses      *client.FakeStreamResponse
+		streamResponses   *client.FakeStreamResponse
 		opts              *DeployOptions
 		expectedErr       error
 	}{
@@ -122,7 +122,7 @@ func Test_ExecuteDeployPreview(t *testing.T) {
 				},
 			},
 			streamResponses: &client.FakeStreamResponse{},
-			expectedErr:  errWait,
+			expectedErr:     errWait,
 		},
 		{
 			name:     "err-wait-resources",
@@ -144,7 +144,7 @@ func Test_ExecuteDeployPreview(t *testing.T) {
 				ErrResources: errResources,
 			},
 			streamResponses: &client.FakeStreamResponse{},
-			expectedErr:  errResources,
+			expectedErr:     errResources,
 		},
 		{
 			name:     "err-wait-resources-timeout",
@@ -165,7 +165,7 @@ func Test_ExecuteDeployPreview(t *testing.T) {
 				},
 			},
 			streamResponses: &client.FakeStreamResponse{},
-			expectedErr:  ErrWaitResourcesTimeout,
+			expectedErr:     ErrWaitResourcesTimeout,
 		},
 	}
 

--- a/pkg/cache/cache_from.go
+++ b/pkg/cache/cache_from.go
@@ -23,14 +23,12 @@ import (
 // CacheFrom is a list of images to import cache from.
 type CacheFrom []string
 
-type ImageCtrlInterface interface {
+type oktetoRegistryInterface interface {
+	HasGlobalPushAccess() (bool, error)
+	IsGlobalRegistry(image string) bool
+
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
-}
-
-type oktetoRegistryInterface interface {
-	GetImageCtrl() ImageCtrlInterface
-	HasGlobalPushAccess() (bool, error)
 }
 
 // UnmarshalYAML implements the Unmarshaler interface of the yaml pkg.
@@ -68,17 +66,16 @@ func (cf *CacheFrom) AddDefaultPullCache(reg oktetoRegistryInterface, image stri
 		oktetoLog.Infof("error trying to access globalPushAccess: %w", err)
 	}
 
-	imageCtrl := reg.GetImageCtrl()
-	_, repo := imageCtrl.GetRegistryAndRepo(image)
-	imageName, _ := imageCtrl.GetRepoNameAndTag(repo)
+	_, repo := reg.GetRegistryAndRepo(image)
+	imageName, _ := reg.GetRepoNameAndTag(repo)
 
 	if hasAccess {
-		globalCacheImage := fmt.Sprintf("%s/%s:cache", constants.GlobalRegistry, imageName)
+		globalCacheImage := fmt.Sprintf("%s/%s:%s", constants.GlobalRegistry, imageName, defaultCacheTag)
 		cf.addCacheFromImage(globalCacheImage)
 		oktetoLog.Debugf("Dynamically adding cache_from: %s", globalCacheImage)
 	}
 
-	devCacheImage := fmt.Sprintf("%s/%s:cache", constants.DevRegistry, imageName)
+	devCacheImage := fmt.Sprintf("%s/%s:%s", constants.DevRegistry, imageName, defaultCacheTag)
 	cf.addCacheFromImage(devCacheImage)
 	oktetoLog.Debugf("Dynamically adding cache_from: %s", devCacheImage)
 }

--- a/pkg/cache/cache_from.go
+++ b/pkg/cache/cache_from.go
@@ -66,8 +66,8 @@ func (cf *CacheFrom) AddDefaultPullCache(reg oktetoRegistryInterface, image stri
 		oktetoLog.Infof("error trying to access globalPushAccess: %w", err)
 	}
 
-	_, repo := reg.GetRegistryAndRepo(image)
-	imageName, _ := reg.GetRepoNameAndTag(repo)
+	_, imageRepo := reg.GetRegistryAndRepo(image)
+	imageName, _ := reg.GetRepoNameAndTag(imageRepo)
 
 	if hasAccess {
 		globalCacheImage := fmt.Sprintf("%s/%s:%s", constants.GlobalRegistry, imageName, defaultCacheTag)

--- a/pkg/cache/cache_from.go
+++ b/pkg/cache/cache_from.go
@@ -1,0 +1,101 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/constants"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+)
+
+// CacheFrom is a list of images to import cache from.
+type CacheFrom []string
+
+type ImageCtrlInterface interface {
+	GetRegistryAndRepo(image string) (string, string)
+	GetRepoNameAndTag(repo string) (string, string)
+}
+
+type oktetoRegistryInterface interface {
+	GetImageCtrl() ImageCtrlInterface
+	HasGlobalPushAccess() (bool, error)
+}
+
+// UnmarshalYAML implements the Unmarshaler interface of the yaml pkg.
+func (cf *CacheFrom) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var single string
+	err := unmarshal(&single)
+	if err == nil {
+		*cf = CacheFrom{single}
+		return nil
+	}
+
+	var multi []string
+	err = unmarshal(&multi)
+	if err == nil {
+		*cf = multi
+		return nil
+	}
+
+	return err
+}
+
+// MarshalYAML implements the marshaler interface of the yaml pkg.
+func (cf *CacheFrom) MarshalYAML() (interface{}, error) {
+	if len(*cf) == 1 {
+		return (*cf)[0], nil
+	}
+
+	return cf, nil
+}
+
+// AddDefaultPullCache appends the default cache layers for a given image
+func (cf *CacheFrom) AddDefaultPullCache(reg oktetoRegistryInterface, image string) {
+	hasAccess, err := reg.HasGlobalPushAccess()
+	if err != nil {
+		oktetoLog.Infof("error trying to access globalPushAccess: %w", err)
+	}
+
+	imageCtrl := reg.GetImageCtrl()
+	_, repo := imageCtrl.GetRegistryAndRepo(image)
+	imageName, _ := imageCtrl.GetRepoNameAndTag(repo)
+
+	if hasAccess {
+		globalCacheImage := fmt.Sprintf("%s/%s:cache", constants.GlobalRegistry, imageName)
+		cf.addCacheFromImage(globalCacheImage)
+		oktetoLog.Debugf("Dynamically adding cache_from: %s", globalCacheImage)
+	}
+
+	devCacheImage := fmt.Sprintf("%s/%s:cache", constants.DevRegistry, imageName)
+	cf.addCacheFromImage(devCacheImage)
+	oktetoLog.Debugf("Dynamically adding cache_from: %s", devCacheImage)
+}
+
+// addCacheFromImage appends a cache image to the list if it's not already there
+func (cf *CacheFrom) addCacheFromImage(imageName string) {
+	if !cf.hasCacheFromImage(imageName) {
+		*cf = append(*cf, imageName)
+	}
+}
+
+// hasCacheFromImage checks if a cache image is already in the list
+func (cf *CacheFrom) hasCacheFromImage(imageName string) bool {
+	for _, cacheFrom := range *cf {
+		if cacheFrom == imageName {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cache/cache_from_test.go
+++ b/pkg/cache/cache_from_test.go
@@ -14,222 +14,222 @@
 package cache
 
 import (
-	"testing"
+    "testing"
 
-	"github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/assert"
 
-	yaml "gopkg.in/yaml.v2"
+    yaml "gopkg.in/yaml.v2"
 )
 
 type mockRegistry struct {
-	isGlobal bool
-	registry string
-	repo     string
-	tag      string
+    isGlobal bool
+    registry string
+    repo     string
+    tag      string
 }
 
 func (mr *mockRegistry) HasGlobalPushAccess() (bool, error) {
-	return mr.isGlobal, nil
+    return mr.isGlobal, nil
 }
 
 func (mr *mockRegistry) IsGlobalRegistry(image string) bool {
-	return mr.isGlobal
+    return mr.isGlobal
 }
 
 func (mr *mockRegistry) GetRegistryAndRepo(_ string) (string, string) {
-	return mr.registry, mr.repo
+    return mr.registry, mr.repo
 }
 
 func (mr *mockRegistry) GetRepoNameAndTag(_ string) (string, string) {
-	return mr.repo, mr.tag
+    return mr.repo, mr.tag
 }
 
 type mockRegistryWithError struct {
-	registry string
-	repo     string
-	tag      string
+    registry string
+    repo     string
+    tag      string
 }
 
 func (*mockRegistryWithError) HasGlobalPushAccess() (bool, error) {
-	return false, assert.AnError
+    return false, assert.AnError
 }
 
 func (*mockRegistryWithError) IsGlobalRegistry(image string) bool {
-	return true
+    return true
 }
 
 func (mr *mockRegistryWithError) GetRegistryAndRepo(_ string) (string, string) {
-	return mr.registry, mr.repo
+    return mr.registry, mr.repo
 }
 
 func (mr *mockRegistryWithError) GetRepoNameAndTag(_ string) (string, string) {
-	return mr.repo, mr.tag
+    return mr.repo, mr.tag
 }
 
 func Test_AddDefaultPullCache(t *testing.T) {
-	reg := &mockRegistry{
-		isGlobal: true,
-		registry: "registry",
-		repo:     "test-account/test-image",
-		tag:      "1.0.0",
-	}
+    reg := &mockRegistry{
+        isGlobal: true,
+        registry: "registry",
+        repo:     "test-account/test-image",
+        tag:      "1.0.0",
+    }
 
-	tests := []struct {
-		name     string
-		image    string
-		cf       CacheFrom
-		expected CacheFrom
-	}{
-		{
-			name:     "already with cache image",
-			image:    "test-account/test-image:1.0.0",
-			cf:       CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
-			expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
-		},
-		{
-			name:     "without cache image",
-			image:    "test-account/test-image:1.0.0",
-			cf:       CacheFrom{},
-			expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
-		},
-	}
+    tests := []struct {
+        name     string
+        image    string
+        cf       CacheFrom
+        expected CacheFrom
+    }{
+        {
+            name:     "already with cache image",
+            image:    "test-account/test-image:1.0.0",
+            cf:       CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+            expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+        },
+        {
+            name:     "without cache image",
+            image:    "test-account/test-image:1.0.0",
+            cf:       CacheFrom{},
+            expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.cf.AddDefaultPullCache(reg, tt.image)
-			assert.Equal(t, tt.expected, tt.cf)
-		})
-	}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            tt.cf.AddDefaultPullCache(reg, tt.image)
+            assert.Equal(t, tt.expected, tt.cf)
+        })
+    }
 }
 
 func Test_AddDefaultPullCache_WithError(t *testing.T) {
-	image := "test-account/test-image:x.y.z"
-	cf := CacheFrom{}
-	expected := CacheFrom{"okteto.dev/test-account/test-image:cache"}
+    image := "test-account/test-image:x.y.z"
+    cf := CacheFrom{}
+    expected := CacheFrom{"okteto.dev/test-account/test-image:cache"}
 
-	registry := &mockRegistryWithError{
-		registry: "registry",
-		repo:     "test-account/test-image",
-		tag:      "1.0.0",
-	}
+    registry := &mockRegistryWithError{
+        registry: "registry",
+        repo:     "test-account/test-image",
+        tag:      "1.0.0",
+    }
 
-	cf.AddDefaultPullCache(registry, image)
+    cf.AddDefaultPullCache(registry, image)
 
-	assert.Equal(t, cf, expected)
+    assert.Equal(t, cf, expected)
 }
 
 func Test_hasCacheFromImage(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		cf       CacheFrom
-		expected bool
-	}{
-		{
-			name:     "not found",
-			input:    "test-registry/test-image:cache",
-			cf:       CacheFrom{"test-registry/test-image:test-tag"},
-			expected: false,
-		},
-		{
-			name:     "found",
-			input:    "test-registry/test-image:cache",
-			cf:       CacheFrom{"test-registry/test-image:cache"},
-			expected: true,
-		},
-	}
+    tests := []struct {
+        name     string
+        input    string
+        cf       CacheFrom
+        expected bool
+    }{
+        {
+            name:     "not found",
+            input:    "test-registry/test-image:cache",
+            cf:       CacheFrom{"test-registry/test-image:test-tag"},
+            expected: false,
+        },
+        {
+            name:     "found",
+            input:    "test-registry/test-image:cache",
+            cf:       CacheFrom{"test-registry/test-image:cache"},
+            expected: true,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := tt.cf.hasCacheFromImage(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := tt.cf.hasCacheFromImage(tt.input)
+            assert.Equal(t, tt.expected, result)
+        })
+    }
 }
 
 func Test_UnmarshalYAML(t *testing.T) {
-	tests := []struct {
-		name     string
-		data     []byte
-		expected interface{}
-	}{
-		{
-			name:     "empty",
-			data:     []byte("[]"),
-			expected: CacheFrom{},
-		},
-		{
-			name:     "one single item",
-			data:     []byte("test-registry/test-image:cache"),
-			expected: CacheFrom{"test-registry/test-image:cache"},
-		},
-		{
-			name:     "one item as list",
-			data:     []byte(`["test-registry/test-image:cache"]`),
-			expected: CacheFrom{"test-registry/test-image:cache"},
-		},
-		{
-			name:     "one item as list",
-			data:     []byte(`["test-registry/test-image:cache"]`),
-			expected: CacheFrom{"test-registry/test-image:cache"},
-		},
-		{
-			name: "two items",
-			data: []byte(`
+    tests := []struct {
+        name     string
+        data     []byte
+        expected interface{}
+    }{
+        {
+            name:     "empty",
+            data:     []byte("[]"),
+            expected: CacheFrom{},
+        },
+        {
+            name:     "one single item",
+            data:     []byte("test-registry/test-image:cache"),
+            expected: CacheFrom{"test-registry/test-image:cache"},
+        },
+        {
+            name:     "one item as list",
+            data:     []byte(`["test-registry/test-image:cache"]`),
+            expected: CacheFrom{"test-registry/test-image:cache"},
+        },
+        {
+            name:     "one item as list",
+            data:     []byte(`["test-registry/test-image:cache"]`),
+            expected: CacheFrom{"test-registry/test-image:cache"},
+        },
+        {
+            name: "two items",
+            data: []byte(`
 - test-registry/test-image:1.0.0
 - test-registry/another-image:1.0.0`),
-			expected: CacheFrom{"test-registry/test-image:1.0.0", "test-registry/another-image:1.0.0"},
-		},
-	}
+            expected: CacheFrom{"test-registry/test-image:1.0.0", "test-registry/another-image:1.0.0"},
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var cf CacheFrom
-			err := yaml.Unmarshal([]byte(tt.data), &cf)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, cf)
-		})
-	}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            var cf CacheFrom
+            err := yaml.Unmarshal([]byte(tt.data), &cf)
+            assert.NoError(t, err)
+            assert.Equal(t, tt.expected, cf)
+        })
+    }
 }
 
 func Test_UnmarshalYAML_WithError(t *testing.T) {
-	var cf CacheFrom
+    var cf CacheFrom
 
-	err := cf.UnmarshalYAML(func(interface{}) error {
-		return assert.AnError
-	})
+    err := cf.UnmarshalYAML(func(interface{}) error {
+        return assert.AnError
+    })
 
-	assert.ErrorIs(t, err, assert.AnError)
+    assert.ErrorIs(t, err, assert.AnError)
 }
 
 func Test_MarshalYAML(t *testing.T) {
-	tests := []struct {
-		name     string
-		cf       CacheFrom
-		expected string
-	}{
-		{
-			name:     "empty",
-			cf:       CacheFrom{},
-			expected: "[]\n",
-		},
-		{
-			name:     "one image",
-			cf:       CacheFrom{"test-registry/test-image:cache"},
-			expected: "- test-registry/test-image:cache\n",
-		},
-		{
-			name:     "two images",
-			cf:       CacheFrom{"test-registry/test-image-1:cache", "test-registry/test-image-2:cache"},
-			expected: "- test-registry/test-image-1:cache\n- test-registry/test-image-2:cache\n",
-		},
-	}
+    tests := []struct {
+        name     string
+        cf       CacheFrom
+        expected string
+    }{
+        {
+            name:     "empty",
+            cf:       CacheFrom{},
+            expected: "[]\n",
+        },
+        {
+            name:     "one image",
+            cf:       CacheFrom{"test-registry/test-image:cache"},
+            expected: "- test-registry/test-image:cache\n",
+        },
+        {
+            name:     "two images",
+            cf:       CacheFrom{"test-registry/test-image-1:cache", "test-registry/test-image-2:cache"},
+            expected: "- test-registry/test-image-1:cache\n- test-registry/test-image-2:cache\n",
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := yaml.Marshal(tt.cf)
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, string(result))
-		})
-	}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result, err := yaml.Marshal(tt.cf)
+            assert.NoError(t, err)
+            assert.Equal(t, tt.expected, string(result))
+        })
+    }
 }

--- a/pkg/cache/cache_from_test.go
+++ b/pkg/cache/cache_from_test.go
@@ -28,8 +28,8 @@ type mockRegistry struct {
 	tag      string
 }
 
-func (*mockRegistry) HasGlobalPushAccess() (bool, error) {
-	return true, nil
+func (mr *mockRegistry) HasGlobalPushAccess() (bool, error) {
+	return mr.isGlobal, nil
 }
 
 func (mr *mockRegistry) IsGlobalRegistry(image string) bool {
@@ -68,6 +68,7 @@ func (mr *mockRegistryWithError) GetRepoNameAndTag(_ string) (string, string) {
 
 func Test_AddDefaultPullCache(t *testing.T) {
 	reg := &mockRegistry{
+		isGlobal: true,
 		registry: "registry",
 		repo:     "test-account/test-image",
 		tag:      "1.0.0",

--- a/pkg/cache/cache_from_test.go
+++ b/pkg/cache/cache_from_test.go
@@ -14,222 +14,222 @@
 package cache
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 
-    yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type mockRegistry struct {
-    isGlobal bool
-    registry string
-    repo     string
-    tag      string
+	isGlobal bool
+	registry string
+	repo     string
+	tag      string
 }
 
 func (mr *mockRegistry) HasGlobalPushAccess() (bool, error) {
-    return mr.isGlobal, nil
+	return mr.isGlobal, nil
 }
 
 func (mr *mockRegistry) IsGlobalRegistry(image string) bool {
-    return mr.isGlobal
+	return mr.isGlobal
 }
 
 func (mr *mockRegistry) GetRegistryAndRepo(_ string) (string, string) {
-    return mr.registry, mr.repo
+	return mr.registry, mr.repo
 }
 
 func (mr *mockRegistry) GetRepoNameAndTag(_ string) (string, string) {
-    return mr.repo, mr.tag
+	return mr.repo, mr.tag
 }
 
 type mockRegistryWithError struct {
-    registry string
-    repo     string
-    tag      string
+	registry string
+	repo     string
+	tag      string
 }
 
 func (*mockRegistryWithError) HasGlobalPushAccess() (bool, error) {
-    return false, assert.AnError
+	return false, assert.AnError
 }
 
 func (*mockRegistryWithError) IsGlobalRegistry(image string) bool {
-    return true
+	return true
 }
 
 func (mr *mockRegistryWithError) GetRegistryAndRepo(_ string) (string, string) {
-    return mr.registry, mr.repo
+	return mr.registry, mr.repo
 }
 
 func (mr *mockRegistryWithError) GetRepoNameAndTag(_ string) (string, string) {
-    return mr.repo, mr.tag
+	return mr.repo, mr.tag
 }
 
 func Test_AddDefaultPullCache(t *testing.T) {
-    reg := &mockRegistry{
-        isGlobal: true,
-        registry: "registry",
-        repo:     "test-account/test-image",
-        tag:      "1.0.0",
-    }
+	reg := &mockRegistry{
+		isGlobal: true,
+		registry: "registry",
+		repo:     "test-account/test-image",
+		tag:      "1.0.0",
+	}
 
-    tests := []struct {
-        name     string
-        image    string
-        cf       CacheFrom
-        expected CacheFrom
-    }{
-        {
-            name:     "already with cache image",
-            image:    "test-account/test-image:1.0.0",
-            cf:       CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
-            expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
-        },
-        {
-            name:     "without cache image",
-            image:    "test-account/test-image:1.0.0",
-            cf:       CacheFrom{},
-            expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
-        },
-    }
+	tests := []struct {
+		name     string
+		image    string
+		cf       CacheFrom
+		expected CacheFrom
+	}{
+		{
+			name:     "already with cache image",
+			image:    "test-account/test-image:1.0.0",
+			cf:       CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+			expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+		},
+		{
+			name:     "without cache image",
+			image:    "test-account/test-image:1.0.0",
+			cf:       CacheFrom{},
+			expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            tt.cf.AddDefaultPullCache(reg, tt.image)
-            assert.Equal(t, tt.expected, tt.cf)
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cf.AddDefaultPullCache(reg, tt.image)
+			assert.Equal(t, tt.expected, tt.cf)
+		})
+	}
 }
 
 func Test_AddDefaultPullCache_WithError(t *testing.T) {
-    image := "test-account/test-image:x.y.z"
-    cf := CacheFrom{}
-    expected := CacheFrom{"okteto.dev/test-account/test-image:cache"}
+	image := "test-account/test-image:x.y.z"
+	cf := CacheFrom{}
+	expected := CacheFrom{"okteto.dev/test-account/test-image:cache"}
 
-    registry := &mockRegistryWithError{
-        registry: "registry",
-        repo:     "test-account/test-image",
-        tag:      "1.0.0",
-    }
+	registry := &mockRegistryWithError{
+		registry: "registry",
+		repo:     "test-account/test-image",
+		tag:      "1.0.0",
+	}
 
-    cf.AddDefaultPullCache(registry, image)
+	cf.AddDefaultPullCache(registry, image)
 
-    assert.Equal(t, cf, expected)
+	assert.Equal(t, cf, expected)
 }
 
 func Test_hasCacheFromImage(t *testing.T) {
-    tests := []struct {
-        name     string
-        input    string
-        cf       CacheFrom
-        expected bool
-    }{
-        {
-            name:     "not found",
-            input:    "test-registry/test-image:cache",
-            cf:       CacheFrom{"test-registry/test-image:test-tag"},
-            expected: false,
-        },
-        {
-            name:     "found",
-            input:    "test-registry/test-image:cache",
-            cf:       CacheFrom{"test-registry/test-image:cache"},
-            expected: true,
-        },
-    }
+	tests := []struct {
+		name     string
+		input    string
+		cf       CacheFrom
+		expected bool
+	}{
+		{
+			name:     "not found",
+			input:    "test-registry/test-image:cache",
+			cf:       CacheFrom{"test-registry/test-image:test-tag"},
+			expected: false,
+		},
+		{
+			name:     "found",
+			input:    "test-registry/test-image:cache",
+			cf:       CacheFrom{"test-registry/test-image:cache"},
+			expected: true,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result := tt.cf.hasCacheFromImage(tt.input)
-            assert.Equal(t, tt.expected, result)
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.cf.hasCacheFromImage(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func Test_UnmarshalYAML(t *testing.T) {
-    tests := []struct {
-        name     string
-        data     []byte
-        expected interface{}
-    }{
-        {
-            name:     "empty",
-            data:     []byte("[]"),
-            expected: CacheFrom{},
-        },
-        {
-            name:     "one single item",
-            data:     []byte("test-registry/test-image:cache"),
-            expected: CacheFrom{"test-registry/test-image:cache"},
-        },
-        {
-            name:     "one item as list",
-            data:     []byte(`["test-registry/test-image:cache"]`),
-            expected: CacheFrom{"test-registry/test-image:cache"},
-        },
-        {
-            name:     "one item as list",
-            data:     []byte(`["test-registry/test-image:cache"]`),
-            expected: CacheFrom{"test-registry/test-image:cache"},
-        },
-        {
-            name: "two items",
-            data: []byte(`
+	tests := []struct {
+		name     string
+		data     []byte
+		expected interface{}
+	}{
+		{
+			name:     "empty",
+			data:     []byte("[]"),
+			expected: CacheFrom{},
+		},
+		{
+			name:     "one single item",
+			data:     []byte("test-registry/test-image:cache"),
+			expected: CacheFrom{"test-registry/test-image:cache"},
+		},
+		{
+			name:     "one item as list",
+			data:     []byte(`["test-registry/test-image:cache"]`),
+			expected: CacheFrom{"test-registry/test-image:cache"},
+		},
+		{
+			name:     "one item as list",
+			data:     []byte(`["test-registry/test-image:cache"]`),
+			expected: CacheFrom{"test-registry/test-image:cache"},
+		},
+		{
+			name: "two items",
+			data: []byte(`
 - test-registry/test-image:1.0.0
 - test-registry/another-image:1.0.0`),
-            expected: CacheFrom{"test-registry/test-image:1.0.0", "test-registry/another-image:1.0.0"},
-        },
-    }
+			expected: CacheFrom{"test-registry/test-image:1.0.0", "test-registry/another-image:1.0.0"},
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            var cf CacheFrom
-            err := yaml.Unmarshal([]byte(tt.data), &cf)
-            assert.NoError(t, err)
-            assert.Equal(t, tt.expected, cf)
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cf CacheFrom
+			err := yaml.Unmarshal([]byte(tt.data), &cf)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, cf)
+		})
+	}
 }
 
 func Test_UnmarshalYAML_WithError(t *testing.T) {
-    var cf CacheFrom
+	var cf CacheFrom
 
-    err := cf.UnmarshalYAML(func(interface{}) error {
-        return assert.AnError
-    })
+	err := cf.UnmarshalYAML(func(interface{}) error {
+		return assert.AnError
+	})
 
-    assert.ErrorIs(t, err, assert.AnError)
+	assert.ErrorIs(t, err, assert.AnError)
 }
 
 func Test_MarshalYAML(t *testing.T) {
-    tests := []struct {
-        name     string
-        cf       CacheFrom
-        expected string
-    }{
-        {
-            name:     "empty",
-            cf:       CacheFrom{},
-            expected: "[]\n",
-        },
-        {
-            name:     "one image",
-            cf:       CacheFrom{"test-registry/test-image:cache"},
-            expected: "- test-registry/test-image:cache\n",
-        },
-        {
-            name:     "two images",
-            cf:       CacheFrom{"test-registry/test-image-1:cache", "test-registry/test-image-2:cache"},
-            expected: "- test-registry/test-image-1:cache\n- test-registry/test-image-2:cache\n",
-        },
-    }
+	tests := []struct {
+		name     string
+		cf       *CacheFrom
+		expected string
+	}{
+		{
+			name:     "empty",
+			cf:       &CacheFrom{},
+			expected: "[]\n",
+		},
+		{
+			name:     "one image",
+			cf:       &CacheFrom{"test-registry/test-image:cache"},
+			expected: "test-registry/test-image:cache\n",
+		},
+		{
+			name:     "two images",
+			cf:       &CacheFrom{"test-registry/test-image-1:cache", "test-registry/test-image-2:cache"},
+			expected: "- test-registry/test-image-1:cache\n- test-registry/test-image-2:cache\n",
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            result, err := yaml.Marshal(tt.cf)
-            assert.NoError(t, err)
-            assert.Equal(t, tt.expected, string(result))
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := yaml.Marshal(tt.cf)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
 }

--- a/pkg/cache/cache_from_test.go
+++ b/pkg/cache/cache_from_test.go
@@ -1,0 +1,217 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type mockRegistry struct {
+	imageCtrl ImageCtrlInterface
+}
+
+func (m *mockRegistry) GetImageCtrl() ImageCtrlInterface {
+	return m.imageCtrl
+}
+
+func (*mockRegistry) HasGlobalPushAccess() (bool, error) {
+	return true, nil
+}
+
+type mockRegistryWithError struct {
+	imageCtrl ImageCtrlInterface
+}
+
+func (m *mockRegistryWithError) GetImageCtrl() ImageCtrlInterface {
+	return m.imageCtrl
+}
+
+func (*mockRegistryWithError) HasGlobalPushAccess() (bool, error) {
+	return false, assert.AnError
+}
+
+type mockImageCtrl struct{}
+
+func (*mockImageCtrl) GetRegistryAndRepo(_ string) (string, string) {
+	return "registry", "test-account/test-image:x.y.z"
+}
+
+func (*mockImageCtrl) GetRepoNameAndTag(_ string) (string, string) {
+	return "test-account/test-image", "x.y.z"
+}
+
+func Test_AddDefaultPullCache(t *testing.T) {
+	imageCtrl := &mockImageCtrl{}
+	reg := &mockRegistry{imageCtrl: imageCtrl}
+
+	tests := []struct {
+		name     string
+		image    string
+		cf       CacheFrom
+		expected CacheFrom
+	}{
+		{
+			name:     "already with cache image",
+			image:    "test-account/test-image:1.0.0",
+			cf:       CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+			expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+		},
+		{
+			name:     "without cache image",
+			image:    "test-account/test-image:1.0.0",
+			cf:       CacheFrom{},
+			expected: CacheFrom{"okteto.global/test-account/test-image:cache", "okteto.dev/test-account/test-image:cache"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cf.AddDefaultPullCache(reg, tt.image)
+			assert.Equal(t, tt.expected, tt.cf)
+		})
+	}
+}
+
+func Test_AddDefaultPullCache_WithError(t *testing.T) {
+	image := "test-account/test-image:x.y.z"
+	cf := CacheFrom{}
+	expected := CacheFrom{"okteto.dev/test-account/test-image:cache"}
+
+	imageCtrl := &mockImageCtrl{}
+	registry := &mockRegistryWithError{imageCtrl: imageCtrl}
+
+	cf.AddDefaultPullCache(registry, image)
+
+	assert.Equal(t, cf, expected)
+}
+
+func Test_hasCacheFromImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		cf       CacheFrom
+		expected bool
+	}{
+		{
+			name:     "not found",
+			input:    "test-registry/test-image:cache",
+			cf:       CacheFrom{"test-registry/test-image:test-tag"},
+			expected: false,
+		},
+		{
+			name:     "found",
+			input:    "test-registry/test-image:cache",
+			cf:       CacheFrom{"test-registry/test-image:cache"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.cf.hasCacheFromImage(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected interface{}
+	}{
+		{
+			name:     "empty",
+			data:     []byte("[]"),
+			expected: CacheFrom{},
+		},
+		{
+			name:     "one single item",
+			data:     []byte("test-registry/test-image:cache"),
+			expected: CacheFrom{"test-registry/test-image:cache"},
+		},
+		{
+			name:     "one item as list",
+			data:     []byte(`["test-registry/test-image:cache"]`),
+			expected: CacheFrom{"test-registry/test-image:cache"},
+		},
+		{
+			name:     "one item as list",
+			data:     []byte(`["test-registry/test-image:cache"]`),
+			expected: CacheFrom{"test-registry/test-image:cache"},
+		},
+		{
+			name: "two items",
+			data: []byte(`
+- test-registry/test-image:1.0.0
+- test-registry/another-image:1.0.0`),
+			expected: CacheFrom{"test-registry/test-image:1.0.0", "test-registry/another-image:1.0.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cf CacheFrom
+			err := yaml.Unmarshal([]byte(tt.data), &cf)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, cf)
+		})
+	}
+}
+
+func Test_UnmarshalYAML_WithError(t *testing.T) {
+	var cf CacheFrom
+
+	err := cf.UnmarshalYAML(func(interface{}) error {
+		return assert.AnError
+	})
+
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func Test_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		cf       CacheFrom
+		expected string
+	}{
+		{
+			name:     "empty",
+			cf:       CacheFrom{},
+			expected: "[]\n",
+		},
+		{
+			name:     "one image",
+			cf:       CacheFrom{"test-registry/test-image:cache"},
+			expected: "- test-registry/test-image:cache\n",
+		},
+		{
+			name:     "two images",
+			cf:       CacheFrom{"test-registry/test-image-1:cache", "test-registry/test-image-2:cache"},
+			expected: "- test-registry/test-image-1:cache\n- test-registry/test-image-2:cache\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := yaml.Marshal(tt.cf)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}

--- a/pkg/cache/constants.go
+++ b/pkg/cache/constants.go
@@ -11,29 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package cache
 
-import "github.com/okteto/okteto/pkg/model"
-
-// BuildOptions define the options available for build
-type BuildOptions struct {
-	BuildArgs     []string
-	CacheFrom     []string
-	File          string
-	NoCache       bool
-	OutputMode    string
-	Path          string
-	Secrets       []string
-	Platform      string
-	Tag           string
-	Target        string
-	Namespace     string
-	BuildToGlobal bool
-	K8sContext    string
-	ExportCache   []string
-	// CommandArgs comes from the user input on the command
-	CommandArgs  []string
-	EnableStages bool
-
-	Manifest *model.Manifest
-}
+const (
+	// defaultCacheTag is the default tag used for the cache image
+	defaultCacheTag = "cache"
+)

--- a/pkg/cache/export_cache.go
+++ b/pkg/cache/export_cache.go
@@ -43,44 +43,37 @@ func (ec *ExportCache) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements the marshaller interface of the yaml pkg.
-func (pec *ExportCache) MarshalYAML() (interface{}, error) {
-	ec := *pec
-	if len(ec) == 1 {
-		return ec[0], nil
+func (ec *ExportCache) MarshalYAML() (interface{}, error) {
+	if len(*ec) == 1 {
+		return (*ec)[0], nil
 	}
 
 	return ec, nil
 }
 
 // AddDefaultPushCache appends the default cache layers for a given image
-func (pec *ExportCache) AddDefaultPushCache(reg oktetoRegistryInterface, image string) {
-	hasAccess, err := reg.HasGlobalPushAccess()
-	if err != nil {
-		oktetoLog.Infof("error trying to access globalPushAccess: %w", err)
-	}
-
+func (ec *ExportCache) AddDefaultPushCache(reg oktetoRegistryInterface, image string) {
 	_, imageRepo := reg.GetRegistryAndRepo(image)
 	imageName, _ := reg.GetRepoNameAndTag(imageRepo)
 
-	if hasAccess {
+	if reg.IsGlobalRegistry(image) {
 		globalCacheImage := fmt.Sprintf("%s/%s:%s", constants.GlobalRegistry, imageName, defaultCacheTag)
-		pec.add(globalCacheImage)
+		ec.add(globalCacheImage)
 		oktetoLog.Debugf("Dynamically adding export_cache: %s", globalCacheImage)
 		return
 	}
 
 	devCacheImage := fmt.Sprintf("%s/%s:%s", constants.DevRegistry, imageName, defaultCacheTag)
-	pec.add(devCacheImage)
+	ec.add(devCacheImage)
 	oktetoLog.Debugf("Dynamically adding export_cache: %s", devCacheImage)
-
 }
 
 // add appends the image to the list of export cache images
-func (pec *ExportCache) add(image string) {
-	for _, c := range *pec {
+func (ec *ExportCache) add(image string) {
+	for _, c := range *ec {
 		if c == image {
 			return
 		}
 	}
-	*pec = append(*pec, image)
+	*ec = append(*ec, image)
 }

--- a/pkg/cache/export_cache.go
+++ b/pkg/cache/export_cache.go
@@ -1,0 +1,77 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/constants"
+)
+
+// ExportCache is a list of images that will be created to export the cache.
+type ExportCache []string
+
+// UnmarshalYAML implements the Unmarshaler interface of the yaml pkg.
+func (ec *ExportCache) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var single string
+	err := unmarshal(&single)
+	if err == nil {
+		*ec = ExportCache{single}
+		return nil
+	}
+
+	var multi []string
+	err = unmarshal(&multi)
+	if err == nil {
+		*ec = multi
+		return nil
+	}
+
+	return err
+}
+
+// MarshalYAML implements the marshaler interface of the yaml pkg.
+func (pec *ExportCache) MarshalYAML() (interface{}, error) {
+	ec := *pec
+	if len(ec) == 1 {
+		return ec[0], nil
+	}
+
+	return ec, nil
+}
+
+// AddDefaultPushCache appends the default cache layers for a given image
+func (pec *ExportCache) AddDefaultPushCache(reg oktetoRegistryInterface, image string) {
+	_, imageRepo := reg.GetRegistryAndRepo(image)
+	imageName, _ := reg.GetRepoNameAndTag(imageRepo)
+
+	if reg.IsGlobalRegistry(image) {
+		newCache := fmt.Sprintf("%s/%s:%s", constants.GlobalRegistry, imageName, defaultCacheTag)
+		pec.add(newCache)
+		return
+	}
+	newDevCache := fmt.Sprintf("%s/%s:%s", constants.DevRegistry, imageName, defaultCacheTag)
+	pec.add(newDevCache)
+
+}
+
+// add appends the image to the list of export cache images
+func (pec *ExportCache) add(image string) {
+	for _, c := range *pec {
+		if c == image {
+			return
+		}
+	}
+	*pec = append(*pec, image)
+}

--- a/pkg/cache/export_cache_test.go
+++ b/pkg/cache/export_cache_test.go
@@ -1,0 +1,151 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestUnmarshalExportCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected *ExportCache
+	}{
+		{
+			name: "single line",
+			data: []byte(`"okteto/okteto:cache"`),
+			expected: &ExportCache{
+				"okteto/okteto:cache",
+			},
+		},
+		{
+			name: "export cache list",
+			data: []byte(`- "okteto/okteto:cache"
+- "okteto/test:cache"`),
+			expected: &ExportCache{
+				"okteto/okteto:cache",
+				"okteto/test:cache",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result *ExportCache
+			err := yaml.UnmarshalStrict(tt.data, &result)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_ExportCacheUnmarshalYAML_WithError(t *testing.T) {
+	var ec ExportCache
+	err := yaml.Unmarshal([]byte("some: invalid: yaml"), &ec)
+	assert.Error(t, err)
+}
+
+func Test_ExportCacheMarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		ec       *ExportCache
+		expected string
+	}{
+		{
+			name:     "empty",
+			ec:       &ExportCache{},
+			expected: "[]\n",
+		},
+		{
+			name:     "one image",
+			ec:       &ExportCache{"test-registry/test-image:cache"},
+			expected: "test-registry/test-image:cache\n",
+		},
+		{
+			name:     "two images",
+			ec:       &ExportCache{"test-registry/test-image-1:cache", "test-registry/test-image-2:cache"},
+			expected: "- test-registry/test-image-1:cache\n- test-registry/test-image-2:cache\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := yaml.Marshal(tt.ec)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func Test_AddDefaultPushCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		isGlobal bool
+		repo     string
+		registry string
+		ec       ExportCache
+		expected ExportCache
+	}{
+		{
+			name:     "already with cache image",
+			image:    "test-account/test-image:1.0.0",
+			isGlobal: true,
+			repo:     "test-image",
+			ec:       ExportCache{"okteto.global/test-image:cache", "okteto.dev/test-image:cache"},
+			expected: ExportCache{"okteto.global/test-image:cache", "okteto.dev/test-image:cache"},
+		},
+		{
+			name:     "without cache image",
+			image:    "okteto.global/test-image:1.0.0",
+			isGlobal: true,
+			repo:     "test-image",
+			ec:       ExportCache{},
+			expected: ExportCache{"okteto.global/test-image:cache"},
+		},
+		{
+			name:     "without cache image not in global",
+			image:    "okteto.dev/test-image:1.0.0",
+			isGlobal: false,
+			repo:     "test-image",
+			registry: "okteto.dev",
+			ec:       ExportCache{},
+			expected: ExportCache{"okteto.dev/test-image:cache"},
+		},
+		{
+			name:     "already defined cache image",
+			image:    "okteto.global/test-image:1.0.0",
+			isGlobal: true,
+			repo:     "test-image",
+			ec:       ExportCache{"okteto.global/test-image:cache"},
+			expected: ExportCache{"okteto.global/test-image:cache"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := &mockRegistry{
+				isGlobal: tt.isGlobal,
+				registry: tt.registry,
+				repo:     tt.repo,
+				tag:      "",
+			}
+			tt.ec.AddDefaultPushCache(reg, tt.image)
+			assert.Equal(t, tt.expected, tt.ec)
+		})
+	}
+}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -32,7 +32,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
-	reg2 "github.com/okteto/okteto/pkg/registry"
+	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/pkg/errors"
 )
@@ -107,7 +107,7 @@ func buildWithOkteto(ctx context.Context, buildOptions *types.BuildOptions) erro
 		}
 	}
 
-	imageCtrl := reg2.NewImageCtrl(okteto.Config{})
+	imageCtrl := registry.NewImageCtrl(okteto.Config{})
 	if okteto.IsOkteto() {
 		buildOptions.Tag = imageCtrl.ExpandOktetoDevRegistry(buildOptions.Tag)
 		buildOptions.Tag = imageCtrl.ExpandOktetoGlobalRegistry(buildOptions.Tag)
@@ -115,9 +115,9 @@ func buildWithOkteto(ctx context.Context, buildOptions *types.BuildOptions) erro
 			buildOptions.CacheFrom[i] = imageCtrl.ExpandOktetoDevRegistry(buildOptions.CacheFrom[i])
 			buildOptions.CacheFrom[i] = imageCtrl.ExpandOktetoGlobalRegistry(buildOptions.CacheFrom[i])
 		}
-		if buildOptions.ExportCache != "" {
-			buildOptions.ExportCache = imageCtrl.ExpandOktetoDevRegistry(buildOptions.ExportCache)
-			buildOptions.ExportCache = imageCtrl.ExpandOktetoGlobalRegistry(buildOptions.ExportCache)
+		for i := range buildOptions.ExportCache {
+			buildOptions.ExportCache[i] = imageCtrl.ExpandOktetoDevRegistry(buildOptions.ExportCache[i])
+			buildOptions.ExportCache[i] = imageCtrl.ExpandOktetoGlobalRegistry(buildOptions.ExportCache[i])
 		}
 	}
 
@@ -158,7 +158,7 @@ func buildWithOkteto(ctx context.Context, buildOptions *types.BuildOptions) erro
 	}
 
 	if err == nil && buildOptions.Tag != "" {
-		if _, err := reg2.NewOktetoRegistry(okteto.Config{}).GetImageTagWithDigest(buildOptions.Tag); err != nil {
+		if _, err := registry.NewOktetoRegistry(okteto.Config{}).GetImageTagWithDigest(buildOptions.Tag); err != nil {
 			oktetoLog.Yellow(`Failed to push '%s' metadata to the registry:
 	  %s,
 	  Retrying ...`, buildOptions.Tag, err.Error())
@@ -210,7 +210,7 @@ func buildWithDocker(ctx context.Context, buildOptions *types.BuildOptions) erro
 }
 
 func validateImage(imageTag string) error {
-	reg := reg2.NewOktetoRegistry(okteto.Config{})
+	reg := registry.NewOktetoRegistry(okteto.Config{})
 	if strings.HasPrefix(imageTag, okteto.Context().Registry) && strings.Count(imageTag, "/") == 2 {
 		return nil
 	}
@@ -240,8 +240,17 @@ func translateDockerErr(err error) error {
 	return err
 }
 
+type regInterface interface {
+	IsOktetoRegistry(image string) bool
+	HasGlobalPushAccess() (bool, error)
+	IsGlobalRegistry(image string) bool
+
+	GetRegistryAndRepo(image string) (string, string)
+	GetRepoNameAndTag(repo string) (string, string)
+}
+
 // OptsFromBuildInfo returns the parsed options for the build from the manifest
-func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *types.BuildOptions) *types.BuildOptions {
+func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *types.BuildOptions, reg regInterface) *types.BuildOptions {
 	if o == nil {
 		o = &types.BuildOptions{}
 	}
@@ -274,7 +283,6 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		file = extractFromContextAndDockerfile(b.Context, b.Dockerfile, svcName)
 	}
 
-	reg := reg2.NewOktetoRegistry(okteto.Config{})
 	if reg.IsOktetoRegistry(b.Image) {
 		defaultBuildArgs := map[string]string{
 			model.OktetoContextEnvVar:   okteto.Context().Name,
@@ -300,6 +308,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		}
 
 		b.CacheFrom.AddDefaultPullCache(reg, b.Image)
+		b.ExportCache.AddDefaultPushCache(reg, b.Image)
 	}
 
 	opts := &types.BuildOptions{

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -298,6 +298,8 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 				Name: key, Value: val,
 			})
 		}
+
+		b.CacheFrom.AddDefaultPullCache(reg, b.Image)
 	}
 
 	opts := &types.BuildOptions{
@@ -350,7 +352,7 @@ func extractFromContextAndDockerfile(context, dockerfile, svcName string) string
 
 // GetVolumesToInclude checks if the path exists, if it doesn't it skip it
 func GetVolumesToInclude(volumesToInclude []model.StackVolume) []model.StackVolume {
-	result := make([]model.StackVolume, 0)
+	var result []model.StackVolume
 	for _, p := range volumesToInclude {
 		if _, err := os.Stat(p.LocalPath); err == nil {
 			result = append(result, p)

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -129,6 +129,9 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
 				BuildArgs:  []string{namespaceEnvVar.String()},
+				CacheFrom: []string{
+					"okteto.dev/movies-service:cache",
+				},
 			},
 		},
 		{
@@ -166,8 +169,11 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				File:       filepath.Join(serviceContext, serviceDockerfile),
 				Target:     "build",
 				Path:       "service",
-				CacheFrom:  []string{"cache-image"},
-				BuildArgs:  []string{namespaceEnvVar.String(), "arg1=value1"},
+				CacheFrom: []string{
+					"cache-image",
+					"okteto.dev/movies-service:cache",
+				},
+				BuildArgs: []string{namespaceEnvVar.String(), "arg1=value1"},
 			},
 		},
 		{
@@ -201,8 +207,11 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				File:       filepath.Join(serviceContext, serviceDockerfile),
 				Target:     "build",
 				Path:       "service",
-				CacheFrom:  []string{"cache-image"},
-				BuildArgs:  []string{namespaceEnvVar.String(), "arg1=value1"},
+				CacheFrom: []string{
+					"cache-image",
+					"okteto.dev/movies-service:cache",
+				},
+				BuildArgs: []string{namespaceEnvVar.String(), "arg1=value1"},
 			},
 		},
 		{
@@ -231,12 +240,15 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			},
 			isOkteto: true,
 			expected: &types.BuildOptions{
-				OutputMode:  oktetoLog.TTYFormat,
-				Tag:         "okteto.dev/mycustomimage:dev",
-				File:        filepath.Join(serviceContext, serviceDockerfile),
-				Target:      "build",
-				Path:        "service",
-				CacheFrom:   []string{"cache-image"},
+				OutputMode: oktetoLog.TTYFormat,
+				Tag:        "okteto.dev/mycustomimage:dev",
+				File:       filepath.Join(serviceContext, serviceDockerfile),
+				Target:     "build",
+				Path:       "service",
+				CacheFrom: []string{
+					"cache-image",
+					"okteto.dev/mycustomimage:cache",
+				},
 				BuildArgs:   []string{namespaceEnvVar.String(), "arg1=value1"},
 				Secrets:     []string{"id=mysecret,src=source"},
 				ExportCache: "export-image",
@@ -250,9 +262,10 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				Platform: "linux/amd64"},
 			isOkteto: true,
 			expected: &types.BuildOptions{
-				BuildArgs: []string{namespaceEnvVar.String()},
-				Platform:  "linux/amd64",
-				Tag:       "okteto.dev/movies-service:okteto",
+				CacheFrom:  []string{"okteto.dev/movies-service:cache"},
+				BuildArgs:  []string{namespaceEnvVar.String()},
+				Platform:   "linux/amd64",
+				Tag:        "okteto.dev/movies-service:okteto",
 				OutputMode: "tty",
 			},
 		},

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -130,9 +130,9 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 		)
 	}
 
-	if buildOptions.ExportCache != "" {
+	for _, exportCacheTo := range buildOptions.ExportCache {
 		exportType := "inline"
-		if buildOptions.ExportCache != buildOptions.Tag {
+		if exportCacheTo != buildOptions.Tag {
 			exportType = "registry"
 		}
 		opt.CacheExports = append(
@@ -140,7 +140,7 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 			client.CacheOptionsEntry{
 				Type: exportType,
 				Attrs: map[string]string{
-					"ref":  buildOptions.ExportCache,
+					"ref":  exportCacheTo,
 					"mode": "max",
 				},
 			},

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -14,300 +14,300 @@
 package build
 
 import (
-	"context"
-	"encoding/base64"
-	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
+    "context"
+    "encoding/base64"
+    "fmt"
+    "net/url"
+    "os"
+    "path/filepath"
+    "strings"
 
-	"github.com/containerd/console"
-	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/cmd/buildctl/build"
-	"github.com/moby/buildkit/session"
-	"github.com/moby/buildkit/session/auth/authprovider"
-	"github.com/moby/buildkit/util/progress/progressui"
-	"github.com/okteto/okteto/pkg/config"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/okteto"
-	"github.com/okteto/okteto/pkg/types"
-	"github.com/pkg/errors"
-	"golang.org/x/oauth2"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/credentials/oauth"
+    "github.com/containerd/console"
+    "github.com/moby/buildkit/client"
+    "github.com/moby/buildkit/cmd/buildctl/build"
+    "github.com/moby/buildkit/session"
+    "github.com/moby/buildkit/session/auth/authprovider"
+    "github.com/moby/buildkit/util/progress/progressui"
+    "github.com/okteto/okteto/pkg/config"
+    oktetoLog "github.com/okteto/okteto/pkg/log"
+    "github.com/okteto/okteto/pkg/okteto"
+    "github.com/okteto/okteto/pkg/types"
+    "github.com/pkg/errors"
+    "golang.org/x/oauth2"
+    "golang.org/x/sync/errgroup"
+    "google.golang.org/grpc/credentials/oauth"
 )
 
 const (
-	frontend = "dockerfile.v0"
+    frontend = "dockerfile.v0"
 )
 
 type buildWriter struct{}
 
 // getSolveOpt returns the buildkit solve options
 func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
-	var localDirs map[string]string
-	var frontendAttrs map[string]string
+    var localDirs map[string]string
+    var frontendAttrs map[string]string
 
-	if uri, err := url.ParseRequestURI(buildOptions.Path); err != nil || (uri != nil && (uri.Scheme == "" || uri.Host == "")) {
+    if uri, err := url.ParseRequestURI(buildOptions.Path); err != nil || (uri != nil && (uri.Scheme == "" || uri.Host == "")) {
 
-		if buildOptions.File == "" {
-			buildOptions.File = filepath.Join(buildOptions.Path, "Dockerfile")
-		}
-		if _, err := os.Stat(buildOptions.File); os.IsNotExist(err) {
-			return nil, fmt.Errorf("Dockerfile '%s' does not exist", buildOptions.File)
-		}
-		localDirs = map[string]string{
-			"context":    buildOptions.Path,
-			"dockerfile": filepath.Dir(buildOptions.File),
-		}
-		frontendAttrs = map[string]string{
-			"filename": filepath.Base(buildOptions.File),
-		}
-	} else {
-		frontendAttrs = map[string]string{
-			"context": buildOptions.Path,
-		}
-	}
+        if buildOptions.File == "" {
+            buildOptions.File = filepath.Join(buildOptions.Path, "Dockerfile")
+        }
+        if _, err := os.Stat(buildOptions.File); os.IsNotExist(err) {
+            return nil, fmt.Errorf("Dockerfile '%s' does not exist", buildOptions.File)
+        }
+        localDirs = map[string]string{
+            "context":    buildOptions.Path,
+            "dockerfile": filepath.Dir(buildOptions.File),
+        }
+        frontendAttrs = map[string]string{
+            "filename": filepath.Base(buildOptions.File),
+        }
+    } else {
+        frontendAttrs = map[string]string{
+            "context": buildOptions.Path,
+        }
+    }
 
-	if buildOptions.Platform != "" {
-		frontendAttrs["platform"] = buildOptions.Platform
-	}
-	if buildOptions.Target != "" {
-		frontendAttrs["target"] = buildOptions.Target
-	}
-	if buildOptions.NoCache {
-		frontendAttrs["no-cache"] = ""
-	}
-	for _, buildArg := range buildOptions.BuildArgs {
-		kv := strings.SplitN(buildArg, "=", 2)
-		if len(kv) != 2 {
-			return nil, fmt.Errorf("invalid build-arg value %s", buildArg)
-		}
-		frontendAttrs["build-arg:"+kv[0]] = kv[1]
-	}
-	attachable := []session.Attachable{}
-	if okteto.IsOkteto() {
-		attachable = append(attachable, newDockerAndOktetoAuthProvider(okteto.Context().Registry, okteto.Context().UserID, okteto.Context().Token, os.Stderr))
-	} else {
-		attachable = append(attachable, authprovider.NewDockerAuthProvider(os.Stderr))
-	}
+    if buildOptions.Platform != "" {
+        frontendAttrs["platform"] = buildOptions.Platform
+    }
+    if buildOptions.Target != "" {
+        frontendAttrs["target"] = buildOptions.Target
+    }
+    if buildOptions.NoCache {
+        frontendAttrs["no-cache"] = ""
+    }
+    for _, buildArg := range buildOptions.BuildArgs {
+        kv := strings.SplitN(buildArg, "=", 2)
+        if len(kv) != 2 {
+            return nil, fmt.Errorf("invalid build-arg value %s", buildArg)
+        }
+        frontendAttrs["build-arg:"+kv[0]] = kv[1]
+    }
+    attachable := []session.Attachable{}
+    if okteto.IsOkteto() {
+        attachable = append(attachable, newDockerAndOktetoAuthProvider(okteto.Context().Registry, okteto.Context().UserID, okteto.Context().Token, os.Stderr))
+    } else {
+        attachable = append(attachable, authprovider.NewDockerAuthProvider(os.Stderr))
+    }
 
-	if len(buildOptions.Secrets) > 0 {
-		secretProvider, err := build.ParseSecret(buildOptions.Secrets)
-		if err != nil {
-			return nil, err
-		}
-		attachable = append(attachable, secretProvider)
-	}
-	opt := &client.SolveOpt{
-		LocalDirs:     localDirs,
-		Frontend:      frontend,
-		FrontendAttrs: frontendAttrs,
-		Session:       attachable,
-		CacheImports:  []client.CacheOptionsEntry{},
-		CacheExports:  []client.CacheOptionsEntry{},
-	}
+    if len(buildOptions.Secrets) > 0 {
+        secretProvider, err := build.ParseSecret(buildOptions.Secrets)
+        if err != nil {
+            return nil, err
+        }
+        attachable = append(attachable, secretProvider)
+    }
+    opt := &client.SolveOpt{
+        LocalDirs:     localDirs,
+        Frontend:      frontend,
+        FrontendAttrs: frontendAttrs,
+        Session:       attachable,
+        CacheImports:  []client.CacheOptionsEntry{},
+        CacheExports:  []client.CacheOptionsEntry{},
+    }
 
-	if buildOptions.Tag != "" {
-		opt.Exports = []client.ExportEntry{
-			{
-				Type: "image",
-				Attrs: map[string]string{
-					"name": buildOptions.Tag,
-					"push": "true",
-				},
-			},
-		}
-	}
-	for _, cacheFromImage := range buildOptions.CacheFrom {
-		opt.CacheImports = append(
-			opt.CacheImports,
-			client.CacheOptionsEntry{
-				Type:  "registry",
-				Attrs: map[string]string{"ref": cacheFromImage},
-			},
-		)
-	}
+    if buildOptions.Tag != "" {
+        opt.Exports = []client.ExportEntry{
+            {
+                Type: "image",
+                Attrs: map[string]string{
+                    "name": buildOptions.Tag,
+                    "push": "true",
+                },
+            },
+        }
+    }
+    for _, cacheFromImage := range buildOptions.CacheFrom {
+        opt.CacheImports = append(
+            opt.CacheImports,
+            client.CacheOptionsEntry{
+                Type:  "registry",
+                Attrs: map[string]string{"ref": cacheFromImage},
+            },
+        )
+    }
 
-	for _, exportCacheTo := range buildOptions.ExportCache {
-		exportType := "inline"
-		if exportCacheTo != buildOptions.Tag {
-			exportType = "registry"
-		}
-		opt.CacheExports = append(
-			opt.CacheExports,
-			client.CacheOptionsEntry{
-				Type: exportType,
-				Attrs: map[string]string{
-					"ref":  exportCacheTo,
-					"mode": "max",
-				},
-			},
-		)
-	}
+    for _, exportCacheTo := range buildOptions.ExportCache {
+        exportType := "inline"
+        if exportCacheTo != buildOptions.Tag {
+            exportType = "registry"
+        }
+        opt.CacheExports = append(
+            opt.CacheExports,
+            client.CacheOptionsEntry{
+                Type: exportType,
+                Attrs: map[string]string{
+                    "ref":  exportCacheTo,
+                    "mode": "max",
+                },
+            },
+        )
+    }
 
-	// TODO(#3548): remove when we upgrade buildkit to 0.11
-	if len(opt.CacheExports) > 1 {
-		opt.CacheExports = opt.CacheExports[:1]
-	}
+    // TODO(#3548): remove when we upgrade buildkit to 0.11
+    if len(opt.CacheExports) > 1 {
+        opt.CacheExports = opt.CacheExports[:1]
+    }
 
-	return opt, nil
+    return opt, nil
 }
 
 func getBuildkitClient(ctx context.Context) (*client.Client, error) {
-	buildkitHost := okteto.Context().Builder
-	octxStore := okteto.ContextStore()
-	for _, octx := range octxStore.Contexts {
-		// if a context configures buildkit with an Okteto Cluster
-		if octx.IsOkteto && octx.Builder == buildkitHost {
-			okteto.Context().Token = octx.Token
-			okteto.Context().Certificate = octx.Certificate
-		}
-	}
-	if okteto.Context().Certificate != "" {
-		certBytes, err := base64.StdEncoding.DecodeString(okteto.Context().Certificate)
-		if err != nil {
-			return nil, fmt.Errorf("certificate decoding error: %w", err)
-		}
+    buildkitHost := okteto.Context().Builder
+    octxStore := okteto.ContextStore()
+    for _, octx := range octxStore.Contexts {
+        // if a context configures buildkit with an Okteto Cluster
+        if octx.IsOkteto && octx.Builder == buildkitHost {
+            okteto.Context().Token = octx.Token
+            okteto.Context().Certificate = octx.Certificate
+        }
+    }
+    if okteto.Context().Certificate != "" {
+        certBytes, err := base64.StdEncoding.DecodeString(okteto.Context().Certificate)
+        if err != nil {
+            return nil, fmt.Errorf("certificate decoding error: %w", err)
+        }
 
-		if err := os.WriteFile(config.GetCertificatePath(), certBytes, 0600); err != nil {
-			return nil, err
-		}
+        if err := os.WriteFile(config.GetCertificatePath(), certBytes, 0600); err != nil {
+            return nil, err
+        }
 
-		c, err := getClientForOktetoCluster(ctx)
-		if err != nil {
-			oktetoLog.Infof("failed to create okteto build client: %s", err)
-			return nil, fmt.Errorf("failed to create the builder client: %v", err)
-		}
+        c, err := getClientForOktetoCluster(ctx)
+        if err != nil {
+            oktetoLog.Infof("failed to create okteto build client: %s", err)
+            return nil, fmt.Errorf("failed to create the builder client: %v", err)
+        }
 
-		return c, nil
-	}
+        return c, nil
+    }
 
-	c, err := client.New(ctx, okteto.Context().Builder, client.WithFailFast())
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create the builder client for %s", okteto.Context().Builder)
-	}
-	return c, nil
+    c, err := client.New(ctx, okteto.Context().Builder, client.WithFailFast())
+    if err != nil {
+        return nil, errors.Wrapf(err, "failed to create the builder client for %s", okteto.Context().Builder)
+    }
+    return c, nil
 }
 
 func getClientForOktetoCluster(ctx context.Context) (*client.Client, error) {
 
-	b, err := url.Parse(okteto.Context().Builder)
-	if err != nil {
-		return nil, errors.Wrapf(err, "invalid buildkit host %s", okteto.Context().Builder)
-	}
+    b, err := url.Parse(okteto.Context().Builder)
+    if err != nil {
+        return nil, errors.Wrapf(err, "invalid buildkit host %s", okteto.Context().Builder)
+    }
 
-	creds := client.WithCredentials(b.Hostname(), config.GetCertificatePath(), "", "")
+    creds := client.WithCredentials(b.Hostname(), config.GetCertificatePath(), "", "")
 
-	oauthToken := &oauth2.Token{
-		AccessToken: okteto.Context().Token,
-	}
+    oauthToken := &oauth2.Token{
+        AccessToken: okteto.Context().Token,
+    }
 
-	rpc := client.WithRPCCreds(oauth.NewOauthAccess(oauthToken))
-	c, err := client.New(ctx, okteto.Context().Builder, client.WithFailFast(), creds, rpc)
-	if err != nil {
-		return nil, err
-	}
+    rpc := client.WithRPCCreds(oauth.NewOauthAccess(oauthToken))
+    c, err := client.New(ctx, okteto.Context().Builder, client.WithFailFast(), creds, rpc)
+    if err != nil {
+        return nil, err
+    }
 
-	return c, nil
+    return c, nil
 }
 
 func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, progress string) error {
-	logFilterRules := []Rule{
-		{
-			condition:   BuildKitMissingCacheCondition,
-			transformer: BuildKitMissingCacheTransformer,
-		},
-	}
-	logFilter := NewBuildKitLogsFilter(logFilterRules)
-	ch := make(chan *client.SolveStatus)
-	ttyChannel := make(chan *client.SolveStatus)
-	plainChannel := make(chan *client.SolveStatus)
-	commandFailChannel := make(chan error, 1)
+    logFilterRules := []Rule{
+        {
+            condition:   BuildKitMissingCacheCondition,
+            transformer: BuildKitMissingCacheTransformer,
+        },
+    }
+    logFilter := NewBuildKitLogsFilter(logFilterRules)
+    ch := make(chan *client.SolveStatus)
+    ttyChannel := make(chan *client.SolveStatus)
+    plainChannel := make(chan *client.SolveStatus)
+    commandFailChannel := make(chan error, 1)
 
-	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		var err error
-		_, err = c.Solve(ctx, nil, *opt, ch)
-		return errors.Wrap(err, "build failed")
-	})
+    eg, ctx := errgroup.WithContext(ctx)
+    eg.Go(func() error {
+        var err error
+        _, err = c.Solve(ctx, nil, *opt, ch)
+        return errors.Wrap(err, "build failed")
+    })
 
-	eg.Go(func() error {
-		done := false
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case ss, ok := <-ch:
-				if ok {
-					logFilter.Run(ss, progress)
-					plainChannel <- ss
-					if progress == oktetoLog.TTYFormat {
-						ttyChannel <- ss
-					}
-				} else {
-					done = true
-				}
-			}
-			if done {
-				close(plainChannel)
-				if progress == oktetoLog.TTYFormat {
-					close(ttyChannel)
-				}
-				break
-			}
-		}
-		return nil
-	})
+    eg.Go(func() error {
+        done := false
+        for {
+            select {
+            case <-ctx.Done():
+                return ctx.Err()
+            case ss, ok := <-ch:
+                if ok {
+                    logFilter.Run(ss, progress)
+                    plainChannel <- ss
+                    if progress == oktetoLog.TTYFormat {
+                        ttyChannel <- ss
+                    }
+                } else {
+                    done = true
+                }
+            }
+            if done {
+                close(plainChannel)
+                if progress == oktetoLog.TTYFormat {
+                    close(ttyChannel)
+                }
+                break
+            }
+        }
+        return nil
+    })
 
-	eg.Go(func() error {
+    eg.Go(func() error {
 
-		w := &buildWriter{}
-		switch progress {
-		case oktetoLog.TTYFormat:
-			var c console.Console
+        w := &buildWriter{}
+        switch progress {
+        case oktetoLog.TTYFormat:
+            var c console.Console
 
-			if cn, err := console.ConsoleFromFile(os.Stdout); err == nil {
-				c = cn
-			} else {
-				oktetoLog.Debugf("could not create console from file: %s ", err)
-			}
-			go func() {
-				if err := progressui.DisplaySolveStatus(context.TODO(), "", c, oktetoLog.GetOutputWriter(), ttyChannel); err != nil {
-					oktetoLog.Infof("could not display solve status: %s", err)
-				}
-			}()
-			// not using shared context to not disrupt display but let it finish reporting errors
-			return progressui.DisplaySolveStatus(context.TODO(), "", nil, w, plainChannel)
-		case "deploy":
-			err := deployDisplayer(context.TODO(), plainChannel)
-			commandFailChannel <- err
-			return err
-		default:
-			// not using shared context to not disrupt display but let it finish reporting errors
-			return progressui.DisplaySolveStatus(context.TODO(), "", nil, oktetoLog.GetOutputWriter(), plainChannel)
-		}
-	})
+            if cn, err := console.ConsoleFromFile(os.Stdout); err == nil {
+                c = cn
+            } else {
+                oktetoLog.Debugf("could not create console from file: %s ", err)
+            }
+            go func() {
+                if err := progressui.DisplaySolveStatus(context.TODO(), "", c, oktetoLog.GetOutputWriter(), ttyChannel); err != nil {
+                    oktetoLog.Infof("could not display solve status: %s", err)
+                }
+            }()
+            // not using shared context to not disrupt display but let it finish reporting errors
+            return progressui.DisplaySolveStatus(context.TODO(), "", nil, w, plainChannel)
+        case "deploy":
+            err := deployDisplayer(context.TODO(), plainChannel)
+            commandFailChannel <- err
+            return err
+        default:
+            // not using shared context to not disrupt display but let it finish reporting errors
+            return progressui.DisplaySolveStatus(context.TODO(), "", nil, oktetoLog.GetOutputWriter(), plainChannel)
+        }
+    })
 
-	err := eg.Wait()
-	// If the command failed, we want to return the error from the command instead of the buildkit error
-	if err != nil {
-		select {
-		case commandErr := <-commandFailChannel:
-			if commandErr != nil {
-				return commandErr
-			}
-			return err
-		default:
-			return err
-		}
-	}
-	return nil
+    err := eg.Wait()
+    // If the command failed, we want to return the error from the command instead of the buildkit error
+    if err != nil {
+        select {
+        case commandErr := <-commandFailChannel:
+            if commandErr != nil {
+                return commandErr
+            }
+            return err
+        default:
+            return err
+        }
+    }
+    return nil
 }
 
 func (*buildWriter) Write(p []byte) (int, error) {
-	msg := strings.TrimSpace(string(p))
-	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, msg)
-	return 0, nil
+    msg := strings.TrimSpace(string(p))
+    oktetoLog.AddToBuffer(oktetoLog.InfoLevel, msg)
+    return 0, nil
 }

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -146,6 +146,12 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 			},
 		)
 	}
+
+	// TODO(#3548): remove when we upgrade buildkit to 0.11
+	if len(opt.CacheExports) > 1 {
+		opt.CacheExports = opt.CacheExports[:1]
+	}
+
 	return opt, nil
 }
 

--- a/pkg/http/transport.go
+++ b/pkg/http/transport.go
@@ -35,7 +35,7 @@ func DefaultTransport() *http.Transport {
 	}
 }
 
-// StrictSSLHTTPClient returns an *http.Transport with RootCAs set with both the SystemCertPool and the given *x509.Certificates
+// StrictSSLTransport returns an *http.Transport with RootCAs set with both the SystemCertPool and the given *x509.Certificates
 // If obtaining SystemCertPool fails, it uses an empty *x509.CertPool as base
 func StrictSSLTransport(certs ...*x509.Certificate) *http.Transport {
 	pool, err := x509.SystemCertPool()

--- a/pkg/k8s/apps/deployments.go
+++ b/pkg/k8s/apps/deployments.go
@@ -208,7 +208,7 @@ func (i *DeploymentApp) PatchAnnotations(ctx context.Context, c kubernetes.Inter
 	return deployments.PatchAnnotations(ctx, i.d, c)
 }
 
-// GetCloned Returns from Kubernetes the cloned deployment
+// GetDevClone Returns from Kubernetes the cloned deployment
 func (i *DeploymentApp) GetDevClone(ctx context.Context, c kubernetes.Interface) (App, error) {
 	clonedName := model.DevCloneName(i.d.Name)
 	d, err := deployments.Get(ctx, clonedName, i.d.Namespace, c)

--- a/pkg/k8s/apps/statefulsets.go
+++ b/pkg/k8s/apps/statefulsets.go
@@ -193,7 +193,7 @@ func (i *StatefulSetApp) Destroy(ctx context.Context, c kubernetes.Interface) er
 	return statefulsets.Destroy(ctx, i.sfs.Name, i.sfs.Namespace, c)
 }
 
-// GetCloned Returns from Kubernetes the cloned statefulset
+// GetDevClone Returns from Kubernetes the cloned statefulset
 func (i *StatefulSetApp) GetDevClone(ctx context.Context, c kubernetes.Interface) (App, error) {
 	clonedName := model.DevCloneName(i.sfs.Name)
 	sfs, err := statefulsets.Get(ctx, clonedName, i.sfs.Namespace, c)

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -28,6 +28,7 @@ import (
 	"github.com/a8m/envsubst"
 	"github.com/compose-spec/godotenv"
 	"github.com/google/uuid"
+	"github.com/okteto/okteto/pkg/cache"
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/filesystem"
@@ -118,21 +119,18 @@ type Args struct {
 
 // BuildInfo represents the build info to generate an image
 type BuildInfo struct {
-	Name             string         `yaml:"name,omitempty"`
-	Context          string         `yaml:"context,omitempty"`
-	Dockerfile       string         `yaml:"dockerfile,omitempty"`
-	CacheFrom        CacheFrom      `yaml:"cache_from,omitempty"`
-	Target           string         `yaml:"target,omitempty"`
-	Args             BuildArgs      `yaml:"args,omitempty"`
-	Image            string         `yaml:"image,omitempty"`
-	VolumesToInclude []StackVolume  `yaml:"-"`
-	ExportCache      string         `yaml:"export_cache,omitempty"`
-	DependsOn        BuildDependsOn `yaml:"depends_on,omitempty"`
-	Secrets          BuildSecrets   `yaml:"secrets,omitempty"`
+	Name             string          `yaml:"name,omitempty"`
+	Context          string          `yaml:"context,omitempty"`
+	Dockerfile       string          `yaml:"dockerfile,omitempty"`
+	CacheFrom        cache.CacheFrom `yaml:"cache_from,omitempty"`
+	Target           string          `yaml:"target,omitempty"`
+	Args             BuildArgs       `yaml:"args,omitempty"`
+	Image            string          `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume   `yaml:"-"`
+	ExportCache      string          `yaml:"export_cache,omitempty"`
+	DependsOn        BuildDependsOn  `yaml:"depends_on,omitempty"`
+	Secrets          BuildSecrets    `yaml:"secrets,omitempty"`
 }
-
-// CacheFrom is a list of images to import cache from.
-type CacheFrom []string
 
 // BuildArg is an argument used on the build step.
 type BuildArg struct {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -119,17 +119,17 @@ type Args struct {
 
 // BuildInfo represents the build info to generate an image
 type BuildInfo struct {
-	Name             string          `yaml:"name,omitempty"`
-	Context          string          `yaml:"context,omitempty"`
-	Dockerfile       string          `yaml:"dockerfile,omitempty"`
-	CacheFrom        cache.CacheFrom `yaml:"cache_from,omitempty"`
-	Target           string          `yaml:"target,omitempty"`
-	Args             BuildArgs       `yaml:"args,omitempty"`
-	Image            string          `yaml:"image,omitempty"`
-	VolumesToInclude []StackVolume   `yaml:"-"`
-	ExportCache      string          `yaml:"export_cache,omitempty"`
-	DependsOn        BuildDependsOn  `yaml:"depends_on,omitempty"`
-	Secrets          BuildSecrets    `yaml:"secrets,omitempty"`
+	Name             string            `yaml:"name,omitempty"`
+	Context          string            `yaml:"context,omitempty"`
+	Dockerfile       string            `yaml:"dockerfile,omitempty"`
+	CacheFrom        cache.CacheFrom   `yaml:"cache_from,omitempty"`
+	Target           string            `yaml:"target,omitempty"`
+	Args             BuildArgs         `yaml:"args,omitempty"`
+	Image            string            `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume     `yaml:"-"`
+	ExportCache      cache.ExportCache `yaml:"export_cache,omitempty"`
+	DependsOn        BuildDependsOn    `yaml:"depends_on,omitempty"`
+	Secrets          BuildSecrets      `yaml:"secrets,omitempty"`
 }
 
 // BuildArg is an argument used on the build step.

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1584,7 +1584,7 @@ func Test_BuildInfoCopy(t *testing.T) {
 		Target:      "target",
 		Image:       "image",
 		CacheFrom:   []string{"cache"},
-		ExportCache: "export",
+		ExportCache: []string{"export"},
 		Args: BuildArgs{
 			BuildArg{
 				Name:  "env",

--- a/pkg/model/devrc.go
+++ b/pkg/model/devrc.go
@@ -32,7 +32,7 @@ type DevRC struct {
 	Timeout              Timeout               `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
-// Get returns a Dev object from a given file
+// GetRc returns a Dev object from a given file
 func GetRc(devPath string) (*DevRC, error) {
 	b, err := os.ReadFile(devPath)
 	if err != nil {
@@ -47,7 +47,7 @@ func GetRc(devPath string) (*DevRC, error) {
 	return dev, nil
 }
 
-// Read reads an okteto manifests
+// ReadRC reads an okteto manifests
 func ReadRC(bytes []byte) (*DevRC, error) {
 	dev := &DevRC{}
 

--- a/pkg/model/forward/global_forward.go
+++ b/pkg/model/forward/global_forward.go
@@ -19,7 +19,7 @@ import (
 
 const malformedGlobalForward = "Wrong global forward syntax '%s', must be of the form 'localPort:serviceName:remotePort'"
 
-// Forward represents a port forwarding definition
+// GlobalForward forwards represents a port forwarding definition
 type GlobalForward struct {
 	Local       int               `json:"localPort" yaml:"localPort"`
 	Remote      int               `json:"remotePort" yaml:"remotePort"`

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -237,7 +237,7 @@ func NewDeployInfo() *DeployInfo {
 	}
 }
 
-// NewDeployInfo creates a deploy Info
+// NewDestroyInfo creates a deploy Info
 func NewDestroyInfo() *DestroyInfo {
 	return &DestroyInfo{
 		Commands: []DeployCommand{},

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/kballard/go-shellquote"
+	"github.com/okteto/okteto/pkg/cache"
 	"github.com/okteto/okteto/pkg/externalresource"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model/forward"
@@ -37,17 +38,17 @@ import (
 
 // BuildInfoRaw represents the build info for serialization
 type buildInfoRaw struct {
-	Name             string         `yaml:"name,omitempty"`
-	Context          string         `yaml:"context,omitempty"`
-	Dockerfile       string         `yaml:"dockerfile,omitempty"`
-	CacheFrom        CacheFrom      `yaml:"cache_from,omitempty"`
-	Target           string         `yaml:"target,omitempty"`
-	Args             BuildArgs      `yaml:"args,omitempty"`
-	Image            string         `yaml:"image,omitempty"`
-	VolumesToInclude []StackVolume  `yaml:"-"`
-	ExportCache      string         `yaml:"export_cache,omitempty"`
-	DependsOn        BuildDependsOn `yaml:"depends_on,omitempty"`
-	Secrets          BuildSecrets   `yaml:"secrets,omitempty"`
+	Name             string          `yaml:"name,omitempty"`
+	Context          string          `yaml:"context,omitempty"`
+	Dockerfile       string          `yaml:"dockerfile,omitempty"`
+	CacheFrom        cache.CacheFrom `yaml:"cache_from,omitempty"`
+	Target           string          `yaml:"target,omitempty"`
+	Args             BuildArgs       `yaml:"args,omitempty"`
+	Image            string          `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume   `yaml:"-"`
+	ExportCache      string          `yaml:"export_cache,omitempty"`
+	DependsOn        BuildDependsOn  `yaml:"depends_on,omitempty"`
+	Secrets          BuildSecrets    `yaml:"secrets,omitempty"`
 }
 
 type syncRaw struct {
@@ -142,34 +143,6 @@ type LabelSelectorRequirement struct {
 type WeightedPodAffinityTerm struct {
 	Weight          int32           `yaml:"weight" json:"weight"`
 	PodAffinityTerm PodAffinityTerm `yaml:"podAffinityTerm" json:"podAffinityTerm"`
-}
-
-// UnmarshalYAML implements the Unmarshaler interface of the yaml pkg.
-func (cf *CacheFrom) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var single string
-	err := unmarshal(&single)
-	if err == nil {
-		*cf = CacheFrom{single}
-		return nil
-	}
-
-	var multi []string
-	err = unmarshal(&multi)
-	if err == nil {
-		*cf = multi
-		return nil
-	}
-
-	return err
-}
-
-// MarshalYAML implements the marshaler interface of the yaml pkg.
-func (cf CacheFrom) MarshalYAML() (interface{}, error) {
-	if len(cf) == 1 {
-		return cf[0], nil
-	}
-
-	return cf, nil
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
@@ -904,7 +877,7 @@ func (d *DeployInfo) MarshalYAML() (interface{}, error) {
 		}
 	}
 	if isCommandList {
-		result := []string{}
+		var result []string
 		for _, cmd := range d.Commands {
 			result = append(result, cmd.Command)
 		}
@@ -1116,7 +1089,7 @@ func (d *DestroyInfo) MarshalYAML() (interface{}, error) {
 		}
 	}
 	if isCommandList {
-		result := []string{}
+		var result []string
 		for _, cmd := range d.Commands {
 			result = append(result, cmd.Command)
 		}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -38,17 +38,17 @@ import (
 
 // BuildInfoRaw represents the build info for serialization
 type buildInfoRaw struct {
-	Name             string          `yaml:"name,omitempty"`
-	Context          string          `yaml:"context,omitempty"`
-	Dockerfile       string          `yaml:"dockerfile,omitempty"`
-	CacheFrom        cache.CacheFrom `yaml:"cache_from,omitempty"`
-	Target           string          `yaml:"target,omitempty"`
-	Args             BuildArgs       `yaml:"args,omitempty"`
-	Image            string          `yaml:"image,omitempty"`
-	VolumesToInclude []StackVolume   `yaml:"-"`
-	ExportCache      string          `yaml:"export_cache,omitempty"`
-	DependsOn        BuildDependsOn  `yaml:"depends_on,omitempty"`
-	Secrets          BuildSecrets    `yaml:"secrets,omitempty"`
+	Name             string            `yaml:"name,omitempty"`
+	Context          string            `yaml:"context,omitempty"`
+	Dockerfile       string            `yaml:"dockerfile,omitempty"`
+	CacheFrom        cache.CacheFrom   `yaml:"cache_from,omitempty"`
+	Target           string            `yaml:"target,omitempty"`
+	Args             BuildArgs         `yaml:"args,omitempty"`
+	Image            string            `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume     `yaml:"-"`
+	ExportCache      cache.ExportCache `yaml:"export_cache,omitempty"`
+	DependsOn        BuildDependsOn    `yaml:"depends_on,omitempty"`
+	Secrets          BuildSecrets      `yaml:"secrets,omitempty"`
 }
 
 type syncRaw struct {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -25,6 +25,7 @@ import (
 	"unicode"
 
 	"github.com/kballard/go-shellquote"
+	"github.com/okteto/okteto/pkg/cache"
 	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/model/forward"
 	apiv1 "k8s.io/api/core/v1"
@@ -237,15 +238,15 @@ type RawMessage struct {
 }
 
 type composeBuildInfo struct {
-	Name             string        `yaml:"name,omitempty"`
-	Context          string        `yaml:"context,omitempty"`
-	Dockerfile       string        `yaml:"dockerfile,omitempty"`
-	CacheFrom        CacheFrom     `yaml:"cache_from,omitempty"`
-	Target           string        `yaml:"target,omitempty"`
-	Args             BuildArgs     `yaml:"args,omitempty"`
-	Image            string        `yaml:"image,omitempty"`
-	VolumesToInclude []StackVolume `yaml:"-"`
-	ExportCache      string        `yaml:"export_cache,omitempty"`
+	Name             string          `yaml:"name,omitempty"`
+	Context          string          `yaml:"context,omitempty"`
+	Dockerfile       string          `yaml:"dockerfile,omitempty"`
+	CacheFrom        cache.CacheFrom `yaml:"cache_from,omitempty"`
+	Target           string          `yaml:"target,omitempty"`
+	Args             BuildArgs       `yaml:"args,omitempty"`
+	Image            string          `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume   `yaml:"-"`
+	ExportCache      string          `yaml:"export_cache,omitempty"`
 }
 
 func (c *composeBuildInfo) toBuildInfo() *BuildInfo {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -238,15 +238,15 @@ type RawMessage struct {
 }
 
 type composeBuildInfo struct {
-	Name             string          `yaml:"name,omitempty"`
-	Context          string          `yaml:"context,omitempty"`
-	Dockerfile       string          `yaml:"dockerfile,omitempty"`
-	CacheFrom        cache.CacheFrom `yaml:"cache_from,omitempty"`
-	Target           string          `yaml:"target,omitempty"`
-	Args             BuildArgs       `yaml:"args,omitempty"`
-	Image            string          `yaml:"image,omitempty"`
-	VolumesToInclude []StackVolume   `yaml:"-"`
-	ExportCache      string          `yaml:"export_cache,omitempty"`
+	Name             string            `yaml:"name,omitempty"`
+	Context          string            `yaml:"context,omitempty"`
+	Dockerfile       string            `yaml:"dockerfile,omitempty"`
+	CacheFrom        cache.CacheFrom   `yaml:"cache_from,omitempty"`
+	Target           string            `yaml:"target,omitempty"`
+	Args             BuildArgs         `yaml:"args,omitempty"`
+	Image            string            `yaml:"image,omitempty"`
+	VolumesToInclude []StackVolume     `yaml:"-"`
+	ExportCache      cache.ExportCache `yaml:"export_cache,omitempty"`
 }
 
 func (c *composeBuildInfo) toBuildInfo() *BuildInfo {

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -36,7 +36,7 @@ type Port struct {
 	Protocol      apiv1.Protocol
 }
 
-func (p Port) GetHostPort() int32          { return 0 }
+func (Port) GetHostPort() int32            { return 0 }
 func (p Port) GetContainerPort() int32     { return p.ContainerPort }
 func (p Port) GetProtocol() apiv1.Protocol { return p.Protocol }
 
@@ -102,7 +102,7 @@ func (ImageCtrl) GetRegistryAndRepo(tag string) (string, string) {
 }
 
 // GetRepoNameAndTag returns the image repo and the tag separated
-func (ImageCtrl) getRepoNameAndTag(image string) (string, string) {
+func (ImageCtrl) GetRepoNameAndTag(image string) (string, string) {
 	var domain, remainder string
 	i := strings.IndexRune(image, '@')
 	if i != -1 {
@@ -125,7 +125,7 @@ func (ImageCtrl) getRepoNameAndTag(image string) (string, string) {
 }
 
 func (ImageCtrl) getExposedPortsFromCfg(cfg *containerv1.ConfigFile) []Port {
-	result := []Port{}
+	var result []Port
 	if cfg.Config.ExposedPorts == nil {
 		return result
 	}

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -264,7 +264,7 @@ func Test_GetRepoNameAndTag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo, tag := ImageCtrl{}.getRepoNameAndTag(tt.image)
+			repo, tag := ImageCtrl{}.GetRepoNameAndTag(tt.image)
 			assert.Equal(t, tt.expected.repo, repo)
 			assert.Equal(t, tt.expected.tag, tag)
 		})
@@ -280,7 +280,7 @@ func TestGetExposedPortsFromCfg(t *testing.T) {
 		{
 			name:     "cfg is nil",
 			cfg:      &v1.ConfigFile{},
-			expected: []Port{},
+			expected: nil,
 		},
 		{
 			name: "cfg is empty",
@@ -288,7 +288,7 @@ func TestGetExposedPortsFromCfg(t *testing.T) {
 				ExposedPorts: map[string]struct{}{},
 			},
 			},
-			expected: []Port{},
+			expected: nil,
 		},
 		{
 			name: "cfg-with-ports-one-malformed",

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	cache "github.com/okteto/okteto/pkg/cache"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
@@ -147,7 +146,10 @@ func (or OktetoRegistry) HasGlobalPushAccess() (bool, error) {
 	return or.client.HasPushAccess(image)
 }
 
-// GetImageCtrl returns the image controller
-func (or OktetoRegistry) GetImageCtrl() cache.ImageCtrlInterface {
-	return or.imageCtrl
+func (or OktetoRegistry) GetRegistryAndRepo(image string) (string, string) {
+	return or.imageCtrl.GetRegistryAndRepo(image)
+}
+
+func (or OktetoRegistry) GetRepoNameAndTag(repo string) (string, string) {
+	return or.imageCtrl.GetRepoNameAndTag(repo)
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	cache "github.com/okteto/okteto/pkg/cache"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
@@ -66,7 +67,7 @@ func (or OktetoRegistry) GetImageTagWithDigest(image string) (string, error) {
 	expandedImage := or.imageCtrl.expandImageRegistries(image)
 
 	registry, repositoryWithTag := or.imageCtrl.GetRegistryAndRepo(expandedImage)
-	repository, _ := or.imageCtrl.getRepoNameAndTag(repositoryWithTag)
+	repository, _ := or.imageCtrl.GetRepoNameAndTag(repositoryWithTag)
 
 	digest, err := or.client.GetDigest(expandedImage)
 	if err != nil {
@@ -119,12 +120,12 @@ func (or OktetoRegistry) GetImageTag(image, service, namespace string) string {
 		}
 		return fmt.Sprintf("%s/%s/%s:okteto", or.config.GetRegistryURL(), namespace, service)
 	}
-	imageWithoutTag, _ := or.imageCtrl.getRepoNameAndTag(image)
+	imageWithoutTag, _ := or.imageCtrl.GetRepoNameAndTag(image)
 	return fmt.Sprintf("%s:okteto", imageWithoutTag)
 }
 
 // GetImageReference returns the values to setup the image environment variables
-func (or OktetoRegistry) GetImageReference(image string) (OktetoImageReference, error) {
+func (OktetoRegistry) GetImageReference(image string) (OktetoImageReference, error) {
 	ref, err := name.ParseReference(image)
 	if err != nil {
 		return OktetoImageReference{}, err
@@ -144,4 +145,9 @@ func (or OktetoRegistry) HasGlobalPushAccess() (bool, error) {
 	}
 	image := or.imageCtrl.ExpandOktetoGlobalRegistry(globalTestImage)
 	return or.client.HasPushAccess(image)
+}
+
+// GetImageCtrl returns the image controller
+func (or OktetoRegistry) GetImageCtrl() cache.ImageCtrlInterface {
+	return or.imageCtrl
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3426

## How to test (Okteto Cloud)

1. `git clone git@github.com:okteto/movies-frontend.git`
2. Edit the `okteto.yml` to be like:
```YAML
build:
  frontend:
    context: .
    dockerfile: Dockerfile
    image: okteto.dev/frontend:1.0.0
    export_cache: okteto.dev/frontend:cache

deploy:
  - name: Deploy Frontend
    command: helm upgrade --install movies-frontend chart --set image=${OKTETO_BUILD_FRONTEND_IMAGE}

dev:
  frontend:
    image: ${OKTETO_BUILD_FRONTEND_DEV_IMAGE}
    command: yarn start
    sync:
      - .:/src
```
3. Run `okd build -l=debug`
4. Notice how you get both errors on pulling the cache images (like:  => `ERROR importing cache manifest from registry.cloud.okteto.net/okteto/frontend:cache` for both `/okteto` and `/{your-username`)
5. When the build suceeds it will export the cache to `okteto.dev`, now run again the build command 
6. Notice how this time the cache from `/{your-username}` is pulled successfully with a message like ` => importing cache manifest from registry.cloud.okteto.net/{your-username}/frontend:cache`

## How to test (Dev Cluster)

1. Switch to your dev cluster context
2. Follow the same steps for testing Okteto Cloud with the difference that here you should be able to push and pull the cache from the Global Registry

## How to test (Vanilla Cluster)

1. Using Docker Desktop, turn on the Kubernetes cluster
4. Select that okteto context (ie. `okteto context use docker-desktop`)
5. Run `okd build -l=debug`
6. Notice how you don't see any errors of cache fail being pulled either being imported