### PR TITLE
Fixed issue where okteto doesnt accept 'Y' as option

### DIFF
--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -254,14 +254,17 @@ func AskYesNo(q string, d YesNoDefault) (bool, error) {
 			break
 		}
 
-		if answer == "y" || answer == "n" {
+		if answer == "y" || answer == "Y" || answer == "n" || answer == "N" {
 			break
 		}
 
-		oktetoLog.Fail("input must be 'y' or 'n'")
+		oktetoLog.Fail("input must be 'Y/y' or 'N/n'")
 	}
 
-	return answer == "y", nil
+	if answer == "y" || answer == "Y" {
+		return true, nil
+	}
+	return false, nil
 }
 
 func AskForOptions(options []string, label string) (string, error) {

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -456,6 +456,18 @@ func Test_AskYesNo(t *testing.T) {
 			answer:   "\n",
 			expected: true,
 		},
+		{
+			name:     "ignores-default-when-answer",
+			def:      YesNoDefault_No,
+			answer:   "Y\n",
+			expected: true,
+		},
+		{
+			name:     "ignores-default-when-answer",
+			def:      YesNoDefault_No,
+			answer:   "N\n",
+			expected: false,
+		},
 	}
 	for _, tt := range tests {
 		// Create a temp dir for files used to mock stdin


### PR DESCRIPTION

Fixes #3476 

This PR fixes the issue where okteto doesnt accept 'Y' or 'N' as options, even when that's the option displayed in the console.

