### PR TITLE
Agustin/5794 kubeconfig with kubetoken client auth e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ executors:
   golang-ci:
     docker:
       - image: okteto/golang-ci:1.18.0
+  golang-ci-new:
+    docker:
+      - image: okteto/golang-ci:2.2.2
 
 jobs:
   build-binaries:
@@ -115,7 +118,7 @@ jobs:
             go version
             go test ./...
   test-integration:
-    executor: golang-ci
+    executor: golang-ci-new
     resource_class: large
     environment:
       OKTETO_URL: https://staging.okteto.dev/

--- a/integration/actions/apply_test.go
+++ b/integration/actions/apply_test.go
@@ -118,6 +118,7 @@ func executeApply(namespace string) error {
 	if _, err := os.Stat(kubepath); err != nil {
 		log.Printf("could not get kubepath: %s", err)
 	}
+	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kubepath))
 	o, err := cmd.CombinedOutput()
 	if err != nil {

--- a/integration/commands/preview.go
+++ b/integration/commands/preview.go
@@ -90,6 +90,7 @@ func RunOktetoDeployPreview(oktetoPath string, deployOptions *DeployPreviewOptio
 func RunOktetoPreviewDestroy(oktetoPath string, destroyOptions *DestroyPreviewOptions) error {
 	log.Printf("okteto destroy %s", oktetoPath)
 	cmd := exec.Command(oktetoPath, "preview", "destroy", destroyOptions.Namespace)
+	cmd.Env = os.Environ()
 	if destroyOptions.Workdir != "" {
 		cmd.Dir = destroyOptions.Workdir
 	}


### PR DESCRIPTION
# Proposed changes
Fixes 2 issues with the CLI e2e tests:
- Use latest version of `golangci`: This is due to an [error from helm](https://github.com/helm/helm/issues/11007). Using the helm version from the `golangi 2.2.2` image behaves correctly with kubeconfig exec sections
- Includes `os.Environ` in some commands that needed them: this was necessary since `okteto` must be in path for the exec command to work properly. 