### PR TITLE
inject OKTETO_ACTION_NAME in remote

### DIFF
--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -50,6 +50,7 @@ ENV {{ .NamespaceEnvVar }} {{ .NamespaceValue }}
 ENV {{ .ContextEnvVar }} {{ .ContextValue }}
 ENV {{ .TokenEnvVar }} {{ .TokenValue }}
 ENV {{ .RemoteDeployEnvVar }} true
+ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
 
 COPY . /okteto/src
 WORKDIR /okteto/src
@@ -69,6 +70,8 @@ type dockerfileTemplateProperties struct {
 	NamespaceValue     string
 	TokenEnvVar        string
 	TokenValue         string
+	ActionNameEnvVar   string
+	ActionNameValue    string
 	RemoteDeployEnvVar string
 	DeployFlags        string
 	RandomInt          int
@@ -169,6 +172,8 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 		NamespaceValue:     okteto.Context().Namespace,
 		TokenEnvVar:        model.OktetoTokenEnvVar,
 		TokenValue:         okteto.Context().Token,
+		ActionNameEnvVar:   model.OktetoActionNameEnvVar,
+		ActionNameValue:    os.Getenv(model.OktetoActionNameEnvVar),
 		RemoteDeployEnvVar: constants.OKtetoDeployRemote,
 		RandomInt:          int(randomNumber.Int64()),
 		DestroyFlags:       strings.Join(getDestroyFlags(opts), " "),

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -17,11 +17,13 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -200,9 +202,10 @@ func TestCreateDockerfile(t *testing.T) {
 		err            error
 	}
 	var tests = []struct {
-		name     string
-		config   config
-		expected expected
+		name            string
+		config          config
+		expected        expected
+		actionNameValue string
 	}{
 		{
 			name: "OS can't access working directory",
@@ -224,6 +227,7 @@ func TestCreateDockerfile(t *testing.T) {
 			expected: expected{
 				dockerfileName: filepath.Clean("/test/deploy"),
 			},
+			actionNameValue: "test",
 		},
 	}
 
@@ -235,6 +239,7 @@ func TestCreateDockerfile(t *testing.T) {
 				destroyImage:         "test-image",
 				workingDirectoryCtrl: wdCtrl,
 			}
+			t.Setenv(model.OktetoActionNameEnvVar, tt.actionNameValue)
 			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts)
 			assert.ErrorIs(t, err, tt.expected.err)
 			assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
@@ -242,6 +247,8 @@ func TestCreateDockerfile(t *testing.T) {
 			if tt.expected.err == nil {
 				_, err = rdc.fs.Stat(filepath.Join("/test", dockerfileTemporalNane))
 				assert.NoError(t, err)
+				content, _ := afero.ReadFile(rdc.fs, filepath.Join("/test", dockerfileTemporalNane))
+				assert.True(t, strings.Contains(string(content), fmt.Sprintf("ENV %s %s", model.OktetoActionNameEnvVar, tt.actionNameValue)))
 			}
 
 		})


### PR DESCRIPTION
# Proposed changes
- Inject `OKTETO_ACTION_NAME` in remote destroy

Fixes #[6123](https://github.com/okteto/app/issues/6123)

When we perform a remote destroy using Okteto UI we check if there is an operation already running. To do so, we check `OKTETO_ACTION_NAME` value. If we don't inject this env in remote, we will not update the config map where information about the destroy action is stored.