### PR TITLE
Fixes the remove of '' when no dev env is specified for okteto destroy

### DIFF
--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -49,7 +49,11 @@ func (ld *localDestroyCommand) destroy(ctx context.Context, opts *Options) error
 
 	err := ld.runDestroy(ctx, opts)
 	if err == nil {
-		oktetoLog.Success("Development environment '%s' successfully destroyed", opts.Name)
+		if opts.Name == "" {
+			oktetoLog.Success("Development environment successfully destroyed")
+		} else {
+			oktetoLog.Success("Development environment '%s' successfully destroyed", opts.Name)
+		}
 	}
 	analytics.TrackDestroy(err == nil, opts.DestroyAll)
 


### PR DESCRIPTION
Fixes: #3487
