### PR TITLE
chore(destroy): better error message when image not accessible

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -252,7 +252,7 @@ func (dc *destroyCommand) getDestroyer(opts *Options) (destroyInterface, error) 
 		runInRemote := !isRemote && (destroyImage != "" || opts.RunInRemote)
 
 		if runInRemote {
-			deployer = newRemoteDestroyer(destroyImage)
+			deployer = newRemoteDestroyer(manifest)
 			oktetoLog.Info("Destroying remotely...")
 		} else {
 			destroyerAll, err := newLocalDestroyerAll(dc.k8sClientProvider, dc.executor, dc.nsDestroyer, dc.oktetoClient)

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -81,16 +81,18 @@ type remoteDestroyCommand struct {
 	fs                   afero.Fs
 	workingDirectoryCtrl filesystem.WorkingDirectoryInterface
 	temporalCtrl         filesystem.TemporalDirectoryInterface
+	manifest             *model.Manifest
 }
 
-func newRemoteDestroyer(destroyImage string) *remoteDestroyCommand {
+func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
 	fs := afero.NewOsFs()
 	return &remoteDestroyCommand{
 		builder:              remoteBuild.NewBuilderFromScratch(),
-		destroyImage:         destroyImage,
+		destroyImage:         manifest.Destroy.Image,
 		fs:                   fs,
 		workingDirectoryCtrl: filesystem.NewOsWorkingDirectoryCtrl(),
 		temporalCtrl:         filesystem.NewTemporalDirectoryCtrl(fs),
+		manifest:             manifest,
 	}
 }
 
@@ -132,6 +134,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 
 	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"})
 	buildOptions.Tag = ""
+	buildOptions.Manifest = rd.manifest
 
 	// we need to call Build() method using a remote builder. This Builder will have
 	// the same behavior as the V1 builder but with a different output taking into
@@ -139,7 +142,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	// executed in the deploy command.
 	if err := rd.builder.Build(ctx, buildOptions); err != nil {
 		return oktetoErrors.UserError{
-			E: fmt.Errorf("error during development environment deployment"),
+			E: fmt.Errorf("error during destroy of the development environment: %w", err),
 		}
 	}
 	oktetoLog.SetStage("done")

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -36,7 +36,7 @@ func (f fakeBuilder) Build(_ context.Context, _ *types.BuildOptions) error {
 	return f.err
 }
 
-func (f fakeBuilder) IsV1() bool { return true }
+func (fakeBuilder) IsV1() bool { return true }
 
 func TestRemoteTest(t *testing.T) {
 	ctx := context.Background()
@@ -90,7 +90,7 @@ func TestRemoteTest(t *testing.T) {
 				builderErr: assert.AnError,
 			},
 			expected: oktetoErrors.UserError{
-				E: fmt.Errorf("error during development environment deployment"),
+				E: fmt.Errorf("error during destroy of the development environment: %w", assert.AnError),
 			},
 		},
 		{


### PR DESCRIPTION
# Proposed changes

Fixes [#6121](https://github.com/okteto/app/issues/6121)

### How to test

1. Create a manifest like this:
```yaml
destroy:
  image: image-that-doesnt-exist:nope
  commands:
    - name: hello
      command: echo "hello world!"
```
1. Run `okteto destroy` 
1. Notice the error message being: "Error during development environment deployment"
1. Now build this branch and run again
1. Notice the error being: "Error during destroying the development environment: error building image: failed to pull image 'image-that-doesnt-exist:nope'. The repository is not accessible or it does not exist."

| Before | After |
|--------|-------|
|  <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/228850303-c2ac5078-47bf-4ce8-828d-059bd32cb2d1.png" />      |       <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/228850336-6d952044-7dc5-4dd5-b40a-a7c3e46861c1.png" /> |





