### PR TITLE
fix destroy remote when adding envs with blank values

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -63,6 +63,9 @@ ENV {{ .NamespaceEnvVar }} {{ .NamespaceValue }}
 ENV {{ .ContextEnvVar }} {{ .ContextValue }}
 ENV {{ .TokenEnvVar }} {{ .TokenValue }}
 ENV {{ .RemoteDeployEnvVar }} true
+{{ if ne .ActionNameValue "" }}
+	ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
+{{ end }}
 
 COPY . /okteto/src
 WORKDIR /okteto/src
@@ -82,6 +85,8 @@ type dockerfileTemplateProperties struct {
 	NamespaceValue     string
 	TokenEnvVar        string
 	TokenValue         string
+	ActionNameEnvVar   string
+	ActionNameValue    string
 	RemoteDeployEnvVar string
 	DeployFlags        string
 	RandomInt          int
@@ -182,6 +187,8 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		NamespaceValue:     okteto.Context().Namespace,
 		TokenEnvVar:        model.OktetoTokenEnvVar,
 		TokenValue:         okteto.Context().Token,
+		ActionNameEnvVar:   model.OktetoActionNameEnvVar,
+		ActionNameValue:    os.Getenv(model.OktetoActionNameEnvVar),
 		RemoteDeployEnvVar: constants.OKtetoDeployRemote,
 		RandomInt:          int(randomNumber.Int64()),
 		DeployFlags:        strings.Join(getDeployFlags(opts), " "),

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -64,7 +64,7 @@ ENV {{ .ContextEnvVar }} {{ .ContextValue }}
 ENV {{ .TokenEnvVar }} {{ .TokenValue }}
 ENV {{ .RemoteDeployEnvVar }} true
 {{ if ne .ActionNameValue "" }}
-	ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
+ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
 {{ end }}
 
 COPY . /okteto/src

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -51,7 +51,7 @@ ENV {{ .ContextEnvVar }} {{ .ContextValue }}
 ENV {{ .TokenEnvVar }} {{ .TokenValue }}
 ENV {{ .RemoteDeployEnvVar }} true
 {{ if ne .ActionNameValue "" }}
-	ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
+ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
 {{ end }}
 
 COPY . /okteto/src

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -50,6 +50,9 @@ ENV {{ .NamespaceEnvVar }} {{ .NamespaceValue }}
 ENV {{ .ContextEnvVar }} {{ .ContextValue }}
 ENV {{ .TokenEnvVar }} {{ .TokenValue }}
 ENV {{ .RemoteDeployEnvVar }} true
+{{ if ne .ActionNameValue "" }}
+	ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
+{{ end }}
 
 COPY . /okteto/src
 WORKDIR /okteto/src
@@ -69,6 +72,8 @@ type dockerfileTemplateProperties struct {
 	NamespaceValue     string
 	TokenEnvVar        string
 	TokenValue         string
+	ActionNameEnvVar   string
+	ActionNameValue    string
 	RemoteDeployEnvVar string
 	DeployFlags        string
 	RandomInt          int
@@ -169,6 +174,8 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 		NamespaceValue:     okteto.Context().Namespace,
 		TokenEnvVar:        model.OktetoTokenEnvVar,
 		TokenValue:         okteto.Context().Token,
+		ActionNameEnvVar:   model.OktetoActionNameEnvVar,
+		ActionNameValue:    os.Getenv(model.OktetoActionNameEnvVar),
 		RemoteDeployEnvVar: constants.OKtetoDeployRemote,
 		RandomInt:          int(randomNumber.Int64()),
 		DestroyFlags:       strings.Join(getDestroyFlags(opts), " "),


### PR DESCRIPTION
# Proposed changes
- do not add ENV to img if value is blank

when an image is built for running destroy operations, some tests added an ENV with a blank value so this caused the destroy operation to fail because the image that would execute the command could not be created.
