### PR TITLE
Added Platform to BuildOptions return of OptsFromBuildInfo

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -309,6 +309,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 		BuildArgs:   model.SerializeBuildArgs(b.Args),
 		NoCache:     o.NoCache,
 		ExportCache: b.ExportCache,
+		Platform:    o.Platform,
 	}
 
 	// if secrets are present at the cmd flag, copy them to opts.Secrets

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -350,7 +350,7 @@ func extractFromContextAndDockerfile(context, dockerfile, svcName string) string
 
 // GetVolumesToInclude checks if the path exists, if it doesn't it skip it
 func GetVolumesToInclude(volumesToInclude []model.StackVolume) []model.StackVolume {
-	result := []model.StackVolume{}
+	result := make([]model.StackVolume, 0)
 	for _, p := range volumesToInclude {
 		if _, err := os.Stat(p.LocalPath); err == nil {
 			result = append(result, p)

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -242,6 +242,20 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				ExportCache: "export-image",
 			},
 		},
+		{
+			name:        "has-platform-option",
+			serviceName: "service",
+			buildInfo:   &model.BuildInfo{},
+			initialOpts: &types.BuildOptions{
+				Platform: "linux/amd64"},
+			isOkteto: true,
+			expected: &types.BuildOptions{
+				BuildArgs: []string{namespaceEnvVar.String()},
+				Platform:  "linux/amd64",
+				Tag:       "okteto.dev/movies-service:okteto",
+				OutputMode: "tty",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

Fixes #3488 

- Add `o.Platform` to buildOptions to transmit this option into the build

## Test

- Default platform for my setup is "linux/arm64" when running `okteto build` this is the platform my images are made into

- using context without buildkit, using my local docker deamon and using dockerhub as registry

```
❯ ok build --platform "linux/amd64"
 i  Building 'Dockerfile' using your local docker daemon
....
 ✓  Image 'teresaromero/go-getting-started' successfully pushed
```
```
❯ docker image inspect teresaromero/go-getting-started:latest
[
    {
        "RepoTags": [
            "teresaromero/go-getting-started:latest"
        ],
    ...
        "Architecture": "amd64",
        "Os": "linux",
...
    }
]

```

- using cloud context, using buildkit for the build and using dockerhub as registry

```
❯ ok build --platform "linux/amd64"
 i  Building 'Dockerfile' in tcp://buildkit.cloud.okteto.net:443...
...
 ✓  Image 'teresaromero/go-getting-started' successfully pushed
```

```
❯ docker image inspect teresaromero/go-getting-started:latest
[
    {
        "RepoTags": [
            "teresaromero/go-getting-started:latest"
        ],
    ...
        "Architecture": "amd64",
        "Os": "linux",
...
    }
]

```

- using cloud context, using buildkit for the build and using external registry

```
❯ ok build -t <registry>/go-getting-started:latest --platform "linux/amd64"
 i  Building 'Dockerfile' in tcp://buildkit.cloud.okteto.net:443...
...
 ✓  Image '<registry>/go-getting-started:latest' successfully pushed
```

```
❯ docker run -it --rm <registry>/go-getting-started:latest
...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```