### PR TITLE
[Backport release-2.14] fix destroy remote when adding envs with blank values

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -63,6 +63,9 @@ ENV {{ .NamespaceEnvVar }} {{ .NamespaceValue }}
 ENV {{ .ContextEnvVar }} {{ .ContextValue }}
 ENV {{ .TokenEnvVar }} {{ .TokenValue }}
 ENV {{ .RemoteDeployEnvVar }} true
+{{ if ne .ActionNameValue "" }}
+ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
+{{ end }}
 
 COPY . /okteto/src
 WORKDIR /okteto/src
@@ -82,6 +85,8 @@ type dockerfileTemplateProperties struct {
 	NamespaceValue     string
 	TokenEnvVar        string
 	TokenValue         string
+	ActionNameEnvVar   string
+	ActionNameValue    string
 	RemoteDeployEnvVar string
 	DeployFlags        string
 	RandomInt          int
@@ -181,6 +186,8 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		NamespaceValue:     okteto.Context().Namespace,
 		TokenEnvVar:        model.OktetoTokenEnvVar,
 		TokenValue:         okteto.Context().Token,
+		ActionNameEnvVar:   model.OktetoActionNameEnvVar,
+		ActionNameValue:    os.Getenv(model.OktetoActionNameEnvVar),
 		RemoteDeployEnvVar: constants.OKtetoDeployRemote,
 		RandomInt:          int(randomNumber.Int64()),
 		DeployFlags:        strings.Join(getDeployFlags(opts), " "),

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -50,6 +50,9 @@ ENV {{ .NamespaceEnvVar }} {{ .NamespaceValue }}
 ENV {{ .ContextEnvVar }} {{ .ContextValue }}
 ENV {{ .TokenEnvVar }} {{ .TokenValue }}
 ENV {{ .RemoteDeployEnvVar }} true
+{{ if ne .ActionNameValue "" }}
+ENV {{ .ActionNameEnvVar }} {{ .ActionNameValue }}
+{{ end }}
 
 COPY . /okteto/src
 WORKDIR /okteto/src


### PR DESCRIPTION
backport 5f8098a3c5f8369b505d2c68fbdc18ec121fc90c from #3504 