### PR TITLE
infer dev name before create remote image

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -136,14 +136,13 @@ func Destroy(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("failed to get the current working directory: %w", err)
 			}
 
-			name := options.Name
 			if options.Name == "" {
 				c, _, err := okteto.NewK8sClientProvider().Provide(okteto.Context().Cfg)
 				if err != nil {
 					return err
 				}
 				inferer := devenvironment.NewNameInferer(c)
-				name = inferer.InferName(ctx, cwd, okteto.Context().Namespace, options.ManifestPathFlag)
+				options.Name = inferer.InferName(ctx, cwd, okteto.Context().Namespace, options.ManifestPathFlag)
 				if err != nil {
 					return fmt.Errorf("could not infer environment name")
 				}
@@ -181,10 +180,10 @@ func Destroy(ctx context.Context) *cobra.Command {
 				secrets:           secrets.NewSecrets(k8sClient),
 				k8sClientProvider: okteto.NewK8sClientProvider(),
 				oktetoClient:      okClient,
-				buildCtrl:         newBuildCtrl(name),
+				buildCtrl:         newBuildCtrl(options.Name),
 			}
 
-			kubeconfigPath := getTempKubeConfigFile(name)
+			kubeconfigPath := getTempKubeConfigFile(options.Name)
 			if err := kubeconfig.Write(okteto.Context().Cfg, kubeconfigPath); err != nil {
 				return err
 			}

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -389,7 +389,7 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDestroyRemote(oktetoPath, destroyOptions))
 
 	_, err = integration.GetDeployment(context.Background(), testNamespace, "my-dep", c)
-	require.NoError(t, err)
+	require.True(t, k8sErrors.IsNotFound(err))
 }
 
 func isImageBuilt(image string) bool {


### PR DESCRIPTION
# Proposed changes

Fixes #https://github.com/okteto/app/issues/6165

the dev name inference on the remote does not work like on local because it has no information about the `.git` (we avoid adding that folder to the remote) so when inferring the name on remote it does not match the real name.