### PR TITLE
fix: e2e test for cmd output

### DIFF
--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -236,7 +236,7 @@ func TestCmdFailOutput(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, 1, numErrors)
+	require.Equal(t, 3, numErrors)
 	stagesToTest := []string{"Load manifest", "Failed command", "done"}
 	for _, ss := range stagesToTest {
 		if _, ok := stageLines[ss]; !ok {
@@ -301,7 +301,7 @@ func TestComposeFailOutput(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, 1, numErrors)
+	require.Equal(t, 3, numErrors)
 	stagesToTest := []string{"Load manifest", "Deploying compose", "done"}
 	for _, ss := range stagesToTest {
 		if _, ok := stageLines[ss]; !ok {


### PR DESCRIPTION
# Proposed changes

Fixes e2e CMDoutput tests. With the new changes in the logs we are showing the same error multiple times if the command runs in the remote environment