### PR TITLE
fix: duplicated logs on same stage

### DIFF
--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -229,7 +229,7 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 			case ss, ok := <-ch:
 				if ok {
 					plainChannel <- ss
-					if progress == oktetoLog.TTYFormat || progress == "deploy" {
+					if progress == oktetoLog.TTYFormat {
 						ttyChannel <- ss
 					}
 				} else {
@@ -238,7 +238,7 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 			}
 			if done {
 				close(plainChannel)
-				if progress == oktetoLog.TTYFormat || progress == "deploy" {
+				if progress == oktetoLog.TTYFormat {
 					close(ttyChannel)
 				}
 				break
@@ -267,8 +267,7 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 			// not using shared context to not disrupt display but let it finish reporting errors
 			return progressui.DisplaySolveStatus(context.TODO(), "", nil, w, plainChannel)
 		case "deploy":
-			go progressui.DisplaySolveStatus(context.TODO(), "", nil, w, plainChannel)
-			err := deployDisplayer(context.TODO(), ttyChannel)
+			err := deployDisplayer(context.TODO(), plainChannel)
 			commandFailChannel <- err
 			return err
 		default:

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -156,6 +156,10 @@ func (t *trace) display() {
 				switch text.Stage {
 				case "done":
 					continue
+				case "Load manifest":
+					if text.Level == "error" {
+						oktetoLog.Fail(text.Message)
+					}
 				default:
 					// Print the information message about the stage if needed
 					if _, ok := t.stages[text.Stage]; !ok {


### PR DESCRIPTION
# Proposed changes

Fixes Duplicated logs on the same stage.

- We were splitting the signal that buildkit send us to save it and put it in the output. This change only uses one channel that is sending the information back to the CLI and is the CLI the one updating the cmap

## Screenshoot:
<img width="907" alt="Captura de Pantalla 2023-04-04 a las 11 13 17" src="https://user-images.githubusercontent.com/25170843/229745544-684918d7-e6b1-424d-afa2-b98946a93304.png">
<img width="681" alt="Captura de Pantalla 2023-03-31 a las 18 19 27" src="https://user-images.githubusercontent.com/25170843/229175635-bdac6048-f5a1-4657-8b57-239f64f68511.png">
