### PR TITLE
fix: destroy with multiple words

### DIFF
--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -233,7 +233,7 @@ func getDestroyFlags(opts *Options) []string {
 	var deployFlags []string
 
 	if opts.Name != "" {
-		deployFlags = append(deployFlags, fmt.Sprintf("--name %s", opts.Name))
+		deployFlags = append(deployFlags, fmt.Sprintf("--name \"%s\"", opts.Name))
 	}
 
 	if opts.Namespace != "" {

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -156,7 +156,16 @@ func TestGetDestroyFlags(t *testing.T) {
 					Name: "test",
 				},
 			},
-			expected: []string{"--name test"},
+			expected: []string{"--name \"test\""},
+		},
+		{
+			name: "name multiple words",
+			config: config{
+				opts: &Options{
+					Name: "this is a test",
+				},
+			},
+			expected: []string{"--name \"this is a test\""},
 		},
 		{
 			name: "namespace set",


### PR DESCRIPTION
# Proposed changes

#3465 follow up

Destroy with multiple words should be scaped
