### PR TITLE
remote output fixes

### DIFF
--- a/cmd/deploy/cfghandler.go
+++ b/cmd/deploy/cfghandler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	apiv1 "k8s.io/api/core/v1"
 )
@@ -72,7 +71,6 @@ func (ch *defaultConfigMapHandler) updateConfigMap(ctx context.Context, cfg *api
 		return err
 	}
 	if errMain != nil {
-		oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, errMain.Error())
 		data.Status = pipeline.ErrorStatus
 	}
 	if err := pipeline.UpdateConfigMap(ctx, cfg, data, c); err != nil {

--- a/cmd/deploy/cfghandler.go
+++ b/cmd/deploy/cfghandler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	apiv1 "k8s.io/api/core/v1"
 )
@@ -71,6 +72,7 @@ func (ch *defaultConfigMapHandler) updateConfigMap(ctx context.Context, cfg *api
 		return err
 	}
 	if errMain != nil {
+		oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, errMain.Error())
 		data.Status = pipeline.ErrorStatus
 	}
 	if err := pipeline.UpdateConfigMap(ctx, cfg, data, c); err != nil {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -332,9 +332,9 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	}
 
 	err = deployer.deploy(ctx, deployOptions)
-	if _, ok := deployer.(*remoteDeployCommand); ok {
-		err = nil
-	}
+	// if _, ok := deployer.(*remoteDeployCommand); ok {
+	// 	err = nil
+	// }
 	if err != nil {
 		if err == oktetoErrors.ErrIntSig {
 			return nil

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -332,9 +332,6 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	}
 
 	err = deployer.deploy(ctx, deployOptions)
-	// if _, ok := deployer.(*remoteDeployCommand); ok {
-	// 	err = nil
-	// }
 	if err != nil {
 		if err == oktetoErrors.ErrIntSig {
 			return nil

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -332,12 +332,14 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	}
 
 	err = deployer.deploy(ctx, deployOptions)
+	if _, ok := deployer.(*remoteDeployCommand); ok {
+		err = nil
+	}
 	if err != nil {
 		if err == oktetoErrors.ErrIntSig {
 			return nil
 		}
 		err = oktetoErrors.UserError{E: err}
-		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, err.Error())
 		data.Status = pipeline.ErrorStatus
 	} else {
 		oktetoLog.SetStage("")

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -16,6 +16,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -304,7 +305,7 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 	err := c.RunDeploy(ctx, opts)
 
 	// we should get a build error because Dockerfile does not exist
-	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), oktetoErrors.InvalidDockerfile))
 
 	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
 	if err != nil {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -16,7 +16,6 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/format"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
@@ -338,8 +336,6 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 	}
 
 	expectedCfg.Data["output"] = cfg.Data["output"]
-
-	assert.True(t, strings.Contains(oktetoLog.GetOutputBuffer().String(), oktetoErrors.InvalidDockerfile))
 
 	assert.Equal(t, expectedCfg.Name, cfg.Name)
 	assert.Equal(t, expectedCfg.Namespace, cfg.Namespace)

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -156,7 +156,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		if errors.As(err, &cmdErr) {
 			oktetoLog.SetStage(cmdErr.Stage)
 			return oktetoErrors.UserError{
-				E: fmt.Errorf("error during development environment deployment: %w", cmdErr.Err),
+				E: cmdErr.Err,
 			}
 		}
 		oktetoLog.SetStage("remote deploy")
@@ -165,7 +165,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 			return userErr
 		}
 		return oktetoErrors.UserError{
-			E: fmt.Errorf("Error during development environment deployment: %w", err),
+			E: err,
 		}
 	}
 	oktetoLog.SetStage("done")

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -15,7 +15,6 @@ package deploy
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -102,7 +101,7 @@ func TestRemoteTest(t *testing.T) {
 				builderErr: assert.AnError,
 			},
 			expected: oktetoErrors.UserError{
-				E: fmt.Errorf("Error during development environment deployment: %w", assert.AnError),
+				E: assert.AnError,
 			},
 		},
 		{
@@ -117,7 +116,7 @@ func TestRemoteTest(t *testing.T) {
 				},
 			},
 			expected: oktetoErrors.UserError{
-				E: fmt.Errorf("error during development environment deployment: %w", assert.AnError),
+				E: assert.AnError,
 			},
 		},
 		{

--- a/cmd/utils/displayer/json.go
+++ b/cmd/utils/displayer/json.go
@@ -83,7 +83,7 @@ func (d *jsonDisplayer) Display(_ string) {
 				case <-d.commandContext.Done():
 				default:
 					line := d.stderrScanner.Text()
-					oktetoLog.FWarning(os.Stdout, line)
+					oktetoLog.FPrintln(os.Stdout, line)
 					continue
 				}
 				break

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -172,9 +172,6 @@ func (t *trace) display() {
 								Stage: text.Stage,
 								Err:   fmt.Errorf(text.Message),
 							}
-							oktetoLog.Fail(text.Message)
-						} else {
-							oktetoLog.Fail(text.Message)
 						}
 					} else {
 						oktetoLog.Println(text.Message)

--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -264,7 +264,6 @@ func (*JSONWriter) IsInteractive() bool {
 }
 
 func convertToJSON(level, stage, message string) string {
-	message = strings.TrimSpace(message)
 	if stage == "" || message == "" {
 		return ""
 	}


### PR DESCRIPTION
## Acceptance criteria
- [x] do not show a warning icon in command output if local deploy doesn't display it
- [x] do not log twice error if stage fails
- [x] add indentation in the UI if the command output has it
# Proposed changes
- do not print as warning errors from command output when using json displayed (the one used in remote deploys)
- do not `trim()` command log
- avoid adding a log in the buffer if it has already been added

## Test scenarios to not log twice same error

Fixes #3456 
- [x] deploy locally works fine using CLI

#### CLI
| Before | After |
|--------|-------|
|  ![Captura de Pantalla 2023-04-11 a las 14 14 40](https://user-images.githubusercontent.com/22500940/231159401-359e8111-cd2e-40ca-85de-42eb5a08846c.png) | ![Captura de Pantalla 2023-04-11 a las 14 16 21](https://user-images.githubusercontent.com/22500940/231159731-fb278530-c51b-43f8-878c-a9fc32aef538.png) |

#### UI 
| Before | After |
|--------|-------|
| <img width="591" alt="Captura de Pantalla 2023-04-12 a las 13 12 15" src="https://user-images.githubusercontent.com/22500940/231440652-44004fab-5335-452c-8f82-42fcfdb02045.png"> | <img width="591" alt="Captura de Pantalla 2023-04-12 a las 13 29 59" src="https://user-images.githubusercontent.com/22500940/231444281-a72bb46b-ddc8-4802-9c71-7a7a6b624aff.png">|

- [x] deploy remotely works fine using CLI
#### CLI
| Before | After |
|--------|-------|
| ![Captura de Pantalla 2023-04-11 a las 14 22 50](https://user-images.githubusercontent.com/22500940/231161085-c1fcb1ef-c018-4393-9fba-9167c69fefa1.png) | ![Captura de Pantalla 2023-04-11 a las 14 32 21](https://user-images.githubusercontent.com/22500940/231163195-09ad3652-40ae-433f-8e4e-f655ab4e2d42.png)|

**NOTE: currently master branch already presents a CLI output without `Load manifest` stage**
#### UI 
| Before | After |
|--------|-------|
| ![Captura de Pantalla 2023-04-11 a las 14 31 17](https://user-images.githubusercontent.com/22500940/231163060-0043a969-1e68-49ce-b4dc-fa283d02dc47.png) | ![Captura de Pantalla 2023-04-11 a las 14 32 48](https://user-images.githubusercontent.com/22500940/231163305-b8d932ab-49af-4972-80d5-90489a1e4f60.png)|

- [x] deploy locally works fine using UI

#### UI 
| Before | After |
|--------|-------|
| <img width="600" alt="Captura de Pantalla 2023-04-12 a las 14 09 24" src="https://user-images.githubusercontent.com/22500940/231452674-8723579c-6a5c-4b30-9a81-02cfd62afa77.png">| <img width="619" alt="Captura de Pantalla 2023-04-12 a las 14 09 58" src="https://user-images.githubusercontent.com/22500940/231452763-9ac596ea-f612-4928-997b-3a58843e870d.png">|

- [x] deploy remotely works fine using UI

#### UI 
| Before | After |
|--------|-------|
| <img width="946" alt="Captura de Pantalla 2023-04-12 a las 14 11 16" src="https://user-images.githubusercontent.com/22500940/231453073-9d3c6ed4-b177-4efa-a94e-87d4d5dd1ce9.png">|<img width="667" alt="Captura de Pantalla 2023-04-12 a las 14 11 39" src="https://user-images.githubusercontent.com/22500940/231453185-f0e77efd-f66b-4219-bc53-9d0dffc2e6f7.png">|

## Test scenarios to indent in UI
done in https://github.com/okteto/app/pull/6204