### PR TITLE
fix .env removal locally

### DIFF
--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -189,7 +189,7 @@ func (ld *localDeployer) runDeploySection(ctx context.Context, opts *Options) er
 	}
 
 	defer func() {
-		if err := ld.Fs.RemoveAll(filepath.Base(oktetoEnvFile.Name())); err != nil {
+		if err := ld.Fs.RemoveAll(filepath.Dir(oktetoEnvFile.Name())); err != nil {
 			oktetoLog.Infof("error removing okteto env file dir: %w", err)
 		}
 	}()

--- a/cmd/deploy/local_test.go
+++ b/cmd/deploy/local_test.go
@@ -22,32 +22,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRunDeploySection(t *testing.T) {
+func TestDeployNotRemovingEnvFile(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	_, err := fs.Create(".env")
 	require.NoError(t, err)
-	tt := []struct {
-		name string
-		opts *Options
-	}{
-		{
-			name: "check that deploy doesn't remove .env file",
-			opts: &Options{
-				Manifest: &model.Manifest{
-					Deploy: &model.DeployInfo{},
-				},
-			},
+	opts := &Options{
+		Manifest: &model.Manifest{
+			Deploy: &model.DeployInfo{},
 		},
 	}
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			localDeployer := localDeployer{
-				Fs: fs,
-			}
-			localDeployer.runDeploySection(context.Background(), tc.opts)
-			_, err := fs.Stat(".env")
-			require.NoError(t, err)
-		})
+	localDeployer := localDeployer{
+		Fs: fs,
 	}
+	localDeployer.runDeploySection(context.Background(), opts)
+	_, err = fs.Stat(".env")
+	require.NoError(t, err)
+
 }

--- a/cmd/deploy/local_test.go
+++ b/cmd/deploy/local_test.go
@@ -1,0 +1,53 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunDeploySection(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	_, err := fs.Create(".env")
+	require.NoError(t, err)
+	tt := []struct {
+		name string
+		opts *Options
+	}{
+		{
+			name: "check that deploy doesn't remove .env file",
+			opts: &Options{
+				Manifest: &model.Manifest{
+					Deploy: &model.DeployInfo{},
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			localDeployer := localDeployer{
+				Fs: fs,
+			}
+			localDeployer.runDeploySection(context.Background(), tc.opts)
+			_, err := fs.Stat(".env")
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes #3532

- local was not cleaning the correct path and could lead to removing the `.env` file
- Added a test to make sure this is not happening again
