### PR TITLE
build empty `.dockerignore` in tmp dir for remote build if no `.oktetodeployignore` provided

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -223,21 +223,22 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 }
 
 func (rd *remoteDeployCommand) createDockerignoreIfNeeded(cwd, tmpDir string) error {
+	dockerignoreContent := []byte(``)
 	dockerignoreFilePath := filepath.Join(cwd, oktetoDockerignoreName)
 	if _, err := rd.fs.Stat(dockerignoreFilePath); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-	} else {
-		dockerignoreContent, err := afero.ReadFile(rd.fs, dockerignoreFilePath)
-		if err != nil {
-			return err
-		}
 
-		err = afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
+	} else {
+		dockerignoreContent, err = afero.ReadFile(rd.fs, dockerignoreFilePath)
 		if err != nil {
 			return err
 		}
+	}
+	err := afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -211,7 +211,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		return "", err
 	}
 
-	err = rd.createDockerignoreIfNeeded(cwd, tmpDir)
+	err = rd.createDockerignore(cwd, tmpDir)
 	if err != nil {
 		return "", err
 	}
@@ -222,7 +222,12 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 	return dockerfile.Name(), nil
 }
 
-func (rd *remoteDeployCommand) createDockerignoreIfNeeded(cwd, tmpDir string) error {
+func (rd *remoteDeployCommand) createDockerignore(cwd, tmpDir string) error {
+	// if we do not create a .dockerignore (with or without content) used to create
+	// the remote executor, we would use the one located in root (the one used to
+	// build the services) so we would create a remote executor without certain files
+	// necessary for the later deployment which would cause an error when deploying
+	// remotely due to the lack of these files.
 	dockerignoreContent := []byte(``)
 	dockerignoreFilePath := filepath.Join(cwd, oktetoDockerignoreName)
 	if _, err := rd.fs.Stat(dockerignoreFilePath); err != nil {


### PR DESCRIPTION
# Proposed changes

- always create `.dockerignore` in tmp dir if no `.oktetodeployignore` provided. If we don't create this file in tmp dir, buildkit lib will use as possible `.dockerignore` the one in the context set it up for the build (folder where user exec okteto deploy)

Fixes #[6214](https://github.com/okteto/app/issues/6214)
