### PR TITLE
feat(build): improve missing cache error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # IDEs
 .vscode
+.idea
 
 # Golang binary
 cli

--- a/pkg/cmd/build/log_filter.go
+++ b/pkg/cmd/build/log_filter.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 )
 
-type ConditionFunc func(vertex *client.Vertex, ss *client.SolveStatus) bool
+type ConditionFunc func(vertex *client.Vertex) bool
 type TransformerFunc func(vertex *client.Vertex, ss *client.SolveStatus, progress string)
 
 type Rule struct {
@@ -28,7 +28,7 @@ func NewBuildKitLogsFilter(rules []Rule) *BuildKitLogsFilter {
 func (lf *BuildKitLogsFilter) Run(ss *client.SolveStatus, progress string) {
 	for _, vertex := range ss.Vertexes {
 		for _, rule := range lf.rules {
-			if rule.condition(vertex, ss) {
+			if rule.condition(vertex) {
 				rule.transformer(vertex, ss, progress)
 			}
 		}
@@ -36,7 +36,7 @@ func (lf *BuildKitLogsFilter) Run(ss *client.SolveStatus, progress string) {
 }
 
 // BuildKitMissingCacheCondition checks if the log contains a missing cache error
-var BuildKitMissingCacheCondition ConditionFunc = func(vertex *client.Vertex, ss *client.SolveStatus) bool {
+var BuildKitMissingCacheCondition ConditionFunc = func(vertex *client.Vertex) bool {
 	importPattern := `importing cache manifest from .*`
 
 	if !regexp.MustCompile(importPattern).MatchString(vertex.Name) {

--- a/pkg/cmd/build/log_filter.go
+++ b/pkg/cmd/build/log_filter.go
@@ -1,0 +1,79 @@
+package build
+
+import (
+	"fmt"
+	"github.com/moby/buildkit/client"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"regexp"
+)
+
+type ConditionFunc func(vertex *client.Vertex, ss *client.SolveStatus) bool
+type TransformerFunc func(vertex *client.Vertex, ss *client.SolveStatus, progress string)
+
+type Rule struct {
+	condition   ConditionFunc
+	transformer TransformerFunc
+}
+
+type BuildKitLogsFilter struct {
+	rules []Rule
+}
+
+func NewBuildKitLogsFilter(rules []Rule) *BuildKitLogsFilter {
+	return &BuildKitLogsFilter{
+		rules: rules,
+	}
+}
+
+func (lf *BuildKitLogsFilter) Run(ss *client.SolveStatus, progress string) {
+	for _, vertex := range ss.Vertexes {
+		for _, rule := range lf.rules {
+			if rule.condition(vertex, ss) {
+				rule.transformer(vertex, ss, progress)
+			}
+		}
+	}
+}
+
+// BuildKitMissingCacheCondition checks if the log contains a missing cache error
+var BuildKitMissingCacheCondition ConditionFunc = func(vertex *client.Vertex, ss *client.SolveStatus) bool {
+	importPattern := `importing cache manifest from .*`
+
+	if !regexp.MustCompile(importPattern).MatchString(vertex.Name) {
+		return false
+	}
+
+	errorPattern := `.*: not found`
+
+	return regexp.MustCompile(errorPattern).MatchString(vertex.Error)
+}
+
+// BuildKitMissingCacheTransformer transforms the missing cache error log to a more user-friendly message
+var BuildKitMissingCacheTransformer TransformerFunc = func(vertex *client.Vertex, ss *client.SolveStatus, progress string) {
+	errorPattern := `(.*): not found`
+	re := regexp.MustCompile(errorPattern)
+	matches := re.FindStringSubmatch(vertex.Error)
+
+	if len(matches) < 2 {
+		return
+	}
+
+	msg := fmt.Sprintf("[skip] cache image not available: %s", matches[1])
+
+	vertex.Error = ""
+
+	if progress == oktetoLog.TTYFormat {
+		vertex.Name = msg
+	} else {
+		vertex.Completed = nil
+		started := vertex.Started
+		completed := started
+		newVertex := &client.Vertex{
+			Name:      msg,
+			Started:   started,
+			Completed: completed,
+		}
+
+		ss.Vertexes = append(ss.Vertexes, newVertex)
+	}
+}

--- a/pkg/cmd/build/log_filter.go
+++ b/pkg/cmd/build/log_filter.go
@@ -76,4 +76,6 @@ var BuildKitMissingCacheTransformer TransformerFunc = func(vertex *client.Vertex
 
 		ss.Vertexes = append(ss.Vertexes, newVertex)
 	}
+
+	oktetoLog.Info(msg)
 }

--- a/pkg/cmd/build/log_filter_test.go
+++ b/pkg/cmd/build/log_filter_test.go
@@ -1,0 +1,228 @@
+package build
+
+import (
+	"github.com/moby/buildkit/client"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNewBuildKitLogsFilterEmptyRules(t *testing.T) {
+	lf := NewBuildKitLogsFilter([]Rule{})
+
+	v := &client.Vertex{
+		Name:  "test log message",
+		Error: assert.AnError.Error(),
+	}
+
+	ss := &client.SolveStatus{
+		Vertexes: []*client.Vertex{v},
+	}
+
+	lf.Run(ss, oktetoLog.TTYFormat)
+
+	assert.Equal(t, "test log message", v.Name)
+	assert.Equal(t, assert.AnError.Error(), v.Error)
+	assert.Equal(t, 1, len(ss.Vertexes))
+}
+
+func TestNewBuildKitLogsFilter(t *testing.T) {
+	now := time.Now()
+
+	rules := []Rule{
+		{
+			condition:   BuildKitMissingCacheCondition,
+			transformer: BuildKitMissingCacheTransformer,
+		},
+	}
+
+	lf := NewBuildKitLogsFilter(rules)
+
+	v := &client.Vertex{
+		Name:      "importing cache manifest from test-registry.com/test-account/test-repo",
+		Error:     "test-registry.com/test-account/test-repo: not found",
+		Started:   &now,
+		Completed: &now,
+	}
+
+	ss := &client.SolveStatus{
+		Vertexes: []*client.Vertex{v},
+	}
+
+	lf.Run(ss, oktetoLog.TTYFormat)
+
+	expected := &client.Vertex{
+		Name:      "[skip] cache image not available: test-registry.com/test-account/test-repo",
+		Error:     "",
+		Started:   &now,
+		Completed: &now,
+	}
+
+	if !reflect.DeepEqual(expected, v) {
+		t.Errorf("expected %v, got %v", expected, v)
+	}
+
+	assert.Equal(t, 1, len(ss.Vertexes))
+}
+
+func TestBuildKitMissingCacheCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		v        *client.Vertex
+		ss       *client.SolveStatus
+		expected bool
+	}{
+		{
+			name: "no match found (error)",
+			v: &client.Vertex{
+				Name:  "importing cache manifest from test-registry.com/test-account/test-repo",
+				Error: "",
+			},
+			ss:       &client.SolveStatus{},
+			expected: false,
+		},
+		{
+			name: "no match found (name)",
+			v: &client.Vertex{
+				Name:  "something else",
+				Error: "test-registry.com/test-account/test-repo: not found",
+			},
+			ss:       &client.SolveStatus{},
+			expected: false,
+		},
+		{
+			name: "match found",
+			v: &client.Vertex{
+				Name:  "importing cache manifest from test-registry.com/test-account/test-repo",
+				Error: "test-registry.com/test-account/test-repo: not found",
+			},
+			ss:       &client.SolveStatus{},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := BuildKitMissingCacheCondition(tc.v, tc.ss)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBuildKitMissingCacheTransformerNotMatching(t *testing.T) {
+	now := time.Now()
+
+	v := &client.Vertex{
+		Name:      "this log should not be transformed",
+		Error:     assert.AnError.Error(),
+		Started:   &now,
+		Completed: &now,
+	}
+
+	expectedV := &client.Vertex{
+		Name:      "this log should not be transformed",
+		Error:     assert.AnError.Error(),
+		Started:   &now,
+		Completed: &now,
+	}
+
+	ss := &client.SolveStatus{
+		Vertexes: []*client.Vertex{v},
+		Statuses: nil,
+		Logs:     nil,
+	}
+
+	expectedSs := &client.SolveStatus{
+		Vertexes: []*client.Vertex{v},
+		Statuses: nil,
+		Logs:     nil,
+	}
+
+	BuildKitMissingCacheTransformer(v, ss, oktetoLog.TTYFormat)
+
+	if !reflect.DeepEqual(expectedV, v) {
+		t.Errorf("expected %v, got %v", v, v)
+	}
+
+	if !reflect.DeepEqual(expectedSs, ss) {
+		t.Errorf("expected %v, got %v", ss, ss)
+	}
+}
+
+func TestBuildKitMissingCacheTransformerTTY(t *testing.T) {
+	now := time.Now()
+
+	v := &client.Vertex{
+		Name:      "importing cache manifest from test-registry.com/test-account/test-repo",
+		Error:     "test-registry.com/test-account/test-repo: not found",
+		Started:   &now,
+		Completed: &now,
+	}
+
+	expected := &client.Vertex{
+		Name:      "[skip] cache image not available: test-registry.com/test-account/test-repo",
+		Error:     "",
+		Started:   &now,
+		Completed: &now,
+	}
+
+	ss := &client.SolveStatus{
+		Vertexes: []*client.Vertex{v},
+		Statuses: nil,
+		Logs:     nil,
+	}
+
+	BuildKitMissingCacheTransformer(v, ss, oktetoLog.TTYFormat)
+
+	if !reflect.DeepEqual(expected, v) {
+		t.Errorf("expected %v, got %v", expected, v)
+	}
+
+	assert.Equal(t, 1, len(ss.Vertexes))
+}
+
+func TestBuildKitMissingCacheTransformerPlain(t *testing.T) {
+	now := time.Now()
+
+	v := &client.Vertex{
+		Name:      "importing cache manifest from test-registry.com/test-account/test-repo",
+		Error:     "test-registry.com/test-account/test-repo: not found",
+		Started:   &now,
+		Completed: &now,
+	}
+
+	expected := &client.Vertex{
+		Name:      "importing cache manifest from test-registry.com/test-account/test-repo",
+		Error:     "",
+		Started:   &now,
+		Completed: nil,
+	}
+
+	expectedNew := &client.Vertex{
+		Name:      "[skip] cache image not available: test-registry.com/test-account/test-repo",
+		Error:     "",
+		Started:   &now,
+		Completed: &now,
+	}
+
+	ss := &client.SolveStatus{
+		Vertexes: []*client.Vertex{v},
+		Statuses: nil,
+		Logs:     nil,
+	}
+
+	BuildKitMissingCacheTransformer(v, ss, oktetoLog.PlainFormat)
+	newVertex := ss.Vertexes[len(ss.Vertexes)-1]
+
+	assert.Equal(t, 2, len(ss.Vertexes))
+
+	if !reflect.DeepEqual(expected, v) {
+		t.Errorf("expected %v, got %v", expected, v)
+	}
+
+	if !reflect.DeepEqual(expectedNew, newVertex) {
+		t.Errorf("expected %v, got %v", expectedNew, newVertex)
+	}
+}

--- a/pkg/cmd/build/log_filter_test.go
+++ b/pkg/cmd/build/log_filter_test.go
@@ -71,7 +71,6 @@ func TestBuildKitMissingCacheCondition(t *testing.T) {
 	tests := []struct {
 		name     string
 		v        *client.Vertex
-		ss       *client.SolveStatus
 		expected bool
 	}{
 		{
@@ -80,7 +79,6 @@ func TestBuildKitMissingCacheCondition(t *testing.T) {
 				Name:  "importing cache manifest from test-registry.com/test-account/test-repo",
 				Error: "",
 			},
-			ss:       &client.SolveStatus{},
 			expected: false,
 		},
 		{
@@ -89,7 +87,6 @@ func TestBuildKitMissingCacheCondition(t *testing.T) {
 				Name:  "something else",
 				Error: "test-registry.com/test-account/test-repo: not found",
 			},
-			ss:       &client.SolveStatus{},
 			expected: false,
 		},
 		{
@@ -98,14 +95,13 @@ func TestBuildKitMissingCacheCondition(t *testing.T) {
 				Name:  "importing cache manifest from test-registry.com/test-account/test-repo",
 				Error: "test-registry.com/test-account/test-repo: not found",
 			},
-			ss:       &client.SolveStatus{},
 			expected: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := BuildKitMissingCacheCondition(tc.v, tc.ss)
+			result := BuildKitMissingCacheCondition(tc.v)
 			assert.Equal(t, tc.expected, result)
 		})
 	}


### PR DESCRIPTION
Fixes #3420

# Proposed changes

This PR introduces a way to manipulate BuildKit logs. The first use-case is rewriting the error when a cache image is not available.

Example (TTY):

| Before | After |
|--------|-------|
|  <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/230659247-ac330607-41cd-4458-b763-de0c060dd5c8.png" />      |       <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/230659338-32b2dc8c-404d-49c6-bce7-89b5cee581be.png" /> |

Example (Plain):

| Before | After |
|--------|-------|
|  <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/230659552-de92b737-bf5a-4f25-a419-3f2b8a994697.png" />      |       <img width="350" height="auto" src="https://user-images.githubusercontent.com/2318450/230659561-0ca80254-8eb7-4009-9de2-59c48d75253c.png" /> |


## Considerations

I dug into the source code of BuildKit to understand how to display best the logs, however, it feels very hacky to do so. The print utility of BuildKit has a lot of logic to sort and group log entries, so any attempt to manipulate them, will result in a long-term "hack" to maintain. By default, the two messages related to the failed cache-from would be printed together in the same group. (Groups are represented with the prefix "#").

BuildKit doesn't offer any hook or utility to manipulate the logs so one way was adding a synthetic log entry (a Vertex) but I wasn't able to put it in the same group, it will always show in the next group.

Happy to see if there are suggestions to improve the change!