### PR TITLE
Apply divert transformation in the local deploy proxy

### DIFF
--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/okteto/okteto/pkg/divert"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/registry"
 
@@ -165,7 +166,7 @@ func (fk *fakeProxy) Start() {
 
 func (*fakeProxy) SetName(_ string) {}
 
-func (*fakeProxy) SetDivert(_ string) {}
+func (*fakeProxy) SetDivert(_ divert.Driver) {}
 
 func (fk *fakeProxy) Shutdown(_ context.Context) error {
 	if fk.errOnShutdown != nil {

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -124,7 +124,7 @@ func (ld *localDeployer) deploy(ctx context.Context, deployOptions *Options) err
 		if err != nil {
 			return err
 		}
-		ld.Proxy.SetDivert(driver.GetDivertNamespace())
+		ld.Proxy.SetDivert(driver)
 		ld.DivertDriver = driver
 	}
 

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -247,11 +247,10 @@ func (ld *localDeployer) runDeploySection(ctx context.Context, opts *Options) er
 	// deploy divert if any
 	if opts.Manifest.Deploy.Divert != nil && opts.Manifest.Deploy.Divert.Namespace != opts.Manifest.Namespace {
 		oktetoLog.SetStage("Deploy Divert")
-		if err := ld.deployDivert(ctx, opts); err != nil {
+		if err := ld.DivertDriver.Deploy(ctx); err != nil {
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error creating divert: %s", err.Error())
 			return err
 		}
-		oktetoLog.Success("Divert from '%s' successfully configured", opts.Manifest.Deploy.Divert.Namespace)
 		oktetoLog.SetStage("")
 	}
 
@@ -300,15 +299,6 @@ func (ld *localDeployer) deployStack(ctx context.Context, opts *Options) error {
 		IsInsideDeploy: true,
 	}
 	return stackCommand.RunDeploy(ctx, composeSectionInfo.Stack, stackOpts)
-}
-
-func (ld *localDeployer) deployDivert(ctx context.Context, opts *Options) error {
-
-	oktetoLog.Spinner(fmt.Sprintf("Deploying divert in namespace %s...", opts.Manifest.Deploy.Divert.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
-	return ld.DivertDriver.Deploy(ctx)
 }
 
 func (ld *localDeployer) deployEndpoints(ctx context.Context, opts *Options) error {

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -139,7 +139,6 @@ func (ld *localDestroyCommand) runDestroy(ctx context.Context, opts *Options) er
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error destroying divert: %s", err.Error())
 			return err
 		}
-		oktetoLog.Success("Divert from '%s' successfully destroyed", ld.manifest.Deploy.Divert.Namespace)
 		oktetoLog.SetStage("")
 	}
 
@@ -281,10 +280,6 @@ func (dc *localDestroyCommand) destroyHelmReleasesIfPresent(ctx context.Context,
 }
 
 func (ld *localDestroyCommand) destroyDivert(ctx context.Context, manifest *model.Manifest) error {
-	oktetoLog.Spinner(fmt.Sprintf("Destroying divert in %s...", manifest.Deploy.Divert.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
 	c, _, err := ld.k8sClientProvider.Provide(okteto.Context().Cfg)
 	if err != nil {
 		return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,4 +85,28 @@ const (
 
 	// OktetoGitCommitEnvVar is the SHA1 hash of the last commit of the branch.
 	OktetoGitCommitEnvVar = "OKTETO_GIT_COMMIT"
+
+	// OktetoDivertWeaverDriver is the divert driver for weaver
+	OktetoDivertWeaverDriver = "weaver"
+
+	// OktetoDivertIstioDriver is the divert driver for istio
+	OktetoDivertIstioDriver = "istio"
+
+	// OktetoDivertIstioExactMatch represents the exact header match type
+	OktetoDivertIstioExactMatch = "exact"
+
+	// OktetoDivertIstioRegexMatch represents the regexp header match type
+	OktetoDivertIstioRegexMatch = "regex"
+
+	// OktetoDivertIstioPrefixMatch represents the prefix header match type
+	OktetoDivertIstioPrefixMatch = "prefix"
+
+	// OktetoDivertDefaultHeaderName the default header name used by okteto to divert traffic
+	OktetoDivertDefaultHeaderName = "x-okteto-divert"
+
+	// OktetoDivertDefaultHeaderValue the default divert header value
+	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
+
+	//OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
 )

--- a/pkg/divert/driver.go
+++ b/pkg/divert/driver.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/divert/istio"
 	"github.com/okteto/okteto/pkg/divert/weaver"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -40,7 +41,7 @@ func New(m *model.Manifest, c kubernetes.Interface) (Driver, error) {
 		return nil, oktetoErrors.ErrDivertNotSupported
 	}
 
-	if m.Deploy.Divert.Driver == model.OktetoDivertWeaverDriver {
+	if m.Deploy.Divert.Driver == constants.OktetoDivertWeaverDriver {
 		return weaver.New(m, c), nil
 	}
 

--- a/pkg/divert/driver.go
+++ b/pkg/divert/driver.go
@@ -23,13 +23,16 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/virtualservices"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 type Driver interface {
 	Deploy(ctx context.Context) error
 	Destroy(ctx context.Context) error
-	GetDivertNamespace() string
+	UpdatePod(spec apiv1.PodSpec) apiv1.PodSpec
+	UpdateVirtualService(vs istioNetworkingV1beta1.VirtualService) istioNetworkingV1beta1.VirtualService
 }
 
 func New(m *model.Manifest, c kubernetes.Interface) (Driver, error) {

--- a/pkg/divert/istio/divert.go
+++ b/pkg/divert/istio/divert.go
@@ -40,6 +40,13 @@ type Driver struct {
 	istioClient istioclientset.Interface
 }
 
+// DivertTransformation represents the annotation for the okteto mutation webhook to divert a virtual service
+type DivertTransformation struct {
+	Namespace string             `json:"namespace"`
+	Header    model.DivertHeader `json:"header"`
+	Routes    []string           `json:"routes,omitempty"`
+}
+
 func New(m *model.Manifest, c kubernetes.Interface, ic istioclientset.Interface) *Driver {
 	return &Driver{
 		name:        m.Name,
@@ -51,9 +58,15 @@ func New(m *model.Manifest, c kubernetes.Interface, ic istioclientset.Interface)
 }
 
 func (d *Driver) Deploy(ctx context.Context) error {
-	oktetoLog.Spinner(fmt.Sprintf("Diverting service %s/%s...", d.divert.Namespace, d.divert.Service))
-	if err := d.retryTranslateDivertService(ctx); err != nil {
-		return err
+	for i := range d.divert.VirtualServices {
+		oktetoLog.Spinner(fmt.Sprintf("Diverting virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
+		oktetoLog.StartSpinner()
+		defer oktetoLog.StopSpinner()
+		if err := d.retryTranslateDivertVirtualService(ctx, d.divert.VirtualServices[i]); err != nil {
+			return err
+		}
+		oktetoLog.StopSpinner()
+		oktetoLog.Success("Virtual service '%s/%s' successfully diverted", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
 	}
 
 	for i := range d.divert.Hosts {
@@ -63,9 +76,13 @@ func (d *Driver) Deploy(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			oktetoLog.Spinner(fmt.Sprintf("Diverting host %s/%s...", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService))
+			oktetoLog.StartSpinner()
+			defer oktetoLog.StopSpinner()
 			if err := d.retryTranslateDivertHost(ctx, d.divert.Hosts[i]); err != nil {
 				return err
 			}
+			oktetoLog.StopSpinner()
+			oktetoLog.Success("Host '%s/%s' successfully diverted", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService)
 		}
 	}
 
@@ -73,24 +90,34 @@ func (d *Driver) Deploy(ctx context.Context) error {
 }
 
 func (d *Driver) Destroy(ctx context.Context) error {
-	oktetoLog.Spinner(fmt.Sprintf("Destroying divert service %s/%s ...", d.divert.Namespace, d.divert.Service))
 	var err error
-	for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
-		vs, err := virtualservices.Get(ctx, d.divert.VirtualService, d.divert.Namespace, d.istioClient)
+	for i := range d.divert.VirtualServices {
+		oktetoLog.Spinner(fmt.Sprintf("Restoring virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
+		oktetoLog.StartSpinner()
+		defer oktetoLog.StopSpinner()
+		for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
+			vs, err := virtualservices.Get(ctx, d.divert.VirtualServices[i].Name, d.divert.VirtualServices[i].Namespace, d.istioClient)
+			if err != nil {
+				return err
+			}
+			restoredVS := d.restoreDivertVirtualService(vs)
+
+			err = virtualservices.Update(ctx, restoredVS, d.istioClient)
+			if err == nil {
+				oktetoLog.StopSpinner()
+				oktetoLog.Success("Virtual service '%s/%s' successfully restored", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
+				break
+			}
+			if !k8sErrors.IsConflict(err) {
+				return err
+			}
+		}
 		if err != nil {
 			return err
 		}
-		restoredVS := d.restoreDivertService(vs)
-
-		err = virtualservices.Update(ctx, restoredVS, d.istioClient)
-		if err == nil {
-			return nil
-		}
-		if !k8sErrors.IsConflict(err) {
-			return err
-		}
 	}
-	return err
+	return nil
+
 }
 
 func (d *Driver) UpdatePod(pod apiv1.PodSpec) apiv1.PodSpec {
@@ -101,14 +128,17 @@ func (d *Driver) UpdateVirtualService(vs istioNetworkingV1beta1.VirtualService) 
 	return d.injectDivertHeader(vs)
 }
 
-func (d *Driver) retryTranslateDivertService(ctx context.Context) error {
+func (d *Driver) retryTranslateDivertVirtualService(ctx context.Context, divertVS model.DivertVirtualService) error {
 	var err error
 	for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
-		vs, err := virtualservices.Get(ctx, d.divert.VirtualService, d.divert.Namespace, d.istioClient)
+		vs, err := virtualservices.Get(ctx, divertVS.Name, divertVS.Namespace, d.istioClient)
 		if err != nil {
 			return err
 		}
-		translatedVS := d.translateDivertService(vs)
+		translatedVS, err := d.translateDivertVirtualService(vs, divertVS.Routes)
+		if err != nil {
+			return err
+		}
 		err = virtualservices.Update(ctx, translatedVS, d.istioClient)
 		if err == nil {
 			return nil

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -14,9 +14,11 @@
 package istio
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
@@ -26,14 +28,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_translateDivertService(t *testing.T) {
+func Test_translateDivertVirtualService(t *testing.T) {
 	tests := []struct {
 		name     string
 		vs       *istioV1beta1.VirtualService
+		header   model.DivertHeader
+		routes   []string
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "match",
+			name: "add-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "service-a",
@@ -41,177 +45,75 @@ func Test_translateDivertService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
+			},
+			header: model.DivertHeader{
+				Name:  constants.OktetoDivertDefaultHeaderName,
+				Match: constants.OktetoDivertIstioExactMatch,
+				Value: "cindy",
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"}}`,
 					},
 				},
 			},
 		},
 		{
-			name: "no-match",
+			name: "add-divert-annotation-with-custom-header",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
+					Name:        "service-a",
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
+			},
+			header: model.DivertHeader{
+				Name:  "custom-header-name",
+				Match: constants.OktetoDivertIstioPrefixMatch,
+				Value: "custom-prefix",
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"custom-header-name","match":"prefix","value":"custom-prefix"}}`,
+					},
+				},
+			},
+		},
+		{
+			name: "add-divert-annotation-with-routes",
+			vs: &istioV1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "service-a",
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+			},
+			header: model.DivertHeader{
+				Name:  constants.OktetoDivertDefaultHeaderName,
+				Match: constants.OktetoDivertIstioExactMatch,
+				Value: "cindy",
+			},
+			routes: []string{"one-route", "another-route"},
+			expected: &istioV1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":["one-route","another-route"]}`,
 					},
 				},
 			},
@@ -222,95 +124,38 @@ func Test_translateDivertService(t *testing.T) {
 		name:      "test",
 		namespace: "cindy",
 		divert: model.DivertDeploy{
-			Namespace:      "staging",
-			Service:        "service-a",
-			VirtualService: "virtual-service-a",
+			VirtualServices: []model.DivertVirtualService{
+				{
+					Name:      "virtual-service-a",
+					Namespace: "staging",
+				},
+			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := d.translateDivertService(tt.vs)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			d.divert.Header = tt.header
+			result, _ := d.translateDivertVirtualService(tt.vs, tt.routes)
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
 
-func Test_restoreDivertService(t *testing.T) {
+func Test_restoreDivertVirtualService(t *testing.T) {
 	tests := []struct {
 		name     string
 		vs       *istioV1beta1.VirtualService
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "clean-divert-routes",
+			name: "clean-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
 					},
 				},
 			},
@@ -321,36 +166,6 @@ func Test_restoreDivertService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
 			},
 		},
 	}
@@ -359,22 +174,19 @@ func Test_restoreDivertService(t *testing.T) {
 		name:      "test",
 		namespace: "cindy",
 		divert: model.DivertDeploy{
-			Namespace:      "staging",
-			Service:        "service-a",
-			VirtualService: "virtual-service-a",
+			VirtualServices: []model.DivertVirtualService{
+				{
+					Name:      "virtual-service-a",
+					Namespace: "staging",
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := d.restoreDivertService(tt.vs)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			result := d.restoreDivertVirtualService(tt.vs)
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
@@ -454,7 +266,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{model.OktetoDivertHeader: "cindy"},
+									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -543,7 +355,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{model.OktetoDivertHeader: "cindy"},
+									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -569,9 +381,12 @@ func Test_translateDivertHost(t *testing.T) {
 		name:      "test",
 		namespace: "cindy",
 		divert: model.DivertDeploy{
-			Namespace:      "staging",
-			Service:        "service-a",
-			VirtualService: "virtual-service-a",
+			VirtualServices: []model.DivertVirtualService{
+				{
+					Name:      "virtual-service-a",
+					Namespace: "staging",
+				},
+			},
 		},
 	}
 	okteto.AddOktetoContext("test", &types.User{Registry: "registry.demo.okteto.dev"}, "okteto", "cyndy")

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -386,7 +386,7 @@ func Test_translateDivertHost(t *testing.T) {
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "divert-host-different-namespace",
+			name: "divert-host-service-same-namespace",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "service-a",
@@ -413,16 +413,6 @@ func Test_translateDivertHost(t *testing.T) {
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
 								{
 									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
 										Host: "service-a",
 										Port: &istioNetworkingV1beta1.PortSelector{
 											Number: 80,
@@ -441,8 +431,9 @@ func Test_translateDivertHost(t *testing.T) {
 					Name:      "service-a",
 					Namespace: "cindy",
 					Labels: map[string]string{
-						"l1":                         "v1",
-						"dev.okteto.com/deployed-by": "test",
+						"l1":                             "v1",
+						"dev.okteto.com/deployed-by":     "test",
+						model.OktetoAutoCreateAnnotation: "true",
 					},
 					Annotations: map[string]string{"a1": "v1"},
 				},
@@ -467,16 +458,6 @@ func Test_translateDivertHost(t *testing.T) {
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
 								{
 									Destination: &istioNetworkingV1beta1.Destination{
 										Host: "service-a.staging.svc.cluster.local",
@@ -494,20 +475,20 @@ func Test_translateDivertHost(t *testing.T) {
 			},
 		},
 		{
-			name: "divert-host-same-namespace",
+			name: "divert-host-service-different-namespace",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "cindy",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
+					Name:            "service-a",
+					Namespace:       "staging",
+					Labels:          map[string]string{"l1": "v1"},
+					Annotations:     map[string]string{"a1": "v1"},
+					ResourceVersion: "version",
 				},
 				Spec: istioNetworkingV1beta1.VirtualService{
 					Gateways: []string{"ingress-http"},
 					Hosts: []string{
-						"service-a-cindy.demo.okteto.dev",
-						"service-a.cindy.svc.cluster.local",
-						"service-a.cindy.com",
+						"service-a.staging.svc.cluster.local",
+						"service-a.staging.com",
 					},
 					Http: []*istioNetworkingV1beta1.HTTPRoute{
 						{
@@ -521,7 +502,7 @@ func Test_translateDivertHost(t *testing.T) {
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
 								{
 									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a",
+										Host: "service-a.staging2.svc.cluster.local",
 										Port: &istioNetworkingV1beta1.PortSelector{
 											Number: 80,
 										},
@@ -539,8 +520,9 @@ func Test_translateDivertHost(t *testing.T) {
 					Name:      "service-a",
 					Namespace: "cindy",
 					Labels: map[string]string{
-						"l1":                         "v1",
-						"dev.okteto.com/deployed-by": "test",
+						"l1":                             "v1",
+						"dev.okteto.com/deployed-by":     "test",
+						model.OktetoAutoCreateAnnotation: "true",
 					},
 					Annotations: map[string]string{"a1": "v1"},
 				},
@@ -549,7 +531,6 @@ func Test_translateDivertHost(t *testing.T) {
 					Hosts: []string{
 						"service-a-cindy.demo.okteto.dev",
 						"service-a.cindy.svc.cluster.local",
-						"service-a.cindy.com",
 					},
 					Http: []*istioNetworkingV1beta1.HTTPRoute{
 						{
@@ -568,7 +549,7 @@ func Test_translateDivertHost(t *testing.T) {
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
 								{
 									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a",
+										Host: "service-a.staging2.svc.cluster.local",
 										Port: &istioNetworkingV1beta1.PortSelector{
 											Number: 80,
 										},

--- a/pkg/divert/weaver/divert.go
+++ b/pkg/divert/weaver/divert.go
@@ -43,6 +43,9 @@ func New(m *model.Manifest, c kubernetes.Interface) *Driver {
 }
 
 func (d *Driver) Deploy(ctx context.Context) error {
+	oktetoLog.Spinner(fmt.Sprintf("Diverting namespace %s...", d.divert.Namespace))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
 	if err := d.initCache(ctx); err != nil {
 		return err
 	}
@@ -53,15 +56,20 @@ func (d *Driver) Deploy(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			oktetoLog.Spinner(fmt.Sprintf("Diverting ingress %s/%s...", in.Namespace, in.Name))
+			oktetoLog.StartSpinner()
+			defer oktetoLog.StopSpinner()
 			if err := d.divertIngress(ctx, name); err != nil {
 				return err
 			}
+			oktetoLog.StopSpinner()
+			oktetoLog.Success("Ingress '%s/%s' successfully diverted", in.Namespace, in.Name)
 		}
 	}
 	return nil
 }
 
-func (*Driver) Destroy(_ context.Context) error {
+func (d *Driver) Destroy(_ context.Context) error {
+	oktetoLog.Success("Divert from '%s' successfully destroyed", d.divert.Namespace)
 	return nil
 }
 

--- a/pkg/divert/weaver/divert_test.go
+++ b/pkg/divert/weaver/divert_test.go
@@ -628,7 +628,6 @@ func Test_divertIngresses(t *testing.T) {
 		Deploy: &model.DeployInfo{
 			Divert: &model.DivertDeploy{
 				Namespace: "staging",
-				Service:   "s1",
 			},
 		},
 	}

--- a/pkg/k8s/virtualservices/crud.go
+++ b/pkg/k8s/virtualservices/crud.go
@@ -15,9 +15,7 @@ package virtualservices
 
 import (
 	"context"
-	"fmt"
 
-	istioNetowrkingV1beta1 "istio.io/api/networking/v1beta1"
 	istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,15 +46,4 @@ func List(ctx context.Context, namespace string, c istioclientset.Interface) ([]
 	}
 
 	return vsList.Items, nil
-}
-
-func GetHTTPRoutePrefixOktetoName(ns string) string {
-	return fmt.Sprintf("okteto-divert-%s", ns)
-}
-
-func GetHTTPRouteOktetoName(ns string, r *istioNetowrkingV1beta1.HTTPRoute) string {
-	if r.Name == "" {
-		return fmt.Sprintf("okteto-divert-%s", ns)
-	}
-	return fmt.Sprintf("okteto-divert-%s-%s", ns, r.Name)
 }

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -270,13 +270,4 @@ const (
 
 	// OktetoImageTagWithVolumes is the tag assigned to an image with volume mounts
 	OktetoImageTagWithVolumes = "okteto-with-volume-mounts"
-
-	// OktetoDivertWeaverDriver is the divert driver for weaver
-	OktetoDivertWeaverDriver = "weaver"
-
-	// OktetoDivertIstioDriver is the divert driver for istio
-	OktetoDivertIstioDriver = "istio"
-
-	// OktetoDivertHeader the header used by okteto to divert traffic
-	OktetoDivertHeader = "x-okteto-divert"
 )

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -262,9 +262,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-with-port",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},
@@ -273,9 +273,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-service",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "",
+				DeprecatedService:    "",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},
@@ -284,9 +284,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-deployment",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "",
 			},
@@ -295,9 +295,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-port",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedDeployment: "deployment",
 			},
 			expectedErr: nil,
@@ -305,9 +305,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ko-without-namespace",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},


### PR DESCRIPTION
This PR applies the virtual service transformation to inject the divert header on every virtual service created by an `okteto deploy` command using the local kubernetes proxy. This way, the okteto manifest configuration is simplified because these virtual services don't need to be configured in the [deploy.divert.hosts](https://www.okteto.com/docs/reference/manifest/#divert) section of the okteto manifest.

The PR does a refactor on the local kubernetes proxy configuration to pass the divert driver. The divert driver interface is aumented with two new methods to perform pods/virtualservices transformations.