### PR TITLE
Support for custom divert headers

### DIFF
--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -247,11 +247,10 @@ func (ld *localDeployer) runDeploySection(ctx context.Context, opts *Options) er
 	// deploy divert if any
 	if opts.Manifest.Deploy.Divert != nil && opts.Manifest.Deploy.Divert.Namespace != opts.Manifest.Namespace {
 		oktetoLog.SetStage("Deploy Divert")
-		if err := ld.deployDivert(ctx, opts); err != nil {
+		if err := ld.DivertDriver.Deploy(ctx); err != nil {
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error creating divert: %s", err.Error())
 			return err
 		}
-		oktetoLog.Success("Divert from '%s' successfully configured", opts.Manifest.Deploy.Divert.Namespace)
 		oktetoLog.SetStage("")
 	}
 
@@ -300,15 +299,6 @@ func (ld *localDeployer) deployStack(ctx context.Context, opts *Options) error {
 		IsInsideDeploy: true,
 	}
 	return stackCommand.RunDeploy(ctx, composeSectionInfo.Stack, stackOpts)
-}
-
-func (ld *localDeployer) deployDivert(ctx context.Context, opts *Options) error {
-
-	oktetoLog.Spinner(fmt.Sprintf("Deploying divert in namespace %s...", opts.Manifest.Deploy.Divert.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
-	return ld.DivertDriver.Deploy(ctx)
 }
 
 func (ld *localDeployer) deployEndpoints(ctx context.Context, opts *Options) error {

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -139,7 +139,6 @@ func (ld *localDestroyCommand) runDestroy(ctx context.Context, opts *Options) er
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error destroying divert: %s", err.Error())
 			return err
 		}
-		oktetoLog.Success("Divert from '%s' successfully destroyed", ld.manifest.Deploy.Divert.Namespace)
 		oktetoLog.SetStage("")
 	}
 
@@ -281,10 +280,6 @@ func (dc *localDestroyCommand) destroyHelmReleasesIfPresent(ctx context.Context,
 }
 
 func (ld *localDestroyCommand) destroyDivert(ctx context.Context, manifest *model.Manifest) error {
-	oktetoLog.Spinner(fmt.Sprintf("Destroying divert in %s...", manifest.Deploy.Divert.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
 	c, _, err := ld.k8sClientProvider.Provide(okteto.Context().Cfg)
 	if err != nil {
 		return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,4 +85,28 @@ const (
 
 	// OktetoGitCommitEnvVar is the SHA1 hash of the last commit of the branch.
 	OktetoGitCommitEnvVar = "OKTETO_GIT_COMMIT"
+
+	// OktetoDivertWeaverDriver is the divert driver for weaver
+	OktetoDivertWeaverDriver = "weaver"
+
+	// OktetoDivertIstioDriver is the divert driver for istio
+	OktetoDivertIstioDriver = "istio"
+
+	// OktetoDivertIstioExactMatch represents the exact header match type
+	OktetoDivertIstioExactMatch = "exact"
+
+	// OktetoDivertIstioRegexMatch represents the regexp header match type
+	OktetoDivertIstioRegexMatch = "regex"
+
+	// OktetoDivertIstioPrefixMatch represents the prefix header match type
+	OktetoDivertIstioPrefixMatch = "prefix"
+
+	// OktetoDivertDefaultHeaderName the default header name used by okteto to divert traffic
+	OktetoDivertDefaultHeaderName = "x-okteto-divert"
+
+	// OktetoDivertDefaultHeaderValue the default divert header value
+	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
+
+	//OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
 )

--- a/pkg/divert/driver.go
+++ b/pkg/divert/driver.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/divert/istio"
 	"github.com/okteto/okteto/pkg/divert/weaver"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -40,7 +41,7 @@ func New(m *model.Manifest, c kubernetes.Interface) (Driver, error) {
 		return nil, oktetoErrors.ErrDivertNotSupported
 	}
 
-	if m.Deploy.Divert.Driver == model.OktetoDivertWeaverDriver {
+	if m.Deploy.Divert.Driver == constants.OktetoDivertWeaverDriver {
 		return weaver.New(m, c), nil
 	}
 

--- a/pkg/divert/istio/divert.go
+++ b/pkg/divert/istio/divert.go
@@ -40,6 +40,13 @@ type Driver struct {
 	istioClient istioclientset.Interface
 }
 
+// DivertTransformation represents the annotation for the okteto mutation webhook to divert a virtual service
+type DivertTransformation struct {
+	Namespace string             `json:"namespace"`
+	Header    model.DivertHeader `json:"header"`
+	Routes    []string           `json:"routes,omitempty"`
+}
+
 func New(m *model.Manifest, c kubernetes.Interface, ic istioclientset.Interface) *Driver {
 	return &Driver{
 		name:        m.Name,
@@ -51,9 +58,15 @@ func New(m *model.Manifest, c kubernetes.Interface, ic istioclientset.Interface)
 }
 
 func (d *Driver) Deploy(ctx context.Context) error {
-	oktetoLog.Spinner(fmt.Sprintf("Diverting service %s/%s...", d.divert.Namespace, d.divert.Service))
-	if err := d.retryTranslateDivertService(ctx); err != nil {
-		return err
+	for i := range d.divert.VirtualServices {
+		oktetoLog.Spinner(fmt.Sprintf("Diverting virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
+		oktetoLog.StartSpinner()
+		defer oktetoLog.StopSpinner()
+		if err := d.retryTranslateDivertVirtualService(ctx, d.divert.VirtualServices[i]); err != nil {
+			return err
+		}
+		oktetoLog.StopSpinner()
+		oktetoLog.Success("Virtual service '%s/%s' successfully diverted", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
 	}
 
 	for i := range d.divert.Hosts {
@@ -63,9 +76,13 @@ func (d *Driver) Deploy(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			oktetoLog.Spinner(fmt.Sprintf("Diverting host %s/%s...", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService))
+			oktetoLog.StartSpinner()
+			defer oktetoLog.StopSpinner()
 			if err := d.retryTranslateDivertHost(ctx, d.divert.Hosts[i]); err != nil {
 				return err
 			}
+			oktetoLog.StopSpinner()
+			oktetoLog.Success("Host '%s/%s' successfully diverted", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService)
 		}
 	}
 
@@ -73,24 +90,34 @@ func (d *Driver) Deploy(ctx context.Context) error {
 }
 
 func (d *Driver) Destroy(ctx context.Context) error {
-	oktetoLog.Spinner(fmt.Sprintf("Destroying divert service %s/%s ...", d.divert.Namespace, d.divert.Service))
 	var err error
-	for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
-		vs, err := virtualservices.Get(ctx, d.divert.VirtualService, d.divert.Namespace, d.istioClient)
+	for i := range d.divert.VirtualServices {
+		oktetoLog.Spinner(fmt.Sprintf("Restoring virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
+		oktetoLog.StartSpinner()
+		defer oktetoLog.StopSpinner()
+		for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
+			vs, err := virtualservices.Get(ctx, d.divert.VirtualServices[i].Name, d.divert.VirtualServices[i].Namespace, d.istioClient)
+			if err != nil {
+				return err
+			}
+			restoredVS := d.restoreDivertVirtualService(vs)
+
+			err = virtualservices.Update(ctx, restoredVS, d.istioClient)
+			if err == nil {
+				oktetoLog.StopSpinner()
+				oktetoLog.Success("Virtual service '%s/%s' successfully restored", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
+				break
+			}
+			if !k8sErrors.IsConflict(err) {
+				return err
+			}
+		}
 		if err != nil {
 			return err
 		}
-		restoredVS := d.restoreDivertService(vs)
-
-		err = virtualservices.Update(ctx, restoredVS, d.istioClient)
-		if err == nil {
-			return nil
-		}
-		if !k8sErrors.IsConflict(err) {
-			return err
-		}
 	}
-	return err
+	return nil
+
 }
 
 func (d *Driver) UpdatePod(pod apiv1.PodSpec) apiv1.PodSpec {
@@ -101,14 +128,17 @@ func (d *Driver) UpdateVirtualService(vs istioNetworkingV1beta1.VirtualService) 
 	return d.injectDivertHeader(vs)
 }
 
-func (d *Driver) retryTranslateDivertService(ctx context.Context) error {
+func (d *Driver) retryTranslateDivertVirtualService(ctx context.Context, divertVS model.DivertVirtualService) error {
 	var err error
 	for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
-		vs, err := virtualservices.Get(ctx, d.divert.VirtualService, d.divert.Namespace, d.istioClient)
+		vs, err := virtualservices.Get(ctx, divertVS.Name, divertVS.Namespace, d.istioClient)
 		if err != nil {
 			return err
 		}
-		translatedVS := d.translateDivertService(vs)
+		translatedVS, err := d.translateDivertVirtualService(vs, divertVS.Routes)
+		if err != nil {
+			return err
+		}
 		err = virtualservices.Update(ctx, translatedVS, d.istioClient)
 		if err == nil {
 			return nil

--- a/pkg/divert/istio/virtualservices.go
+++ b/pkg/divert/istio/virtualservices.go
@@ -14,11 +14,12 @@
 package istio
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/k8s/labels"
-	"github.com/okteto/okteto/pkg/k8s/virtualservices"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
@@ -26,66 +27,34 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (d *Driver) translateDivertService(vs *istioV1beta1.VirtualService) *istioV1beta1.VirtualService {
-	result := vs.DeepCopy()
-	httpRoutes := []*istioNetworkingV1beta1.HTTPRoute{}
-	for i := range result.Spec.Http {
-		if strings.HasPrefix(result.Spec.Http[i].Name, virtualservices.GetHTTPRoutePrefixOktetoName(d.namespace)) {
-			continue
-		}
-		httpRoutes = append(httpRoutes, result.Spec.Http[i])
-	}
-	result.Spec.Http = httpRoutes
-	httpRoutes = []*istioNetworkingV1beta1.HTTPRoute{}
-	for _, httpRoute := range result.Spec.Http {
-		httpRoute := httpRoute.DeepCopy()
-		httpRoute.Name = virtualservices.GetHTTPRouteOktetoName(d.namespace, httpRoute)
-		for j := range httpRoute.Match {
-			if httpRoute.Match[j].Headers == nil {
-				httpRoute.Match[j].Headers = map[string]*istioNetworkingV1beta1.StringMatch{}
-			}
-			switch d.divert.Header.Match {
-			case model.OktetoDivertIstioExactMatch:
-				httpRoute.Match[j].Headers[d.divert.Header.Name] = &istioNetworkingV1beta1.StringMatch{
-					MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: d.divert.Header.Value},
-				}
-			case model.OktetoDivertIstioRegexMatch:
-				httpRoute.Match[j].Headers[d.divert.Header.Name] = &istioNetworkingV1beta1.StringMatch{
-					MatchType: &istioNetworkingV1beta1.StringMatch_Regex{Regex: d.divert.Header.Value},
-				}
-			case model.OktetoDivertIstioPrefixMatch:
-				httpRoute.Match[j].Headers[d.divert.Header.Name] = &istioNetworkingV1beta1.StringMatch{
-					MatchType: &istioNetworkingV1beta1.StringMatch_Prefix{Prefix: d.divert.Header.Value},
-				}
-			}
-		}
-		matchService := false
-		for j := range httpRoute.Route {
-			parts := strings.Split(httpRoute.Route[j].Destination.Host, ".")
-			if parts[0] == d.divert.Service {
-				httpRoute.Route[j].Destination.Host = fmt.Sprintf("%s.%s.svc.cluster.local", parts[0], d.namespace)
-				matchService = true
-			}
-		}
-		if matchService {
-			httpRoutes = append(httpRoutes, httpRoute)
-		}
-	}
-	httpRoutes = append(httpRoutes, result.Spec.Http...)
-	result.Spec.Http = httpRoutes
-	return result
+func (d *Driver) getDivertAnnotationName() string {
+	return fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, d.namespace, d.name)
 }
 
-func (d *Driver) restoreDivertService(vs *istioV1beta1.VirtualService) *istioV1beta1.VirtualService {
+func (d *Driver) translateDivertVirtualService(vs *istioV1beta1.VirtualService, routes []string) (*istioV1beta1.VirtualService, error) {
 	result := vs.DeepCopy()
-	httpRoutes := []*istioNetworkingV1beta1.HTTPRoute{}
-	for i := range result.Spec.Http {
-		if strings.HasPrefix(result.Spec.Http[i].Name, virtualservices.GetHTTPRoutePrefixOktetoName(d.namespace)) {
-			continue
-		}
-		httpRoutes = append(httpRoutes, result.Spec.Http[i])
+	if result.Annotations == nil {
+		result.Annotations = map[string]string{}
 	}
-	result.Spec.Http = httpRoutes
+	annotation := DivertTransformation{
+		Namespace: d.namespace,
+		Header:    d.divert.Header,
+		Routes:    routes,
+	}
+	bytes, err := json.Marshal(annotation)
+	if err != nil {
+		return nil, err
+	}
+	result.Annotations[d.getDivertAnnotationName()] = string(bytes)
+	return result, nil
+}
+
+func (d *Driver) restoreDivertVirtualService(vs *istioV1beta1.VirtualService) *istioV1beta1.VirtualService {
+	result := vs.DeepCopy()
+	if result.Annotations == nil {
+		result.Annotations = map[string]string{}
+	}
+	delete(result.Annotations, d.getDivertAnnotationName())
 	return result
 }
 
@@ -126,7 +95,7 @@ func (d *Driver) injectDivertHeader(vsSpec istioNetworkingV1beta1.VirtualService
 		if vsSpec.Http[i].Headers.Request.Set == nil {
 			vsSpec.Http[i].Headers.Request.Set = map[string]string{}
 		}
-		vsSpec.Http[i].Headers.Request.Set[model.OktetoDivertDefaultHeaderName] = d.namespace
+		vsSpec.Http[i].Headers.Request.Set[constants.OktetoDivertDefaultHeaderName] = d.namespace
 	}
 	return vsSpec
 }

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -14,9 +14,11 @@
 package istio
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
@@ -26,15 +28,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_translateDivertService(t *testing.T) {
+func Test_translateDivertVirtualService(t *testing.T) {
 	tests := []struct {
 		name     string
 		vs       *istioV1beta1.VirtualService
 		header   model.DivertHeader
+		routes   []string
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "match-default-header",
+			name: "add-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "service-a",
@@ -42,109 +45,26 @@ func Test_translateDivertService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
 			},
 			header: model.DivertHeader{
-				Name:  model.OktetoDivertDefaultHeaderName,
-				Match: model.OktetoDivertIstioExactMatch,
+				Name:  constants.OktetoDivertDefaultHeaderName,
+				Match: constants.OktetoDivertIstioExactMatch,
 				Value: "cindy",
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"}}`,
 					},
 				},
 			},
 		},
 		{
-			name: "match-custom-header",
+			name: "add-divert-annotation-with-custom-header",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "service-a",
@@ -152,187 +72,48 @@ func Test_translateDivertService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
 			},
 			header: model.DivertHeader{
-				Name:  "custom-name",
-				Match: "prefix",
+				Name:  "custom-header-name",
+				Match: constants.OktetoDivertIstioPrefixMatch,
 				Value: "custom-prefix",
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"custom-name": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Prefix{Prefix: "custom-prefix"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"custom-header-name","match":"prefix","value":"custom-prefix"}}`,
 					},
 				},
 			},
 		},
 		{
-			name: "no-match",
+			name: "add-divert-annotation-with-routes",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
+					Name:        "service-a",
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
 				},
 			},
 			header: model.DivertHeader{
-				Name:  model.OktetoDivertDefaultHeaderName,
-				Match: model.OktetoDivertIstioExactMatch,
+				Name:  constants.OktetoDivertDefaultHeaderName,
+				Match: constants.OktetoDivertIstioExactMatch,
 				Value: "cindy",
 			},
+			routes: []string{"one-route", "another-route"},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":["one-route","another-route"]}`,
 					},
 				},
 			},
@@ -343,97 +124,38 @@ func Test_translateDivertService(t *testing.T) {
 		name:      "test",
 		namespace: "cindy",
 		divert: model.DivertDeploy{
-			Namespace:      "staging",
-			Service:        "service-a",
-			VirtualService: "virtual-service-a",
+			VirtualServices: []model.DivertVirtualService{
+				{
+					Name:      "virtual-service-a",
+					Namespace: "staging",
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d.divert.Header = tt.header
-			result := d.translateDivertService(tt.vs)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				for j := range tt.expected.Spec.Http[i].Match {
-					assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Match[j].Headers, tt.expected.Spec.Http[i].Match[j].Headers))
-				}
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			result, _ := d.translateDivertVirtualService(tt.vs, tt.routes)
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
 
-func Test_restoreDivertService(t *testing.T) {
+func Test_restoreDivertVirtualService(t *testing.T) {
 	tests := []struct {
 		name     string
 		vs       *istioV1beta1.VirtualService
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "clean-divert-routes",
+			name: "clean-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
 					},
 				},
 			},
@@ -444,36 +166,6 @@ func Test_restoreDivertService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
 			},
 		},
 	}
@@ -482,22 +174,19 @@ func Test_restoreDivertService(t *testing.T) {
 		name:      "test",
 		namespace: "cindy",
 		divert: model.DivertDeploy{
-			Namespace:      "staging",
-			Service:        "service-a",
-			VirtualService: "virtual-service-a",
+			VirtualServices: []model.DivertVirtualService{
+				{
+					Name:      "virtual-service-a",
+					Namespace: "staging",
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := d.restoreDivertService(tt.vs)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			result := d.restoreDivertVirtualService(tt.vs)
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
@@ -577,7 +266,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{model.OktetoDivertDefaultHeaderName: "cindy"},
+									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -666,7 +355,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{model.OktetoDivertDefaultHeaderName: "cindy"},
+									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -692,9 +381,12 @@ func Test_translateDivertHost(t *testing.T) {
 		name:      "test",
 		namespace: "cindy",
 		divert: model.DivertDeploy{
-			Namespace:      "staging",
-			Service:        "service-a",
-			VirtualService: "virtual-service-a",
+			VirtualServices: []model.DivertVirtualService{
+				{
+					Name:      "virtual-service-a",
+					Namespace: "staging",
+				},
+			},
 		},
 	}
 	okteto.AddOktetoContext("test", &types.User{Registry: "registry.demo.okteto.dev"}, "okteto", "cyndy")

--- a/pkg/divert/weaver/divert.go
+++ b/pkg/divert/weaver/divert.go
@@ -43,6 +43,9 @@ func New(m *model.Manifest, c kubernetes.Interface) *Driver {
 }
 
 func (d *Driver) Deploy(ctx context.Context) error {
+	oktetoLog.Spinner(fmt.Sprintf("Diverting namespace %s...", d.divert.Namespace))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
 	if err := d.initCache(ctx); err != nil {
 		return err
 	}
@@ -53,15 +56,20 @@ func (d *Driver) Deploy(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			oktetoLog.Spinner(fmt.Sprintf("Diverting ingress %s/%s...", in.Namespace, in.Name))
+			oktetoLog.StartSpinner()
+			defer oktetoLog.StopSpinner()
 			if err := d.divertIngress(ctx, name); err != nil {
 				return err
 			}
+			oktetoLog.StopSpinner()
+			oktetoLog.Success("Ingress '%s/%s' successfully diverted", in.Namespace, in.Name)
 		}
 	}
 	return nil
 }
 
-func (*Driver) Destroy(_ context.Context) error {
+func (d *Driver) Destroy(_ context.Context) error {
+	oktetoLog.Success("Divert from '%s' successfully destroyed", d.divert.Namespace)
 	return nil
 }
 

--- a/pkg/divert/weaver/divert_test.go
+++ b/pkg/divert/weaver/divert_test.go
@@ -628,7 +628,6 @@ func Test_divertIngresses(t *testing.T) {
 		Deploy: &model.DeployInfo{
 			Divert: &model.DivertDeploy{
 				Namespace: "staging",
-				Service:   "s1",
 			},
 		},
 	}

--- a/pkg/k8s/virtualservices/crud.go
+++ b/pkg/k8s/virtualservices/crud.go
@@ -15,9 +15,7 @@ package virtualservices
 
 import (
 	"context"
-	"fmt"
 
-	istioNetowrkingV1beta1 "istio.io/api/networking/v1beta1"
 	istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,15 +46,4 @@ func List(ctx context.Context, namespace string, c istioclientset.Interface) ([]
 	}
 
 	return vsList.Items, nil
-}
-
-func GetHTTPRoutePrefixOktetoName(ns string) string {
-	return fmt.Sprintf("okteto-divert-%s", ns)
-}
-
-func GetHTTPRouteOktetoName(ns string, r *istioNetowrkingV1beta1.HTTPRoute) string {
-	if r.Name == "" {
-		return fmt.Sprintf("okteto-divert-%s", ns)
-	}
-	return fmt.Sprintf("okteto-divert-%s-%s", ns, r.Name)
 }

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -270,25 +270,4 @@ const (
 
 	// OktetoImageTagWithVolumes is the tag assigned to an image with volume mounts
 	OktetoImageTagWithVolumes = "okteto-with-volume-mounts"
-
-	// OktetoDivertWeaverDriver is the divert driver for weaver
-	OktetoDivertWeaverDriver = "weaver"
-
-	// OktetoDivertIstioDriver is the divert driver for istio
-	OktetoDivertIstioDriver = "istio"
-
-	// OktetoDivertIstioExactMatch represents the exact header match type
-	OktetoDivertIstioExactMatch = "exact"
-
-	// OktetoDivertIstioRegexMatch represents the regexp header match type
-	OktetoDivertIstioRegexMatch = "regex"
-
-	// OktetoDivertIstioPrefixMatch represents the prefix header match type
-	OktetoDivertIstioPrefixMatch = "prefix"
-
-	// OktetoDivertDefaultHeaderName the default header name used by okteto to divert traffic
-	OktetoDivertDefaultHeaderName = "x-okteto-divert"
-
-	// OktetoDivertDefaultHeaderValue the default divert header value
-	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
 )

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -277,6 +277,18 @@ const (
 	// OktetoDivertIstioDriver is the divert driver for istio
 	OktetoDivertIstioDriver = "istio"
 
-	// OktetoDivertHeader the header used by okteto to divert traffic
-	OktetoDivertHeader = "x-okteto-divert"
+	// OktetoDivertIstioExactMatch represents the exact header match type
+	OktetoDivertIstioExactMatch = "exact"
+
+	// OktetoDivertIstioRegexMatch represents the regexp header match type
+	OktetoDivertIstioRegexMatch = "regex"
+
+	// OktetoDivertIstioPrefixMatch represents the prefix header match type
+	OktetoDivertIstioPrefixMatch = "prefix"
+
+	// OktetoDivertDefaultHeaderName the default header name used by okteto to divert traffic
+	OktetoDivertDefaultHeaderName = "x-okteto-divert"
+
+	// OktetoDivertDefaultHeaderValue the default divert header value
+	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
 )

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -195,12 +195,20 @@ type DestroyInfo struct {
 // DivertDeploy represents information about the deploy divert configuration
 type DivertDeploy struct {
 	Driver               string       `json:"driver,omitempty" yaml:"driver,omitempty"`
+	Header               DivertHeader `json:"header,omitempty" yaml:"header,omitempty"`
 	Namespace            string       `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Service              string       `json:"service,omitempty" yaml:"service,omitempty"`
 	DeprecatedPort       int          `json:"port,omitempty" yaml:"port,omitempty"`
 	DeprecatedDeployment string       `json:"deployment,omitempty" yaml:"deployment,omitempty"`
 	VirtualService       string       `json:"virtualService,omitempty" yaml:"virtualService,omitempty"`
 	Hosts                []DivertHost `json:"hosts,omitempty" yaml:"hosts,omitempty"`
+}
+
+// DivertHeader represents the header used for redirecting a virtual service
+type DivertHeader struct {
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	Match string `json:"match,omitempty" yaml:"match,omitempty"`
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // DivertHost represents a host from a virtual service in a namespace to be diverted
@@ -795,6 +803,11 @@ func (m *Manifest) validateDivert() error {
 		if m.Deploy.Divert.VirtualService == "" {
 			return fmt.Errorf("the field 'deploy.divert.virtualService' is mandatory")
 		}
+		switch m.Deploy.Divert.Header.Match {
+		case OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch:
+		default:
+			return fmt.Errorf("supported divert header match types are %s, %s and %s", OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch)
+		}
 		for i := range m.Deploy.Divert.Hosts {
 			if m.Deploy.Divert.Hosts[i].VirtualService == "" {
 				return fmt.Errorf("the field 'deploy.divert.hosts.virtualService' is mandatory")
@@ -814,6 +827,19 @@ func (m *Manifest) setDefaults() error {
 		var err error
 		if m.Deploy.Divert.Driver == "" {
 			m.Deploy.Divert.Driver = OktetoDivertWeaverDriver
+		}
+		if m.Deploy.Divert.Header.Name == "" {
+			m.Deploy.Divert.Header.Name = OktetoDivertDefaultHeaderName
+		}
+		if m.Deploy.Divert.Header.Match == "" {
+			m.Deploy.Divert.Header.Match = OktetoDivertIstioExactMatch
+		}
+		if m.Deploy.Divert.Header.Value == "" {
+			m.Deploy.Divert.Header.Value = OktetoDivertDefaultHeaderValue
+		}
+		m.Deploy.Divert.Header.Value, err = ExpandEnv(m.Deploy.Divert.Header.Value, false)
+		if err != nil {
+			return err
 		}
 		m.Deploy.Divert.Namespace, err = ExpandEnv(m.Deploy.Divert.Namespace, false)
 		if err != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -194,14 +194,14 @@ type DestroyInfo struct {
 
 // DivertDeploy represents information about the deploy divert configuration
 type DivertDeploy struct {
-	Driver               string       `json:"driver,omitempty" yaml:"driver,omitempty"`
-	Header               DivertHeader `json:"header,omitempty" yaml:"header,omitempty"`
-	Namespace            string       `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Service              string       `json:"service,omitempty" yaml:"service,omitempty"`
-	DeprecatedPort       int          `json:"port,omitempty" yaml:"port,omitempty"`
-	DeprecatedDeployment string       `json:"deployment,omitempty" yaml:"deployment,omitempty"`
-	VirtualService       string       `json:"virtualService,omitempty" yaml:"virtualService,omitempty"`
-	Hosts                []DivertHost `json:"hosts,omitempty" yaml:"hosts,omitempty"`
+	Driver               string                 `json:"driver,omitempty" yaml:"driver,omitempty"`
+	Header               DivertHeader           `json:"header,omitempty" yaml:"header,omitempty"`
+	Namespace            string                 `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	DeprecatedService    string                 `json:"service,omitempty" yaml:"service,omitempty"`
+	DeprecatedPort       int                    `json:"port,omitempty" yaml:"port,omitempty"`
+	DeprecatedDeployment string                 `json:"deployment,omitempty" yaml:"deployment,omitempty"`
+	VirtualServices      []DivertVirtualService `json:"virtualServices,omitempty" yaml:"virtualServices,omitempty"`
+	Hosts                []DivertHost           `json:"hosts,omitempty" yaml:"hosts,omitempty"`
 }
 
 // DivertHeader represents the header used for redirecting a virtual service
@@ -209,6 +209,13 @@ type DivertHeader struct {
 	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
 	Match string `json:"match,omitempty" yaml:"match,omitempty"`
 	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+// DivertVirtualService represents a virtual service in a namespace to be diverted
+type DivertVirtualService struct {
+	Name      string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace string   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Routes    []string `json:"routes,omitempty" yaml:"routes,omitempty"`
 }
 
 // DivertHost represents a host from a virtual service in a namespace to be diverted
@@ -790,30 +797,51 @@ func (m *Manifest) validateDivert() error {
 	if m.Deploy.Divert == nil {
 		return nil
 	}
-	if m.Deploy.Divert.Namespace == "" {
-		return fmt.Errorf("the field 'deploy.divert.namespace' is mandatory")
-	}
 
 	switch m.Deploy.Divert.Driver {
-	case OktetoDivertWeaverDriver:
-	case OktetoDivertIstioDriver:
-		if m.Deploy.Divert.Service == "" {
-			return fmt.Errorf("the field 'deploy.divert.service' is mandatory")
+	case constants.OktetoDivertWeaverDriver:
+		if m.Deploy.Divert.Namespace == "" {
+			return fmt.Errorf("the field 'deploy.divert.namespace' is mandatory")
 		}
-		if m.Deploy.Divert.VirtualService == "" {
-			return fmt.Errorf("the field 'deploy.divert.virtualService' is mandatory")
+		if len(m.Deploy.Divert.VirtualServices) > 0 {
+			return fmt.Errorf("the field 'deploy.divert.virtualServices' is not supported with the weaver driver")
+		}
+		if len(m.Deploy.Divert.Hosts) > 0 {
+			return fmt.Errorf("the field 'deploy.divert.host' is not supported with the weaver driver")
+		}
+	case constants.OktetoDivertIstioDriver:
+		if m.Deploy.Divert.DeprecatedService != "" {
+			return fmt.Errorf("the field 'deploy.divert.service' is not supported with the istio driver")
+		}
+		if m.Deploy.Divert.Namespace != "" {
+			return fmt.Errorf("the field 'deploy.divert.namespace' is not supported with the istio driver")
 		}
 		switch m.Deploy.Divert.Header.Match {
-		case OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch:
+		case constants.OktetoDivertIstioExactMatch, constants.OktetoDivertIstioRegexMatch, constants.OktetoDivertIstioPrefixMatch:
 		default:
-			return fmt.Errorf("supported divert header match types are %s, %s and %s", OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch)
+			return fmt.Errorf("supported divert header match types are %s, %s and %s",
+				constants.OktetoDivertIstioExactMatch,
+				constants.OktetoDivertIstioRegexMatch,
+				constants.OktetoDivertIstioPrefixMatch,
+			)
+		}
+		if len(m.Deploy.Divert.VirtualServices) == 0 {
+			return fmt.Errorf("the field 'deploy.divert.virtualServices' is mandatory")
+		}
+		for i := range m.Deploy.Divert.VirtualServices {
+			if m.Deploy.Divert.VirtualServices[i].Name == "" {
+				return fmt.Errorf("the field 'deploy.divert.virtualServices[%d].name' is mandatory", i)
+			}
+			if m.Deploy.Divert.VirtualServices[i].Namespace == "" {
+				return fmt.Errorf("the field 'deploy.divert.virtualServices[%d].namespace' is mandatory", i)
+			}
 		}
 		for i := range m.Deploy.Divert.Hosts {
 			if m.Deploy.Divert.Hosts[i].VirtualService == "" {
-				return fmt.Errorf("the field 'deploy.divert.hosts.virtualService' is mandatory")
+				return fmt.Errorf("the field 'deploy.divert.hosts[%d].virtualService' is mandatory", i)
 			}
 			if m.Deploy.Divert.Hosts[i].Namespace == "" {
-				return fmt.Errorf("the field 'deploy.divert.hosts.namespace' is mandatory")
+				return fmt.Errorf("the field 'deploy.divert.hosts[%d].namespace' is mandatory", i)
 			}
 		}
 	default:
@@ -826,16 +854,16 @@ func (m *Manifest) setDefaults() error {
 	if m.Deploy != nil && m.Deploy.Divert != nil {
 		var err error
 		if m.Deploy.Divert.Driver == "" {
-			m.Deploy.Divert.Driver = OktetoDivertWeaverDriver
+			m.Deploy.Divert.Driver = constants.OktetoDivertWeaverDriver
 		}
 		if m.Deploy.Divert.Header.Name == "" {
-			m.Deploy.Divert.Header.Name = OktetoDivertDefaultHeaderName
+			m.Deploy.Divert.Header.Name = constants.OktetoDivertDefaultHeaderName
 		}
 		if m.Deploy.Divert.Header.Match == "" {
-			m.Deploy.Divert.Header.Match = OktetoDivertIstioExactMatch
+			m.Deploy.Divert.Header.Match = constants.OktetoDivertIstioExactMatch
 		}
 		if m.Deploy.Divert.Header.Value == "" {
-			m.Deploy.Divert.Header.Value = OktetoDivertDefaultHeaderValue
+			m.Deploy.Divert.Header.Value = constants.OktetoDivertDefaultHeaderValue
 		}
 		m.Deploy.Divert.Header.Value, err = ExpandEnv(m.Deploy.Divert.Header.Value, false)
 		if err != nil {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -262,9 +262,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-with-port",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},
@@ -273,9 +273,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-service",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "",
+				DeprecatedService:    "",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},
@@ -284,9 +284,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-deployment",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "",
 			},
@@ -295,9 +295,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-port",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedDeployment: "deployment",
 			},
 			expectedErr: nil,
@@ -305,9 +305,9 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ko-without-namespace",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},


### PR DESCRIPTION
This PR adds support to configure the headers used in the istio divert driver to redirect traffix from the shared namespace to the developer namespace.

There are use cases to use different headers than `x-okteto-divert`. For example, a user might have their application already instrumented using the standard `baggage` header. Their could resue that using this configuration:
```
deploy:
   divert:
      header:
          name: baggage
          match: regex
          value: ^.*\bokteto-divert\\s*=\\s*${OKTETO_NAMESPACE}\b.*$
```
and configuring a `SIDECAR_INBOUND` istio envoy filter to transform the `x-okteto-divert` header into a baggage header in incoming requests.