### PR TITLE
Support for diverting a list of virtual services

### DIFF
--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -247,11 +247,10 @@ func (ld *localDeployer) runDeploySection(ctx context.Context, opts *Options) er
 	// deploy divert if any
 	if opts.Manifest.Deploy.Divert != nil && opts.Manifest.Deploy.Divert.Namespace != opts.Manifest.Namespace {
 		oktetoLog.SetStage("Deploy Divert")
-		if err := ld.deployDivert(ctx, opts); err != nil {
+		if err := ld.DivertDriver.Deploy(ctx); err != nil {
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error creating divert: %s", err.Error())
 			return err
 		}
-		oktetoLog.Success("Divert from '%s' successfully configured", opts.Manifest.Deploy.Divert.Namespace)
 		oktetoLog.SetStage("")
 	}
 
@@ -300,15 +299,6 @@ func (ld *localDeployer) deployStack(ctx context.Context, opts *Options) error {
 		IsInsideDeploy: true,
 	}
 	return stackCommand.RunDeploy(ctx, composeSectionInfo.Stack, stackOpts)
-}
-
-func (ld *localDeployer) deployDivert(ctx context.Context, opts *Options) error {
-
-	oktetoLog.Spinner(fmt.Sprintf("Deploying divert in namespace %s...", opts.Manifest.Deploy.Divert.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
-	return ld.DivertDriver.Deploy(ctx)
 }
 
 func (ld *localDeployer) deployEndpoints(ctx context.Context, opts *Options) error {

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -139,7 +139,6 @@ func (ld *localDestroyCommand) runDestroy(ctx context.Context, opts *Options) er
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error destroying divert: %s", err.Error())
 			return err
 		}
-		oktetoLog.Success("Divert from '%s' successfully destroyed", ld.manifest.Deploy.Divert.Namespace)
 		oktetoLog.SetStage("")
 	}
 
@@ -281,10 +280,6 @@ func (dc *localDestroyCommand) destroyHelmReleasesIfPresent(ctx context.Context,
 }
 
 func (ld *localDestroyCommand) destroyDivert(ctx context.Context, manifest *model.Manifest) error {
-	oktetoLog.Spinner(fmt.Sprintf("Destroying divert in %s...", manifest.Deploy.Divert.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-
 	c, _, err := ld.k8sClientProvider.Provide(okteto.Context().Cfg)
 	if err != nil {
 		return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,4 +85,28 @@ const (
 
 	// OktetoGitCommitEnvVar is the SHA1 hash of the last commit of the branch.
 	OktetoGitCommitEnvVar = "OKTETO_GIT_COMMIT"
+
+	// OktetoDivertWeaverDriver is the divert driver for weaver
+	OktetoDivertWeaverDriver = "weaver"
+
+	// OktetoDivertIstioDriver is the divert driver for istio
+	OktetoDivertIstioDriver = "istio"
+
+	// OktetoDivertIstioExactMatch represents the exact header match type
+	OktetoDivertIstioExactMatch = "exact"
+
+	// OktetoDivertIstioRegexMatch represents the regexp header match type
+	OktetoDivertIstioRegexMatch = "regex"
+
+	// OktetoDivertIstioPrefixMatch represents the prefix header match type
+	OktetoDivertIstioPrefixMatch = "prefix"
+
+	// OktetoDivertDefaultHeaderName the default header name used by okteto to divert traffic
+	OktetoDivertDefaultHeaderName = "x-okteto-divert"
+
+	// OktetoDivertDefaultHeaderValue the default divert header value
+	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
+
+	//OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
 )

--- a/pkg/divert/driver.go
+++ b/pkg/divert/driver.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/divert/istio"
 	"github.com/okteto/okteto/pkg/divert/weaver"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -40,7 +41,7 @@ func New(m *model.Manifest, c kubernetes.Interface) (Driver, error) {
 		return nil, oktetoErrors.ErrDivertNotSupported
 	}
 
-	if m.Deploy.Divert.Driver == model.OktetoDivertWeaverDriver {
+	if m.Deploy.Divert.Driver == constants.OktetoDivertWeaverDriver {
 		return weaver.New(m, c), nil
 	}
 

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -14,9 +14,11 @@
 package istio
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
@@ -35,7 +37,7 @@ func Test_translateDivertVirtualService(t *testing.T) {
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "match-default-header-all-routes",
+			name: "add-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "service-a",
@@ -43,177 +45,26 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
 			},
 			header: model.DivertHeader{
-				Name:  model.OktetoDivertDefaultHeaderName,
-				Match: model.OktetoDivertIstioExactMatch,
+				Name:  constants.OktetoDivertDefaultHeaderName,
+				Match: constants.OktetoDivertIstioExactMatch,
 				Value: "cindy",
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "okteto-divert-cindy-service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"}}`,
 					},
 				},
 			},
 		},
 		{
-			name: "match-default-header-single-route",
+			name: "add-divert-annotation-with-custom-header",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "service-a",
@@ -221,341 +72,48 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
 			},
 			header: model.DivertHeader{
-				Name:  model.OktetoDivertDefaultHeaderName,
-				Match: model.OktetoDivertIstioExactMatch,
-				Value: "cindy",
-			},
-			routes: []string{"service-a"},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "match-custom-header",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-			header: model.DivertHeader{
-				Name:  "custom-name",
-				Match: "prefix",
+				Name:  "custom-header-name",
+				Match: constants.OktetoDivertIstioPrefixMatch,
 				Value: "custom-prefix",
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"custom-name": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Prefix{Prefix: "custom-prefix"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"custom-header-name","match":"prefix","value":"custom-prefix"}}`,
 					},
 				},
 			},
 		},
 		{
-			name: "no-match",
+			name: "add-divert-annotation-with-routes",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
+					Name:        "service-a",
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
 				},
 			},
 			header: model.DivertHeader{
-				Name:  model.OktetoDivertDefaultHeaderName,
-				Match: model.OktetoDivertIstioExactMatch,
+				Name:  constants.OktetoDivertDefaultHeaderName,
+				Match: constants.OktetoDivertIstioExactMatch,
 				Value: "cindy",
 			},
-			routes: []string{"no-match"},
+			routes: []string{"one-route", "another-route"},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":["one-route","another-route"]}`,
 					},
 				},
 			},
@@ -577,16 +135,8 @@ func Test_translateDivertVirtualService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d.divert.Header = tt.header
-			result := d.translateDivertVirtualService(tt.vs, tt.routes)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				for j := range tt.expected.Spec.Http[i].Match {
-					assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Match[j].Headers, tt.expected.Spec.Http[i].Match[j].Headers))
-				}
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			result, _ := d.translateDivertVirtualService(tt.vs, tt.routes)
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
@@ -598,68 +148,14 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "clean-divert-routes",
+			name: "clean-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
 					},
 				},
 			},
@@ -669,36 +165,6 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
 				},
 			},
 		},
@@ -720,13 +186,7 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := d.restoreDivertVirtualService(tt.vs)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
@@ -806,7 +266,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{model.OktetoDivertDefaultHeaderName: "cindy"},
+									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -895,7 +355,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{model.OktetoDivertDefaultHeaderName: "cindy"},
+									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -942,46 +402,6 @@ func Test_translateDivertHost(t *testing.T) {
 				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
 				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
 			}
-		})
-	}
-}
-
-func Test_matchHTTPRoute(t *testing.T) {
-	tests := []struct {
-		name   string
-		r      *istioNetworkingV1beta1.HTTPRoute
-		routes []string
-		result bool
-	}{
-		{
-			name: "empty-routes",
-			r: &istioNetworkingV1beta1.HTTPRoute{
-				Name: "my-route",
-			},
-			result: true,
-		},
-		{
-			name: "match-routes",
-			r: &istioNetworkingV1beta1.HTTPRoute{
-				Name: "my-route",
-			},
-			routes: []string{"other-route", "my-route"},
-			result: true,
-		},
-		{
-			name: "no-match-routes",
-			r: &istioNetworkingV1beta1.HTTPRoute{
-				Name: "my-route",
-			},
-			routes: []string{"other-route", "another-route"},
-			result: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := matchHTTPRoute(tt.r, tt.routes)
-			assert.Equal(t, result, tt.result)
 		})
 	}
 }

--- a/pkg/divert/weaver/divert.go
+++ b/pkg/divert/weaver/divert.go
@@ -43,6 +43,9 @@ func New(m *model.Manifest, c kubernetes.Interface) *Driver {
 }
 
 func (d *Driver) Deploy(ctx context.Context) error {
+	oktetoLog.Spinner(fmt.Sprintf("Diverting namespace %s...", d.divert.Namespace))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
 	if err := d.initCache(ctx); err != nil {
 		return err
 	}
@@ -53,15 +56,20 @@ func (d *Driver) Deploy(ctx context.Context) error {
 			return ctx.Err()
 		default:
 			oktetoLog.Spinner(fmt.Sprintf("Diverting ingress %s/%s...", in.Namespace, in.Name))
+			oktetoLog.StartSpinner()
+			defer oktetoLog.StopSpinner()
 			if err := d.divertIngress(ctx, name); err != nil {
 				return err
 			}
+			oktetoLog.StopSpinner()
+			oktetoLog.Success("Ingress '%s/%s' successfully diverted", in.Namespace, in.Name)
 		}
 	}
 	return nil
 }
 
-func (*Driver) Destroy(_ context.Context) error {
+func (d *Driver) Destroy(_ context.Context) error {
+	oktetoLog.Success("Divert from '%s' successfully destroyed", d.divert.Namespace)
 	return nil
 }
 

--- a/pkg/divert/weaver/divert_test.go
+++ b/pkg/divert/weaver/divert_test.go
@@ -628,7 +628,6 @@ func Test_divertIngresses(t *testing.T) {
 		Deploy: &model.DeployInfo{
 			Divert: &model.DivertDeploy{
 				Namespace: "staging",
-				Service:   "s1",
 			},
 		},
 	}

--- a/pkg/k8s/virtualservices/crud.go
+++ b/pkg/k8s/virtualservices/crud.go
@@ -15,9 +15,7 @@ package virtualservices
 
 import (
 	"context"
-	"fmt"
 
-	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
 	istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,15 +46,4 @@ func List(ctx context.Context, namespace string, c istioclientset.Interface) ([]
 	}
 
 	return vsList.Items, nil
-}
-
-func GetHTTPRoutePrefixOktetoName(ns string) string {
-	return fmt.Sprintf("okteto-divert-%s", ns)
-}
-
-func GetHTTPRouteOktetoName(ns string, r *istioNetworkingV1beta1.HTTPRoute) string {
-	if r.Name == "" {
-		return fmt.Sprintf("okteto-divert-%s", ns)
-	}
-	return fmt.Sprintf("okteto-divert-%s-%s", ns, r.Name)
 }

--- a/pkg/k8s/virtualservices/crud.go
+++ b/pkg/k8s/virtualservices/crud.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	istioNetowrkingV1beta1 "istio.io/api/networking/v1beta1"
+	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
 	istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +54,7 @@ func GetHTTPRoutePrefixOktetoName(ns string) string {
 	return fmt.Sprintf("okteto-divert-%s", ns)
 }
 
-func GetHTTPRouteOktetoName(ns string, r *istioNetowrkingV1beta1.HTTPRoute) string {
+func GetHTTPRouteOktetoName(ns string, r *istioNetworkingV1beta1.HTTPRoute) string {
 	if r.Name == "" {
 		return fmt.Sprintf("okteto-divert-%s", ns)
 	}

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -270,25 +270,4 @@ const (
 
 	// OktetoImageTagWithVolumes is the tag assigned to an image with volume mounts
 	OktetoImageTagWithVolumes = "okteto-with-volume-mounts"
-
-	// OktetoDivertWeaverDriver is the divert driver for weaver
-	OktetoDivertWeaverDriver = "weaver"
-
-	// OktetoDivertIstioDriver is the divert driver for istio
-	OktetoDivertIstioDriver = "istio"
-
-	// OktetoDivertIstioExactMatch represents the exact header match type
-	OktetoDivertIstioExactMatch = "exact"
-
-	// OktetoDivertIstioRegexMatch represents the regexp header match type
-	OktetoDivertIstioRegexMatch = "regex"
-
-	// OktetoDivertIstioPrefixMatch represents the prefix header match type
-	OktetoDivertIstioPrefixMatch = "prefix"
-
-	// OktetoDivertDefaultHeaderName the default header name used by okteto to divert traffic
-	OktetoDivertDefaultHeaderName = "x-okteto-divert"
-
-	// OktetoDivertDefaultHeaderValue the default divert header value
-	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
 )

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -799,7 +799,7 @@ func (m *Manifest) validateDivert() error {
 	}
 
 	switch m.Deploy.Divert.Driver {
-	case OktetoDivertWeaverDriver:
+	case constants.OktetoDivertWeaverDriver:
 		if m.Deploy.Divert.Namespace == "" {
 			return fmt.Errorf("the field 'deploy.divert.namespace' is mandatory")
 		}
@@ -809,7 +809,7 @@ func (m *Manifest) validateDivert() error {
 		if len(m.Deploy.Divert.Hosts) > 0 {
 			return fmt.Errorf("the field 'deploy.divert.host' is not supported with the weaver driver")
 		}
-	case OktetoDivertIstioDriver:
+	case constants.OktetoDivertIstioDriver:
 		if m.Deploy.Divert.DeprecatedService != "" {
 			return fmt.Errorf("the field 'deploy.divert.service' is not supported with the istio driver")
 		}
@@ -817,9 +817,13 @@ func (m *Manifest) validateDivert() error {
 			return fmt.Errorf("the field 'deploy.divert.namespace' is not supported with the istio driver")
 		}
 		switch m.Deploy.Divert.Header.Match {
-		case OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch:
+		case constants.OktetoDivertIstioExactMatch, constants.OktetoDivertIstioRegexMatch, constants.OktetoDivertIstioPrefixMatch:
 		default:
-			return fmt.Errorf("supported divert header match types are %s, %s and %s", OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch)
+			return fmt.Errorf("supported divert header match types are %s, %s and %s",
+				constants.OktetoDivertIstioExactMatch,
+				constants.OktetoDivertIstioRegexMatch,
+				constants.OktetoDivertIstioPrefixMatch,
+			)
 		}
 		if len(m.Deploy.Divert.VirtualServices) == 0 {
 			return fmt.Errorf("the field 'deploy.divert.virtualServices' is mandatory")
@@ -850,16 +854,16 @@ func (m *Manifest) setDefaults() error {
 	if m.Deploy != nil && m.Deploy.Divert != nil {
 		var err error
 		if m.Deploy.Divert.Driver == "" {
-			m.Deploy.Divert.Driver = OktetoDivertWeaverDriver
+			m.Deploy.Divert.Driver = constants.OktetoDivertWeaverDriver
 		}
 		if m.Deploy.Divert.Header.Name == "" {
-			m.Deploy.Divert.Header.Name = OktetoDivertDefaultHeaderName
+			m.Deploy.Divert.Header.Name = constants.OktetoDivertDefaultHeaderName
 		}
 		if m.Deploy.Divert.Header.Match == "" {
-			m.Deploy.Divert.Header.Match = OktetoDivertIstioExactMatch
+			m.Deploy.Divert.Header.Match = constants.OktetoDivertIstioExactMatch
 		}
 		if m.Deploy.Divert.Header.Value == "" {
-			m.Deploy.Divert.Header.Value = OktetoDivertDefaultHeaderValue
+			m.Deploy.Divert.Header.Value = constants.OktetoDivertDefaultHeaderValue
 		}
 		m.Deploy.Divert.Header.Value, err = ExpandEnv(m.Deploy.Divert.Header.Value, false)
 		if err != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -194,14 +194,14 @@ type DestroyInfo struct {
 
 // DivertDeploy represents information about the deploy divert configuration
 type DivertDeploy struct {
-	Driver               string       `json:"driver,omitempty" yaml:"driver,omitempty"`
-	Header               DivertHeader `json:"header,omitempty" yaml:"header,omitempty"`
-	Namespace            string       `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Service              string       `json:"service,omitempty" yaml:"service,omitempty"`
-	DeprecatedPort       int          `json:"port,omitempty" yaml:"port,omitempty"`
-	DeprecatedDeployment string       `json:"deployment,omitempty" yaml:"deployment,omitempty"`
-	VirtualService       string       `json:"virtualService,omitempty" yaml:"virtualService,omitempty"`
-	Hosts                []DivertHost `json:"hosts,omitempty" yaml:"hosts,omitempty"`
+	Driver               string                 `json:"driver,omitempty" yaml:"driver,omitempty"`
+	Header               DivertHeader           `json:"header,omitempty" yaml:"header,omitempty"`
+	Namespace            string                 `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	DeprecatedService    string                 `json:"service,omitempty" yaml:"service,omitempty"`
+	DeprecatedPort       int                    `json:"port,omitempty" yaml:"port,omitempty"`
+	DeprecatedDeployment string                 `json:"deployment,omitempty" yaml:"deployment,omitempty"`
+	VirtualServices      []DivertVirtualService `json:"virtualServices,omitempty" yaml:"virtualServices,omitempty"`
+	Hosts                []DivertHost           `json:"hosts,omitempty" yaml:"hosts,omitempty"`
 }
 
 // DivertHeader represents the header used for redirecting a virtual service
@@ -209,6 +209,13 @@ type DivertHeader struct {
 	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
 	Match string `json:"match,omitempty" yaml:"match,omitempty"`
 	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+// DivertVirtualService represents a virtual service in a namespace to be diverted
+type DivertVirtualService struct {
+	Name      string   `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace string   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Routes    []string `json:"routes,omitempty" yaml:"routes,omitempty"`
 }
 
 // DivertHost represents a host from a virtual service in a namespace to be diverted
@@ -790,30 +797,47 @@ func (m *Manifest) validateDivert() error {
 	if m.Deploy.Divert == nil {
 		return nil
 	}
-	if m.Deploy.Divert.Namespace == "" {
-		return fmt.Errorf("the field 'deploy.divert.namespace' is mandatory")
-	}
 
 	switch m.Deploy.Divert.Driver {
 	case OktetoDivertWeaverDriver:
-	case OktetoDivertIstioDriver:
-		if m.Deploy.Divert.Service == "" {
-			return fmt.Errorf("the field 'deploy.divert.service' is mandatory")
+		if m.Deploy.Divert.Namespace == "" {
+			return fmt.Errorf("the field 'deploy.divert.namespace' is mandatory")
 		}
-		if m.Deploy.Divert.VirtualService == "" {
-			return fmt.Errorf("the field 'deploy.divert.virtualService' is mandatory")
+		if len(m.Deploy.Divert.VirtualServices) > 0 {
+			return fmt.Errorf("the field 'deploy.divert.virtualServices' is not supported with the weaver driver")
+		}
+		if len(m.Deploy.Divert.Hosts) > 0 {
+			return fmt.Errorf("the field 'deploy.divert.host' is not supported with the weaver driver")
+		}
+	case OktetoDivertIstioDriver:
+		if m.Deploy.Divert.DeprecatedService != "" {
+			return fmt.Errorf("the field 'deploy.divert.service' is not supported with the istio driver")
+		}
+		if m.Deploy.Divert.Namespace != "" {
+			return fmt.Errorf("the field 'deploy.divert.namespace' is not supported with the istio driver")
 		}
 		switch m.Deploy.Divert.Header.Match {
 		case OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch:
 		default:
 			return fmt.Errorf("supported divert header match types are %s, %s and %s", OktetoDivertIstioExactMatch, OktetoDivertIstioRegexMatch, OktetoDivertIstioPrefixMatch)
 		}
+		if len(m.Deploy.Divert.VirtualServices) == 0 {
+			return fmt.Errorf("the field 'deploy.divert.virtualServices' is mandatory")
+		}
+		for i := range m.Deploy.Divert.VirtualServices {
+			if m.Deploy.Divert.VirtualServices[i].Name == "" {
+				return fmt.Errorf("the field 'deploy.divert.virtualServices[%d].name' is mandatory", i)
+			}
+			if m.Deploy.Divert.VirtualServices[i].Namespace == "" {
+				return fmt.Errorf("the field 'deploy.divert.virtualServices[%d].namespace' is mandatory", i)
+			}
+		}
 		for i := range m.Deploy.Divert.Hosts {
 			if m.Deploy.Divert.Hosts[i].VirtualService == "" {
-				return fmt.Errorf("the field 'deploy.divert.hosts.virtualService' is mandatory")
+				return fmt.Errorf("the field 'deploy.divert.hosts[%d].virtualService' is mandatory", i)
 			}
 			if m.Deploy.Divert.Hosts[i].Namespace == "" {
-				return fmt.Errorf("the field 'deploy.divert.hosts.namespace' is mandatory")
+				return fmt.Errorf("the field 'deploy.divert.hosts[%d].namespace' is mandatory", i)
 			}
 		}
 	default:

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -262,7 +262,7 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-with-port",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
 				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
@@ -273,7 +273,7 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-service",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
 				DeprecatedService:    "",
 				DeprecatedPort:       8080,
@@ -284,7 +284,7 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-deployment",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
 				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
@@ -295,7 +295,7 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ok-without-port",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
 				DeprecatedService:    "service",
 				DeprecatedDeployment: "deployment",
@@ -305,7 +305,7 @@ func Test_validateDivert(t *testing.T) {
 		{
 			name: "divert-ko-without-namespace",
 			divert: DivertDeploy{
-				Driver:               OktetoDivertWeaverDriver,
+				Driver:               constants.OktetoDivertWeaverDriver,
 				Namespace:            "",
 				DeprecatedService:    "service",
 				DeprecatedPort:       8080,

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -264,7 +264,7 @@ func Test_validateDivert(t *testing.T) {
 			divert: DivertDeploy{
 				Driver:               OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},
@@ -275,7 +275,7 @@ func Test_validateDivert(t *testing.T) {
 			divert: DivertDeploy{
 				Driver:               OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "",
+				DeprecatedService:    "",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},
@@ -286,7 +286,7 @@ func Test_validateDivert(t *testing.T) {
 			divert: DivertDeploy{
 				Driver:               OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "",
 			},
@@ -297,7 +297,7 @@ func Test_validateDivert(t *testing.T) {
 			divert: DivertDeploy{
 				Driver:               OktetoDivertWeaverDriver,
 				Namespace:            "namespace",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedDeployment: "deployment",
 			},
 			expectedErr: nil,
@@ -307,7 +307,7 @@ func Test_validateDivert(t *testing.T) {
 			divert: DivertDeploy{
 				Driver:               OktetoDivertWeaverDriver,
 				Namespace:            "",
-				Service:              "service",
+				DeprecatedService:    "service",
 				DeprecatedPort:       8080,
 				DeprecatedDeployment: "deployment",
 			},


### PR DESCRIPTION
This PR adds support to divert several virtual services (potentially from different namespaces) using a single okteto manifest. It also supports the option to filter the destination routes you want to divert, instead of matching the destination ruotes by service name. Both changes increase the flexibility of the divert implementation to support new use cases.

The PR includes a refactor of the spinner messages because we cannot rely on `deploy.divert.namespace` to be available anymore. `deploy.divert.namespace` will be empty in the istio driver
