### PR TITLE
Translate virtual service in okteto mutation webhook using an annotation

### DIFF
--- a/pkg/divert/istio/virtualservices.go
+++ b/pkg/divert/istio/virtualservices.go
@@ -14,11 +14,11 @@
 package istio
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/okteto/okteto/pkg/k8s/labels"
-	"github.com/okteto/okteto/pkg/k8s/virtualservices"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
@@ -26,75 +26,34 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (d *Driver) translateDivertVirtualService(vs *istioV1beta1.VirtualService, routes []string) *istioV1beta1.VirtualService {
-	result := vs.DeepCopy()
-	httpRoutes := []*istioNetworkingV1beta1.HTTPRoute{}
-	for i := range result.Spec.Http {
-		if strings.HasPrefix(result.Spec.Http[i].Name, virtualservices.GetHTTPRoutePrefixOktetoName(d.namespace)) {
-			continue
-		}
-		httpRoutes = append(httpRoutes, result.Spec.Http[i])
-	}
-	result.Spec.Http = httpRoutes
-	httpRoutes = []*istioNetworkingV1beta1.HTTPRoute{}
-	for _, httpRoute := range result.Spec.Http {
-		if !matchHTTPRoute(httpRoute, routes) {
-			continue
-		}
-		httpRoute := httpRoute.DeepCopy()
-		httpRoute.Name = virtualservices.GetHTTPRouteOktetoName(d.namespace, httpRoute)
-		for j := range httpRoute.Match {
-			if httpRoute.Match[j].Headers == nil {
-				httpRoute.Match[j].Headers = map[string]*istioNetworkingV1beta1.StringMatch{}
-			}
-			switch d.divert.Header.Match {
-			case model.OktetoDivertIstioExactMatch:
-				httpRoute.Match[j].Headers[d.divert.Header.Name] = &istioNetworkingV1beta1.StringMatch{
-					MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: d.divert.Header.Value},
-				}
-			case model.OktetoDivertIstioRegexMatch:
-				httpRoute.Match[j].Headers[d.divert.Header.Name] = &istioNetworkingV1beta1.StringMatch{
-					MatchType: &istioNetworkingV1beta1.StringMatch_Regex{Regex: d.divert.Header.Value},
-				}
-			case model.OktetoDivertIstioPrefixMatch:
-				httpRoute.Match[j].Headers[d.divert.Header.Name] = &istioNetworkingV1beta1.StringMatch{
-					MatchType: &istioNetworkingV1beta1.StringMatch_Prefix{Prefix: d.divert.Header.Value},
-				}
-			}
-		}
-		for j := range httpRoute.Route {
-			parts := strings.Split(httpRoute.Route[j].Destination.Host, ".")
-			httpRoute.Route[j].Destination.Host = fmt.Sprintf("%s.%s.svc.cluster.local", parts[0], d.namespace)
-		}
-		httpRoutes = append(httpRoutes, httpRoute)
-	}
-	httpRoutes = append(httpRoutes, result.Spec.Http...)
-	result.Spec.Http = httpRoutes
-	return result
+func (d *Driver) getDivertAnnotationName() string {
+	return fmt.Sprintf(model.OktetoDivertAnnotationTemplate, d.namespace, d.name)
 }
 
-func matchHTTPRoute(r *istioNetworkingV1beta1.HTTPRoute, routes []string) bool {
-	if len(routes) == 0 {
-		return true
+func (d *Driver) translateDivertVirtualService(vs *istioV1beta1.VirtualService, routes []string) (*istioV1beta1.VirtualService, error) {
+	result := vs.DeepCopy()
+	if result.Annotations == nil {
+		result.Annotations = map[string]string{}
 	}
-	for _, routeName := range routes {
-		if r.Name == routeName {
-			return true
-		}
+	annotation := DivertTransformation{
+		Namespace: d.namespace,
+		Header:    d.divert.Header,
+		Routes:    routes,
 	}
-	return false
+	bytes, err := json.Marshal(annotation)
+	if err != nil {
+		return nil, err
+	}
+	result.Annotations[d.getDivertAnnotationName()] = string(bytes)
+	return result, nil
 }
 
 func (d *Driver) restoreDivertVirtualService(vs *istioV1beta1.VirtualService) *istioV1beta1.VirtualService {
 	result := vs.DeepCopy()
-	httpRoutes := []*istioNetworkingV1beta1.HTTPRoute{}
-	for i := range result.Spec.Http {
-		if strings.HasPrefix(result.Spec.Http[i].Name, virtualservices.GetHTTPRoutePrefixOktetoName(d.namespace)) {
-			continue
-		}
-		httpRoutes = append(httpRoutes, result.Spec.Http[i])
+	if result.Annotations == nil {
+		result.Annotations = map[string]string{}
 	}
-	result.Spec.Http = httpRoutes
+	delete(result.Annotations, d.getDivertAnnotationName())
 	return result
 }
 

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -14,6 +14,7 @@
 package istio
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -35,64 +36,13 @@ func Test_translateDivertVirtualService(t *testing.T) {
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "match-default-header-all-routes",
+			name: "add-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "service-a",
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
 				},
 			},
 			header: model.DivertHeader{
@@ -102,118 +52,18 @@ func Test_translateDivertVirtualService(t *testing.T) {
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "okteto-divert-cindy-service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(model.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"}}`,
 					},
 				},
 			},
 		},
 		{
-			name: "match-default-header-single-route",
+			name: "add-divert-annotation-with-custom-header",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "service-a",
@@ -221,298 +71,32 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
 				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
 			},
 			header: model.DivertHeader{
-				Name:  model.OktetoDivertDefaultHeaderName,
-				Match: model.OktetoDivertIstioExactMatch,
-				Value: "cindy",
-			},
-			routes: []string{"service-a"},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-a",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "service-b",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "match-custom-header",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-			header: model.DivertHeader{
-				Name:  "custom-name",
-				Match: "prefix",
+				Name:  "custom-header-name",
+				Match: model.OktetoDivertIstioPrefixMatch,
 				Value: "custom-prefix",
 			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"custom-name": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Prefix{Prefix: "custom-prefix"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(model.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"custom-header-name","match":"prefix","value":"custom-prefix"}}`,
 					},
 				},
 			},
 		},
 		{
-			name: "no-match",
+			name: "add-divert-annotation-with-routes",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
+					Name:        "service-a",
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
 				},
 			},
 			header: model.DivertHeader{
@@ -520,42 +104,15 @@ func Test_translateDivertVirtualService(t *testing.T) {
 				Match: model.OktetoDivertIstioExactMatch,
 				Value: "cindy",
 			},
-			routes: []string{"no-match"},
+			routes: []string{"one-route", "another-route"},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-b",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-b.staging.svc.cluster.local",
-						"service-b.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-b.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Labels:    map[string]string{"l1": "v1"},
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(model.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":["one-route","another-route"]}`,
 					},
 				},
 			},
@@ -577,16 +134,8 @@ func Test_translateDivertVirtualService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d.divert.Header = tt.header
-			result := d.translateDivertVirtualService(tt.vs, tt.routes)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				for j := range tt.expected.Spec.Http[i].Match {
-					assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Match[j].Headers, tt.expected.Spec.Http[i].Match[j].Headers))
-				}
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			result, _ := d.translateDivertVirtualService(tt.vs, tt.routes)
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
@@ -598,68 +147,14 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 		expected *istioV1beta1.VirtualService
 	}{
 		{
-			name: "clean-divert-routes",
+			name: "clean-divert-annotation",
 			vs: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Headers: map[string]*istioNetworkingV1beta1.StringMatch{
-										"x-okteto-divert": {
-											MatchType: &istioNetworkingV1beta1.StringMatch_Exact{Exact: "cindy"},
-										},
-									},
-									Port: 80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.cindy.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
+					Name:      "service-a",
+					Namespace: "staging",
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(model.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
 					},
 				},
 			},
@@ -669,36 +164,6 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 					Namespace:   "staging",
 					Labels:      map[string]string{"l1": "v1"},
 					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
 				},
 			},
 		},
@@ -720,13 +185,7 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := d.restoreDivertVirtualService(tt.vs)
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
+			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
 	}
 }
@@ -942,46 +401,6 @@ func Test_translateDivertHost(t *testing.T) {
 				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
 				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
 			}
-		})
-	}
-}
-
-func Test_matchHTTPRoute(t *testing.T) {
-	tests := []struct {
-		name   string
-		r      *istioNetworkingV1beta1.HTTPRoute
-		routes []string
-		result bool
-	}{
-		{
-			name: "empty-routes",
-			r: &istioNetworkingV1beta1.HTTPRoute{
-				Name: "my-route",
-			},
-			result: true,
-		},
-		{
-			name: "match-routes",
-			r: &istioNetworkingV1beta1.HTTPRoute{
-				Name: "my-route",
-			},
-			routes: []string{"other-route", "my-route"},
-			result: true,
-		},
-		{
-			name: "no-match-routes",
-			r: &istioNetworkingV1beta1.HTTPRoute{
-				Name: "my-route",
-			},
-			routes: []string{"other-route", "another-route"},
-			result: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := matchHTTPRoute(tt.r, tt.routes)
-			assert.Equal(t, result, tt.result)
 		})
 	}
 }

--- a/pkg/k8s/virtualservices/crud.go
+++ b/pkg/k8s/virtualservices/crud.go
@@ -15,9 +15,7 @@ package virtualservices
 
 import (
 	"context"
-	"fmt"
 
-	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
 	istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioclientset "istio.io/client-go/pkg/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,15 +46,4 @@ func List(ctx context.Context, namespace string, c istioclientset.Interface) ([]
 	}
 
 	return vsList.Items, nil
-}
-
-func GetHTTPRoutePrefixOktetoName(ns string) string {
-	return fmt.Sprintf("okteto-divert-%s", ns)
-}
-
-func GetHTTPRouteOktetoName(ns string, r *istioNetworkingV1beta1.HTTPRoute) string {
-	if r.Name == "" {
-		return fmt.Sprintf("okteto-divert-%s", ns)
-	}
-	return fmt.Sprintf("okteto-divert-%s-%s", ns, r.Name)
 }

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -291,4 +291,7 @@ const (
 
 	// OktetoDivertDefaultHeaderValue the default divert header value
 	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
+
+	//OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
 )


### PR DESCRIPTION
This PR moves the virtual service transformation to the okteto mutation webhook. This is needed to handle changes in the virtual service done by CI tools. Otherwise, an update in the virtual service destroys the divert configuration.

The new implementation injects an annotation in the virtual service, and the transformation is done by the okteto mutation webhook.
