### PR TITLE
Fix multicluster preview deploy

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -286,6 +286,9 @@ func getLoggedUserContext(ctx context.Context, c *ContextCommand, ctxOptions *Co
 
 	okteto.Context().Token = user.Token
 
+	if ctxOptions.Namespace == "" {
+		ctxOptions.Namespace = user.Namespace
+	}
 	userContext, err := c.getUserContext(ctx, ctxOptions.Namespace)
 	if err != nil {
 		return nil, err

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -68,12 +67,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{
-				Namespace: opts.name,
-				Show:      true,
-			}); err != nil {
-				return err
-			}
+			oktetoLog.Information("Using %s @ %s as context", opts.name, okteto.RemoveSchema(okteto.Context().Name))
 
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -67,6 +68,9 @@ func Deploy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
+				return err
+			}
 			oktetoLog.Information("Using %s @ %s as context", opts.name, okteto.RemoveSchema(okteto.Context().Name))
 
 			if !okteto.IsOkteto() {
@@ -109,7 +113,7 @@ func (pw *Command) ExecuteDeployPreview(ctx context.Context, opts *DeployOptions
 		return nil
 	}
 
-	if err := pw.waitUntilRunning(ctx, opts.name, okteto.Context().Namespace, resp.Action, opts.timeout); err != nil {
+	if err := pw.waitUntilRunning(ctx, opts.name, opts.name, resp.Action, opts.timeout); err != nil {
 		return err
 	}
 	oktetoLog.Success("Preview environment '%s' successfully deployed", opts.name)
@@ -192,7 +196,7 @@ func (pw *Command) waitUntilRunning(ctx context.Context, name, namespace string,
 	return nil
 }
 func (pw *Command) waitToBeDeployed(ctx context.Context, name string, a *types.Action, timeout time.Duration) error {
-	return pw.okClient.Pipeline().WaitForActionToFinish(ctx, name, okteto.Context().Namespace, a.Name, timeout)
+	return pw.okClient.Pipeline().WaitForActionToFinish(ctx, name, name, a.Name, timeout)
 }
 
 func (pw *Command) waitForResourcesToBeRunning(ctx context.Context, name string, timeout time.Duration) error {

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/constants"
@@ -63,6 +64,9 @@ func Destroy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
+				return err
+			}
 			oktetoLog.Information("Using %s @ %s as context", name, okteto.RemoveSchema(okteto.Context().Name))
 
 			if !okteto.IsOkteto() {

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/constants"
@@ -64,13 +63,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			ctxOptions := &contextCMD.ContextOptions{
-				Namespace: ctxResource.Namespace,
-				Show:      true,
-			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
-				return err
-			}
+			oktetoLog.Information("Using %s @ %s as context", name, okteto.RemoveSchema(okteto.Context().Name))
 
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster

--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strings"
 
-	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -46,12 +45,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			ctxOptions := &contextCMD.ContextOptions{
-				Namespace: ctxResource.Namespace,
-			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
-				return err
-			}
+			oktetoLog.Information("Using %s @ %s as context", previewName, okteto.RemoveSchema(okteto.Context().Name))
 
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster

--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -45,6 +46,9 @@ func Endpoints(ctx context.Context) *cobra.Command {
 				return err
 			}
 
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
+				return err
+			}
 			oktetoLog.Information("Using %s @ %s as context", previewName, okteto.RemoveSchema(okteto.Context().Name))
 
 			if !okteto.IsOkteto() {


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/5460

- Use the preview used by the user in the flags instead of setting it in the context and using it across the code.
- @maroshii can you create a pipeline installer with these changes. I think the only that could recreate the namespace is creating a namespace, but I'll need to check it out before making the changes
