### PR TITLE
fix(translate): use selector name if available

### DIFF
--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"path"
 	"reflect"
@@ -1845,5 +1846,46 @@ func Test_translateAnnotations(t *testing.T) {
 			require.Equal(t, previousAppTemplateAnnotations, tt.tr.App.TemplateObjectMeta().Annotations)
 		})
 	}
+}
 
+func Test_getDevName(t *testing.T) {
+	var tests = []struct {
+		name     string
+		tr       Translation
+		expected string
+	}{
+		{
+			name: "missing name",
+			tr: Translation{
+				Dev: &model.Dev{},
+			},
+			expected: "",
+		},
+		{
+			name: "use-dev-name",
+			tr: Translation{
+				Dev: &model.Dev{
+					Name: "test-name",
+				},
+			},
+			expected: "test-name",
+		},
+		{
+			name: "use-selector",
+			tr: Translation{
+				Dev: &model.Dev{
+					Selector: map[string]string{
+						"app.kubernetes.io/component": "test-name",
+					},
+				},
+			},
+			expected: "test-name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.tr.getDevName()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3484 

## How to test

1. First, follow the comments in the issue to replicate the bug
2. To validate this change, continue by checking out the branch, build the CLI
3. Update the `okteto.yml` to be as follows:
```yaml
icon: https://apps.okteto.com/movies/icon.png

build:
  api:
    context: api
  frontend:
    context: frontend

deploy:
  - helm upgrade --install movies chart
    --set api.image=${OKTETO_BUILD_API_IMAGE}
    --set frontend.image=${OKTETO_BUILD_FRONTEND_IMAGE}

dev:
  api:
    command: yarn start
    sync:
      - api:/src
      - frontend:/frontend
    forward:
      - 9229:9229
    services:
    - selector:
         app.kubernetes.io/component: frontend
      sync:
      - frontend:/usr/src/app
  frontend:
    image: okteto/node:14
    command: bash
    sync:
      - frontend:/usr/src/app
```
4. Run `okteto up api`
5. Run `kubectl get deployments frontend-okteto -n andrea -o yaml  | grep detached`
6. Notice the output being: `detached.dev.okteto.com: frontend`