### PR TITLE
Added dev.okteto.com/namespace label to external resource objects when they are being created

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,4 +85,7 @@ const (
 
 	// OktetoGitCommitEnvVar is the SHA1 hash of the last commit of the branch.
 	OktetoGitCommitEnvVar = "OKTETO_GIT_COMMIT"
+
+	// OktetoNamespaceLabel is the label used to identify the namespace where the resource lives
+	OktetoNamespaceLabel = "dev.okteto.com/namespace"
 )

--- a/pkg/externalresource/control.go
+++ b/pkg/externalresource/control.go
@@ -27,7 +27,7 @@ func (c *K8sControl) Deploy(ctx context.Context, name, ns string, er *ExternalRe
 		return fmt.Errorf("error creating external CRD client: %s", err.Error())
 	}
 
-	externalResourceCRD := translate(name, er)
+	externalResourceCRD := translate(name, ns, er, time.Now())
 
 	old, err := k8sclient.ExternalResources(ns).Get(ctx, externalResourceCRD.Name, metav1.GetOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
@@ -79,7 +79,7 @@ func (c *K8sControl) List(ctx context.Context, ns string, labelSelector string) 
 	return result, nil
 }
 
-func translate(name string, externalResource *ExternalResource) *k8s.External {
+func translate(name, ns string, externalResource *ExternalResource, now time.Time) *k8s.External {
 	var externalEndpointsSpec []k8s.Endpoint
 	for _, endpoint := range externalResource.Endpoints {
 		externalEndpointsSpec = append(externalEndpointsSpec, k8s.Endpoint(*endpoint))
@@ -99,9 +99,13 @@ func translate(name string, externalResource *ExternalResource) *k8s.External {
 			APIVersion: fmt.Sprintf("%s/%s", k8s.GroupName, k8s.GroupVersion),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: format.ResourceK8sMetaString(name),
+			Name:      format.ResourceK8sMetaString(name),
+			Namespace: ns,
 			Annotations: map[string]string{
-				constants.LastUpdatedAnnotation: time.Now().UTC().Format(constants.TimeFormat),
+				constants.LastUpdatedAnnotation: now.UTC().Format(constants.TimeFormat),
+			},
+			Labels: map[string]string{
+				constants.OktetoNamespaceLabel: ns,
 			},
 		},
 		Spec: k8s.ExternalResourceSpec{

--- a/pkg/externalresource/control.go
+++ b/pkg/externalresource/control.go
@@ -79,7 +79,7 @@ func (c *K8sControl) List(ctx context.Context, ns string, labelSelector string) 
 	return result, nil
 }
 
-func translate(name, ns string, externalResource *ExternalResource, now time.Time) *k8s.External {
+func translate(name, namespace string, externalResource *ExternalResource, now time.Time) *k8s.External {
 	var externalEndpointsSpec []k8s.Endpoint
 	for _, endpoint := range externalResource.Endpoints {
 		externalEndpointsSpec = append(externalEndpointsSpec, k8s.Endpoint(*endpoint))
@@ -100,12 +100,12 @@ func translate(name, ns string, externalResource *ExternalResource, now time.Tim
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      format.ResourceK8sMetaString(name),
-			Namespace: ns,
+			Namespace: namespace,
 			Annotations: map[string]string{
 				constants.LastUpdatedAnnotation: now.UTC().Format(constants.TimeFormat),
 			},
 			Labels: map[string]string{
-				constants.OktetoNamespaceLabel: ns,
+				constants.OktetoNamespaceLabel: namespace,
 			},
 		},
 		Spec: k8s.ExternalResourceSpec{


### PR DESCRIPTION
Partially Fixes # https://github.com/okteto/app/issues/6269

Include the label `dev.okteto.com/namespace` in the external resources when they are created/updated as that would help us to list all external resources within different namespaces in mor efficient way
