### PR TITLE
Improve kubetoken performance with a cache #5858

### DIFF
--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -24,6 +24,7 @@ import (
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/okteto/kubetoken"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,7 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 		namespace := args[1]
 
 		cacheFileName := path.Join(config.GetDotKubeFolder(), oktetoTokenCacheFileName)
-		cache := &okteto.KubeTokenCache{StringStore: &okteto.FileByteStore{FileName: cacheFileName}}
+		cache := &kubetoken.Cache{StringStore: &kubetoken.FileByteStore{FileName: cacheFileName}}
 		// Return early if we have a valid token in the cache before we run the context command to improve performance
 		if token, err := cache.Get(context, namespace); err == nil && token != "" {
 			cmd.Print(token)
@@ -64,7 +65,7 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return errors.ErrContextIsNotOktetoCluster
 		}
 
-		c, err := okteto.NewKubeTokenClient(okteto.Context().Name, okteto.Context().Token, namespace, cache)
+		c, err := kubetoken.NewClient(okteto.Context().Name, okteto.Context().Token, namespace, cache)
 		if err != nil {
 			return fmt.Errorf("failed to initialize the kubetoken client: %w", err)
 		}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -45,8 +45,8 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 		context := args[0]
 		namespace := args[1]
 
-		cacheFile := path.Join(config.GetDotKubeFolder(), oktetoTokenCacheFileName)
-		cache := &okteto.FileCache{File: cacheFile}
+		cacheFileName := path.Join(config.GetDotKubeFolder(), oktetoTokenCacheFileName)
+		cache := &okteto.KubeTokenFileCache{File: cacheFileName}
 		if token, err := cache.Get(context, namespace); err == nil && token != nil {
 			tokenString, _ := json.MarshalIndent(token, "", "\t")
 

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -46,7 +46,7 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 		namespace := args[1]
 
 		cacheFileName := path.Join(config.GetDotKubeFolder(), oktetoTokenCacheFileName)
-		cache := &kubetoken.Cache{StringStore: &kubetoken.FileByteStore{FileName: cacheFileName}}
+		cache := &kubetoken.Cache{StringStore: kubetoken.NewFileByteStore(cacheFileName)}
 		// Return early if we have a valid token in the cache before we run the context command to improve performance
 		if token, err := cache.Get(context, namespace); err == nil && token != "" {
 			cmd.Print(token)

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -15,7 +15,6 @@ package kubetoken
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -47,10 +46,8 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 
 		cacheFileName := path.Join(config.GetDotKubeFolder(), oktetoTokenCacheFileName)
 		cache := &okteto.KubeTokenFileCache{File: cacheFileName}
-		if token, err := cache.Get(context, namespace); err == nil && token != nil {
-			tokenString, _ := json.MarshalIndent(token, "", "\t")
-
-			cmd.Print(string(tokenString))
+		if token, err := cache.Get(context, namespace); err == nil {
+			cmd.Print(token)
 			return nil
 		}
 

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -45,8 +45,9 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 		namespace := args[1]
 
 		cacheFileName := path.Join(config.GetDotKubeFolder(), oktetoTokenCacheFileName)
-		cache := &okteto.KubeTokenFileCache{File: cacheFileName}
-		if token, err := cache.Get(context, namespace); err == nil {
+		cache := &okteto.KubeTokenCache{StringStore: &okteto.FileByteStore{FileName: cacheFileName}}
+		// Return early if we have a valid token in the cache before we run the context command to improve performance
+		if token, err := cache.Get(context, namespace); err == nil && token != "" {
 			cmd.Print(token)
 			return nil
 		}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -46,7 +46,7 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 		namespace := args[1]
 
 		cacheFileName := path.Join(config.GetDotKubeFolder(), oktetoTokenCacheFileName)
-		cache := &kubetoken.Cache{StringStore: kubetoken.NewFileByteStore(cacheFileName)}
+		cache := kubetoken.NewCache(cacheFileName)
 		// Return early if we have a valid token in the cache before we run the context command to improve performance
 		if token, err := cache.Get(context, namespace); err == nil && token != "" {
 			cmd.Print(token)

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/okteto/kubetoken"
 	"github.com/spf13/cobra"
@@ -51,6 +52,8 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 		if token, err := cache.Get(context, namespace); err == nil && token != "" {
 			cmd.Print(token)
 			return nil
+		} else {
+			log.Debugf("failed to get token from cache: %w", err)
 		}
 
 		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,10 +228,14 @@ func homedirWindows() (string, error) {
 	return home, nil
 }
 
+func GetDotKubeFolder() string {
+	return filepath.Join(GetUserHomeDir(), ".kube")
+}
+
 // GetKubeconfigPath returns the path to the kubeconfig file, taking the KUBECONFIG env var into consideration
 func GetKubeconfigPath() []string {
-	home := GetUserHomeDir()
-	kubeconfig := []string{filepath.Join(home, ".kube", "config")}
+	kubeFolder := GetDotKubeFolder()
+	kubeconfig := []string{filepath.Join(kubeFolder, "config")}
 	kubeconfigEnv := os.Getenv(constants.KubeConfigEnvVar)
 	if len(kubeconfigEnv) > 0 {
 		kubeconfig = splitKubeConfigEnv(kubeconfigEnv)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -44,6 +44,9 @@ const (
 	// OktetoAutodiscoveryReleaseName defines the name used for helm release when autodiscovery
 	OktetoAutodiscoveryReleaseName = "OKTETO_AUTODISCOVERY_RELEASE_NAME"
 
+	// OktetoKubetokenNoCache disables the kubetoken cache
+	OktetoKubetokenNoCache = "OKTETO_KUBETOKEN_NO_CACHE"
+
 	// LastUpdatedAnnotation indicates update timestamp
 	LastUpdatedAnnotation = "dev.okteto.com/last-updated"
 

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -69,7 +69,7 @@ func (*OktetoClientProvider) Provide() (types.OktetoInterface, error) {
 
 // NewOktetoClient creates a new client to connect with Okteto API
 func NewOktetoClient() (*OktetoClient, error) {
-	httpClient, u, err := NewOktetoHttpClient(Context().Name, Context().Token, "graphql")
+	httpClient, u, err := NewOktetoHttpClient(Context().Name, Context().Token, "graphql", Context().Certificate, Context().IsInsecure)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func NewOktetoClient() (*OktetoClient, error) {
 	return newOktetoClientFromGraphqlClient(u, httpClient)
 }
 
-func NewOktetoHttpClient(contextName, token, oktetoUrlPath string) (*http.Client, string, error) {
+func NewOktetoHttpClient(contextName, token, oktetoUrlPath, certificate string, isInsecure bool) (*http.Client, string, error) {
 	if token == "" {
 		return nil, "", fmt.Errorf(oktetoErrors.ErrNotLogged, contextName)
 	}
@@ -95,7 +95,7 @@ func NewOktetoHttpClient(contextName, token, oktetoUrlPath string) (*http.Client
 
 	if insecureSkipTLSVerify {
 		ctxHttpClient = oktetoHttp.InsecureHTTPClient()
-	} else if cert, err := GetContextCertificate(); err == nil {
+	} else if cert, err := GetContextCertificate(certificate, isInsecure); err == nil {
 		ctxHttpClient = oktetoHttp.StrictSSLHTTPClient(cert)
 	}
 
@@ -122,7 +122,7 @@ func NewOktetoClientFromUrlAndToken(url, token string) (*OktetoClient, error) {
 
 	if insecureSkipTLSVerify {
 		ctxHttpClient = oktetoHttp.InsecureHTTPClient()
-	} else if cert, err := GetContextCertificate(); err == nil {
+	} else if cert, err := GetContextCertificate(Context().Certificate, Context().IsInsecure); err == nil {
 		ctxHttpClient = oktetoHttp.StrictSSLHTTPClient(cert)
 	}
 
@@ -144,7 +144,7 @@ func NewOktetoClientFromUrl(url string) (*OktetoClient, error) {
 
 	if insecureSkipTLSVerify {
 		ctxHttpClient = oktetoHttp.InsecureHTTPClient()
-	} else if cert, err := GetContextCertificate(); err == nil {
+	} else if cert, err := GetContextCertificate(Context().Certificate, Context().IsInsecure); err == nil {
 		ctxHttpClient = oktetoHttp.StrictSSLHTTPClient(cert)
 	}
 

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -69,7 +69,7 @@ func (*OktetoClientProvider) Provide() (types.OktetoInterface, error) {
 
 // NewOktetoClient creates a new client to connect with Okteto API
 func NewOktetoClient() (*OktetoClient, error) {
-	httpClient, u, err := newOktetoHttpClient(Context().Name, Context().Token, "graphql")
+	httpClient, u, err := NewOktetoHttpClient(Context().Name, Context().Token, "graphql")
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func NewOktetoClient() (*OktetoClient, error) {
 	return newOktetoClientFromGraphqlClient(u, httpClient)
 }
 
-func newOktetoHttpClient(contextName, token, oktetoUrlPath string) (*http.Client, string, error) {
+func NewOktetoHttpClient(contextName, token, oktetoUrlPath string) (*http.Client, string, error) {
 	if token == "" {
 		return nil, "", fmt.Errorf(oktetoErrors.ErrNotLogged, contextName)
 	}

--- a/pkg/okteto/config.go
+++ b/pkg/okteto/config.go
@@ -17,11 +17,13 @@ import "crypto/x509"
 
 type Config struct{}
 
-func (Config) IsOktetoCluster() bool                             { return IsOkteto() }
-func (Config) GetGlobalNamespace() string                        { return Context().GlobalNamespace }
-func (Config) GetNamespace() string                              { return Context().Namespace }
-func (Config) GetRegistryURL() string                            { return Context().Registry }
-func (Config) GetUserID() string                                 { return Context().UserID }
-func (Config) GetToken() string                                  { return Context().Token }
-func (Config) GetContextCertificate() (*x509.Certificate, error) { return GetContextCertificate() }
-func (Config) IsInsecureSkipTLSVerifyPolicy() bool               { return Context().IsInsecure }
+func (Config) IsOktetoCluster() bool      { return IsOkteto() }
+func (Config) GetGlobalNamespace() string { return Context().GlobalNamespace }
+func (Config) GetNamespace() string       { return Context().Namespace }
+func (Config) GetRegistryURL() string     { return Context().Registry }
+func (Config) GetUserID() string          { return Context().UserID }
+func (Config) GetToken() string           { return Context().Token }
+func (Config) GetContextCertificate() (*x509.Certificate, error) {
+	return GetContextCertificate(Context().Certificate, Context().IsInsecure)
+}
+func (Config) IsInsecureSkipTLSVerifyPolicy() bool { return Context().IsInsecure }

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -515,9 +515,8 @@ func GetSubdomain() string {
 	return strings.Replace(Context().Registry, "registry.", "", 1)
 }
 
-func GetContextCertificate() (*x509.Certificate, error) {
-	certB64 := Context().Certificate
-	certPEM, err := base64.StdEncoding.DecodeString(certB64)
+func GetContextCertificate(certificateBase64Encoded string, isInsecure bool) (*x509.Certificate, error) {
+	certPEM, err := base64.StdEncoding.DecodeString(certificateBase64Encoded)
 
 	if err != nil {
 		oktetoLog.Debugf("couldn't decode context certificate from base64: %s", err)
@@ -542,7 +541,7 @@ func GetContextCertificate() (*x509.Certificate, error) {
 		strictTLSOnce.Do(func() {
 			oktetoLog.Debugf("certificate issuer %s", cert.Issuer)
 			oktetoLog.Debugf("context certificate not trusted by system roots: %s", err)
-			if !Context().IsInsecure {
+			if !isInsecure {
 				return
 			}
 			if cert.Issuer.CommonName == config.OktetoDefaultSelfSignedIssuer {

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -15,6 +15,7 @@ type stringStore interface {
 
 type Cache struct {
 	StringStore stringStore
+	Now         func() time.Time
 }
 
 type storeRegister struct {
@@ -50,7 +51,7 @@ func (c *Cache) Get(contextName, namespace string) (string, error) {
 
 	for _, register := range store {
 		if register.ContextName == contextName && register.Namespace == namespace {
-			now := time.Now() // TODO: inject this
+			now := c.Now()
 			if register.Token.Status.ExpirationTimestamp.Time.After(now) {
 				tokenString, _ := json.MarshalIndent(register.Token, "", "\t")
 

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -59,7 +59,7 @@ func (c *Cache) read() ([]storeRegister, error) {
 func (c *Cache) Get(contextName, namespace string) (string, error) {
 	store, err := c.read()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error while reading: %w", err)
 	}
 
 	for _, register := range store {
@@ -101,7 +101,7 @@ func updateStore(store []storeRegister, contextName, namespace string, token aut
 
 func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1.TokenRequest) error {
 	store, err := c.read()
-	if err != nil && errors.Is(err, errCacheIsCorrupted) {
+	if err != nil && !errors.Is(err, errCacheIsCorrupted) {
 		return err
 	}
 

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -29,6 +29,10 @@ func (c *Cache) read() ([]storeRegister, error) {
 		return nil, err
 	}
 
+	if len(contents) == 0 {
+		return []storeRegister{}, nil
+	}
+
 	var store []storeRegister
 
 	if err := json.Unmarshal(contents, &store); err != nil {

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -17,6 +17,12 @@ type Cache struct {
 	StringStore stringStore
 }
 
+type storeRegister struct {
+	ContextName string                        `json:"context"`
+	Namespace   string                        `json:"namespace"`
+	Token       authenticationv1.TokenRequest `json:"token"`
+}
+
 func (c *Cache) read() ([]storeRegister, error) {
 	contents, err := c.StringStore.Get()
 	if err != nil {

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -57,7 +57,7 @@ func (c *Cache) Get(contextName, namespace string) (string, error) {
 
 				return string(tokenString), nil
 			} else {
-				// TODO: we could invalidate this cache here
+				// TODO: we could remove this cache register here
 				return "", nil
 			}
 		}

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -31,35 +31,6 @@ func NewCache(fileName string) *Cache {
 	}
 }
 
-type storeRegister struct {
-	Token authenticationv1.TokenRequest `json:"token"`
-}
-
-type key struct {
-	ContextName string `json:"context"`
-	Namespace   string `json:"namespace"`
-}
-
-// storeRegistry is a map of key to storeRegister
-type storeRegistry map[key]storeRegister
-
-// These implementations are needed to make the key type marshalable
-// With this we are able to use the key type as a map key in the storeRegistry
-func (k key) MarshalText() (text []byte, err error) {
-	type alias key
-	return json.Marshal(alias(k))
-}
-
-func (k *key) UnmarshalText(data []byte) error {
-	type alias key
-	var receiver alias
-	if err := json.Unmarshal(data, &receiver); err != nil {
-		return err
-	}
-	*k = key(receiver)
-	return nil
-}
-
 func (c *Cache) read() (storeRegistry, error) {
 	contents, err := c.StringStore.Get()
 	if err != nil {

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -10,7 +10,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 )
 
-const cacheIsCorrupted = "cache is corrupted"
+var errCacheIsCorrupted = fmt.Errorf("cache is corrupted")
 
 type stringStore interface {
 	Get() ([]byte, error)
@@ -50,7 +50,7 @@ func (c *Cache) read() ([]storeRegister, error) {
 	var store []storeRegister
 
 	if err := json.Unmarshal(contents, &store); err != nil {
-		return nil, fmt.Errorf(cacheIsCorrupted)
+		return nil, errCacheIsCorrupted
 	}
 
 	return store, nil
@@ -101,7 +101,7 @@ func updateStore(store []storeRegister, contextName, namespace string, token aut
 
 func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1.TokenRequest) error {
 	store, err := c.read()
-	if err != nil && errors.Is(err, fmt.Errorf(cacheIsCorrupted)) {
+	if err != nil && errors.Is(err, errCacheIsCorrupted) {
 		return err
 	}
 

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/okteto/okteto/pkg/log"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	authenticationv1 "k8s.io/api/authentication/v1"
 )
 
@@ -27,7 +27,7 @@ func NewCache(fileName string) *Cache {
 	return &Cache{
 		StringStore: NewFileByteStore(fileName),
 		Now:         time.Now,
-		Debug:       log.Debugf,
+		Debug:       oktetoLog.Debugf,
 	}
 }
 

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -1,0 +1,91 @@
+package kubetoken
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+type stringStore interface {
+	Get() ([]byte, error)
+	Set([]byte) error
+}
+
+type Cache struct {
+	StringStore stringStore
+}
+
+func (c *Cache) read() ([]storeRegister, error) {
+	contents, err := c.StringStore.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	var store []storeRegister
+
+	if err := json.Unmarshal(contents, &store); err != nil {
+		return nil, fmt.Errorf("error decoding") // TODO: we should probably delete the file contents
+	}
+
+	return store, nil
+}
+
+func (c *Cache) Get(contextName, namespace string) (string, error) {
+	store, err := c.read()
+	if err != nil {
+		return "", err
+	}
+
+	for _, register := range store {
+		if register.ContextName == contextName && register.Namespace == namespace {
+			now := time.Now() // TODO: inject this
+			if register.Token.Status.ExpirationTimestamp.Time.After(now) {
+				tokenString, _ := json.MarshalIndent(register.Token, "", "\t")
+
+				return string(tokenString), nil
+			} else {
+				// TODO: we could invalidate this cache here
+				return "", nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1.TokenRequest) error {
+	store, err := c.read()
+	if err != nil {
+		return err
+	}
+
+	existed := false
+	for i, r := range store {
+		if r.ContextName == contextName && r.Namespace == namespace {
+			store[i].Token = token
+			existed = true
+		}
+	}
+	if !existed {
+		store = append(store, storeRegister{
+			ContextName: contextName,
+			Namespace:   namespace,
+			Token:       token,
+		})
+	}
+
+	newStore, err := json.MarshalIndent(store, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	return c.StringStore.Set(newStore)
+}
+
+func (c *Cache) Set(contextName, namespace string, token authenticationv1.TokenRequest) {
+	if err := c.setWithErr(contextName, namespace, token); err != nil {
+		// TODO: log this
+	}
+}

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -21,6 +21,13 @@ type Cache struct {
 	Now         func() time.Time
 }
 
+func NewCache(fileName string) *Cache {
+	return &Cache{
+		StringStore: NewFileByteStore(fileName),
+		Now:         time.Now,
+	}
+}
+
 type storeRegister struct {
 	ContextName string                        `json:"context"`
 	Namespace   string                        `json:"namespace"`

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -29,12 +29,27 @@ type stringStore interface {
 	Set([]byte) error
 }
 
+type CacheGetSetter interface {
+	cacheGetter
+	cacheSetter
+}
+
+type cacheGetter interface {
+	Get(contextName, namespace string) (string, error)
+}
+
+type cacheSetter interface {
+	Set(contextName, namespace string, token authenticationv1.TokenRequest)
+}
+
+// Cache is a cache that stores the kubetoken with the underlying store. It handles expiration
 type Cache struct {
 	StringStore stringStore
 	Now         func() time.Time
 	Debug       func(string, ...interface{})
 }
 
+// NewCache returns a new cache which uses the given file as the underlying store
 func NewCache(fileName string) *Cache {
 	return &Cache{
 		StringStore: NewFileByteStore(fileName),

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -2,11 +2,14 @@ package kubetoken
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 )
+
+const cacheIsCorrupted = "cache is corrupted"
 
 type stringStore interface {
 	Get() ([]byte, error)
@@ -37,7 +40,7 @@ func (c *Cache) read() ([]storeRegister, error) {
 	var store []storeRegister
 
 	if err := json.Unmarshal(contents, &store); err != nil {
-		return nil, fmt.Errorf("error decoding") // TODO: we should probably delete the file contents
+		return nil, fmt.Errorf(cacheIsCorrupted)
 	}
 
 	return store, nil
@@ -57,7 +60,8 @@ func (c *Cache) Get(contextName, namespace string) (string, error) {
 
 				return string(tokenString), nil
 			} else {
-				// TODO: we could remove this cache register here
+				// This expired token should get overwritten later on a successful request
+				// We won't delete it here so we reduce the number of times we open the file
 				return "", nil
 			}
 		}
@@ -87,7 +91,7 @@ func updateStore(store []storeRegister, contextName, namespace string, token aut
 
 func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1.TokenRequest) error {
 	store, err := c.read()
-	if err != nil {
+	if err != nil && errors.Is(err, fmt.Errorf(cacheIsCorrupted)) {
 		return err
 	}
 

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/okteto/okteto/pkg/log"
 	authenticationv1 "k8s.io/api/authentication/v1"
 )
 
@@ -19,12 +20,14 @@ type stringStore interface {
 type Cache struct {
 	StringStore stringStore
 	Now         func() time.Time
+	Debug       func(string, ...interface{})
 }
 
 func NewCache(fileName string) *Cache {
 	return &Cache{
 		StringStore: NewFileByteStore(fileName),
 		Now:         time.Now,
+		Debug:       log.Debugf,
 	}
 }
 
@@ -114,6 +117,6 @@ func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1
 
 func (c *Cache) Set(contextName, namespace string, token authenticationv1.TokenRequest) {
 	if err := c.setWithErr(contextName, namespace, token); err != nil {
-		// TODO: log this
+		c.Debug("failed to write kubetoken cache: %w", err)
 	}
 }

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -1,3 +1,15 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package kubetoken
 
 import (

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -43,37 +43,20 @@ type key struct {
 // storeRegistry is a map of key to storeRegister
 type storeRegistry map[key]storeRegister
 
-func (s storeRegistry) MarshalJSON() ([]byte, error) {
-	m := map[string]storeRegister{}
-
-	for k, v := range s {
-		marshaledKey, err := json.Marshal(k)
-		if err != nil {
-			return nil, err
-		}
-
-		m[string(marshaledKey)] = v
-	}
-
-	return json.Marshal(m)
+// These implementations are needed to make the key type marshalable
+// With this we are able to use the key type as a map key in the storeRegistry
+func (k key) MarshalText() (text []byte, err error) {
+	type alias key
+	return json.Marshal(alias(k))
 }
 
-func (s storeRegistry) UnmarshalJSON(data []byte) error {
-	m := map[string]storeRegister{}
-
-	if err := json.Unmarshal(data, &m); err != nil {
+func (k *key) UnmarshalText(data []byte) error {
+	type alias key
+	var receiver alias
+	if err := json.Unmarshal(data, &receiver); err != nil {
 		return err
 	}
-
-	for k, v := range m {
-		var key key
-		if err := json.Unmarshal([]byte(k), &key); err != nil {
-			return err
-		}
-
-		s[key] = v
-	}
-
+	*k = key(receiver)
 	return nil
 }
 

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -66,12 +66,7 @@ func (c *Cache) Get(contextName, namespace string) (string, error) {
 	return "", nil
 }
 
-func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1.TokenRequest) error {
-	store, err := c.read()
-	if err != nil {
-		return err
-	}
-
+func updateStore(store []storeRegister, contextName, namespace string, token authenticationv1.TokenRequest) []storeRegister {
 	existed := false
 	for i, r := range store {
 		if r.ContextName == contextName && r.Namespace == namespace {
@@ -86,6 +81,17 @@ func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1
 			Token:       token,
 		})
 	}
+
+	return store
+}
+
+func (c *Cache) setWithErr(contextName, namespace string, token authenticationv1.TokenRequest) error {
+	store, err := c.read()
+	if err != nil {
+		return err
+	}
+
+	store = updateStore(store, contextName, namespace, token)
 
 	newStore, err := json.MarshalIndent(store, "", "\t")
 	if err != nil {

--- a/pkg/okteto/kubetoken/cache.go
+++ b/pkg/okteto/kubetoken/cache.go
@@ -40,7 +40,7 @@ type storeRegister struct {
 func (c *Cache) read() ([]storeRegister, error) {
 	contents, err := c.StringStore.Get()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error while trying to get kubetoken cache: %w", err)
 	}
 
 	if len(contents) == 0 {

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -41,16 +41,11 @@ func TestFileCacheGet(t *testing.T) {
 	context := "context"
 	namespace := "namespace"
 
-	store := []storeRegister{
-		{
-			ContextName: context,
-			Namespace:   namespace,
-			Token:       token,
+	store := storeRegistry{
+		key(context, namespace): {
+			Token: token,
 		},
-		{
-			ContextName: "other-context",
-			Namespace:   "other-namespace",
-		},
+		"other": {},
 	}
 
 	storeString, err := json.Marshal(store)
@@ -128,11 +123,9 @@ func TestFileCacheSet(t *testing.T) {
 
 	context := "context"
 	namespace := "namespace"
-	expectedStore := []storeRegister{
-		{
-			ContextName: context,
-			Namespace:   namespace,
-			Token:       token,
+	expectedStore := storeRegistry{
+		key(context, namespace): {
+			Token: token,
 		},
 	}
 
@@ -181,51 +174,37 @@ func TestUpdateStore(t *testing.T) {
 		context   string
 		ns        string
 		token     authenticationv1.TokenRequest
-		store     []storeRegister
-		wantStore []storeRegister
+		store     storeRegistry
+		wantStore storeRegistry
 	}{
 		{
 			name:    "new entry",
 			context: "c4",
 			ns:      "n4",
 			token:   t4,
-			store: []storeRegister{
-				{
-					ContextName: "c1",
-					Namespace:   "n1",
-					Token:       t1,
+			store: storeRegistry{
+				key("c1", "n1"): {
+					Token: t1,
 				},
-				{
-					ContextName: "c2",
-					Namespace:   "n2",
-					Token:       t2,
+				key("c2", "n2"): {
+					Token: t2,
 				},
-				{
-					ContextName: "c3",
-					Namespace:   "n3",
-					Token:       t3,
+				key("c3", "n3"): {
+					Token: t3,
 				},
 			},
-			wantStore: []storeRegister{
-				{
-					ContextName: "c1",
-					Namespace:   "n1",
-					Token:       t1,
+			wantStore: storeRegistry{
+				key("c1", "n1"): {
+					Token: t1,
 				},
-				{
-					ContextName: "c2",
-					Namespace:   "n2",
-					Token:       t2,
+				key("c2", "n2"): {
+					Token: t2,
 				},
-				{
-					ContextName: "c3",
-					Namespace:   "n3",
-					Token:       t3,
+				key("c3", "n3"): {
+					Token: t3,
 				},
-				{
-					ContextName: "c4",
-					Namespace:   "n4",
-					Token:       t4,
+				key("c4", "n4"): {
+					Token: t4,
 				}},
 		},
 		{
@@ -233,38 +212,26 @@ func TestUpdateStore(t *testing.T) {
 			context: "c2",
 			ns:      "n2",
 			token:   t4,
-			store: []storeRegister{
-				{
-					ContextName: "c1",
-					Namespace:   "n1",
-					Token:       t1,
+			store: storeRegistry{
+				key("c1", "n1"): {
+					Token: t1,
 				},
-				{
-					ContextName: "c2",
-					Namespace:   "n2",
-					Token:       t2,
+				key("c2", "n2"): {
+					Token: t2,
 				},
-				{
-					ContextName: "c3",
-					Namespace:   "n3",
-					Token:       t3,
+				key("c3", "n3"): {
+					Token: t3,
 				},
 			},
-			wantStore: []storeRegister{
-				{
-					ContextName: "c1",
-					Namespace:   "n1",
-					Token:       t1,
+			wantStore: storeRegistry{
+				key("c1", "n1"): {
+					Token: t1,
 				},
-				{
-					ContextName: "c2",
-					Namespace:   "n2",
-					Token:       t4,
+				key("c2", "n2"): {
+					Token: t4,
 				},
-				{
-					ContextName: "c3",
-					Namespace:   "n3",
-					Token:       t3,
+				key("c3", "n3"): {
+					Token: t3,
 				},
 			},
 		},
@@ -273,12 +240,10 @@ func TestUpdateStore(t *testing.T) {
 			context: "c1",
 			ns:      "n1",
 			token:   t1,
-			store:   []storeRegister{},
-			wantStore: []storeRegister{
-				{
-					ContextName: "c1",
-					Namespace:   "n1",
-					Token:       t1,
+			store:   storeRegistry{},
+			wantStore: storeRegistry{
+				key("c1", "n1"): {
+					Token: t1,
 				},
 			},
 		},
@@ -286,8 +251,8 @@ func TestUpdateStore(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			result := updateStore(tc.store, tc.context, tc.ns, tc.token)
-			require.ElementsMatch(t, tc.wantStore, result)
+			updateStore(tc.store, tc.context, tc.ns, tc.token)
+			require.EqualValues(t, tc.wantStore, tc.store)
 		})
 	}
 }

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -1,0 +1,17 @@
+package kubetoken
+
+import "testing"
+
+func TestFileCache(t *testing.T) {
+
+	// Test file does not exist
+
+	// Test file has corrupted data
+
+	// Test error while writing file
+
+	// Test error while stat file
+
+	// Test token expiration
+
+}

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -27,7 +27,7 @@ func (s *mockStore) Set(value []byte) error {
 
 func TestFileCache(t *testing.T) {
 
-	// Test file has corrupted data
+	// TODO: Test file has corrupted data
 
 	expirationTime := time.Now()
 

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -26,9 +26,6 @@ func (s *mockStore) Set(value []byte) error {
 }
 
 func TestFileCacheGet(t *testing.T) {
-
-	// TODO: Test file has corrupted data
-
 	expirationTime := time.Now()
 
 	token := authenticationv1.TokenRequest{
@@ -293,7 +290,4 @@ func TestUpdateStore(t *testing.T) {
 			require.ElementsMatch(t, tc.wantStore, result)
 		})
 	}
-}
-
-func TestFileCacheInteractions(t *testing.T) {
 }

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -1,6 +1,29 @@
 package kubetoken
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mockStore struct {
+	data     []byte
+	getError error
+	setError error
+}
+
+func (s *mockStore) Get() ([]byte, error) {
+	return s.data, s.getError
+}
+
+func (s *mockStore) Set(value []byte) error {
+	s.data = value
+	return s.setError
+}
 
 func TestFileCache(t *testing.T) {
 
@@ -8,4 +31,44 @@ func TestFileCache(t *testing.T) {
 
 	// Test token expiration
 
+	// Test token not expired
+
+	now := time.Now()
+	expirationTime := now.Add(time.Minute)
+
+	token := authenticationv1.TokenRequest{
+		Status: authenticationv1.TokenRequestStatus{
+			ExpirationTimestamp: metav1.Time{
+				Time: expirationTime,
+			},
+		},
+	}
+
+	context := "context"
+	namespace := "namespace"
+
+	store := []storeRegister{
+		{
+			ContextName: context,
+			Namespace:   namespace,
+			Token:       token,
+		},
+	}
+
+	storeString, err := json.Marshal(store)
+	require.NoError(t, err)
+
+	c := Cache{
+		StringStore: &mockStore{data: storeString},
+		Now: func() time.Time {
+			return now
+		},
+	}
+
+	result, err := c.Get(context, namespace)
+	require.NoError(t, err)
+
+	tokenString, err := json.Marshal(token)
+	require.NoError(t, err)
+	require.JSONEq(t, string(tokenString), result)
 }

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -177,29 +177,12 @@ func TestUpdateStore(t *testing.T) {
 		},
 	}
 
-	store := []storeRegister{
-		{
-			ContextName: "c1",
-			Namespace:   "n1",
-			Token:       t1,
-		},
-		{
-			ContextName: "c2",
-			Namespace:   "n2",
-			Token:       t2,
-		},
-		{
-			ContextName: "c3",
-			Namespace:   "n3",
-			Token:       t3,
-		},
-	}
-
 	tt := []struct {
 		name      string
 		context   string
 		ns        string
 		token     authenticationv1.TokenRequest
+		store     []storeRegister
 		wantStore []storeRegister
 	}{
 		{
@@ -207,17 +190,67 @@ func TestUpdateStore(t *testing.T) {
 			context: "c4",
 			ns:      "n4",
 			token:   t4,
-			wantStore: append(store, storeRegister{
-				ContextName: "c4",
-				Namespace:   "n4",
-				Token:       t4,
-			}),
+			store: []storeRegister{
+				{
+					ContextName: "c1",
+					Namespace:   "n1",
+					Token:       t1,
+				},
+				{
+					ContextName: "c2",
+					Namespace:   "n2",
+					Token:       t2,
+				},
+				{
+					ContextName: "c3",
+					Namespace:   "n3",
+					Token:       t3,
+				},
+			},
+			wantStore: []storeRegister{
+				{
+					ContextName: "c1",
+					Namespace:   "n1",
+					Token:       t1,
+				},
+				{
+					ContextName: "c2",
+					Namespace:   "n2",
+					Token:       t2,
+				},
+				{
+					ContextName: "c3",
+					Namespace:   "n3",
+					Token:       t3,
+				},
+				{
+					ContextName: "c4",
+					Namespace:   "n4",
+					Token:       t4,
+				}},
 		},
 		{
 			name:    "update entry",
 			context: "c2",
 			ns:      "n2",
 			token:   t4,
+			store: []storeRegister{
+				{
+					ContextName: "c1",
+					Namespace:   "n1",
+					Token:       t1,
+				},
+				{
+					ContextName: "c2",
+					Namespace:   "n2",
+					Token:       t2,
+				},
+				{
+					ContextName: "c3",
+					Namespace:   "n3",
+					Token:       t3,
+				},
+			},
 			wantStore: []storeRegister{
 				{
 					ContextName: "c1",
@@ -236,11 +269,25 @@ func TestUpdateStore(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "empty store",
+			context: "c1",
+			ns:      "n1",
+			token:   t1,
+			store:   []storeRegister{},
+			wantStore: []storeRegister{
+				{
+					ContextName: "c1",
+					Namespace:   "n1",
+					Token:       t1,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			result := updateStore(store, tc.context, tc.ns, tc.token)
+			result := updateStore(tc.store, tc.context, tc.ns, tc.token)
 			require.ElementsMatch(t, tc.wantStore, result)
 		})
 	}

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -1,3 +1,15 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package kubetoken
 
 import (

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -4,13 +4,7 @@ import "testing"
 
 func TestFileCache(t *testing.T) {
 
-	// Test file does not exist
-
 	// Test file has corrupted data
-
-	// Test error while writing file
-
-	// Test error while stat file
 
 	// Test token expiration
 

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -120,7 +120,9 @@ func TestFileCacheGet(t *testing.T) {
 }
 
 func TestFileCacheSet(t *testing.T) {
-	stringStore := &mockStore{}
+	stringStore := &mockStore{
+		data: []byte("[{\" corrupted data"),
+	}
 	c := Cache{
 		StringStore: stringStore,
 	}

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -25,7 +25,7 @@ func (s *mockStore) Set(value []byte) error {
 	return s.setError
 }
 
-func TestFileCache(t *testing.T) {
+func TestFileCacheGet(t *testing.T) {
 
 	// TODO: Test file has corrupted data
 
@@ -117,5 +117,35 @@ func TestFileCache(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestFileCacheSet(t *testing.T) {
+	stringStore := &mockStore{}
+	c := Cache{
+		StringStore: stringStore,
+	}
+
+	token := authenticationv1.TokenRequest{}
+
+	context := "context"
+	namespace := "namespace"
+	expectedStore := []storeRegister{
+		{
+			ContextName: context,
+			Namespace:   namespace,
+			Token:       token,
+		},
+	}
+
+	expectedStoreString, err := json.Marshal(expectedStore)
+	require.NoError(t, err)
+
+	err = c.setWithErr("context", "namespace", token)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(expectedStoreString), string(stringStore.data))
+
+}
+
+func TestFileCacheInteractions(t *testing.T) {
 }

--- a/pkg/okteto/kubetoken/cache_test.go
+++ b/pkg/okteto/kubetoken/cache_test.go
@@ -42,10 +42,10 @@ func TestFileCacheGet(t *testing.T) {
 	namespace := "namespace"
 
 	store := storeRegistry{
-		key(context, namespace): {
+		key{context, namespace}: {
 			Token: token,
 		},
-		"other": {},
+		key{"oth", "er"}: {},
 	}
 
 	storeString, err := json.Marshal(store)
@@ -124,7 +124,7 @@ func TestFileCacheSet(t *testing.T) {
 	context := "context"
 	namespace := "namespace"
 	expectedStore := storeRegistry{
-		key(context, namespace): {
+		key{context, namespace}: {
 			Token: token,
 		},
 	}
@@ -183,27 +183,27 @@ func TestUpdateStore(t *testing.T) {
 			ns:      "n4",
 			token:   t4,
 			store: storeRegistry{
-				key("c1", "n1"): {
+				key{"c1", "n1"}: {
 					Token: t1,
 				},
-				key("c2", "n2"): {
+				key{"c2", "n2"}: {
 					Token: t2,
 				},
-				key("c3", "n3"): {
+				key{"c3", "n3"}: {
 					Token: t3,
 				},
 			},
 			wantStore: storeRegistry{
-				key("c1", "n1"): {
+				key{"c1", "n1"}: {
 					Token: t1,
 				},
-				key("c2", "n2"): {
+				key{"c2", "n2"}: {
 					Token: t2,
 				},
-				key("c3", "n3"): {
+				key{"c3", "n3"}: {
 					Token: t3,
 				},
-				key("c4", "n4"): {
+				key{"c4", "n4"}: {
 					Token: t4,
 				}},
 		},
@@ -213,24 +213,24 @@ func TestUpdateStore(t *testing.T) {
 			ns:      "n2",
 			token:   t4,
 			store: storeRegistry{
-				key("c1", "n1"): {
+				key{"c1", "n1"}: {
 					Token: t1,
 				},
-				key("c2", "n2"): {
+				key{"c2", "n2"}: {
 					Token: t2,
 				},
-				key("c3", "n3"): {
+				key{"c3", "n3"}: {
 					Token: t3,
 				},
 			},
 			wantStore: storeRegistry{
-				key("c1", "n1"): {
+				key{"c1", "n1"}: {
 					Token: t1,
 				},
-				key("c2", "n2"): {
+				key{"c2", "n2"}: {
 					Token: t4,
 				},
-				key("c3", "n3"): {
+				key{"c3", "n3"}: {
 					Token: t3,
 				},
 			},
@@ -242,7 +242,7 @@ func TestUpdateStore(t *testing.T) {
 			token:   t1,
 			store:   storeRegistry{},
 			wantStore: storeRegistry{
-				key("c1", "n1"): {
+				key{"c1", "n1"}: {
 					Token: t1,
 				},
 			},

--- a/pkg/okteto/kubetoken/kubetoken_client.go
+++ b/pkg/okteto/kubetoken/kubetoken_client.go
@@ -10,7 +10,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package kubetoken
 
 import (

--- a/pkg/okteto/kubetoken/kubetoken_client.go
+++ b/pkg/okteto/kubetoken/kubetoken_client.go
@@ -80,7 +80,7 @@ func (c *Client) GetKubeToken() (string, error) {
 	token := authenticationv1.TokenRequest{}
 
 	if err := json.Unmarshal(body, &token); err != nil {
-		return "", fmt.Errorf("failed to unmarshal kubetoken response: %w", err) // TODO check this error
+		return "", fmt.Errorf("failed to unmarshal kubetoken response: %w", err)
 	}
 
 	c.cache.Set(c.contextName, c.namespace, token)

--- a/pkg/okteto/kubetoken/kubetoken_client.go
+++ b/pkg/okteto/kubetoken/kubetoken_client.go
@@ -26,10 +26,7 @@ import (
 
 const kubetokenPath = "auth/kubetoken"
 
-type cacheSetter interface {
-	Set(contextName, namespace string, token authenticationv1.TokenRequest)
-}
-
+// Client is a client to get a kubernetes token from the okteto API
 type Client struct {
 	httpClient  *http.Client
 	url         string

--- a/pkg/okteto/kubetoken/kubetoken_client.go
+++ b/pkg/okteto/kubetoken/kubetoken_client.go
@@ -27,12 +27,6 @@ import (
 
 const kubetokenPath = "auth/kubetoken"
 
-type storeRegister struct {
-	ContextName string                        `json:"context"`
-	Namespace   string                        `json:"namespace"`
-	Token       authenticationv1.TokenRequest `json:"token"`
-}
-
 type cacheSetter interface {
 	Set(contextName, namespace string, token authenticationv1.TokenRequest)
 }

--- a/pkg/okteto/kubetoken/kubetoken_client.go
+++ b/pkg/okteto/kubetoken/kubetoken_client.go
@@ -39,12 +39,12 @@ type Client struct {
 	cache       cacheSetter
 }
 
-func NewClient(contextName, token, namespace string, cache cacheSetter) (*Client, error) {
+func NewClient(contextName, token, namespace, certificate string, isInsecure bool, cache cacheSetter) (*Client, error) {
 	if contextName == "" {
 		return nil, oktetoErrors.ErrCtxNotSet
 	}
 
-	httpClient, url, err := okteto.NewOktetoHttpClient(contextName, token, fmt.Sprintf("%s/%s", kubetokenPath, namespace))
+	httpClient, url, err := okteto.NewOktetoHttpClient(contextName, token, fmt.Sprintf("%s/%s", kubetokenPath, namespace), certificate, isInsecure)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/okteto/kubetoken/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken/kubetoken_client_test.go
@@ -82,7 +82,6 @@ func (m *mockCache) Set(_, _ string, token authenticationv1.TokenRequest) {
 }
 
 func TestGetKubeTokenCache(t *testing.T) {
-	t.Parallel()
 
 	expectedToken := &authenticationv1.TokenRequest{
 		Spec: authenticationv1.TokenRequestSpec{

--- a/pkg/okteto/kubetoken/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken/kubetoken_client_test.go
@@ -158,17 +158,3 @@ func TestGetKubeTokenUnauthorizedErr(t *testing.T) {
 	_, err := c.GetKubeToken()
 	require.Equal(t, fmt.Errorf(oktetoErrors.ErrNotLogged, context), err)
 }
-
-func TestFileCache(t *testing.T) {
-
-	// Test file does not exist
-
-	// Test file has corrupted data
-
-	// Test error while writing file
-
-	// Test error while stat file
-
-	// Test token expiration
-
-}

--- a/pkg/okteto/kubetoken/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken/kubetoken_client_test.go
@@ -1,4 +1,4 @@
-package okteto
+package kubetoken
 
 import (
 	"encoding/json"
@@ -23,7 +23,7 @@ func TestNewKubeTokenClient(t *testing.T) {
 		contextName    string
 		token          string
 		expectedError  error
-		expectedClient *KubeTokenClient
+		expectedClient *Client
 	}{
 		{
 
@@ -47,7 +47,7 @@ func TestNewKubeTokenClient(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
-			client, err := NewKubeTokenClient(tc.contextName, tc.token, "test", &mockCache{})
+			client, err := NewClient(tc.contextName, tc.token, "test", &mockCache{})
 
 			require.Equal(t, tc.expectedError, err)
 			require.Equal(t, tc.expectedClient, client)
@@ -58,14 +58,14 @@ func TestNewKubeTokenClient(t *testing.T) {
 	t.Run("Parse error", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewKubeTokenClient("not!!://a.url", "mytoken", "test", &mockCache{})
+		_, err := NewClient("not!!://a.url", "mytoken", "test", &mockCache{})
 		require.Error(t, err)
 	})
 
 	t.Run("No error", func(t *testing.T) {
 		t.Parallel()
 
-		client, err := NewKubeTokenClient("cloud.okteto.com", "mytoken", "testns", &mockCache{})
+		client, err := NewClient("cloud.okteto.com", "mytoken", "testns", &mockCache{})
 		require.NoError(t, err)
 
 		require.Equal(t, "https://cloud.okteto.com/auth/kubetoken/testns", client.url)
@@ -123,7 +123,7 @@ func TestGetKubeTokenCache(t *testing.T) {
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			c := &KubeTokenClient{
+			c := &Client{
 				httpClient: s.Client(),
 				url:        s.URL,
 				cache:      tc.cache,
@@ -148,7 +148,7 @@ func TestGetKubeTokenUnauthorizedErr(t *testing.T) {
 
 	context := "testctx"
 
-	c := &KubeTokenClient{
+	c := &Client{
 		httpClient:  s.Client(),
 		url:         s.URL,
 		contextName: context,

--- a/pkg/okteto/kubetoken/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken/kubetoken_client_test.go
@@ -51,7 +51,6 @@ func TestNewKubeTokenClient(t *testing.T) {
 
 			require.Equal(t, tc.expectedError, err)
 			require.Equal(t, tc.expectedClient, client)
-			require.Equal(t, tc.contextName, client.contextName)
 		})
 	}
 

--- a/pkg/okteto/kubetoken/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken/kubetoken_client_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestNewKubeTokenClient(t *testing.T) {
-	t.Parallel()
-
 	tt := []struct {
 		testName       string
 		contextName    string
@@ -45,8 +43,6 @@ func TestNewKubeTokenClient(t *testing.T) {
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
-			t.Parallel()
-
 			client, err := NewClient(tc.contextName, tc.token, "test", &mockCache{})
 
 			require.Equal(t, tc.expectedError, err)
@@ -55,15 +51,11 @@ func TestNewKubeTokenClient(t *testing.T) {
 	}
 
 	t.Run("Parse error", func(t *testing.T) {
-		t.Parallel()
-
 		_, err := NewClient("not!!://a.url", "mytoken", "test", &mockCache{})
 		require.Error(t, err)
 	})
 
 	t.Run("No error", func(t *testing.T) {
-		t.Parallel()
-
 		client, err := NewClient("cloud.okteto.com", "mytoken", "testns", &mockCache{})
 		require.NoError(t, err)
 
@@ -136,8 +128,6 @@ func TestGetKubeTokenCache(t *testing.T) {
 }
 
 func TestGetKubeTokenUnauthorizedErr(t *testing.T) {
-	t.Parallel()
-
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))

--- a/pkg/okteto/kubetoken/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken/kubetoken_client_test.go
@@ -1,3 +1,15 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package kubetoken
 
 import (

--- a/pkg/okteto/kubetoken/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken/kubetoken_client_test.go
@@ -43,7 +43,7 @@ func TestNewKubeTokenClient(t *testing.T) {
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
-			client, err := NewClient(tc.contextName, tc.token, "test", &mockCache{})
+			client, err := NewClient(tc.contextName, tc.token, "test", "", false, &mockCache{})
 
 			require.Equal(t, tc.expectedError, err)
 			require.Equal(t, tc.expectedClient, client)
@@ -51,12 +51,12 @@ func TestNewKubeTokenClient(t *testing.T) {
 	}
 
 	t.Run("Parse error", func(t *testing.T) {
-		_, err := NewClient("not!!://a.url", "mytoken", "test", &mockCache{})
+		_, err := NewClient("not!!://a.url", "mytoken", "test", "", false, &mockCache{})
 		require.Error(t, err)
 	})
 
 	t.Run("No error", func(t *testing.T) {
-		client, err := NewClient("cloud.okteto.com", "mytoken", "testns", &mockCache{})
+		client, err := NewClient("cloud.okteto.com", "mytoken", "testns", "", false, &mockCache{})
 		require.NoError(t, err)
 
 		require.Equal(t, "https://cloud.okteto.com/auth/kubetoken/testns", client.url)

--- a/pkg/okteto/kubetoken/noopcache.go
+++ b/pkg/okteto/kubetoken/noopcache.go
@@ -1,0 +1,28 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package kubetoken
+
+import authenticationv1 "k8s.io/api/authentication/v1"
+
+// NoopCache is a cache that does nothing
+type NoopCache struct{}
+
+// Set does nothing
+func (n NoopCache) Set(contextName, namespace string, token authenticationv1.TokenRequest) {
+	// do nothing
+}
+
+// Get does nothing
+func (n NoopCache) Get(contextName, namespace string) (string, error) {
+	return "", nil
+}

--- a/pkg/okteto/kubetoken/registry.go
+++ b/pkg/okteto/kubetoken/registry.go
@@ -1,0 +1,36 @@
+package kubetoken
+
+import (
+	"encoding/json"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+type storeRegister struct {
+	Token authenticationv1.TokenRequest `json:"token"`
+}
+
+type key struct {
+	ContextName string `json:"context"`
+	Namespace   string `json:"namespace"`
+}
+
+// storeRegistry is a map of key to storeRegister
+type storeRegistry map[key]storeRegister
+
+// These implementations are needed to make the key type marshalable
+// With this we are able to use the key type as a map key in the storeRegistry
+func (k key) MarshalText() (text []byte, err error) {
+	type alias key
+	return json.Marshal(alias(k))
+}
+
+func (k *key) UnmarshalText(data []byte) error {
+	type alias key
+	var receiver alias
+	if err := json.Unmarshal(data, &receiver); err != nil {
+		return err
+	}
+	*k = key(receiver)
+	return nil
+}

--- a/pkg/okteto/kubetoken/registry.go
+++ b/pkg/okteto/kubetoken/registry.go
@@ -1,3 +1,15 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package kubetoken
 
 import (

--- a/pkg/okteto/kubetoken/store.go
+++ b/pkg/okteto/kubetoken/store.go
@@ -16,9 +16,11 @@ func (s *FileByteStore) Get() ([]byte, error) {
 			return nil, fmt.Errorf("error checking if file exists: %w", err)
 		}
 
-		if err := os.WriteFile(s.FileName, []byte("[]"), 0600); err != nil {
+		f, err := os.Create(s.FileName)
+		if err != nil {
 			return nil, fmt.Errorf("error creating file: %w", err)
 		}
+		defer f.Close()
 	}
 
 	contents, err := os.ReadFile(s.FileName)

--- a/pkg/okteto/kubetoken/store.go
+++ b/pkg/okteto/kubetoken/store.go
@@ -1,0 +1,34 @@
+package kubetoken
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+type FileByteStore struct {
+	FileName string
+}
+
+func (s *FileByteStore) Get() ([]byte, error) {
+	if _, err := os.Stat(s.FileName); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("error checking if file exists: %w", err)
+		}
+
+		if err := os.WriteFile(s.FileName, []byte("[]"), 0600); err != nil {
+			return nil, fmt.Errorf("error creating file: %w", err)
+		}
+	}
+
+	contents, err := os.ReadFile(s.FileName)
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	return contents, nil
+}
+
+func (s *FileByteStore) Set(value []byte) error {
+	return os.WriteFile(s.FileName, value, 0600)
+}

--- a/pkg/okteto/kubetoken/store.go
+++ b/pkg/okteto/kubetoken/store.go
@@ -20,7 +20,7 @@ func NewFileByteStore(fileName string) *FileByteStore {
 		},
 		osReadFile: os.ReadFile,
 		writeFile: func(filename string, data []byte) error {
-			return os.WriteFile(filename, data, 0764)
+			return os.WriteFile(filename, data, 0664)
 		},
 	}
 }

--- a/pkg/okteto/kubetoken/store.go
+++ b/pkg/okteto/kubetoken/store.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 )
 
+// NewFileByteStore creates a new FileByteStore that uses a file to store the bytes.
+// The file handling implementations are instantiated with the os package.
 func NewFileByteStore(fileName string) *FileByteStore {
 	return &FileByteStore{
 		FileName: fileName,

--- a/pkg/okteto/kubetoken/store.go
+++ b/pkg/okteto/kubetoken/store.go
@@ -1,3 +1,15 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package kubetoken
 
 import (

--- a/pkg/okteto/kubetoken/store_test.go
+++ b/pkg/okteto/kubetoken/store_test.go
@@ -1,0 +1,13 @@
+package kubetoken
+
+import "testing"
+
+func TestByteStore(t *testing.T) {
+
+	// Test file does not exist
+
+	// Test error while writing file
+
+	// Test error while stat file
+
+}

--- a/pkg/okteto/kubetoken/store_test.go
+++ b/pkg/okteto/kubetoken/store_test.go
@@ -1,10 +1,49 @@
 package kubetoken
 
-import "testing"
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestByteStore(t *testing.T) {
 
 	// Test file does not exist
+
+	t.Run("file does not exist", func(t *testing.T) {
+		calledStat := false
+		calledCreate := false
+		calledReadFile := false
+
+		f := FileByteStore{
+			FileName: "does-not-exist",
+			osStat: func(name string) (os.FileInfo, error) {
+				require.Equal(t, "does-not-exist", name)
+				calledStat = true
+				return nil, os.ErrNotExist
+			},
+			osCreate: func(name string) (*os.File, error) {
+				require.Equal(t, "does-not-exist", name)
+				calledCreate = true
+				return nil, nil
+			},
+			osReadFile: func(filename string) ([]byte, error) {
+				require.Equal(t, "does-not-exist", filename)
+				calledReadFile = true
+				return nil, nil
+			},
+		}
+
+		contents, err := f.Get()
+		require.NoError(t, err)
+		require.True(t, calledStat)
+		require.True(t, calledCreate)
+		require.True(t, calledReadFile)
+		require.Empty(t, contents)
+	})
+
+	// Test file does not exist and cannot be created
 
 	// Test error while writing file
 

--- a/pkg/okteto/kubetoken/store_test.go
+++ b/pkg/okteto/kubetoken/store_test.go
@@ -4,49 +4,143 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestByteStore(t *testing.T) {
-
-	// Test file does not exist
-
 	t.Run("file does not exist", func(t *testing.T) {
 		calledStat := false
 		calledCreate := false
 		calledReadFile := false
 
+		fileName := "does-not-exist"
+
 		f := FileByteStore{
-			FileName: "does-not-exist",
+			FileName: fileName,
 			osStat: func(name string) (os.FileInfo, error) {
-				require.Equal(t, "does-not-exist", name)
+				require.Equal(t, fileName, name)
 				calledStat = true
 				return nil, os.ErrNotExist
 			},
 			osCreate: func(name string) (*os.File, error) {
-				require.Equal(t, "does-not-exist", name)
+				require.Equal(t, fileName, name)
 				calledCreate = true
 				return nil, nil
 			},
-			osReadFile: func(filename string) ([]byte, error) {
-				require.Equal(t, "does-not-exist", filename)
+			osReadFile: func(name string) ([]byte, error) {
+				require.Equal(t, fileName, name)
 				calledReadFile = true
 				return nil, nil
 			},
 		}
 
 		contents, err := f.Get()
+		require.Empty(t, contents)
 		require.NoError(t, err)
+
 		require.True(t, calledStat)
 		require.True(t, calledCreate)
 		require.True(t, calledReadFile)
-		require.Empty(t, contents)
 	})
 
-	// Test file does not exist and cannot be created
+	t.Run("file does not exist, error while stating file", func(t *testing.T) {
+		calledStat := false
 
-	// Test error while writing file
+		fileName := "does-not-exist"
 
-	// Test error while stat file
+		f := FileByteStore{
+			FileName: fileName,
+			osStat: func(name string) (os.FileInfo, error) {
+				require.Equal(t, fileName, name)
+				calledStat = true
+				return nil, assert.AnError
+			},
+		}
+
+		contents, err := f.Get()
+		require.Empty(t, contents)
+		require.Error(t, err)
+
+		require.True(t, calledStat)
+	})
+
+	t.Run("file does not exist and cannot be created", func(t *testing.T) {
+		calledStat := false
+		calledCreate := false
+
+		fileName := "does-not-exist"
+
+		f := FileByteStore{
+			FileName: fileName,
+			osStat: func(name string) (os.FileInfo, error) {
+				require.Equal(t, fileName, name)
+				calledStat = true
+				return nil, os.ErrNotExist
+			},
+			osCreate: func(name string) (*os.File, error) {
+				require.Equal(t, fileName, name)
+				calledCreate = true
+				return nil, assert.AnError
+			},
+		}
+
+		contents, err := f.Get()
+		require.Empty(t, contents)
+		require.Error(t, err)
+
+		require.True(t, calledStat)
+		require.True(t, calledCreate)
+	})
+
+	t.Run("file exists, error while reading file", func(t *testing.T) {
+		calledStat := false
+		calledReadFile := false
+
+		fileName := "does-not-exist"
+
+		f := FileByteStore{
+			FileName: fileName,
+			osStat: func(name string) (os.FileInfo, error) {
+				require.Equal(t, fileName, name)
+				calledStat = true
+				return nil, nil
+			},
+			osReadFile: func(name string) ([]byte, error) {
+				require.Equal(t, fileName, name)
+				calledReadFile = true
+				return nil, assert.AnError
+			},
+		}
+
+		contents, err := f.Get()
+		require.Empty(t, contents)
+		require.Error(t, err)
+
+		require.True(t, calledStat)
+		require.True(t, calledReadFile)
+	})
+
+	t.Run("set", func(t *testing.T) {
+		calledWriteFile := false
+
+		fileName := "does-not-exist"
+
+		errorReturned := assert.AnError
+
+		f := FileByteStore{
+			FileName: fileName,
+			writeFile: func(name string, data []byte) error {
+				require.Equal(t, fileName, name)
+				calledWriteFile = true
+				return errorReturned
+			},
+		}
+
+		err := f.Set([]byte("hello"))
+		require.Equal(t, errorReturned, err)
+
+		require.True(t, calledWriteFile)
+	})
 
 }

--- a/pkg/okteto/kubetoken/store_test.go
+++ b/pkg/okteto/kubetoken/store_test.go
@@ -23,7 +23,7 @@ func TestByteStore(t *testing.T) {
 				calledStat = true
 				return nil, os.ErrNotExist
 			},
-			osCreate: func(name string) (*os.File, error) {
+			createFile: func(name string) (*os.File, error) {
 				require.Equal(t, fileName, name)
 				calledCreate = true
 				return nil, nil
@@ -78,7 +78,7 @@ func TestByteStore(t *testing.T) {
 				calledStat = true
 				return nil, os.ErrNotExist
 			},
-			osCreate: func(name string) (*os.File, error) {
+			createFile: func(name string) (*os.File, error) {
 				require.Equal(t, fileName, name)
 				calledCreate = true
 				return nil, assert.AnError

--- a/pkg/okteto/kubetoken/store_test.go
+++ b/pkg/okteto/kubetoken/store_test.go
@@ -1,3 +1,15 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package kubetoken
 
 import (

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -18,15 +18,35 @@ import (
 	"io"
 	"net/http"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 )
 
 const kubetokenPath = "auth/kubetoken"
 
+type fileCache struct {
+	file string
+}
+
+func (c *fileCache) Get(contextName, namespace string) (*authenticationv1.TokenRequest, error) {
+	return nil, nil
+}
+
+func (c *fileCache) Set(contextName, namespace string, token *authenticationv1.TokenRequest) error {
+	return nil
+}
+
+type cache interface {
+	Get(contextName, namespace string) (*authenticationv1.TokenRequest, error)
+	Set(contextName, namespace string, token *authenticationv1.TokenRequest) error
+}
+
 type KubeTokenClient struct {
 	httpClient  *http.Client
 	url         string
 	contextName string
+	cache       cache
 }
 
 func NewKubeTokenClient(contextName, token, namespace string) (*KubeTokenClient, error) {

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -15,9 +15,12 @@ package okteto
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 
@@ -26,16 +29,95 @@ import (
 
 const kubetokenPath = "auth/kubetoken"
 
-type fileCache struct {
-	file string
+type storeRegister struct {
+	ContextName string                         `json:"context"`
+	Namespace   string                         `json:"namespace"`
+	Token       *authenticationv1.TokenRequest `json:"token"`
 }
 
-func (c *fileCache) Get(contextName, namespace string) (*authenticationv1.TokenRequest, error) {
+type FileCache struct {
+	File string
+}
+
+func (c *FileCache) read() ([]storeRegister, error) {
+	if _, err := os.Stat(c.File); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("error checking if file exists: %w", err)
+		}
+
+		if err := os.WriteFile(c.File, []byte("[]"), 0600); err != nil {
+			return nil, fmt.Errorf("error creating file: %w", err)
+		}
+	}
+
+	file, err := os.Open(c.File)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file: %w", err)
+	}
+
+	defer file.Close()
+
+	var store []storeRegister
+
+	if err := json.NewDecoder(file).Decode(&store); err != nil {
+		return nil, fmt.Errorf("error decoding") // TODO: we should probably delete the file contents
+	}
+
+	return store, nil
+}
+
+func (c *FileCache) Get(contextName, namespace string) (*authenticationv1.TokenRequest, error) {
+	store, err := c.read()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, register := range store {
+		if register.ContextName == contextName && register.Namespace == namespace {
+			now := time.Now() // TODO: inject this
+			fmt.Printf("token expiration time: %v, now: %v\n\n", register.Token.Status.ExpirationTimestamp.Time, now)
+			if register.Token.Status.ExpirationTimestamp.Time.After(now) {
+				return register.Token, nil
+			} else {
+				// TODO: we could invalidate this cache here
+				return nil, nil
+			}
+		}
+	}
+
 	return nil, nil
 }
 
-func (c *fileCache) Set(contextName, namespace string, token *authenticationv1.TokenRequest) error {
-	return nil
+func (c *FileCache) Set(contextName, namespace string, token *authenticationv1.TokenRequest) error {
+	store, err := c.read()
+	if err != nil {
+		return err
+	}
+
+	existed := false
+	for i, r := range store {
+		if r.ContextName == contextName && r.Namespace == namespace {
+			store[i].Token = token
+			existed = true
+		}
+	}
+	if !existed {
+		store = append(store, storeRegister{
+			ContextName: contextName,
+			Namespace:   namespace,
+			Token:       token,
+		})
+	}
+
+	newStore, err := json.MarshalIndent(store, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("new store: %s", string(newStore))
+	fmt.Printf("writing to file: %s", c.File)
+
+	return os.WriteFile(c.File, newStore, 0600)
 }
 
 type cache interface {
@@ -51,7 +133,7 @@ type KubeTokenClient struct {
 	cache       cache
 }
 
-func NewKubeTokenClient(contextName, token, namespace string) (*KubeTokenClient, error) {
+func NewKubeTokenClient(contextName, token, namespace string, cache cache) (*KubeTokenClient, error) {
 	if contextName == "" {
 		return nil, oktetoErrors.ErrCtxNotSet
 	}
@@ -66,6 +148,7 @@ func NewKubeTokenClient(contextName, token, namespace string) (*KubeTokenClient,
 		url:         url,
 		contextName: contextName,
 		namespace:   namespace,
+		cache:       cache,
 	}, nil
 }
 
@@ -74,9 +157,11 @@ func (c *KubeTokenClient) GetKubeToken() (string, error) {
 	if err != nil {
 		// skippping cache
 		// TODO: log this
+		return "", err
 	}
 
 	if token != nil {
+		// TODO: handle expiration logic
 		tokenString, _ := json.Marshal(token)
 		return string(tokenString), nil
 	}
@@ -108,6 +193,8 @@ func (c *KubeTokenClient) GetKubeToken() (string, error) {
 	if err := c.cache.Set(c.contextName, c.namespace, token); err != nil {
 		// skippping cache
 		// TODO: log this
+		return "", err
+
 	}
 
 	return string(body), nil

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -6,7 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,7 +70,25 @@ func TestNewKubeTokenClient(t *testing.T) {
 	})
 }
 
-func TestGetKubeToken(t *testing.T) {
+type mockCache struct {
+	token    *authenticationv1.TokenRequest
+	err      error
+	getCount int
+	setCount int
+}
+
+func (m *mockCache) Get(_, _ string) (*authenticationv1.TokenRequest, error) {
+	m.getCount++
+	return m.token, m.err
+}
+
+func (m *mockCache) Set(_, _ string, token *authenticationv1.TokenRequest) error {
+	m.setCount++
+	m.token = token
+	return nil
+}
+
+func TestGetKubeTokenCache(t *testing.T) {
 	t.Parallel()
 
 	expectedToken := "token"
@@ -78,14 +99,70 @@ func TestGetKubeToken(t *testing.T) {
 
 	defer s.Close()
 
+	cache := &mockCache{}
+
 	c := &KubeTokenClient{
 		httpClient: s.Client(),
 		url:        s.URL,
+		cache:      cache,
 	}
 
-	token, err := c.GetKubeToken()
-	require.NoError(t, err)
-	require.Equal(t, expectedToken, token)
+	// TODO: the tests should have better checks for the cache
+	t.Run("Cache get error", func(t *testing.T) {
+		cache.token = nil
+		cache.err = assert.AnError
+
+		token, err := c.GetKubeToken()
+		require.NoError(t, err)
+		require.Equal(t, expectedToken, token)
+		require.Equal(t, 1, cache.getCount)
+		require.Equal(t, 1, cache.setCount)
+	})
+
+	t.Run("Cache set error", func(t *testing.T) {
+		cache.token = nil
+		cache.err = assert.AnError
+
+		token, err := c.GetKubeToken()
+		require.NoError(t, err)
+		require.Equal(t, expectedToken, token)
+		require.Equal(t, 1, cache.getCount)
+		require.Equal(t, 1, cache.setCount)
+	})
+
+	t.Run("Cache get and set error", func(t *testing.T) {
+		cache.token = nil
+		cache.err = assert.AnError
+
+		token, err := c.GetKubeToken()
+		require.NoError(t, err)
+		require.Equal(t, expectedToken, token)
+		require.Equal(t, 1, cache.getCount)
+		require.Equal(t, 1, cache.setCount)
+	})
+
+	t.Run("Cache hit", func(t *testing.T) {
+		cache.token = nil
+		cache.err = nil
+
+		token, err := c.GetKubeToken()
+		require.NoError(t, err)
+		require.Equal(t, expectedToken, token)
+		require.Equal(t, 1, cache.getCount)
+		require.Equal(t, 0, cache.setCount)
+	})
+
+	t.Run("Cache miss", func(t *testing.T) {
+		cache.token = nil
+		cache.err = nil
+
+		token, err := c.GetKubeToken()
+		require.NoError(t, err)
+		require.Equal(t, expectedToken, token)
+		require.Equal(t, 1, cache.getCount)
+		require.Equal(t, 1, cache.setCount)
+	})
+
 }
 
 func TestGetKubeTokenUnauthorizedErr(t *testing.T) {

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -158,3 +158,17 @@ func TestGetKubeTokenUnauthorizedErr(t *testing.T) {
 	_, err := c.GetKubeToken()
 	require.Equal(t, fmt.Errorf(oktetoErrors.ErrNotLogged, context), err)
 }
+
+func TestFileCache(t *testing.T) {
+
+	// Test file does not exist
+
+	// Test file has corrupted data
+
+	// Test error while writing file
+
+	// Test error while stat file
+
+	// Test token expiration
+
+}

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -75,10 +75,10 @@ func TestNewKubeTokenClient(t *testing.T) {
 }
 
 type mockCache struct {
-	token *authenticationv1.TokenRequest
+	token authenticationv1.TokenRequest
 }
 
-func (m *mockCache) Set(_, _ string, token *authenticationv1.TokenRequest) {
+func (m *mockCache) Set(_, _ string, token authenticationv1.TokenRequest) {
 	m.token = token
 }
 

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -48,24 +48,25 @@ func TestNewKubeTokenClient(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 
-			client, err := NewKubeTokenClient(tc.contextName, tc.token, "test")
+			client, err := NewKubeTokenClient(tc.contextName, tc.token, "test", "file")
 
 			require.Equal(t, tc.expectedError, err)
 			require.Equal(t, tc.expectedClient, client)
+			require.Equal(t, tc.contextName, client.contextName)
 		})
 	}
 
 	t.Run("Parse error", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewKubeTokenClient("not!!://a.url", "mytoken", "test")
+		_, err := NewKubeTokenClient("not!!://a.url", "mytoken", "test", "file")
 		require.Error(t, err)
 	})
 
 	t.Run("No error", func(t *testing.T) {
 		t.Parallel()
 
-		client, err := NewKubeTokenClient("cloud.okteto.com", "mytoken", "testns")
+		client, err := NewKubeTokenClient("cloud.okteto.com", "mytoken", "testns", "file")
 		require.NoError(t, err)
 
 		require.Equal(t, "https://cloud.okteto.com/auth/kubetoken/testns", client.url)


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/5858

Uses a file cache that will look something like this:
```
{
	"{\"context\":\"https://okteto.agustin.dev.okteto.net\",\"namespace\":\"agustinramirodiaz\"}": {
		"token": {...}
         }

	"{\"context\":\"https://cloud.okteto.net\",\"namespace\":\"my-cloud-ns\"}": {
		"token": {...}
         }

}
```

It's not the prettiest, but I think it has advantages:
- We can use structs as keys
- We rely on a lot of "automatic" code from json marshallers, so we don't need to create our custom marshalling
- It's a map so it's got efficient lookup

---

Tested scenarios:
- token expired
- token did not expire
- cache file does not exist
- cache file is corrupted
- some cache registry token field is wrongly marshaled 

All of them work correctly and self-heal from the bad states by re-requesting the token and cleaning up the cache file

---

The implementation details have 3 levels of abstraction that build on top of each other:
- A `byte[]` storage
- A cache
- And the kubetoken client uses the cache
