### PR TITLE
Always use baggage header name for istio divert driver

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -96,7 +96,7 @@ const (
 	OktetoDivertBaggageHeader = "baggage"
 
 	// OktetoDivertHeaderName the default header name used by okteto to divert traffic
-	OktetoDivertHeaderName = "x-okteto-divert"
+	OktetoDivertHeaderName = "okteto-divert"
 
 	//OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
 	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s-%s"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -92,20 +92,11 @@ const (
 	// OktetoDivertIstioDriver is the divert driver for istio
 	OktetoDivertIstioDriver = "istio"
 
-	// OktetoDivertIstioExactMatch represents the exact header match type
-	OktetoDivertIstioExactMatch = "exact"
+	// OktetoDivertBaggageHeader represents the baggage header
+	OktetoDivertBaggageHeader = "baggage"
 
-	// OktetoDivertIstioRegexMatch represents the regexp header match type
-	OktetoDivertIstioRegexMatch = "regex"
-
-	// OktetoDivertIstioPrefixMatch represents the prefix header match type
-	OktetoDivertIstioPrefixMatch = "prefix"
-
-	// OktetoDivertDefaultHeaderName the default header name used by okteto to divert traffic
-	OktetoDivertDefaultHeaderName = "x-okteto-divert"
-
-	// OktetoDivertDefaultHeaderValue the default divert header value
-	OktetoDivertDefaultHeaderValue = "${OKTETO_NAMESPACE}"
+	// OktetoDivertHeaderName the default header name used by okteto to divert traffic
+	OktetoDivertHeaderName = "x-okteto-divert"
 
 	//OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
 	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s-%s"

--- a/pkg/divert/istio/divert.go
+++ b/pkg/divert/istio/divert.go
@@ -42,9 +42,8 @@ type Driver struct {
 
 // DivertTransformation represents the annotation for the okteto mutation webhook to divert a virtual service
 type DivertTransformation struct {
-	Namespace string             `json:"namespace"`
-	Header    model.DivertHeader `json:"header"`
-	Routes    []string           `json:"routes,omitempty"`
+	Namespace string   `json:"namespace"`
+	Routes    []string `json:"routes,omitempty"`
 }
 
 func New(m *model.Manifest, c kubernetes.Interface, ic istioclientset.Interface) *Driver {

--- a/pkg/divert/istio/virtualservices.go
+++ b/pkg/divert/istio/virtualservices.go
@@ -38,7 +38,6 @@ func (d *Driver) translateDivertVirtualService(vs *istioV1beta1.VirtualService, 
 	}
 	annotation := DivertTransformation{
 		Namespace: d.namespace,
-		Header:    d.divert.Header,
 		Routes:    routes,
 	}
 	bytes, err := json.Marshal(annotation)
@@ -92,10 +91,10 @@ func (d *Driver) injectDivertHeader(vsSpec istioNetworkingV1beta1.VirtualService
 		if vsSpec.Http[i].Headers.Request == nil {
 			vsSpec.Http[i].Headers.Request = &istioNetworkingV1beta1.Headers_HeaderOperations{}
 		}
-		if vsSpec.Http[i].Headers.Request.Set == nil {
-			vsSpec.Http[i].Headers.Request.Set = map[string]string{}
+		if vsSpec.Http[i].Headers.Request.Add == nil {
+			vsSpec.Http[i].Headers.Request.Add = map[string]string{}
 		}
-		vsSpec.Http[i].Headers.Request.Set[constants.OktetoDivertDefaultHeaderName] = d.namespace
+		vsSpec.Http[i].Headers.Request.Add[constants.OktetoDivertBaggageHeader] = fmt.Sprintf("%s=%s", constants.OktetoDivertHeaderName, d.namespace)
 	}
 	return vsSpec
 }

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -116,7 +116,7 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 					Namespace: "staging",
 					Annotations: map[string]string{
 						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
 					},
 				},
 			},
@@ -227,7 +227,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Add: map[string]string{constants.OktetoDivertBaggageHeader: "x-okteto-divert=cindy"},
+									Add: map[string]string{constants.OktetoDivertBaggageHeader: "okteto-divert=cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -316,7 +316,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Add: map[string]string{constants.OktetoDivertBaggageHeader: "x-okteto-divert=cindy"},
+									Add: map[string]string{constants.OktetoDivertBaggageHeader: "okteto-divert=cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -32,7 +32,6 @@ func Test_translateDivertVirtualService(t *testing.T) {
 	tests := []struct {
 		name     string
 		vs       *istioV1beta1.VirtualService
-		header   model.DivertHeader
 		routes   []string
 		expected *istioV1beta1.VirtualService
 	}{
@@ -46,11 +45,6 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Annotations: map[string]string{"a1": "v1"},
 				},
 			},
-			header: model.DivertHeader{
-				Name:  constants.OktetoDivertDefaultHeaderName,
-				Match: constants.OktetoDivertIstioExactMatch,
-				Value: "cindy",
-			},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "service-a",
@@ -58,34 +52,7 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Labels:    map[string]string{"l1": "v1"},
 					Annotations: map[string]string{
 						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"}}`,
-					},
-				},
-			},
-		},
-		{
-			name: "add-divert-annotation-with-custom-header",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-			},
-			header: model.DivertHeader{
-				Name:  "custom-header-name",
-				Match: constants.OktetoDivertIstioPrefixMatch,
-				Value: "custom-prefix",
-			},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-a",
-					Namespace: "staging",
-					Labels:    map[string]string{"l1": "v1"},
-					Annotations: map[string]string{
-						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"custom-header-name","match":"prefix","value":"custom-prefix"}}`,
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy"}`,
 					},
 				},
 			},
@@ -100,11 +67,6 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Annotations: map[string]string{"a1": "v1"},
 				},
 			},
-			header: model.DivertHeader{
-				Name:  constants.OktetoDivertDefaultHeaderName,
-				Match: constants.OktetoDivertIstioExactMatch,
-				Value: "cindy",
-			},
 			routes: []string{"one-route", "another-route"},
 			expected: &istioV1beta1.VirtualService{
 				ObjectMeta: metav1.ObjectMeta{
@@ -113,7 +75,7 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Labels:    map[string]string{"l1": "v1"},
 					Annotations: map[string]string{
 						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"x-okteto-divert","match":"exact","value":"cindy"},"routes":["one-route","another-route"]}`,
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","routes":["one-route","another-route"]}`,
 					},
 				},
 			},
@@ -134,7 +96,6 @@ func Test_translateDivertVirtualService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d.divert.Header = tt.header
 			result, _ := d.translateDivertVirtualService(tt.vs, tt.routes)
 			assert.Equal(t, result.Annotations, tt.expected.Annotations)
 		})
@@ -266,7 +227,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
+									Add: map[string]string{constants.OktetoDivertBaggageHeader: "x-okteto-divert=cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
@@ -355,7 +316,7 @@ func Test_translateDivertHost(t *testing.T) {
 							},
 							Headers: &istioNetworkingV1beta1.Headers{
 								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Set: map[string]string{constants.OktetoDivertDefaultHeaderName: "cindy"},
+									Add: map[string]string{constants.OktetoDivertBaggageHeader: "x-okteto-divert=cindy"},
 								},
 							},
 							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -195,20 +195,12 @@ type DestroyInfo struct {
 // DivertDeploy represents information about the deploy divert configuration
 type DivertDeploy struct {
 	Driver               string                 `json:"driver,omitempty" yaml:"driver,omitempty"`
-	Header               DivertHeader           `json:"header,omitempty" yaml:"header,omitempty"`
 	Namespace            string                 `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	DeprecatedService    string                 `json:"service,omitempty" yaml:"service,omitempty"`
 	DeprecatedPort       int                    `json:"port,omitempty" yaml:"port,omitempty"`
 	DeprecatedDeployment string                 `json:"deployment,omitempty" yaml:"deployment,omitempty"`
 	VirtualServices      []DivertVirtualService `json:"virtualServices,omitempty" yaml:"virtualServices,omitempty"`
 	Hosts                []DivertHost           `json:"hosts,omitempty" yaml:"hosts,omitempty"`
-}
-
-// DivertHeader represents the header used for redirecting a virtual service
-type DivertHeader struct {
-	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
-	Match string `json:"match,omitempty" yaml:"match,omitempty"`
-	Value string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 // DivertVirtualService represents a virtual service in a namespace to be diverted
@@ -816,15 +808,6 @@ func (m *Manifest) validateDivert() error {
 		if m.Deploy.Divert.Namespace != "" {
 			return fmt.Errorf("the field 'deploy.divert.namespace' is not supported with the istio driver")
 		}
-		switch m.Deploy.Divert.Header.Match {
-		case constants.OktetoDivertIstioExactMatch, constants.OktetoDivertIstioRegexMatch, constants.OktetoDivertIstioPrefixMatch:
-		default:
-			return fmt.Errorf("supported divert header match types are %s, %s and %s",
-				constants.OktetoDivertIstioExactMatch,
-				constants.OktetoDivertIstioRegexMatch,
-				constants.OktetoDivertIstioPrefixMatch,
-			)
-		}
 		if len(m.Deploy.Divert.VirtualServices) == 0 {
 			return fmt.Errorf("the field 'deploy.divert.virtualServices' is mandatory")
 		}
@@ -855,19 +838,6 @@ func (m *Manifest) setDefaults() error {
 		var err error
 		if m.Deploy.Divert.Driver == "" {
 			m.Deploy.Divert.Driver = constants.OktetoDivertWeaverDriver
-		}
-		if m.Deploy.Divert.Header.Name == "" {
-			m.Deploy.Divert.Header.Name = constants.OktetoDivertDefaultHeaderName
-		}
-		if m.Deploy.Divert.Header.Match == "" {
-			m.Deploy.Divert.Header.Match = constants.OktetoDivertIstioExactMatch
-		}
-		if m.Deploy.Divert.Header.Value == "" {
-			m.Deploy.Divert.Header.Value = constants.OktetoDivertDefaultHeaderValue
-		}
-		m.Deploy.Divert.Header.Value, err = ExpandEnv(m.Deploy.Divert.Header.Value, false)
-		if err != nil {
-			return err
 		}
 		m.Deploy.Divert.Namespace, err = ExpandEnv(m.Deploy.Divert.Namespace, false)
 		if err != nil {


### PR DESCRIPTION
Instead of letting the user define the header name used for istio, we are now always using the [baggage](https://www.w3.org/TR/baggage/). The baggage header is a standard to propagate application context.

We weren't using it before because we didn't have a way to append pairs to the baggage hader value, but it's diable using the [add](https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations) istio header operator