### PR TITLE
Add replicas field in Services to specify the required replicas for services and scale back the original deployment after okteto down

### DIFF
--- a/pkg/cmd/down/run.go
+++ b/pkg/cmd/down/run.go
@@ -42,6 +42,15 @@ func Run(dev *model.Dev, app apps.App, trMap map[string]*apps.Translation, wait 
 			if err := services.DestroyDev(ctx, dev, c); err != nil {
 				return err
 			}
+			if tr.Dev != dev {
+				if err := tr.DevModeOff(); err != nil {
+					oktetoLog.Infof("failed to turn devmode off: %s", err)
+				}
+				if err := tr.App.Deploy(ctx, c); err != nil {
+					return err
+				}
+			}
+
 		} else {
 			if err := tr.DevModeOff(); err != nil {
 				oktetoLog.Infof("failed to turn devmode off: %s", err)

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -94,9 +94,12 @@ func (tr *Translation) translate() error {
 		tr.DevApp.TemplateObjectMeta().Labels[model.InteractiveDevLabel] = tr.getDevName()
 		TranslateOktetoSyncSecret(tr.DevApp.PodSpec(), tr.Dev.Name)
 	} else {
-		if tr.DevApp.Replicas() == 0 {
+		if tr.Dev.Replicas != nil {
+			tr.DevApp.SetReplicas(int32(*tr.Dev.Replicas))
+		} else if tr.DevApp.Replicas() == 0 {
 			tr.DevApp.SetReplicas(1)
 		}
+
 		tr.DevApp.TemplateObjectMeta().Labels[model.DetachedDevLabel] = tr.getDevName()
 		TranslatePodAffinity(tr.DevApp.PodSpec(), tr.MainDev.Name)
 	}

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -94,6 +94,9 @@ func (tr *Translation) translate() error {
 		tr.DevApp.TemplateObjectMeta().Labels[model.InteractiveDevLabel] = tr.getDevName()
 		TranslateOktetoSyncSecret(tr.DevApp.PodSpec(), tr.Dev.Name)
 	} else {
+		if tr.DevApp.Replicas() == 0 {
+			tr.DevApp.SetReplicas(1)
+		}
 		tr.DevApp.TemplateObjectMeta().Labels[model.DetachedDevLabel] = tr.getDevName()
 		TranslatePodAffinity(tr.DevApp.PodSpec(), tr.MainDev.Name)
 	}

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -697,7 +697,7 @@ services:
 
 	// checking dev d2 state
 
-	//There should be one replica if Deployment replicas are zero and replicas not specified in manifest
+	// There should be one replica if Deployment replicas are zero and replicas not specified in manifest
 	if tr2.DevApp.Replicas() != 1 {
 		t.Fatalf("dev d2 is running %d replicas", tr2.DevApp.Replicas())
 	}
@@ -712,7 +712,7 @@ services:
 		t.Fatalf("'%s' annotation not eliminated on 'okteto down'", model.AppReplicasAnnotation)
 	}
 
-	//Deployment scale back up to original replicas
+	// Deployment scale back up to original replicas
 	if tr2.App.Replicas() != 0 {
 		t.Fatalf("d2 is running %d replicas after 'okteto down'", tr2.App.Replicas())
 	}
@@ -813,7 +813,7 @@ services:
 
 	// checking dev d2 state
 
-	//Service replicas should be equal to replicas specified in the manifest
+	// Service replicas should be equal to replicas specified in the manifest
 	if tr2.DevApp.Replicas() != 5 {
 		t.Fatalf("dev d2 is running %d replicas", tr2.DevApp.Replicas())
 	}
@@ -828,7 +828,7 @@ services:
 		t.Fatalf("'%s' annotation not eliminated on 'okteto down'", model.AppReplicasAnnotation)
 	}
 
-	//Deployment scale back up to original replicas
+	// Deployment scale back up to original replicas
 	if tr2.App.Replicas() != 3 {
 		t.Fatalf("d2 is running %d replicas after 'okteto down'", tr2.App.Replicas())
 	}

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -17,11 +17,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
@@ -601,6 +602,237 @@ services:
 	if tr2.App.Replicas() != 3 {
 		t.Fatalf("d2 is running %d replicas after 'okteto down'", tr2.App.Replicas())
 	}
+}
+
+func Test_translateServiceWithZeroDeploymentReplicas(t *testing.T) {
+	file, err := os.CreateTemp("", "okteto-secret-test")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+	manifest := []byte(fmt.Sprintf(`name: web
+namespace: n
+container: dev
+image: web:latest
+annotations:
+  key1: value1
+command: ["./run_web.sh"]
+metadata:
+  labels:
+    app: web
+workdir: /app
+securityContext:
+  runAsUser: 100
+  runAsGroup: 101
+  fsGroup: 102
+serviceAccount: sa
+sync:
+  - .:/app
+  - sub:/path
+volumes:
+  - /go/pkg/
+  - /root/.cache/go-build
+tolerations:
+  - key: nvidia/gpu
+    operator: Exists
+nodeSelector:
+  disktype: ssd
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: role
+          operator: In
+          values:
+          - web-server
+      topologyKey: kubernetes.io/hostname
+secrets:
+  - %s:/remote
+resources:
+  limits:
+    cpu: 2
+    memory: 1Gi
+    nvidia.com/gpu: 1
+    amd.com/gpu: 1
+services:
+  - name: worker
+    container: dev
+    image: worker:latest
+    command: ["./run_worker.sh"]
+    annotations:
+      key2: value2
+    sync:
+       - worker:/src`, file.Name()))
+
+	manifest1, err := model.Read(manifest)
+	require.NoError(t, err)
+
+	dev1 := manifest1.Dev["web"]
+
+	dev2 := dev1.Services[0]
+	d2 := deployments.Sandbox(dev2)
+	d2.UID = types.UID("deploy2")
+	delete(d2.Annotations, model.OktetoAutoCreateAnnotation)
+	d2.Spec.Replicas = pointer.Int32Ptr(0)
+	d2.Namespace = dev1.Namespace
+
+	translationRules := make(map[string]*Translation)
+	ctx := context.Background()
+
+	c := fake.NewSimpleClientset(d2)
+	require.NoError(t, loadServiceTranslations(ctx, dev1, false, translationRules, c))
+	tr2 := translationRules[dev2.Name]
+	require.NoError(t, tr2.translate())
+
+	// checking d2 state
+	d2Orig := deployments.Sandbox(dev2)
+	if tr2.App.Replicas() != 0 {
+		t.Fatalf("d2 is running %d replicas", tr2.App.Replicas())
+	}
+
+	marshalledD2, _ := yaml.Marshal(tr2.App.PodSpec())
+	marshalledD2Orig, _ := yaml.Marshal(d2Orig.Spec.Template.Spec)
+	if !bytes.Equal(marshalledD2, marshalledD2Orig) {
+		t.Fatalf("Wrong d2 generation.\nActual %+v, \nExpected %+v", string(marshalledD2), string(marshalledD2Orig))
+	}
+
+	// checking dev d2 state
+
+	//There should be one replica if Deployment replicas are zero and replicas not specified in manifest
+	if tr2.DevApp.Replicas() != 1 {
+		t.Fatalf("dev d2 is running %d replicas", tr2.DevApp.Replicas())
+	}
+
+	require.NoError(t, tr2.DevModeOff())
+
+	if _, ok := tr2.App.ObjectMeta().Labels[constants.DevLabel]; ok {
+		t.Fatalf("'%s' label not eliminated on 'okteto down'", constants.DevLabel)
+	}
+
+	if _, ok := tr2.App.ObjectMeta().Annotations[model.AppReplicasAnnotation]; ok {
+		t.Fatalf("'%s' annotation not eliminated on 'okteto down'", model.AppReplicasAnnotation)
+	}
+
+	//Deployment scale back up to original replicas
+	if tr2.App.Replicas() != 0 {
+		t.Fatalf("d2 is running %d replicas after 'okteto down'", tr2.App.Replicas())
+	}
+
+}
+
+func Test_translateServiceWithReplicasSpecifiedInServiceManifest(t *testing.T) {
+	file, err := os.CreateTemp("", "okteto-secret-test")
+	require.NoError(t, err)
+	defer os.Remove(file.Name())
+	manifest := []byte(fmt.Sprintf(`name: web
+namespace: n
+container: dev
+image: web:latest
+annotations:
+  key1: value1
+command: ["./run_web.sh"]
+metadata:
+  labels:
+    app: web
+workdir: /app
+securityContext:
+  runAsUser: 100
+  runAsGroup: 101
+  fsGroup: 102
+serviceAccount: sa
+sync:
+  - .:/app
+  - sub:/path
+volumes:
+  - /go/pkg/
+  - /root/.cache/go-build
+tolerations:
+  - key: nvidia/gpu
+    operator: Exists
+nodeSelector:
+  disktype: ssd
+affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: role
+          operator: In
+          values:
+          - web-server
+      topologyKey: kubernetes.io/hostname
+secrets:
+  - %s:/remote
+resources:
+  limits:
+    cpu: 2
+    memory: 1Gi
+    nvidia.com/gpu: 1
+    amd.com/gpu: 1
+services:
+  - name: worker
+    replicas: 5
+    container: dev
+    image: worker:latest
+    command: ["./run_worker.sh"]
+    annotations:
+      key2: value2
+    sync:
+       - worker:/src`, file.Name()))
+
+	manifest1, err := model.Read(manifest)
+	require.NoError(t, err)
+
+	dev1 := manifest1.Dev["web"]
+
+	dev2 := dev1.Services[0]
+	d2 := deployments.Sandbox(dev2)
+	d2.UID = types.UID("deploy2")
+	delete(d2.Annotations, model.OktetoAutoCreateAnnotation)
+	d2.Spec.Replicas = pointer.Int32Ptr(3)
+	d2.Namespace = dev1.Namespace
+
+	translationRules := make(map[string]*Translation)
+	ctx := context.Background()
+
+	c := fake.NewSimpleClientset(d2)
+	require.NoError(t, loadServiceTranslations(ctx, dev1, false, translationRules, c))
+	tr2 := translationRules[dev2.Name]
+	require.NoError(t, tr2.translate())
+
+	// checking d2 state
+	d2Orig := deployments.Sandbox(dev2)
+	if tr2.App.Replicas() != 0 {
+		t.Fatalf("d2 is running %d replicas", tr2.App.Replicas())
+	}
+
+	marshalledD2, _ := yaml.Marshal(tr2.App.PodSpec())
+	marshalledD2Orig, _ := yaml.Marshal(d2Orig.Spec.Template.Spec)
+	if !bytes.Equal(marshalledD2, marshalledD2Orig) {
+		t.Fatalf("Wrong d2 generation.\nActual %+v, \nExpected %+v", string(marshalledD2), string(marshalledD2Orig))
+	}
+
+	// checking dev d2 state
+
+	//Service replicas should be equal to replicas specified in the manifest
+	if tr2.DevApp.Replicas() != 5 {
+		t.Fatalf("dev d2 is running %d replicas", tr2.DevApp.Replicas())
+	}
+
+	require.NoError(t, tr2.DevModeOff())
+
+	if _, ok := tr2.App.ObjectMeta().Labels[constants.DevLabel]; ok {
+		t.Fatalf("'%s' label not eliminated on 'okteto down'", constants.DevLabel)
+	}
+
+	if _, ok := tr2.App.ObjectMeta().Annotations[model.AppReplicasAnnotation]; ok {
+		t.Fatalf("'%s' annotation not eliminated on 'okteto down'", model.AppReplicasAnnotation)
+	}
+
+	//Deployment scale back up to original replicas
+	if tr2.App.Replicas() != 3 {
+		t.Fatalf("d2 is running %d replicas after 'okteto down'", tr2.App.Replicas())
+	}
+
 }
 
 func Test_translateWithoutVolumes(t *testing.T) {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -737,6 +737,10 @@ func (dev *Dev) Validate() error {
 		dev.Image = &BuildInfo{}
 	}
 
+	if dev.Replicas != nil {
+		return fmt.Errorf("replicas cannot be specified for main dev container")
+	}
+
 	if ValidKubeNameRegex.MatchString(dev.Name) {
 		return errBadName
 	}

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -94,7 +94,7 @@ type Dev struct {
 	EnvFiles             EnvFiles              `json:"envFiles,omitempty" yaml:"envFiles,omitempty"`
 	Environment          Environment           `json:"environment,omitempty" yaml:"environment,omitempty"`
 	Volumes              []Volume              `json:"volumes,omitempty" yaml:"volumes,omitempty"`
-
+	Replicas             *int                  `json:"replicas,omitempty" yaml:"replicas,omitempty"`
 	// Deprecated fields
 	Healthchecks bool   `json:"healthchecks,omitempty" yaml:"healthchecks,omitempty"`
 	Labels       Labels `json:"labels,omitempty" yaml:"labels,omitempty"`

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -531,6 +531,34 @@ func TestDev_validateName(t *testing.T) {
 	}
 }
 
+func TestDev_validateReplicas(t *testing.T) {
+	replicasNumber := 5
+	dev := &Dev{
+		Name:            "test",
+		ImagePullPolicy: apiv1.PullAlways,
+		Image:           &BuildInfo{},
+		Push:            &BuildInfo{},
+		Replicas:        &replicasNumber,
+		Sync: Sync{
+			Folders: []SyncFolder{
+				{
+					LocalPath:  ".",
+					RemotePath: "/app",
+				},
+			},
+		},
+	}
+	// Since dev isn't being unmarshalled through Read, apply defaults
+	// before validating.
+	if err := dev.SetDefaults(); err != nil {
+		t.Fatalf("error applying defaults: %v", err)
+	}
+	if err := dev.Validate(); err == nil {
+		t.Errorf("Dev.validate() error = %v, wantErr %v", err, true)
+	}
+
+}
+
 func TestDev_readImageContext(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes #3485 and #3363

Fixes following issues
1. Added a `replicas` field in the manifest to specify the required number of replicas for `services `.
2. If the replicas are not specified in manifest and if the original deployment has 0 replicas, create one service replica.
3. Fixed an issue where okteto down doesn't scale back the original deployments specified under `services` in the manifest.