### PR TITLE
fix: e2e test for remote deploy

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -148,8 +148,10 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		return err
 	}
 
-	buildOptions := build.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"})
+	buildOptions := build.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{OutputMode: "deploy"})
 	buildOptions.Manifest = deployOptions.Manifest
+
+	oktetoLog.Printf("%v\n", buildOptions)
 
 	// we need to call Build() method using a remote builder. This Builder will have
 	// the same behavior as the V1 builder but with a different output taking into

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -151,8 +151,6 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	buildOptions := build.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{OutputMode: "deploy"})
 	buildOptions.Manifest = deployOptions.Manifest
 
-	oktetoLog.Printf("%v\n", buildOptions)
-
 	// we need to call Build() method using a remote builder. This Builder will have
 	// the same behavior as the V1 builder but with a different output taking into
 	// account that we must not confuse the user with build messages since this logic is

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -148,8 +148,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		return err
 	}
 
-	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"}, rd.builderV2.Registry)
-	buildOptions.Tag = ""
+	buildOptions := build.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"})
 	buildOptions.Manifest = deployOptions.Manifest
 
 	// we need to call Build() method using a remote builder. This Builder will have

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -146,8 +146,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 		return err
 	}
 
-	buildOptions := build.OptsFromBuildInfo("", "", buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"}, rd.registry)
-	buildOptions.Tag = ""
+	buildOptions := build.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "deploy"})
 	buildOptions.Manifest = rd.manifest
 
 	// we need to call Build() method using a remote builder. This Builder will have

--- a/contributing.md
+++ b/contributing.md
@@ -110,11 +110,11 @@ This will create the `okteto` binary in the `bin` folder. You can execute the bi
 bin/okteto
 ```
 
-After you make more changes, simply run `make` again to recompile your changes. 
+After you make more changes, simply run `make` again to recompile your changes.
 
 ### Executing
 
-In order to execute the `okteto` binary locally, you can do this manually by creating a copy of it to your project directory. 
+In order to execute the `okteto` binary locally, you can do this manually by creating a copy of it to your project directory.
 
 However, there's an easy and preferred way for doing this by creating an `alias` using the following command:
 
@@ -124,7 +124,7 @@ alias <alias-name> = /path/to/okteto/binary
 
 This will make sure the `alias-name` is in sync with your okteto binary. However, this is a temporary alias. If you'd like to create a permanent alias, you can read more about it [here](https://www.freecodecamp.org/news/how-to-create-your-own-command-in-linux/).
 
-**Note:** Don't use `alias-name` as *okteto* since the actual okteto CLI tool installed locally will get in conflict with executable `okteto` binary.  
+**Note:** Don't use `alias-name` as _okteto_ since the actual okteto CLI tool installed locally will get in conflict with executable `okteto` binary.
 
 ### Testing
 

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -57,7 +57,7 @@ deploy:
     context: app
     image: okteto.dev/app:dev
 deploy:
-  image: okteto/installer:1.7.5
+  image: okteto/installer:1.8.9
   commands:
   - name: deploy nginx
     command: kubectl create deployment my-dep --image=busybox`

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -341,6 +341,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 	return opts
 }
 
+// OptsFromBuildInfoForRemoteDeploy returns the options for the remote deploy
 func OptsFromBuildInfoForRemoteDeploy(b *model.BuildInfo, o *types.BuildOptions) *types.BuildOptions {
 	opts := &types.BuildOptions{
 		Path:       b.Context,

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -341,6 +341,16 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 	return opts
 }
 
+func OptsFromBuildInfoForRemoteDeploy(b *model.BuildInfo, o *types.BuildOptions) *types.BuildOptions {
+	opts := &types.BuildOptions{
+		Path:       b.Context,
+		OutputMode: o.OutputMode,
+		File:       b.Dockerfile,
+		Platform:   o.Platform,
+	}
+	return opts
+}
+
 func extractFromContextAndDockerfile(context, dockerfile, svcName string) string {
 	if filepath.IsAbs(dockerfile) {
 		return dockerfile

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -363,6 +363,55 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 	}
 }
 
+func TestOptsFromBuildInfoForRemoteDeploy(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildInfo *model.BuildInfo
+		expected  *types.BuildOptions
+	}{
+		{
+			name: "all fields set",
+			buildInfo: &model.BuildInfo{
+				Name:        "movies-service",
+				Context:     "service",
+				Dockerfile:  "Dockerfile",
+				Target:      "build",
+				CacheFrom:   []string{"cache-image"},
+				Image:       "okteto.dev/movies-service:dev",
+				ExportCache: []string{"export-image"},
+			},
+			expected: &types.BuildOptions{
+				File:       "Dockerfile",
+				OutputMode: "deploy",
+				Path:       "service",
+			},
+		},
+		{
+			name: "just the fields needed",
+			buildInfo: &model.BuildInfo{
+				Name:        "movies-service",
+				Context:     "service",
+				Dockerfile:  "Dockerfile",
+				Target:      "build",
+				CacheFrom:   []string{"cache-image"},
+				Image:       "okteto.dev/movies-service:dev",
+				ExportCache: []string{"export-image"},
+			},
+			expected: &types.BuildOptions{
+				File:       "Dockerfile",
+				OutputMode: "deploy",
+				Path:       "service",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := OptsFromBuildInfoForRemoteDeploy(tt.buildInfo, &types.BuildOptions{OutputMode: "deploy"})
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestExtractFromContextAndDockerfile(t *testing.T) {
 	buildName := "frontendTest"
 	mockDir := "mockDir"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -60,7 +60,7 @@ const (
 	OktetoCLIImageForRemoteTemplate = "okteto/okteto:%s"
 
 	// OktetoPipelineRunnerImage defines image to use for remote deployments if empty
-	OktetoPipelineRunnerImage = "okteto/installer:1.7.6"
+	OktetoPipelineRunnerImage = "okteto/installer:1.8.9"
 
 	// OktetoEnvFile defines the name for okteto env file
 	OktetoEnvFile = "OKTETO_ENV"


### PR DESCRIPTION
# Proposed changes

Fixes e2e test that is failing

- Use a different getOpts for the remote deploy. There is no point in getting all the options for the remote build if we are going to unset it after it
