### PR TITLE
fix device resource parsing

### DIFF
--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -94,8 +94,9 @@ resources:
   limits:
     cpu: 2
     memory: 1Gi
-    nvidia.com/gpu: 1
     amd.com/gpu: 1
+    sgx.intel.com/epc: 1
+    squat.ai/fuse: 1
 services:
   - name: worker
     container: dev
@@ -303,10 +304,11 @@ services:
 				},
 				Resources: apiv1.ResourceRequirements{
 					Limits: apiv1.ResourceList{
-						"cpu":            resource.MustParse("2"),
-						"memory":         resource.MustParse("1Gi"),
-						"nvidia.com/gpu": resource.MustParse("1"),
-						"amd.com/gpu":    resource.MustParse("1"),
+						"cpu":               resource.MustParse("2"),
+						"memory":            resource.MustParse("1Gi"),
+						"amd.com/gpu":       resource.MustParse("1"),
+						"sgx.intel.com/epc": resource.MustParse("1"),
+						"squat.ai/fuse":     resource.MustParse("1"),
 					},
 				},
 				VolumeMounts: []apiv1.VolumeMount{
@@ -1273,8 +1275,9 @@ resources:
   limits:
     cpu: 2
     memory: 1Gi
-    nvidia.com/gpu: 1
     amd.com/gpu: 1
+    sgx.intel.com/epc: 1
+    squat.ai/fuse: 1
 services:
   - name: worker
     image: worker:latest
@@ -1477,10 +1480,11 @@ services:
 				},
 				Resources: apiv1.ResourceRequirements{
 					Limits: apiv1.ResourceList{
-						"cpu":            resource.MustParse("2"),
-						"memory":         resource.MustParse("1Gi"),
-						"nvidia.com/gpu": resource.MustParse("1"),
-						"amd.com/gpu":    resource.MustParse("1"),
+						"cpu":               resource.MustParse("2"),
+						"memory":            resource.MustParse("1Gi"),
+						"amd.com/gpu":       resource.MustParse("1"),
+						"sgx.intel.com/epc": resource.MustParse("1"),
+						"squat.ai/fuse":     resource.MustParse("1"),
 					},
 				},
 				VolumeMounts: []apiv1.VolumeMount{

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -13,8 +13,6 @@
 
 package model
 
-import apiv1 "k8s.io/api/core/v1"
-
 const (
 
 	// DevCloneLabel indicates it is a dev pod clone
@@ -155,15 +153,10 @@ const (
 	// DefaultImage default image for sandboxes
 	DefaultImage = "okteto/dev:latest"
 
-	// ResourceAMDGPU amd.com/gpu resource
-	ResourceAMDGPU apiv1.ResourceName = "amd.com/gpu"
-	// ResourceNVIDIAGPU nvidia.com/gpu resource
-	ResourceNVIDIAGPU apiv1.ResourceName = "nvidia.com/gpu"
-
 	// this path is expected by remote
 	authorizedKeysPath = "/var/okteto/remote/authorized_keys"
 
-	syncFieldDocsURL = "https:// okteto.com/docs/reference/manifest/#sync-string-required"
+	syncFieldDocsURL = "https://okteto.com/docs/reference/manifest/#sync-string-required"
 
 	// HelmSecretType indicates the type for secrets created by Helm
 	HelmSecretType = "helm.sh/release.v1"


### PR DESCRIPTION
# Proposed changes

Fixes #3563

* rather than taking two hardcoded values, all keys in resources are selected by containing '/' and considered as device links
* typo fix for the `syncFieldDocsURL` const