### PR TITLE
Remove preview from deployPreview mutation response

### DIFF
--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -107,8 +107,8 @@ type previewEnv struct {
 }
 
 type deployPreviewResponse struct {
-	Action  actionStruct
-	Preview previewIDStruct
+	Id     graphql.String
+	Action actionStruct
 }
 
 type previewIDStruct struct {
@@ -164,7 +164,7 @@ func (c *previewClient) DeployPreview(ctx context.Context, name, scope, reposito
 			Status: string(mutationStruct.Response.Action.Status),
 		}
 		previewResponse.Preview = &types.Preview{
-			ID: string(mutationStruct.Response.Preview.Id),
+			ID: string(mutationStruct.Response.Id),
 		}
 	} else {
 		mutationStruct := deployPreviewMutation{}
@@ -189,7 +189,7 @@ func (c *previewClient) DeployPreview(ctx context.Context, name, scope, reposito
 			Status: string(mutationStruct.Response.Action.Status),
 		}
 		previewResponse.Preview = &types.Preview{
-			ID: string(mutationStruct.Response.Preview.Id),
+			ID: string(mutationStruct.Response.Id),
 		}
 	}
 	return previewResponse, nil

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -87,13 +87,11 @@ func TestDeployPreview(t *testing.T) {
 				client: &fakeGraphQLClient{
 					mutationResult: &deployPreviewMutation{
 						Response: deployPreviewResponse{
+							Id: "test",
 							Action: actionStruct{
 								Id:     "test",
 								Name:   "test",
 								Status: ProgressingStatus,
-							},
-							Preview: previewIDStruct{
-								Id: "test",
 							},
 						},
 					},
@@ -141,13 +139,11 @@ func TestDeployPreview(t *testing.T) {
 				client: &fakeGraphQLClient{
 					mutationResult: &deployPreviewMutation{
 						Response: deployPreviewResponse{
+							Id: "test",
 							Action: actionStruct{
 								Id:     "test",
 								Name:   "test",
 								Status: ProgressingStatus,
-							},
-							Preview: previewIDStruct{
-								Id: "test",
 							},
 						},
 					},


### PR DESCRIPTION
We don't really need the preview object in the deploy mutation given that the mutation returns the id at the top level.