### PR TITLE
Set the sleep and wake command to perform actions on current  namespace

### DIFF
--- a/cmd/namespace/sleep.go
+++ b/cmd/namespace/sleep.go
@@ -29,17 +29,18 @@ func Sleep(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sleep <name>",
 		Short: "Sleeps a namespace",
-		Args:  utils.ExactArgsAccepted(1, ""),
+		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nsToSleep := args[0]
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{Namespace: nsToSleep, Show: true}); err != nil {
-				return err
-			}
-
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
-
+			nsToSleep := okteto.Context().Namespace
+			if len(args) > 0 {
+				nsToSleep = args[0]
+			}
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{Namespace: nsToSleep, Show: true}); err != nil {
+				return err
+			}
 			nsCmd, err := NewCommand()
 			if err != nil {
 				return err

--- a/cmd/namespace/sleep.go
+++ b/cmd/namespace/sleep.go
@@ -31,20 +31,24 @@ func Sleep(ctx context.Context) *cobra.Command {
 		Short: "Sleeps a namespace",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !okteto.IsOkteto() {
-				return oktetoErrors.ErrContextIsNotOktetoCluster
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
+				return err
 			}
+
 			nsToSleep := okteto.Context().Namespace
 			if len(args) > 0 {
 				nsToSleep = args[0]
 			}
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{Namespace: nsToSleep, Show: true}); err != nil {
-				return err
+
+			if !okteto.IsOkteto() {
+				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
+
 			nsCmd, err := NewCommand()
 			if err != nil {
 				return err
 			}
+
 			err = nsCmd.ExecuteSleepNamespace(ctx, nsToSleep)
 			return err
 		},

--- a/cmd/namespace/wake.go
+++ b/cmd/namespace/wake.go
@@ -28,9 +28,12 @@ func Wake(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wake <name>",
 		Short: "Wakes a namespace",
-		Args:  utils.ExactArgsAccepted(1, ""),
+		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nsToWake := args[0]
+			nsToWake := okteto.Context().Namespace
+			if len(args) > 0 {
+				nsToWake = args[0]
+			}
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{Namespace: nsToWake, Show: true}); err != nil {
 				return err
 			}


### PR DESCRIPTION
# Proposed changes

This PR adds a little functionality to the new commands `sleep` and `wake` that have been added to Oketo CLI after [this](https://github.com/okteto/okteto/pull/3479) PR being merged. Initially, `sleep` and  `wake` commands required an argument to work. However, this is not how we want the user to use it.

With this PR being merged, the user can use `sleep` and `wake` commands without passing any argument. **If no argument is passed, the command will be executed on the current namespace.**

For more reference, refer to [this](https://github.com/okteto/docs/pull/366#issuecomment-1518517252) conversation.
