### PR TITLE
Add external resources to preview endpoints

### DIFF
--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -84,8 +84,10 @@ type resourceInfo struct {
 	DeployedBy graphql.String
 }
 type previewEndpoints struct {
+	Endpoints    []endpointURL
 	Deployments  []deploymentEndpoint
 	Statefulsets []statefulsetEdnpoint
+	Externals    []externalEndpoints
 }
 
 type deploymentEndpoint struct {
@@ -93,6 +95,9 @@ type deploymentEndpoint struct {
 }
 
 type statefulsetEdnpoint struct {
+	Endpoints []endpointURL
+}
+type externalEndpoints struct {
 	Endpoints []endpointURL
 }
 
@@ -240,20 +245,39 @@ func (c *previewClient) ListEndpoints(ctx context.Context, previewName string) (
 		return nil, err
 	}
 
-	for _, d := range queryStruct.Response.Deployments {
-		for _, endpoint := range d.Endpoints {
-			endpoints = append(endpoints, types.Endpoint{
-				URL: string(endpoint.Url),
-			})
-		}
+	var endpointsMap = map[graphql.String]bool{}
+
+	for _, endpoint := range queryStruct.Response.Endpoints {
+		endpointsMap[endpoint.Url] = true
 	}
 
+	// @francisco - 2023//05/02
+	// The backend Endpoints field was being return empty in some older versions
+	// of the okteto api. Lets make sure we correctly resolve the endpoints from
+	// the known resources. All this below should be safe to remove in newer versions
+	// of the okteto cli
+	// <-- LEGACY START -->
+	for _, d := range queryStruct.Response.Deployments {
+		for _, endpoint := range d.Endpoints {
+			endpointsMap[endpoint.Url] = true
+		}
+	}
 	for _, sfs := range queryStruct.Response.Statefulsets {
 		for _, endpoint := range sfs.Endpoints {
-			endpoints = append(endpoints, types.Endpoint{
-				URL: string(endpoint.Url),
-			})
+			endpointsMap[endpoint.Url] = true
 		}
+	}
+	for _, ext := range queryStruct.Response.Externals {
+		for _, endpoint := range ext.Endpoints {
+			endpointsMap[endpoint.Url] = true
+		}
+	}
+	// <-- LEGACY END -->
+
+	for url := range endpointsMap {
+		endpoints = append(endpoints, types.Endpoint{
+			URL: string(url),
+		})
 	}
 	return endpoints, nil
 }

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -252,10 +252,9 @@ func (c *previewClient) ListEndpoints(ctx context.Context, previewName string) (
 	}
 
 	// @francisco - 2023//05/02
-	// The backend Endpoints field was being return empty in some older versions
-	// of the okteto api. Lets make sure we correctly resolve the endpoints from
-	// the known resources. All this below should be safe to remove in newer versions
-	// of the okteto cli
+	// The backend Endpoints field was being return empty in okteto clusters <1.9
+	// Lets make sure we correctly resolve the endpoints from the known resources
+	// All this below should be safe to remove in newer versions of the okteto cli
 	// <-- LEGACY START -->
 	for _, d := range queryStruct.Response.Deployments {
 		for _, endpoint := range d.Endpoints {

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -320,21 +320,52 @@ func TestListEndpoints(t *testing.T) {
 				client: &fakeGraphQLClient{
 					queryResult: &listPreviewEndpoints{
 						Response: previewEndpoints{
+							Endpoints: []endpointURL{
+								{Url: "https://test.test1"},
+								{Url: "https://test.test2"},
+							},
+						},
+					},
+					err: nil,
+				},
+				name: "test",
+			},
+			expected: expected{
+				response: []types.Endpoint{
+					{
+						URL: "https://test.test1",
+					},
+					{
+						URL: "https://test.test2",
+					},
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "no error legacy",
+			input: input{
+				client: &fakeGraphQLClient{
+					queryResult: &listPreviewEndpoints{
+						Response: previewEndpoints{
+							Externals: []externalEndpoints{
+								{
+									Endpoints: []endpointURL{
+										{Url: "https://test.test1"},
+									},
+								},
+							},
 							Deployments: []deploymentEndpoint{
 								{
 									Endpoints: []endpointURL{
-										{
-											Url: "https://test.test",
-										},
+										{Url: "https://test.test2"},
 									},
 								},
 							},
 							Statefulsets: []statefulsetEdnpoint{
 								{
 									Endpoints: []endpointURL{
-										{
-											Url: "https://test.test",
-										},
+										{Url: "https://test.test3"},
 									},
 								},
 							},
@@ -347,10 +378,13 @@ func TestListEndpoints(t *testing.T) {
 			expected: expected{
 				response: []types.Endpoint{
 					{
-						URL: "https://test.test",
+						URL: "https://test.test1",
 					},
 					{
-						URL: "https://test.test",
+						URL: "https://test.test2",
+					},
+					{
+						URL: "https://test.test3",
 					},
 				},
 				err: nil,
@@ -377,7 +411,9 @@ func TestListEndpoints(t *testing.T) {
 			}
 			response, err := pc.ListEndpoints(context.Background(), tc.input.name)
 			assert.ErrorIs(t, err, tc.expected.err)
-			assert.Equal(t, tc.expected.response, response)
+			for _, ep := range response {
+				assert.Contains(t, tc.expected.response, types.Endpoint{URL: ep.URL})
+			}
 		})
 	}
 }


### PR DESCRIPTION
External resources are not being listed when running: `okteto preview endpoints {name}`

Two different fixes here:

- We first try to read the `preview.Endpoints` value which is already being returned by the api and fallback to listing by resource. 
- In the fallback, we now read the `externals` value from the preview response to resolve the external resources endpoints.

Note that currently, the api is not returning correctly the endpoints in `preview.endpoints` so we'll always list endpoints from the fallback. This change goes along with an api change that takes care of correctly returning the canonical `previews.endpoints`