### PR TITLE
fix: consume envs from dependency

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -116,7 +116,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("'dependencies' is only supported in clusters that have Okteto installed")
 			}
 
-			if err := validateAndSet(options.Variables, os.Setenv); err != nil {
+			if err := validateAndSetVariables(options, os.Setenv); err != nil {
 				return err
 			}
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -116,7 +116,10 @@ func Deploy(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("'dependencies' is only supported in clusters that have Okteto installed")
 			}
 
-			if err := validateAndSetVariables(options, os.Setenv); err != nil {
+			deployVariables := getVariablesWithoutEscapedValues(options.Variables)
+
+			options.Variables = deployVariables
+			if err := validateAndSetVariablesAsEnvs(options.Variables, os.Setenv); err != nil {
 				return err
 			}
 

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -186,25 +186,22 @@ func (ld *localDeployer) deploy(ctx context.Context, deployOptions *Options) err
 
 func (ld *localDeployer) setDefaultVariables(opts *Options) {
 	for _, k := range defaultVariables {
-		if k == model.OktetoDomainEnvVar {
-			continue
-		}
-		if k == constants.KubeConfigEnvVar {
-			opts.Variables = append(opts.Variables, fmt.Sprintf("%s=%s", constants.KubeConfigEnvVar, ld.TempKubeconfigFile))
-		} else if k == model.OktetoNamespaceEnvVar {
-			opts.Variables = append(opts.Variables, fmt.Sprintf("%s=%s", model.OktetoNamespaceEnvVar, okteto.Context().Namespace))
-		} else if k == constants.OktetoAutodiscoveryReleaseName {
-			opts.Variables = append(opts.Variables, fmt.Sprintf("%s=%s", constants.OktetoAutodiscoveryReleaseName, format.ResourceK8sMetaString(opts.Name)))
-
-		} else {
+		switch k {
+		case model.OktetoDomainEnvVar:
+			if okteto.IsOkteto() {
+				opts.Variables = append(
+					opts.Variables, fmt.Sprintf("%s=%s", k, okteto.GetSubdomain()),
+				)
+			}
+		case constants.KubeConfigEnvVar:
+			opts.Variables = append(opts.Variables, fmt.Sprintf("%s=%s", k, ld.TempKubeconfigFile))
+		case model.OktetoNamespaceEnvVar:
+			opts.Variables = append(opts.Variables, fmt.Sprintf("%s=%s", k, okteto.Context().Namespace))
+		case constants.OktetoAutodiscoveryReleaseName:
+			opts.Variables = append(opts.Variables, fmt.Sprintf("%s=%s", k, format.ResourceK8sMetaString(opts.Name)))
+		default:
 			opts.Variables = append(opts.Variables, fmt.Sprintf("%s=%s", k, "true"))
 		}
-	}
-
-	if okteto.IsOkteto() {
-		opts.Variables = append(
-			opts.Variables, fmt.Sprintf("%s=%s", model.OktetoDomainEnvVar, okteto.GetSubdomain()),
-		)
 	}
 }
 

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -23,21 +23,20 @@ type envVar struct {
 	value string
 }
 
-func validateAndSetVariables(opts *Options, setEnv func(key, value string) error) error {
-	cleanEscapedVariables(opts)
-	envVars, err := parse(opts.Variables)
+func validateAndSetVariablesAsEnvs(variables []string, setEnv func(key, value string) error) error {
+	envVars, err := parse(variables)
 	if err != nil {
 		return err
 	}
 	return setOptionVarsAsEnvs(envVars, setEnv)
 }
 
-func cleanEscapedVariables(opts *Options) {
+func getVariablesWithoutEscapedValues(variables []string) []string {
 	cleanedVariables := []string{}
-	for _, v := range opts.Variables {
+	for _, v := range variables {
 		cleanedVariables = append(cleanedVariables, strings.ReplaceAll(v, "\"", ""))
 	}
-	opts.Variables = cleanedVariables
+	return cleanedVariables
 }
 
 func parse(variables []string) ([]envVar, error) {

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -23,12 +23,25 @@ type envVar struct {
 	value string
 }
 
-func validateAndSet(variables []string, setEnv func(key, value string) error) error {
-	envVars, err := parse(variables)
+func validateAndSetVariables(opts *Options, setEnv func(key, value string) error) error {
+	err := cleanEscapedVariables(opts)
+	if err != nil {
+		return err
+	}
+	envVars, err := parse(opts.Variables)
 	if err != nil {
 		return err
 	}
 	return setOptionVarsAsEnvs(envVars, setEnv)
+}
+
+func cleanEscapedVariables(opts *Options) error {
+	cleanedVariables := []string{}
+	for _, v := range opts.Variables {
+		cleanedVariables = append(cleanedVariables, strings.ReplaceAll(v, "\"", ""))
+	}
+	opts.Variables = cleanedVariables
+	return nil
 }
 
 func parse(variables []string) ([]envVar, error) {

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -24,10 +24,7 @@ type envVar struct {
 }
 
 func validateAndSetVariables(opts *Options, setEnv func(key, value string) error) error {
-	err := cleanEscapedVariables(opts)
-	if err != nil {
-		return err
-	}
+	cleanEscapedVariables(opts)
 	envVars, err := parse(opts.Variables)
 	if err != nil {
 		return err
@@ -35,13 +32,12 @@ func validateAndSetVariables(opts *Options, setEnv func(key, value string) error
 	return setOptionVarsAsEnvs(envVars, setEnv)
 }
 
-func cleanEscapedVariables(opts *Options) error {
+func cleanEscapedVariables(opts *Options) {
 	cleanedVariables := []string{}
 	for _, v := range opts.Variables {
 		cleanedVariables = append(cleanedVariables, strings.ReplaceAll(v, "\"", ""))
 	}
 	opts.Variables = cleanedVariables
-	return nil
 }
 
 func parse(variables []string) ([]envVar, error) {

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -65,12 +65,41 @@ func Test_validateAndSet(t *testing.T) {
 				return nil
 			}
 
-			opts := &Options{Variables: tt.variables}
-
-			err := validateAndSetVariables(opts, setEnvStorage)
+			err := validateAndSetVariablesAsEnvs(tt.variables, setEnvStorage)
 
 			assert.Equal(t, tt.expectedError, err)
 			assert.True(t, reflect.DeepEqual(tt.expectedEnvs, envVarStorage))
+		})
+	}
+}
+
+func Test_getVariablesWithoutEscapedValues(t *testing.T) {
+	var tests = []struct {
+		name      string
+		variables []string
+		expected  []string
+	}{
+		{
+			name:      "whitout escaped values",
+			variables: []string{"NAME=test"},
+			expected:  []string{"NAME=test"},
+		},
+		{
+			name:      "no vars to clean escaped values",
+			variables: []string{},
+			expected:  []string{},
+		},
+		{
+			name:      "clean excaped values",
+			variables: []string{"NAME=\"this is a multi word value\""},
+			expected:  []string{"NAME=this is a multi word value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getVariablesWithoutEscapedValues(tt.variables)
+			assert.ElementsMatch(t, result, tt.expected)
 		})
 	}
 }

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -65,7 +65,9 @@ func Test_validateAndSet(t *testing.T) {
 				return nil
 			}
 
-			err := validateAndSet(tt.variables, setEnvStorage)
+			opts := &Options{Variables: tt.variables}
+
+			err := validateAndSetVariables(opts, setEnvStorage)
 
 			assert.Equal(t, tt.expectedError, err)
 			assert.True(t, reflect.DeepEqual(tt.expectedEnvs, envVarStorage))

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -43,17 +43,6 @@ deploy:
 deploy:
   - kubectl apply -f k8s.yml
 `
-	oktetoManifestWithDependency = `
-deploy:
-  - kubectl create cm $OKTETO_DEPENDENCY_TEST_VARIABLE_CMNAME --from-literal=key1=$CMDATA
-dependencies:
-  test:
-    repository: https://github.com/okteto/go-getting-started
-    variables:
-      CMNAME: testName
-      CMDATA: Hello World!
-    wait: true
-`
 )
 
 // TestDeployPipelineManifest tests the following scenario:
@@ -165,40 +154,6 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
-// TestDeployPipelineAndConsumerEnvsFromDependency tests the following scenario:
-// - Deploying a dependency
-// - Consume dependency's variable from main pipeline
-func TestDeployPipelineAndConsumerEnvsFromDependency(t *testing.T) {
-	t.Parallel()
-	oktetoPath, err := integration.GetOktetoPath()
-	require.NoError(t, err)
-	dir := t.TempDir()
-
-	testNamespace := integration.GetTestNamespace("TestDeploy", user)
-	namespaceOpts := &commands.NamespaceOptions{
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-	}
-	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
-	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
-
-	require.NoError(t, createOktetoManifestWithDepedency(dir))
-
-	deployOptions := &commands.DeployOptions{
-		Workdir:      dir,
-		ManifestPath: "okteto.yml",
-		Namespace:    testNamespace,
-		OktetoHome:   dir,
-		Token:        token,
-	}
-	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
-	content, err := os.ReadFile("test.txt")
-	require.NoError(t, err)
-	require.Equal(t, content, "Hello world!")
-}
-
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {
 	dockerfilePath := filepath.Join(dir, pipelineManifestName)
 	dockerfileContent := []byte(pipelineManifest)
@@ -226,15 +181,6 @@ func createK8sManifest(dir string) error {
 	dockerfilePath := filepath.Join(dir, k8sManifestName)
 	dockerfileContent := []byte(k8sManifestTemplate)
 	if err := os.WriteFile(dockerfilePath, dockerfileContent, 0600); err != nil {
-		return err
-	}
-	return nil
-}
-
-func createOktetoManifestWithDepedency(dir string) error {
-	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-	oktetoManifestContent := []byte(oktetoManifestWithDependency)
-	if err := os.WriteFile(oktetoManifestPath, oktetoManifestContent, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -43,6 +43,17 @@ deploy:
 deploy:
   - kubectl apply -f k8s.yml
 `
+	oktetoManifestWithDependency = `
+deploy:
+  - kubectl create cm $OKTETO_DEPENDENCY_TEST_VARIABLE_CMNAME --from-literal=key1=$CMDATA
+dependencies:
+  test:
+    repository: https://github.com/okteto/go-getting-started
+    variables:
+      CMNAME: testName
+      CMDATA: Hello World!
+    wait: true
+`
 )
 
 // TestDeployPipelineManifest tests the following scenario:
@@ -154,6 +165,40 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
+// TestDeployPipelineAndConsumerEnvsFromDependency tests the following scenario:
+// - Deploying a dependency
+// - Consume dependency's variable from main pipeline
+func TestDeployPipelineAndConsumerEnvsFromDependency(t *testing.T) {
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+	dir := t.TempDir()
+
+	testNamespace := integration.GetTestNamespace("TestDeploy", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+
+	require.NoError(t, createOktetoManifestWithDepedency(dir))
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:      dir,
+		ManifestPath: "okteto.yml",
+		Namespace:    testNamespace,
+		OktetoHome:   dir,
+		Token:        token,
+	}
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+	content, err := os.ReadFile("test.txt")
+	require.NoError(t, err)
+	require.Equal(t, content, "Hello world!")
+}
+
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {
 	dockerfilePath := filepath.Join(dir, pipelineManifestName)
 	dockerfileContent := []byte(pipelineManifest)
@@ -181,6 +226,15 @@ func createK8sManifest(dir string) error {
 	dockerfilePath := filepath.Join(dir, k8sManifestName)
 	dockerfileContent := []byte(k8sManifestTemplate)
 	if err := os.WriteFile(dockerfilePath, dockerfileContent, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createOktetoManifestWithDepedency(dir string) error {
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	oktetoManifestContent := []byte(oktetoManifestWithDependency)
+	if err := os.WriteFile(oktetoManifestPath, oktetoManifestContent, 0600); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
# Proposed changes
- remove default variables to be pushed as `OKTETO_DEPENDENCY` vars into the config map
- add unit test
- add e2e test covering the following scenarios:
  - consume as env a value coming from dependency variable
  - consume as env a value coming from dependency `OKTETO_ENV`

In order to be able to pass the e2e test, we need first of all to have an installer with these changes and [this fix](https://github.com/okteto/pipeline-installer-image/pull/94)
