### PR TITLE
e2e for consuming envs from dependency

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -116,7 +116,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("'dependencies' is only supported in clusters that have Okteto installed")
 			}
 
-			if err := validateAndSet(options.Variables, os.Setenv); err != nil {
+			if err := validateAndSetVariables(options, os.Setenv); err != nil {
 				return err
 			}
 

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -23,12 +23,25 @@ type envVar struct {
 	value string
 }
 
-func validateAndSet(variables []string, setEnv func(key, value string) error) error {
-	envVars, err := parse(variables)
+func validateAndSetVariables(opts *Options, setEnv func(key, value string) error) error {
+	err := cleanEscapedVariables(opts)
+	if err != nil {
+		return err
+	}
+	envVars, err := parse(opts.Variables)
 	if err != nil {
 		return err
 	}
 	return setOptionVarsAsEnvs(envVars, setEnv)
+}
+
+func cleanEscapedVariables(opts *Options) error {
+	cleanedVariables := []string{}
+	for _, v := range opts.Variables {
+		cleanedVariables = append(cleanedVariables, strings.ReplaceAll(v, "\"", ""))
+	}
+	opts.Variables = cleanedVariables
+	return nil
 }
 
 func parse(variables []string) ([]envVar, error) {

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -24,10 +24,7 @@ type envVar struct {
 }
 
 func validateAndSetVariables(opts *Options, setEnv func(key, value string) error) error {
-	err := cleanEscapedVariables(opts)
-	if err != nil {
-		return err
-	}
+	cleanEscapedVariables(opts)
 	envVars, err := parse(opts.Variables)
 	if err != nil {
 		return err
@@ -35,13 +32,12 @@ func validateAndSetVariables(opts *Options, setEnv func(key, value string) error
 	return setOptionVarsAsEnvs(envVars, setEnv)
 }
 
-func cleanEscapedVariables(opts *Options) error {
+func cleanEscapedVariables(opts *Options) {
 	cleanedVariables := []string{}
 	for _, v := range opts.Variables {
 		cleanedVariables = append(cleanedVariables, strings.ReplaceAll(v, "\"", ""))
 	}
 	opts.Variables = cleanedVariables
-	return nil
 }
 
 func parse(variables []string) ([]envVar, error) {

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -65,7 +65,9 @@ func Test_validateAndSet(t *testing.T) {
 				return nil
 			}
 
-			err := validateAndSet(tt.variables, setEnvStorage)
+			opts := &Options{Variables: tt.variables}
+
+			err := validateAndSetVariables(opts, setEnvStorage)
 
 			assert.Equal(t, tt.expectedError, err)
 			assert.True(t, reflect.DeepEqual(tt.expectedEnvs, envVarStorage))

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -43,6 +43,17 @@ deploy:
 deploy:
   - kubectl apply -f k8s.yml
 `
+	oktetoManifestWithDependency = `
+deploy:
+  - kubectl create cm $OKTETO_DEPENDENCY_TEST_VARIABLE_CMNAME --from-literal=key1=$CMDATA
+dependencies:
+  test:
+    repository: https://github.com/okteto/go-getting-started
+    variables:
+      CMNAME: testName
+      CMDATA: Hello World!
+    wait: true
+`
 )
 
 // TestDeployPipelineManifest tests the following scenario:
@@ -154,6 +165,40 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
+// TestDeployPipelineAndConsumerEnvsFromDependency tests the following scenario:
+// - Deploying a dependency
+// - Consume dependency's variable from main pipeline
+func TestDeployPipelineAndConsumerEnvsFromDependency(t *testing.T) {
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+	dir := t.TempDir()
+
+	testNamespace := integration.GetTestNamespace("TestDeploy", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+
+	require.NoError(t, createOktetoManifestWithDepedency(dir))
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:      dir,
+		ManifestPath: "okteto.yml",
+		Namespace:    testNamespace,
+		OktetoHome:   dir,
+		Token:        token,
+	}
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+	content, err := os.ReadFile("test.txt")
+	require.NoError(t, err)
+	require.Equal(t, content, "Hello world!")
+}
+
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {
 	dockerfilePath := filepath.Join(dir, pipelineManifestName)
 	dockerfileContent := []byte(pipelineManifest)
@@ -181,6 +226,15 @@ func createK8sManifest(dir string) error {
 	dockerfilePath := filepath.Join(dir, k8sManifestName)
 	dockerfileContent := []byte(k8sManifestTemplate)
 	if err := os.WriteFile(dockerfilePath, dockerfileContent, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createOktetoManifestWithDepedency(dir string) error {
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	oktetoManifestContent := []byte(oktetoManifestWithDependency)
+	if err := os.WriteFile(oktetoManifestPath, oktetoManifestContent, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -45,13 +45,13 @@ deploy:
 `
 	oktetoManifestWithDependency = `
 deploy:
-  - kubectl create cm $OKTETO_DEPENDENCY_TEST_VARIABLE_CMNAME --from-literal=key1=$CMDATA
+  - kubectl create cm $OKTETO_DEPENDENCY_TEST_VARIABLE_CMNAME --from-literal=key1="$OKTETO_DEPENDENCY_TEST_VARIABLE_MY_DYNAMIC_APP_ENV"
 dependencies:
   test:
     repository: https://github.com/okteto/go-getting-started
+    branch: generating-dynamic-envs
     variables:
-      CMNAME: testName
-      CMDATA: Hello World!
+      CMNAME: test
     wait: true
 `
 )
@@ -181,7 +181,7 @@ func TestDeployPipelineAndConsumerEnvsFromDependency(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	require.NoError(t, createOktetoManifestWithDepedency(dir))
@@ -194,9 +194,7 @@ func TestDeployPipelineAndConsumerEnvsFromDependency(t *testing.T) {
 		Token:        token,
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
-	content, err := os.ReadFile("test.txt")
 	require.NoError(t, err)
-	require.Equal(t, content, "Hello world!")
 }
 
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {

--- a/integration/okteto/pipeline_test.go
+++ b/integration/okteto/pipeline_test.go
@@ -98,7 +98,7 @@ func TestDeployPipelineAndConsumerEnvsFromDependency(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	require.NoError(t, createOktetoManifestWithDepedency(dir))


### PR DESCRIPTION
# Proposed changes
- add e2e for -> https://github.com/okteto/okteto/pull/3593

e2e test requires a new installer version so it will not pass until https://github.com/okteto/okteto/pull/3593 generates a new installer version 

**ignore any changes that are not related to the e2e test. The other changes are reviewed in: https://github.com/okteto/okteto/pull/3593**