### PR TITLE
Modify okteto  ns create command to prevent selecting the  new namespace as current namespace

### DIFF
--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -30,6 +30,7 @@ type ContextOptions struct {
 	OnlyOkteto            bool
 	Show                  bool
 	Save                  bool
+	SetCurrentNs          bool
 	IsCtxCommand          bool
 	CheckNamespaceAccess  bool
 	IsOkteto              bool


### PR DESCRIPTION
# Proposed changes

Fixes #3579

![image](https://github.com/okteto/okteto/assets/86051118/821d9fd0-327d-4672-bd86-2d9c9e383989)


