### PR TITLE
Remove behaviour of setting service replicas one, if deployment replicas is zero

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -96,8 +96,6 @@ func (tr *Translation) translate() error {
 	} else {
 		if tr.Dev.Replicas != nil {
 			tr.DevApp.SetReplicas(int32(*tr.Dev.Replicas))
-		} else if tr.DevApp.Replicas() == 0 {
-			tr.DevApp.SetReplicas(1)
 		}
 
 		tr.DevApp.TemplateObjectMeta().Labels[model.DetachedDevLabel] = tr.getDevName()

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -700,7 +700,7 @@ services:
 	// checking dev d2 state
 
 	// There should be one replica if Deployment replicas are zero and replicas not specified in manifest
-	if tr2.DevApp.Replicas() != 1 {
+	if tr2.DevApp.Replicas() != 0 {
 		t.Fatalf("dev d2 is running %d replicas", tr2.DevApp.Replicas())
 	}
 

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -699,7 +699,7 @@ services:
 
 	// checking dev d2 state
 
-	// There should be one replica if Deployment replicas are zero and replicas not specified in manifest
+	// There should be zero replica if Deployment replicas are zero and replicas not specified in manifest
 	if tr2.DevApp.Replicas() != 0 {
 		t.Fatalf("dev d2 is running %d replicas", tr2.DevApp.Replicas())
 	}


### PR DESCRIPTION
Currently if the original deployment replicas is zero, service replicas are automatically setting to one. We want to remove this behaviour as per this discussion.
https://github.com/okteto/docs/pull/391#discussion_r1187205934
