### PR TITLE
Okteto deploy with only dependencies

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -275,10 +275,10 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	oktetoLog.Debug("found okteto manifest")
 	dc.PipelineType = deployOptions.Manifest.Type
 
-	if deployOptions.Manifest.Deploy == nil {
-		return oktetoErrors.ErrManifestFoundButNoDeployCommands
+	if deployOptions.Manifest.Deploy == nil && deployOptions.Manifest.Dependencies == nil {
+		return oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands
 	}
-	if len(deployOptions.servicesToDeploy) > 0 && deployOptions.Manifest.Deploy.ComposeSection == nil {
+	if len(deployOptions.servicesToDeploy) > 0 && deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection == nil {
 		return oktetoErrors.ErrDeployCantDeploySvcsIfNotCompose
 	}
 
@@ -310,7 +310,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		Icon:       deployOptions.Manifest.Icon,
 	}
 
-	if !deployOptions.Manifest.IsV2 && deployOptions.Manifest.Type == model.StackType {
+	if !deployOptions.Manifest.IsV2 && deployOptions.Manifest.Type == model.StackType && deployOptions.Manifest.Deploy != nil {
 		data.Manifest = deployOptions.Manifest.Deploy.ComposeSection.Stack.Manifest
 	}
 
@@ -326,6 +326,10 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 			return errStatus
 		}
 		return err
+	}
+
+	if deployOptions.Manifest.Deploy == nil {
+		return nil
 	}
 
 	if err := buildImages(ctx, dc.Builder.Build, dc.Builder.GetServicesToBuild, deployOptions); err != nil {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -136,6 +136,25 @@ var fakeManifest *model.Manifest = &model.Manifest{
 	},
 }
 
+var fakeManifestWithDependency *model.Manifest = &model.Manifest{
+	Dependencies: model.ManifestDependencies{
+		"a": &model.Dependency{
+			Namespace: "b",
+		},
+		"b": &model.Dependency{},
+	},
+}
+
+var noDeployNorDependenciesManifest *model.Manifest = &model.Manifest{
+	Name: "testManifest",
+	Build: model.ManifestBuild{
+		"service1": &model.BuildInfo{
+			Dockerfile: "Dockerfile",
+			Image:      "testImage",
+		},
+	},
+}
+
 type fakeProxy struct {
 	errOnShutdown error
 	port          int
@@ -264,6 +283,45 @@ func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 	}
 	c := &DeployCommand{
 		GetManifest: getManifestWithError,
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+			return &localDeployer{
+				Proxy:      p,
+				Executor:   e,
+				Kubeconfig: &fakeKubeConfig{},
+				Fs:         afero.NewMemMapFs(),
+			}, nil
+		},
+		K8sClientProvider: test.NewFakeK8sProvider(),
+	}
+	ctx := context.Background()
+	opts := &Options{
+		Name:         "movies",
+		ManifestPath: "",
+		Variables:    []string{},
+	}
+
+	err := c.RunDeploy(ctx, opts)
+
+	assert.Error(t, err)
+	// No command was executed
+	assert.Len(t, e.executed, 0)
+	// Proxy wasn't started
+	assert.False(t, p.started)
+}
+
+func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
+	p := &fakeProxy{}
+	e := &fakeExecutor{}
+	okteto.CurrentStore = &okteto.OktetoContextStore{
+		Contexts: map[string]*okteto.OktetoContext{
+			"test": {
+				Namespace: "test",
+			},
+		},
+		CurrentContext: "test",
+	}
+	c := &DeployCommand{
+		GetManifest: getManifestWithNoDeployNorDependency,
 		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:      p,
@@ -649,10 +707,17 @@ func getFakeManifest(_ string) (*model.Manifest, error) {
 	return fakeManifest, nil
 }
 
+func getFakeManifestWithDependency(_ string) (*model.Manifest, error) {
+	return fakeManifestWithDependency, nil
+}
+
 func getErrorManifest(_ string) (*model.Manifest, error) {
 	return errorManifest, nil
 }
 
+func getManifestWithNoDeployNorDependency(_ string) (*model.Manifest, error) {
+	return noDeployNorDependenciesManifest, nil
+}
 func TestBuildImages(t *testing.T) {
 	testCases := []struct {
 		name                 string
@@ -973,4 +1038,59 @@ func TestDeployDependencies(t *testing.T) {
 			assert.ErrorIs(t, tc.expected, dc.deployDependencies(context.Background(), &Options{Manifest: fakeManifest}))
 		})
 	}
+}
+
+func TestDeployOnlyDependencies(t *testing.T) {
+	p := &fakeProxy{}
+	e := &fakeExecutor{}
+	okteto.CurrentStore = &okteto.OktetoContextStore{
+		Contexts: map[string]*okteto.OktetoContext{
+			"test": {
+				Namespace: "test",
+			},
+		},
+		CurrentContext: "test",
+	}
+	deployment := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				model.DeployedByLabel: "movies",
+			},
+			Namespace: "test",
+		},
+	}
+
+	cp := fakeExternalControlProvider{
+		control: &fakeExternalControl{},
+	}
+	clientProvider := test.NewFakeK8sProvider(deployment)
+	c := &DeployCommand{
+		PipelineCMD:        fakePipelineDeployer{nil},
+		GetManifest:        getFakeManifestWithDependency,
+		K8sClientProvider:  clientProvider,
+		GetExternalControl: cp.getFakeExternalControl,
+		Fs:                 afero.NewMemMapFs(),
+		CfgMapHandler:      newDefaultConfigMapHandler(clientProvider),
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+			return &localDeployer{
+				Proxy:              p,
+				Executor:           e,
+				Kubeconfig:         &fakeKubeConfig{},
+				ConfigMapHandler:   &fakeCmapHandler{},
+				K8sClientProvider:  clientProvider,
+				GetExternalControl: cp.getFakeExternalControl,
+				Fs:                 afero.NewMemMapFs(),
+			}, nil
+		},
+	}
+	ctx := context.Background()
+	opts := &Options{
+		Name:         "movies",
+		ManifestPath: "",
+		Variables:    []string{},
+	}
+
+	err := c.RunDeploy(ctx, opts)
+
+	assert.NoError(t, err)
 }

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -38,11 +38,15 @@ func Delete(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a namespace",
-		Args:  utils.ExactArgsAccepted(1, ""),
+		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nsToDelete := args[0]
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
 				return err
+			}
+
+			nsToDelete := okteto.Context().Namespace
+			if len(args) > 0 {
+				nsToDelete = args[0]
 			}
 
 			if !okteto.IsOkteto() {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -143,6 +143,9 @@ var (
 	// ErrManifestFoundButNoDeployCommands raised when a manifest is found but no deploy commands are defined
 	ErrManifestFoundButNoDeployCommands = errors.New("found okteto manifest, but no deploy commands where defined")
 
+	// ErrManifestFoundButNoDeployAndDependenciesCommands raised when a manifest is found but no deploy or dependencies commands are defined
+	ErrManifestFoundButNoDeployAndDependenciesCommands = errors.New("found okteto manifest, but no deploy or dependencies commands were defined")
+
 	// ErrDeployCantDeploySvcsIfNotCompose raised when a manifest is found but no compose info is detected and args are passed to deploy command
 	ErrDeployCantDeploySvcsIfNotCompose = errors.New("services args are can only be used while trying to deploy a compose")
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -1042,7 +1042,7 @@ func (d *ManifestDevs) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func isManifestFieldNotFound(err error) bool {
-	manifestFields := []string{"devs", "dev", "name", "icon", "variables", "deploy", "destroy", "build", "namespace", "context"}
+	manifestFields := []string{"devs", "dev", "name", "icon", "variables", "deploy", "destroy", "build", "namespace", "context", "dependencies"}
 	for _, field := range manifestFields {
 		if strings.Contains(err.Error(), fmt.Sprintf("field %s not found", field)) {
 			return true


### PR DESCRIPTION
# Proposed changes

Fixes #3364

Okteto deploy fails if manifest only has dependencies section. This PR makes changes so that it does not fail.
