### PR TITLE
feat: add label flag to deploy preview command

### DIFF
--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -49,6 +49,7 @@ type DeployOptions struct {
 	timeout            time.Duration
 	variables          []string
 	wait               bool
+	labels             []string
 }
 
 // Deploy Deploy a preview environment
@@ -92,6 +93,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a preview environment variable (can be set more than once)")
 	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", false, "wait until the preview environment deployment finishes (defaults to false)")
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "relative path within the repository to the okteto manifest (default to okteto.yaml or .okteto/okteto.yaml)")
+	cmd.Flags().StringArrayVarP(&opts.labels, "label", "l", []string{}, "set a preview environment label (can be set more than once)")
 
 	cmd.Flags().StringVarP(&opts.deprecatedFilename, "filename", "", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
 	if err := cmd.Flags().MarkHidden("filename"); err != nil {
@@ -137,7 +139,7 @@ func (pw *Command) deployPreview(ctx context.Context, opts *DeployOptions) (*typ
 		})
 	}
 
-	return pw.okClient.Previews().DeployPreview(ctx, opts.name, opts.scope, opts.repository, opts.branch, opts.sourceUrl, opts.file, varList)
+	return pw.okClient.Previews().DeployPreview(ctx, opts.name, opts.scope, opts.repository, opts.branch, opts.sourceUrl, opts.file, varList, opts.labels)
 }
 
 func (pw *Command) waitUntilRunning(ctx context.Context, name, namespace string, a *types.Action, timeout time.Duration) error {

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -46,6 +46,9 @@ func (fc fakeGraphQLClient) Query(ctx context.Context, q interface{}, _ map[stri
 }
 func (fc fakeGraphQLClient) Mutate(ctx context.Context, m interface{}, _ map[string]interface{}) error {
 	if fc.mutationResult != nil {
+		if isAnInterface(m) {
+			m = reflect.ValueOf(m).Elem().Interface()
+		}
 		entityType := reflect.TypeOf(m).Elem()
 		for i := 0; i < entityType.NumField(); i++ {
 			value := entityType.Field(i)
@@ -55,6 +58,10 @@ func (fc fakeGraphQLClient) Mutate(ctx context.Context, m interface{}, _ map[str
 		}
 	}
 	return fc.err
+}
+
+func isAnInterface(m interface{}) bool {
+	return reflect.TypeOf(m).Kind() == reflect.Ptr && reflect.TypeOf(m).Elem().Kind() == reflect.Interface
 }
 
 type fakeGraphQLMultipleCallsClient struct {

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -28,6 +28,7 @@ func TestDeployPreview(t *testing.T) {
 		client    *fakeGraphQLClient
 		name      string
 		variables []types.Variable
+		labels    []string
 	}
 	type expected struct {
 		response *types.PreviewResponse
@@ -166,6 +167,40 @@ func TestDeployPreview(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "with labels - no error",
+			input: input{
+				client: &fakeGraphQLClient{
+					mutationResult: &deployPreviewMutation{
+						Response: deployPreviewResponse{
+							Id: "test",
+							Action: actionStruct{
+								Id:     "test",
+								Name:   "test",
+								Status: ProgressingStatus,
+							},
+						},
+					},
+					err: nil,
+				},
+				name:      "test",
+				variables: []types.Variable{},
+				labels:    []string{"value", "key"},
+			},
+			expected: expected{
+				response: &types.PreviewResponse{
+					Action: &types.Action{
+						ID:     "test",
+						Name:   "test",
+						Status: progressingStatus,
+					},
+					Preview: &types.Preview{
+						ID: "test",
+					},
+				},
+				err: nil,
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -173,7 +208,7 @@ func TestDeployPreview(t *testing.T) {
 				client:             tc.input.client,
 				namespaceValidator: newNamespaceValidator(),
 			}
-			response, err := pc.DeployPreview(context.Background(), tc.input.name, "", "", "", "", "", tc.input.variables)
+			response, err := pc.DeployPreview(context.Background(), tc.input.name, "", "", "", "", "", tc.input.variables, tc.input.labels)
 			assert.ErrorIs(t, err, tc.expected.err)
 			assert.Equal(t, tc.expected.response, response)
 		})

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -46,7 +46,7 @@ type NamespaceInterface interface {
 // PreviewInterface represents the client that connects to the preview functions
 type PreviewInterface interface {
 	List(ctx context.Context) ([]Preview, error)
-	DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []Variable) (*PreviewResponse, error)
+	DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []Variable, labels []string) (*PreviewResponse, error)
 	GetResourcesStatus(ctx context.Context, previewName, devName string) (map[string]string, error)
 	Destroy(ctx context.Context, previewName string) error
 	ListEndpoints(ctx context.Context, previewName string) ([]Endpoint, error)


### PR DESCRIPTION
# Proposed changes

Fixes #3607

- Add a `label` flag to deploy command to deploy a preview environment using the labels passed
- Refactor the deploy preview graphql code so it's more readable
