### PR TITLE
Change value for OktetoPipelineRunnerImage

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -60,7 +60,7 @@ const (
 	OktetoCLIImageForRemoteTemplate = "okteto/okteto:%s"
 
 	// OktetoPipelineRunnerImage defines image to use for remote deployments if empty
-	OktetoPipelineRunnerImage = "okteto/installer:1.8.9"
+	OktetoPipelineRunnerImage = "okteto/pipeline-runner:1.0.1"
 
 	// OktetoEnvFile defines the name for okteto env file
 	OktetoEnvFile = "OKTETO_ENV"


### PR DESCRIPTION
Related to https://github.com/okteto/app/issues/6395. 

# Proposed changes

Default OktetoPipelineRunnerImage was using the installer image instead of the pipeline runner image.
This fixes the default value.

