### PR TITLE
feat: add server name flag

### DIFF
--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -40,6 +40,9 @@ To set your default context, run the ` + "`okteto context`" + ` command:
 This will prompt you to select one of your existing contexts or to create a new one.
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// TODO @jpf-okteto: Context().PersistentPreRun overrides Context().Root().PersistentPreRun()
+			// https://github.com/okteto/okteto/issues/3617
+			cmd.Root().PersistentPreRun(cmd, args)
 			okteto.SetInsecureSkipTLSVerifyPolicy(ctxOptions.InsecureSkipTlsVerify)
 		},
 		RunE: Use().RunE,

--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func main() {
 	oktetoLog.Init(logrus.WarnLevel)
 	var logLevel string
 	var outputMode string
+	var serverNameOverride string
 
 	if err := analytics.Init(); err != nil {
 		oktetoLog.Infof("error initializing okteto analytics: %s", err)
@@ -103,6 +104,7 @@ func main() {
 			ccmd.SilenceUsage = true
 			oktetoLog.SetLevel(logLevel)
 			oktetoLog.SetOutputFormat(outputMode)
+			okteto.SetServerNameOverride(serverNameOverride)
 			oktetoLog.Infof("started %s", strings.Join(os.Args, " "))
 		},
 		PersistentPostRun: func(ccmd *cobra.Command, args []string) {
@@ -112,6 +114,9 @@ func main() {
 
 	root.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "warn", "amount of information outputted (debug, info, warn, error)")
 	root.PersistentFlags().StringVar(&outputMode, "log-output", oktetoLog.TTYFormat, "output format for logs (tty, plain, json)")
+
+	root.PersistentFlags().StringVarP(&serverNameOverride, "server-name", "s", "", "The address and port of the Okteto Ingress server")
+	_ = root.PersistentFlags().MarkHidden("server-name")
 
 	root.AddCommand(cmd.Analytics())
 	root.AddCommand(cmd.Version())

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -1,13 +1,12 @@
 package http
 
 import (
-	"crypto/x509"
 	"net/http"
 )
 
 // StrictSSLHTTPClient receives multiple *x509.Certificate and returns an *http.Client with a StrictSSLTransport
-func StrictSSLHTTPClient(certs ...*x509.Certificate) *http.Client {
-	transport := StrictSSLTransport(certs...)
+func StrictSSLHTTPClient(opts *SSLTransportOption) *http.Client {
+	transport := StrictSSLTransport(opts)
 
 	return &http.Client{
 		Transport: transport,

--- a/pkg/http/intercept.go
+++ b/pkg/http/intercept.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"net"
+	"net/url"
+)
+
+type Intercept map[string]struct{}
+
+func (i Intercept) ShouldInterceptAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	_, ok := i[host]
+	return ok
+}
+
+func (i Intercept) AppendURLs(urls ...string) {
+	for _, u := range urls {
+		up, err := url.Parse(u)
+		if err != nil {
+			continue
+		}
+		if up.Hostname() == "" {
+			continue
+		}
+		i[up.Hostname()] = struct{}{}
+	}
+}

--- a/pkg/http/intercept_test.go
+++ b/pkg/http/intercept_test.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInterceptAppend(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name: "nothing",
+		},
+		{
+			name:     "single item",
+			input:    []string{"https://example.com"},
+			expected: []string{"example.com"},
+		},
+		{
+			name:     "multiple items",
+			input:    []string{"https://example.com", "https://foo.dev"},
+			expected: []string{"example.com", "foo.dev"},
+		},
+		{
+			name:     "repeated items",
+			input:    []string{"https://example.com/alice", "https://foo.dev", "https://example.com/bob"},
+			expected: []string{"example.com", "foo.dev"},
+		},
+		{
+			name:     "multiple items",
+			input:    []string{"https://example.com", "https://foo.dev"},
+			expected: []string{"example.com", "foo.dev"},
+		},
+		{
+			name:     "an invalid item",
+			input:    []string{"https://example.com", "oneTwOthReE", "https://foo.dev"},
+			expected: []string{"example.com", "foo.dev"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := Intercept{}
+			i.AppendURLs(tt.input...)
+
+			r := []string{}
+			for k, _ := range i {
+				r = append(r, k)
+			}
+			assert.ElementsMatch(t, tt.expected, r)
+		})
+	}
+}
+
+func TestInterceptMatch(t *testing.T) {
+	tests := []struct {
+		name      string
+		bootstrap []string
+		expected  map[string]bool
+	}{
+		{
+			name:      "multiple items",
+			bootstrap: []string{"https://example.com", "https://foo.dev"},
+			expected:  map[string]bool{"example.com:443": true, "foo.dev:443": true, "foo.dev:445": true, "missing.port": false, "other.com:443": false},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := Intercept{}
+			i.AppendURLs(tt.bootstrap...)
+
+			for k, v := range tt.expected {
+				assert.Equal(t, v, i.ShouldInterceptAddr(k), k)
+			}
+		})
+	}
+}

--- a/pkg/http/options.go
+++ b/pkg/http/options.go
@@ -1,0 +1,9 @@
+package http
+
+import "crypto/x509"
+
+type SSLTransportOption struct {
+	Certs           []*x509.Certificate
+	ServerName      string
+	URLsToIntercept []string
+}

--- a/pkg/okteto/config.go
+++ b/pkg/okteto/config.go
@@ -25,3 +25,4 @@ func (Config) GetUserID() string                                 { return Contex
 func (Config) GetToken() string                                  { return Context().Token }
 func (Config) GetContextCertificate() (*x509.Certificate, error) { return GetContextCertificate() }
 func (Config) IsInsecureSkipTLSVerifyPolicy() bool               { return Context().IsInsecure }
+func (Config) GetServerNameOverride() string                     { return GetServerNameOverride() }

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -67,6 +67,7 @@ type fakeClientConfig struct {
 	token       string
 	isInsecure  bool
 	cert        *x509.Certificate
+	serverName  string
 }
 
 func (f fakeClientConfig) GetRegistryURL() string                            { return f.registryURL }
@@ -74,6 +75,7 @@ func (f fakeClientConfig) GetUserID() string                                 { r
 func (f fakeClientConfig) GetToken() string                                  { return f.token }
 func (f fakeClientConfig) IsInsecureSkipTLSVerifyPolicy() bool               { return f.isInsecure }
 func (f fakeClientConfig) GetContextCertificate() (*x509.Certificate, error) { return f.cert, nil }
+func (f fakeClientConfig) GetServerNameOverride() string                     { return f.serverName }
 
 func TestGetDigest(t *testing.T) {
 	unautorizedErr := &transport.Error{

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -33,6 +33,7 @@ type configInterface interface {
 	GetToken() string
 	IsInsecureSkipTLSVerifyPolicy() bool
 	GetContextCertificate() (*x509.Certificate, error)
+	GetServerNameOverride() string
 }
 
 type registryConfig interface {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -31,6 +31,7 @@ type FakeConfig struct {
 	Token                       string
 	InsecureSkipTLSVerifyPolicy bool
 	ContextCertificate          *x509.Certificate
+	ServerName                  string
 }
 
 func (fc FakeConfig) IsOktetoCluster() bool               { return fc.IsOktetoClusterCfg }
@@ -43,6 +44,7 @@ func (fc FakeConfig) IsInsecureSkipTLSVerifyPolicy() bool { return fc.InsecureSk
 func (fc FakeConfig) GetContextCertificate() (*x509.Certificate, error) {
 	return fc.ContextCertificate, nil
 }
+func (fc FakeConfig) GetServerNameOverride() string { return fc.ServerName }
 
 func TestGetImageTagWithDigest(t *testing.T) {
 	type expected struct {


### PR DESCRIPTION
This PR adds a new global flag `--server-name`/`-s` which overrides Okteto API / Okteto Registry address.

The flag accepts a hostname or IP and a port separated by `:`.

Resolves:
- https://github.com/okteto/app/issues/6455

Tests:
- incluster with okteto/go-getting-started:
  - `namespace list`
  - `context`
  - `deploy -s internal-ip:443`
    - not including buildkit endpoint override

Tech debt:
- https://github.com/okteto/okteto/issues/3617