### PR TITLE
remove server-name shorthand

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 	root.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "warn", "amount of information outputted (debug, info, warn, error)")
 	root.PersistentFlags().StringVar(&outputMode, "log-output", oktetoLog.TTYFormat, "output format for logs (tty, plain, json)")
 
-	root.PersistentFlags().StringVarP(&serverNameOverride, "server-name", "s", "", "The address and port of the Okteto Ingress server")
+	root.PersistentFlags().StringVarP(&serverNameOverride, "server-name", "", "", "The address and port of the Okteto Ingress server")
 	_ = root.PersistentFlags().MarkHidden("server-name")
 
 	root.AddCommand(cmd.Analytics())


### PR DESCRIPTION
# Proposed changes

Fix issue with flag shorthand overlapping `-s`

```
/usr/local/bin/okteto preview deploy previewactions-linux-1684177360-cindylopez --scope personal --branch master --repository https://github.com/okteto/movies --wait: panic: unable to redefine 's' shorthand in "deploy" flagset: it's already used for "scope" flag
```

This is due to a new flag introduced with this PR: https://github.com/okteto/okteto/pull/3618

I am removing the new shorthand for the new flag, because `scope` is already using `-s`