### PR TITLE
Use chart runner and installer images for remote deploy/destroy

### DIFF
--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -38,13 +38,6 @@ const (
 )
 
 func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Options, cwd string, c kubernetes.Interface) error {
-	if deployOptions.RunInRemote {
-		if deployOptions.Manifest.Deploy != nil {
-			if deployOptions.Manifest.Deploy.Image == "" {
-				deployOptions.Manifest.Deploy.Image = constants.OktetoPipelineRunnerImage
-			}
-		}
-	}
 
 	if deployOptions.Manifest.Context == "" {
 		deployOptions.Manifest.Context = okteto.Context().Name

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -516,9 +516,9 @@ func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, c
 		err      error
 	)
 
-	isRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
+	isDeployRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
 
-	if isRemote || manifest.Deploy.Image == "" {
+	if isDeployRemote || manifest.Deploy.Image == "" {
 		deployer, err = newLocalDeployer(ctx, cwd, opts, cmapHandler)
 		if err != nil {
 			return nil, fmt.Errorf("could not initialize local deploy command: %w", err)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -83,7 +83,7 @@ type DeployCommand struct {
 	K8sClientProvider  okteto.K8sClientProvider
 	Builder            *buildv2.OktetoBuilder
 	GetExternalControl func(cfg *rest.Config) ExternalResourceInterface
-	GetDeployer        func(context.Context, *model.Manifest, *Options, string, *buildv2.OktetoBuilder, configMapHandler) (deployerInterface, error)
+	GetDeployer        func(context.Context, *model.Manifest, *Options, *buildv2.OktetoBuilder, configMapHandler) (deployerInterface, error)
 	EndpointGetter     func() (EndpointGetter, error)
 	DeployWaiter       DeployWaiter
 	CfgMapHandler      configMapHandler
@@ -243,7 +243,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				oktetoLog.StartSpinner()
 				defer oktetoLog.StopSpinner()
 
-				deployer, err := c.GetDeployer(ctx, options.Manifest, options, "", nil, nil)
+				deployer, err := c.GetDeployer(ctx, options.Manifest, options, nil, nil)
 				if err != nil {
 					return err
 				}
@@ -347,7 +347,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		oktetoLog.Infof("failed to recreate failed pods: %s", err.Error())
 	}
 
-	deployer, err := dc.GetDeployer(ctx, deployOptions.Manifest, deployOptions, cwd, dc.Builder, dc.CfgMapHandler)
+	deployer, err := dc.GetDeployer(ctx, deployOptions.Manifest, deployOptions, dc.Builder, dc.CfgMapHandler)
 	if err != nil {
 		return err
 	}
@@ -510,7 +510,7 @@ func getDefaultTimeout() time.Duration {
 	return parsed
 }
 
-func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, cwd string, builder *buildv2.OktetoBuilder, cmapHandler configMapHandler) (deployerInterface, error) {
+func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, builder *buildv2.OktetoBuilder, cmapHandler configMapHandler) (deployerInterface, error) {
 
 	// isDeployRemote represents wheather the process is comming from a remote deploy
 	// if true it should get the local deployer
@@ -526,7 +526,7 @@ func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, c
 	// run local
 	oktetoLog.Info("Deploying locally...")
 
-	deployer, err := newLocalDeployer(ctx, cwd, opts, cmapHandler)
+	deployer, err := newLocalDeployer(ctx, opts, cmapHandler)
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize local deploy command: %w", err)
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -518,7 +518,7 @@ func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, c
 
 	isDeployRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
 
-	if isDeployRemote || manifest.Deploy.Image == "" {
+	if isDeployRemote || !opts.RunInRemote {
 		deployer, err = newLocalDeployer(ctx, cwd, opts, cmapHandler)
 		if err != nil {
 			return nil, fmt.Errorf("could not initialize local deploy command: %w", err)

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -322,7 +322,7 @@ func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
 	}
 	c := &DeployCommand{
 		GetManifest: getManifestWithNoDeployNorDependency,
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:      p,
 				Executor:   e,
@@ -1083,7 +1083,7 @@ func TestDeployOnlyDependencies(t *testing.T) {
 		GetExternalControl: cp.getFakeExternalControl,
 		Fs:                 afero.NewMemMapFs(),
 		CfgMapHandler:      newDefaultConfigMapHandler(clientProvider),
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:              p,
 				Executor:           e,

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -283,7 +283,7 @@ func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 	}
 	c := &DeployCommand{
 		GetManifest: getManifestWithError,
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:      p,
 				Executor:   e,
@@ -366,7 +366,7 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 	builder := test.NewFakeOktetoBuilder(registry)
 	c := &DeployCommand{
 		GetManifest: getErrorManifest,
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:             p,
 				Executor:          e,
@@ -441,7 +441,7 @@ func TestDeployWithErrorExecutingCommands(t *testing.T) {
 	}
 	c := &DeployCommand{
 		GetManifest: getFakeManifest,
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:             p,
 				Executor:          e,
@@ -521,7 +521,7 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 	clientProvider := test.NewFakeK8sProvider(cmap, deployment)
 	c := &DeployCommand{
 		GetManifest: getFakeManifest,
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:             p,
 				Executor:          e,
@@ -581,7 +581,7 @@ func TestDeployWithErrorShuttingdownProxy(t *testing.T) {
 	clientProvider := test.NewFakeK8sProvider(deployment)
 	c := &DeployCommand{
 		GetManifest: getFakeManifest,
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:              p,
 				Executor:           e,
@@ -660,7 +660,7 @@ func TestDeployWithoutErrors(t *testing.T) {
 		GetExternalControl: cp.getFakeExternalControl,
 		Fs:                 afero.NewMemMapFs(),
 		CfgMapHandler:      newDefaultConfigMapHandler(clientProvider),
-		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ string, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
+		GetDeployer: func(ctx context.Context, manifest *model.Manifest, opts *Options, _ *buildv2.OktetoBuilder, _ configMapHandler) (deployerInterface, error) {
 			return &localDeployer{
 				Proxy:              p,
 				Executor:           e,

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -55,7 +55,7 @@ type localDeployer struct {
 }
 
 // newLocalDeployer initializes a local deployer from a name and a boolean indicating if we should run with bash or not
-func newLocalDeployer(ctx context.Context, cwd string, options *Options, cmapHandler configMapHandler) (*localDeployer, error) {
+func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configMapHandler) (*localDeployer, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the current working directory: %w", err)

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -125,7 +125,7 @@ func newRemoteDeployer(builder *buildv2.OktetoBuilder) *remoteDeployCommand {
 
 func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Options) error {
 
-	if deployOptions.Manifest.Deploy.Image == "" {
+	if deployOptions.Manifest != nil && deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.Image == "" {
 		deployOptions.Manifest.Deploy.Image = constants.OktetoPipelineRunnerImage
 	}
 

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -124,6 +124,11 @@ func newRemoteDeployer(builder *buildv2.OktetoBuilder) *remoteDeployCommand {
 }
 
 func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Options) error {
+
+	if deployOptions.Manifest.Deploy.Image == "" {
+		deployOptions.Manifest.Deploy.Image = constants.OktetoPipelineRunnerImage
+	}
+
 	cwd, err := rd.getOriginalCWD(deployOptions.ManifestPathFlag)
 	if err != nil {
 		return err

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	templateName           = "dockerfile"
-	dockerfileTemporalNane = "deploy"
+	dockerfileTemporalName = "deploy"
 	oktetoDockerignoreName = ".oktetodeployignore"
 	dockerfileTemplate     = `
 FROM {{ .OktetoCLIImage }} as okteto-cli
@@ -227,7 +227,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		DeployFlags:        strings.Join(getDeployFlags(opts), " "),
 	}
 
-	dockerfile, err := rd.fs.Create(filepath.Join(tmpDir, dockerfileTemporalNane))
+	dockerfile, err := rd.fs.Create(filepath.Join(tmpDir, dockerfileTemporalName))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -51,10 +51,13 @@ FROM {{ .OktetoCLIImage }} as okteto-cli
 FROM alpine as certs
 RUN apk update && apk add ca-certificates
 
+FROM {{ .InstallerImage }} as installer
+
 FROM {{ .UserDeployImage }} as deploy
 
 ENV PATH="${PATH}:/okteto/bin"
 COPY --from=certs /etc/ssl/certs /etc/ssl/certs
+COPY --from=installer /app/bin/* /okteto/bin/
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 {{range $key, $val := .OktetoBuildEnvVars }}
@@ -84,6 +87,7 @@ RUN okteto deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" {{ .De
 
 type dockerfileTemplateProperties struct {
 	OktetoCLIImage     string
+	InstallerImage     string
 	UserDeployImage    string
 	OktetoBuildEnvVars map[string]string
 	ContextEnvVar      string
@@ -125,8 +129,13 @@ func newRemoteDeployer(builder *buildv2.OktetoBuilder) *remoteDeployCommand {
 
 func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Options) error {
 
+	sc, err := rd.clusterMetadata(ctx)
+	if err != nil {
+		return err
+	}
+
 	if deployOptions.Manifest != nil && deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.Image == "" {
-		deployOptions.Manifest.Deploy.Image = constants.OktetoPipelineRunnerImage
+		deployOptions.Manifest.Deploy.Image = sc.PipelineRunnerImage
 	}
 
 	cwd, err := rd.getOriginalCWD(deployOptions.ManifestPathFlag)
@@ -139,7 +148,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		return err
 	}
 
-	dockerfile, err := rd.createDockerfile(tmpDir, deployOptions)
+	dockerfile, err := rd.createDockerfile(tmpDir, deployOptions, sc.PipelineInstallerImage)
 	if err != nil {
 		return err
 	}
@@ -156,11 +165,6 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 
 	// undo modification of CWD for Build command
 	if err := rd.workingDirectoryCtrl.Change(cwd); err != nil {
-		return err
-	}
-
-	sc, err := rd.clusterMetadata(ctx)
-	if err != nil {
 		return err
 	}
 
@@ -200,7 +204,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 
 func (rd *remoteDeployCommand) cleanUp(ctx context.Context, err error) {}
 
-func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (string, error) {
+func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options, installerImage string) (string, error) {
 	cwd, err := rd.workingDirectoryCtrl.Get()
 	if err != nil {
 		return "", err
@@ -216,6 +220,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 	dockerfileSyntax := dockerfileTemplateProperties{
 		OktetoCLIImage:     getOktetoCLIVersion(config.VersionString),
 		UserDeployImage:    opts.Manifest.Deploy.Image,
+		InstallerImage:     installerImage,
 		OktetoBuildEnvVars: rd.builderV2.GetBuildEnvVars(),
 		ContextEnvVar:      model.OktetoContextEnvVar,
 		ContextValue:       okteto.Context().Name,

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -284,7 +284,7 @@ func TestCreateDockerfile(t *testing.T) {
 				fs:                   fs,
 				workingDirectoryCtrl: wdCtrl,
 			}
-			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts)
+			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts, "")
 			assert.ErrorIs(t, err, tt.expected.err)
 			assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
 

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -289,7 +289,7 @@ func TestCreateDockerfile(t *testing.T) {
 			assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
 
 			if tt.expected.err == nil {
-				_, err = rdc.fs.Stat(filepath.Join("/test", dockerfileTemporalNane))
+				_, err = rdc.fs.Stat(filepath.Join("/test", dockerfileTemporalName))
 				assert.NoError(t, err)
 			}
 

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -335,7 +335,7 @@ func TestCreateDockerfile(t *testing.T) {
 				registry:             newFakeRegistry(),
 			}
 			t.Setenv(model.OktetoActionNameEnvVar, tt.actionNameValue)
-			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts)
+			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts, "")
 			assert.ErrorIs(t, err, tt.expected.err)
 			assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -60,7 +60,10 @@ const (
 	OktetoCLIImageForRemoteTemplate = "okteto/okteto:%s"
 
 	// OktetoPipelineRunnerImage defines image to use for remote deployments if empty
-	OktetoPipelineRunnerImage = "okteto/installer:1.8.9"
+	OktetoPipelineRunnerImage = "okteto/pipeline-runner:1.0.0"
+
+	// OktetoPipelineInstallerImage defines image to use for binaries at remote deployment
+	OktetoPipelineInstallerImage = "okteto/installer:1.8.9"
 
 	// OktetoEnvFile defines the name for okteto env file
 	OktetoEnvFile = "OKTETO_ENV"

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -270,6 +270,10 @@ func (c *userClient) GetClusterMetadata(ctx context.Context, ns string) (types.C
 			metadata.Certificate = cert
 		case "internalIngressControllerNetworkAddress":
 			metadata.ServerName = string(v.Value)
+		case "pipelineInstallerImage":
+			metadata.PipelineInstallerImage = string(v.Value)
+		case "pipelineRunnerImage":
+			metadata.PipelineRunnerImage = string(v.Value)
 		}
 	}
 	return metadata, nil

--- a/pkg/types/cluster_metadata.go
+++ b/pkg/types/cluster_metadata.go
@@ -15,6 +15,8 @@ package types
 
 // ClusterMetadata represents the okteto cluster metadata
 type ClusterMetadata struct {
-	Certificate []byte
-	ServerName  string
+	Certificate            []byte
+	ServerName             string
+	PipelineInstallerImage string
+	PipelineRunnerImage    string
 }


### PR DESCRIPTION
# Proposed changes

Resolves partially https://github.com/okteto/app/issues/6395

Currently when `okteto deploy --remote` and `okteto destroy --remote` the base image used by default was the installer.

This PR changes this, so the base image by default, is the pipeline runner. The binaries are taken from the installer, and okteto cli is overriden by the actual version that is running the command, not the installer.
The references of the images are now set by the response of the `metadata` query, which returns from the backend the values of the images to use.

**Refactor of GetDeployer**
There has been a refactor done in order to set the image to use for `Deploy.Image` as for the remote deploy command this was set way before remote flow was running, and for destroy was done at the remote flow.
Also, there is a fix under `GetDeployer` which determine if the deploy is remote or not. 3 states determine if the deployment should be remote:
- Based on the flag `--remote`  (if true, deploy should be remote)
- Based on env `OKTETO_REMOTE_CLI_IMAGE` which indicates if the flow is running inside a remote (if true, deploy should be local, over any other condition)
- Based on the `Deploy.Image` at the manifest, if exisit, deploy should be remote, even if there is no flag at the command

Additionally, unused `cwd` has been remove from this function.

## Testing done
In order to test the changes `go-getting-started` has been the repo used. Here the manifest does not have a Deploy.Image by default

- Running `okteto deploy --remote` with commands at the deploy manifest

```
# manifest.Deploy
deploy:
  commands:
    - okteto version
    - kustomize version
    - helm version
    - bazel version
    - kubectl apply -f k8s.yml


❯ ok deploy --remote --log-output plain
...
INFO: Running stage 'okteto version'
okteto version latest
INFO: Running stage 'kustomize version'
v5.0.0
INFO: Running stage 'helm version'
version.BuildInfo{Version:"v3.11.1", GitCommit:"293b50c65d4d56187cd4e2f390f0ada46b4c4737", GitTreeState:"clean", GoVersion:"go1.18.10"}
INFO: Running stage 'bazel version'
Extracting Bazel installation...
Build label: 4.2.2
Build target: bazel-out/k8-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Thu Dec 2 18:15:58 2021 (1638468958)
Build timestamp: 1638468958
Build timestamp as int: 1638468958
INFO: Running stage 'kubectl apply -f k8s.yml'
deployment.apps/hello-world unchanged
service/hello-world unchanged
ingress.networking.k8s.io/hello-world configured
...
```

- Running `okteto deploy` with `manifest.Deploy.Image` runs the pipeline in remote mode with the base image set under the manifest
- Running `okteto deploy` without flag or image runs the process locally
- Running `okteto destroy --remote` with commands referencing the binaries, also work as expected
- Running remote deploys with an old backend not having the query implemented returns the default values present at the cli constants
- Running remote deploys when backend does not return the images triggers an error
