### PR TITLE
fix: performance issues on `git status`

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -70,7 +70,6 @@ func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
 		}
 
 		ch <- cleanStatus{status.IsClean(), nil}
-		return
 	}()
 
 	select {
@@ -186,7 +185,7 @@ func (ogr oktetoGitWorktree) Status(ctx context.Context) (oktetoGitStatus, error
 		return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
 	}
 
-	lines := strings.Split(string(output), "\000")
+	lines := strings.Split(output, "\000")
 	stat := make(map[string]*git.FileStatus, len(lines))
 	for _, line := range lines {
 		// line example values can be: "M modified-file.go", "?? new-file.go", etc

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -76,7 +75,6 @@ func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
 		return false, ctxWithTimeout.Err()
 	case res := <-ch:
 		return res.IsClean, res.Err
-
 	}
 }
 
@@ -169,24 +167,10 @@ func (ogr oktetoGitWorktree) Status(ctx context.Context, localGit LocalGitInterf
 		return oktetoGitStatus{status: status}, nil
 	}
 
-	output, err := localGit.Status(ctx, ogr.GetRoot(), 0)
+	status, err := localGit.Status(ctx, ogr.GetRoot(), 0)
 	if err != nil {
 		return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
 	}
 
-	lines := strings.Split(output, "\000")
-	stat := make(map[string]*git.FileStatus, len(lines))
-	for _, line := range lines {
-		// line example values can be: "M modified-file.go", "?? new-file.go", etc
-		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", 2)
-		if len(parts) == 2 {
-			stat[strings.Trim(parts[1], " ")] = &git.FileStatus{
-				Staging: git.StatusCode([]byte(parts[0])[0]),
-			}
-		} else {
-			return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: unexpected status line")
-		}
-	}
-
-	return oktetoGitStatus{status: stat}, nil
+	return oktetoGitStatus{status: status}, nil
 }

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -35,11 +35,11 @@ func newGitRepoController() gitRepoController {
 }
 
 type cleanStatus struct {
-	IsClean bool
-	Err     error
+	isClean bool
+	err     error
 }
 
-// IsClean checks if the repository have changes over the commit
+// isClean checks if the repository have changes over the commit
 func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
@@ -74,7 +74,7 @@ func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
 		oktetoLog.Warning("Timeout exceeded calculating git status: assuming dirty commit")
 		return false, ctxWithTimeout.Err()
 	case res := <-ch:
-		return res.IsClean, res.Err
+		return res.isClean, res.err
 	}
 }
 

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -289,21 +289,23 @@ func TestGetSHA(t *testing.T) {
 			config: config{
 				repositoryGetter: fakeRepositoryGetter{
 					repository: []*fakeRepository{
-						{
-							worktree: &fakeWorktree{
-								status: oktetoGitStatus{
-									status: git.Status{
-										"test-file.go": &git.FileStatus{
-											Staging:  git.Unmodified,
-											Worktree: git.Unmodified,
-										},
-									},
-								},
-							},
-							head: plumbing.NewHashReference("test", plumbing.NewHash("test")),
-						},
+						//{
+						//	worktree: &fakeWorktree{
+						//		status: oktetoGitStatus{
+						//			status: git.Status{
+						//				"test-file.go": &git.FileStatus{
+						//					Staging:  git.Unmodified,
+						//					Worktree: git.Unmodified,
+						//				},
+						//			},
+						//		},
+						//	},
+						//	head: plumbing.NewHashReference("test", plumbing.NewHash("test")),
+						//},
 					},
-					err: []error{nil, assert.AnError},
+					err: []error{
+						//nil,
+						assert.AnError},
 				},
 			},
 			expected: expected{
@@ -316,11 +318,23 @@ func TestGetSHA(t *testing.T) {
 			config: config{
 				repositoryGetter: fakeRepositoryGetter{
 					repository: []*fakeRepository{
-						{
-							head: nil,
-							err:  assert.AnError,
-						},
+						//{
+						//	worktree: &fakeWorktree{
+						//		status: oktetoGitStatus{
+						//			status: git.Status{
+						//				"test-file.go": &git.FileStatus{
+						//					Staging:  git.Unmodified,
+						//					Worktree: git.Unmodified,
+						//				},
+						//			},
+						//		},
+						//	},
+						//	head: plumbing.NewHashReference("test", plumbing.NewHash("test")),
+						//},
 					},
+					err: []error{
+						//nil,
+						assert.AnError},
 				},
 			},
 			expected: expected{

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -15,66 +15,11 @@ package repository
 
 import (
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/stretchr/testify/mock"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/stretchr/testify/assert"
 )
-
-// CommandContextMock is a mock for the exec.CommandContext.
-type CommandContextMock struct {
-	mock.Mock
-}
-
-func (m *CommandContextMock) Output() ([]byte, error) {
-	args := m.Called()
-	return args.Get(0).([]byte), args.Error(1)
-}
-
-// fixDubiousOwnershipConfigMock is a mock for the fixDubiousOwnershipConfig.
-func fixDubiousOwnershipConfigMock(dirPath string) error {
-	// You could add some logic here to simulate different scenarios.
-	return nil
-}
-
-//func TestRunGitStatusCommand(t *testing.T) {
-//	ctx := context.Background()
-
-//// Test when fixAttempt is more than 0
-//gitPath, dirPath := "/usr/bin/git", "/path/to/repo"
-//output, err := runGitStatusCommand(ctx, gitPath, dirPath, 1)
-//assert.Equal(t, "", output)
-//assert.EqualError(t, err, "failed to get status: too many attempts")
-
-// Test when command execution returns "detected dubious ownership in repository" error
-//mockCmd := new(CommandContextMock)
-//mockCmd.On("Output").Return(nil, errors.New("detected dubious ownership in repository"))
-//output, err := runGitStatusCommand(ctx, gitPath, dirPath, 0)
-//assert.Equal(t, "", output)
-//assert.Nil(t, err)
-//mockCmd.AssertCalled(t, "Output")
-
-// Test when fixDubiousOwnershipConfig fails
-// (you'd need to implement this part yourself)
-
-//// Test when command executes without any error
-//mockCmd = new(CommandContextMock)
-//mockCmd.On("Output").Return([]byte("M file1.txt\n"), nil)
-//output, err = runGitStatusCommand(ctx, gitPath, dirPath, 0)
-//assert.Equal(t, "M file1.txt\n", output)
-//assert.Nil(t, err)
-//mockCmd.AssertCalled(t, "Output")
-//}
-
-//func TestIsClean_Timeout(t *testing.T) {
-//	repo := Repository{
-//		control: gitRepoController{
-//			repoGetter: tt.config.repositoryGetter,
-//		},
-//	}
-//	isClean, err := repo.IsClean()
-//}
 
 func TestIsClean(t *testing.T) {
 	type config struct {
@@ -90,7 +35,6 @@ func TestIsClean(t *testing.T) {
 		expected expected
 	}{
 		{
-			// TODO: verify this test
 			name: "dir is not a repository",
 			config: config{
 				repositoryGetter: &fakeRepositoryGetter{
@@ -128,11 +72,7 @@ func TestIsClean(t *testing.T) {
 						{
 							worktree: &fakeWorktree{
 								status: oktetoGitStatus{
-									status: git.Status{
-										//"test-file.go": &git.FileStatus{
-										//	Worktree: nil,
-										//},
-									},
+									status: git.Status{},
 								},
 								err: assert.AnError,
 							},

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -1,0 +1,72 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+type CommandExecutor interface {
+	RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
+	LookPath(file string) (string, error)
+}
+
+type LocalExec struct{}
+
+func (le *LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+	c := exec.CommandContext(ctx, name, arg...)
+	c.Dir = dir
+	return c.Output()
+}
+
+func (le *LocalExec) LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
+type LocalGitInterface interface {
+	Status(ctx context.Context, dirPath string, fixAttempt int) (string, error)
+	Exists() (string, error)
+	FixDubiousOwnershipConfig(path string) error
+}
+
+type LocalGit struct {
+	gitPath string
+	exec    CommandExecutor
+}
+
+func NewLocalGit(gitPath string, exec CommandExecutor) *LocalGit {
+	return &LocalGit{
+		gitPath: gitPath,
+		exec:    exec,
+	}
+}
+
+func (lg *LocalGit) Status(ctx context.Context, dirPath string, fixAttempt int) (string, error) {
+	if fixAttempt > 0 {
+		return "", fmt.Errorf("failed to get status: too many attempts")
+	}
+
+	output, err := lg.exec.RunCommand(ctx, lg.gitPath, "status", "--porcelain", "-z")
+	if err != nil {
+		if errors.Is(err, errors.New("detected dubious ownership in repository")) {
+			err = lg.FixDubiousOwnershipConfig(dirPath)
+			if err != nil {
+				return "", fmt.Errorf("failed to get status: cannot recover")
+			}
+			fixAttempt++
+			return lg.Status(ctx, dirPath, fixAttempt)
+		}
+	}
+
+	return string(output), err
+}
+
+func (lg *LocalGit) FixDubiousOwnershipConfig(path string) error {
+	_, err := lg.exec.RunCommand(context.Background(), lg.gitPath, "config", "--global", "--add", "safe.directory", path)
+	return err
+}
+
+func (lg *LocalGit) Exists() (string, error) {
+	return exec.LookPath("git")
+}

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -51,6 +51,7 @@ func NewLocalGit(gitPath string, exec CommandExecutor) *LocalGit {
 	}
 }
 
+// Status returns the status of the repository at the given path
 func (lg *LocalGit) Status(ctx context.Context, dirPath string, fixAttempt int) (git.Status, error) {
 	if fixAttempt > 0 {
 		return git.Status{}, errLocalGitCannotGetStatusTooManyAttempts
@@ -76,11 +77,13 @@ func (lg *LocalGit) Status(ctx context.Context, dirPath string, fixAttempt int) 
 	return status, err
 }
 
+// FixDubiousOwnershipConfig adds the given path to the git config safe.directory to avoid the dubious ownership error
 func (lg *LocalGit) FixDubiousOwnershipConfig(path string) error {
 	_, err := lg.exec.RunCommand(context.Background(), lg.gitPath, "config", "--global", "--add", "safe.directory", path)
 	return err
 }
 
+// Exists checks if git binary exists in the system
 func (lg *LocalGit) Exists() (string, error) {
 	return lg.exec.LookPath("git")
 }

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -22,13 +22,13 @@ type CommandExecutor interface {
 
 type LocalExec struct{}
 
-func (le *LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+func (*LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
 	c := exec.CommandContext(ctx, name, arg...)
 	c.Dir = dir
 	return c.Output()
 }
 
-func (le *LocalExec) LookPath(file string) (string, error) {
+func (*LocalExec) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
@@ -85,7 +85,7 @@ func (lg *LocalGit) Exists() (string, error) {
 	return lg.exec.LookPath("git")
 }
 
-func (lg *LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
+func (*LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
 	lines := strings.Split(gitStatusOutput, "\000")
 	status := make(map[string]*git.FileStatus, len(lines))
 

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -1,0 +1,166 @@
+package repository
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type mockLocalExec struct {
+	runCommand func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
+	lookPath   func(file string) (string, error)
+}
+
+func (mle *mockLocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+	if mle.runCommand != nil {
+		return mle.runCommand(ctx, dir, name, arg...)
+	}
+	return nil, assert.AnError
+}
+
+func (mle *mockLocalExec) LookPath(file string) (string, error) {
+	if mle.lookPath != nil {
+		return mle.lookPath(file)
+	}
+	return "", assert.AnError
+}
+
+func TestLocalGit_Exists(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mockExec func() *mockLocalExec
+		err      error
+	}{
+		{
+			name: "git exists",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					lookPath: func(file string) (string, error) {
+						return "/usr/bin/git", nil
+					},
+				}
+			},
+			err: nil,
+		},
+		{
+			name: "git not found",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					lookPath: func(file string) (string, error) {
+						return "", assert.AnError
+					},
+				}
+			},
+			err: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mockExec())
+			_, err := lg.Exists()
+			assert.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestLocalGit_FixDubiousOwnershipConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mockExec func() *mockLocalExec
+		err      error
+	}{
+		{
+			name: "success",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return []byte(""), nil
+					},
+				}
+			},
+			err: nil,
+		},
+		{
+			name: "failure",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			err: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mockExec())
+			err := lg.FixDubiousOwnershipConfig("/test/dir")
+
+			assert.ErrorIs(t, err, tt.err)
+		})
+	}
+}
+
+func TestLocalGit_Status(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		fixAttempts int
+		mock        func() *mockLocalExec
+		expectedErr error
+	}{
+		{
+			name:        "success",
+			fixAttempts: 0,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return []byte("M modified-file.go"), nil
+					},
+				}
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "fail to parse git status output",
+			fixAttempts: 0,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return []byte("unexpected_output_in_git_status"), nil
+					},
+				}
+			},
+			expectedErr: errLocalGitInvalidStatusOutput,
+		},
+		{
+			name:        "failure due to too many attempts",
+			fixAttempts: 1,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedErr: errLocalGitCannotGetStatusTooManyAttempts,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mock())
+			_, err := lg.Status(context.Background(), "/test/dir", tt.fixAttempts)
+
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -26,8 +26,6 @@ func (mle *mockLocalExec) LookPath(file string) (string, error) {
 }
 
 func TestLocalGit_Exists(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		mockExec func() *mockLocalExec
@@ -67,8 +65,6 @@ func TestLocalGit_Exists(t *testing.T) {
 }
 
 func TestLocalGit_FixDubiousOwnershipConfig(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		mockExec func() *mockLocalExec
@@ -109,8 +105,6 @@ func TestLocalGit_FixDubiousOwnershipConfig(t *testing.T) {
 }
 
 func TestLocalGit_Status(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name        string
 		fixAttempts int

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -74,7 +74,7 @@ func TestLocalGit_FixDubiousOwnershipConfig(t *testing.T) {
 			name: "success",
 			mockExec: func() *mockLocalExec {
 				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+					runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
 						return []byte(""), nil
 					},
 				}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -40,7 +40,7 @@ type repositoryInterface interface {
 
 // NewRepository creates a repository controller
 func NewRepository(path string) Repository {
-	url, err := giturls.Parse(path)
+	repoUrl, err := giturls.Parse(path)
 	if err != nil {
 		oktetoLog.Infof("could not parse url: %w", err)
 	}
@@ -53,7 +53,7 @@ func NewRepository(path string) Repository {
 	}
 	return Repository{
 		path:    path,
-		url:     url,
+		url:     repoUrl,
 		control: controller,
 	}
 }

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -50,12 +50,13 @@ type fakeWorktree struct {
 	err    error
 }
 
-func (fw fakeWorktree) Status() (gitStatusInterface, error) {
+func (fw fakeWorktree) Status() (oktetoGitStatus, error) {
 	return fw.status, fw.err
 }
 
 type fakeStatus struct {
 	isClean bool
+	getRoot string
 }
 
 func (fs fakeStatus) IsClean() bool {

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -30,7 +30,7 @@ type fakeRepositoryGetter struct {
 	callCount  int
 }
 
-func (frg fakeRepositoryGetter) get(_ string) (gitRepositoryInterface, error) {
+func (frg *fakeRepositoryGetter) get(_ string) (gitRepositoryInterface, error) {
 	i := frg.callCount
 	frg.callCount++
 	if frg.err != nil && frg.err[i] != nil {

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -63,7 +63,7 @@ func (fw fakeWorktree) GetRoot() string {
 	return fw.root
 }
 
-func (fw fakeWorktree) Status(context.Context) (oktetoGitStatus, error) {
+func (fw fakeWorktree) Status(context.Context, LocalGitInterface) (oktetoGitStatus, error) {
 	return fw.status, fw.err
 }
 

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -33,7 +33,7 @@ type fakeRepositoryGetter struct {
 func (frg fakeRepositoryGetter) get(_ string) (gitRepositoryInterface, error) {
 	i := frg.callCount
 	frg.callCount++
-	if frg.err[i] != nil {
+	if frg.err != nil && frg.err[i] != nil {
 		return nil, frg.err[i]
 	}
 	return frg.repository[i], nil


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/6518

We've noticed a huge delay in the function that gets the repo status using the golang library `git-go` so we've decided to implement a different mechanism. If the host running the CLI has `git` installed, we will use `git status` and parse the output. If git is not installed, we rely on the library. However, if the library takes more than 1 second, we assume the commit is not clean and we try to build which if already built it should be quick.

## How to test

1. Using a large repo, try running `okteto deploy` and observe how slow it can be between the messages ` i  Using <okteto user> @ <okteto url> as context` and `⠋ Checking images to build...`
2. Try it again using the CLI built with this branch and observe the difference in time
