### PR TITLE
fix: buil args expansion

### DIFF
--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -1339,7 +1339,10 @@ func getBuildArgs(unmarshal func(interface{}) error) (map[string]string, error) 
 		return nil, err
 	}
 	for key, value := range rawMap {
-		result[key] = value
+		result[key], err = ExpandEnv(value, true)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -2724,14 +2724,16 @@ func TestBuildArgsUnmarshalling(t *testing.T) {
 		},
 		{
 			name: "map with env var",
-			data: []byte("KEY: $VALUE"),
+			data: []byte("KEY: $MYVAR"),
 			expected: BuildArgs{
 				{
 					Name:  "KEY",
-					Value: "$VALUE",
+					Value: "actual-value",
 				},
 			},
-			env: map[string]string{},
+			env: map[string]string{
+				"MYVAR": "actual-value",
+			},
 		},
 	}
 


### PR DESCRIPTION
# Proposed changes

Fixes #3632 

| Before | After |
|--------|-------|
|   <img width="414" alt="Captura de Pantalla 2023-05-24 a las 19 27 20" src="https://github.com/okteto/okteto/assets/25170843/9371f2f9-93ca-4219-930f-a211fd264b25">  |  <img width="424" alt="Captura de Pantalla 2023-05-24 a las 19 24 01" src="https://github.com/okteto/okteto/assets/25170843/c19fc91c-154c-4b5e-908e-a60cfe7e4df8">  |

# Manifest used to test:

```yaml
build:
  api:
    context: .
    args:
      URL: https://${OKTETO_NAMESPACE}.com
deploy:
  - echo $URL
```

