### PR TITLE
fix(build): vanilla cluster should not reach out to okteto registry

### DIFF
--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -15,6 +15,7 @@ package v2
 
 import (
 	"fmt"
+	"github.com/okteto/okteto/pkg/okteto"
 
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/format"
@@ -35,7 +36,15 @@ type imageWithVolumesTagger struct {
 	cfg oktetoBuilderConfigInterface
 }
 
-var targetRegistries = []string{constants.GlobalRegistry, constants.DevRegistry}
+func getTargetRegistries() []string {
+	registries := []string{}
+
+	if okteto.IsOkteto() {
+		registries = append(registries, constants.GlobalRegistry, constants.DevRegistry)
+	}
+
+	return registries
+}
 
 // newImageTagger returns a new image tagger
 func newImageTagger(cfg oktetoBuilderConfigInterface) imageTagger {
@@ -71,7 +80,7 @@ func (i imageTagger) getPossibleHashImages(manifestName, svcToBuildName, sha str
 	// manifestName can be not sanitized when option name is used at deploy
 	sanitizedName := format.ResourceK8sMetaString(manifestName)
 	tagsToCheck := []string{}
-	for _, targetRegistry := range targetRegistries {
+	for _, targetRegistry := range getTargetRegistries() {
 		tagsToCheck = append(tagsToCheck, getImageFromTmpl(targetRegistry, sanitizedName, svcToBuildName, sha))
 	}
 	return tagsToCheck
@@ -81,7 +90,7 @@ func (i imageTagger) getPossibleHashImages(manifestName, svcToBuildName, sha str
 func (i imageTagger) getPossibleTags(manifestName, svcToBuildName, sha string) []string {
 	tags := i.getPossibleHashImages(manifestName, svcToBuildName, sha)
 	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	for _, targetRegistry := range targetRegistries {
+	for _, targetRegistry := range getTargetRegistries() {
 		tags = append(tags, getImageFromTmpl(targetRegistry, sanitizedName, svcToBuildName, model.OktetoDefaultImageTag))
 	}
 	return tags
@@ -119,7 +128,7 @@ func (i imageWithVolumesTagger) getPossibleHashImages(manifestName, svcToBuildNa
 	// manifestName can be not sanitized when option name is used at deploy
 	sanitizedName := format.ResourceK8sMetaString(manifestName)
 	tagsToCheck := []string{}
-	for _, targetRegistry := range targetRegistries {
+	for _, targetRegistry := range getTargetRegistries() {
 		tagsToCheck = append(tagsToCheck, getImageFromTmplWithVolumesAndSHA(targetRegistry, sanitizedName, svcToBuildName, sha))
 	}
 	return tagsToCheck
@@ -129,7 +138,7 @@ func (i imageWithVolumesTagger) getPossibleHashImages(manifestName, svcToBuildNa
 func (i imageWithVolumesTagger) getPossibleTags(manifestName, svcToBuildName, sha string) []string {
 	tags := i.getPossibleHashImages(manifestName, svcToBuildName, sha)
 	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	for _, targetRegistry := range targetRegistries {
+	for _, targetRegistry := range getTargetRegistries() {
 		tags = append(tags, getImageFromTmpl(targetRegistry, sanitizedName, svcToBuildName, model.OktetoImageTagWithVolumes))
 	}
 	return tags

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -14,6 +14,7 @@
 package v2
 
 import (
+	"github.com/okteto/okteto/pkg/okteto"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -318,6 +319,42 @@ func TestImageTaggerWithVolumesGetPossibleTags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tagger := newImageWithVolumesTagger(fakeConfig{})
 			assert.Equal(t, tc.expectedImages, tagger.getPossibleTags("test", "test", tc.sha))
+		})
+	}
+}
+
+func Test_getTargetRegistries(t *testing.T) {
+	tt := []struct {
+		name     string
+		isOkteto bool
+		expected []string
+	}{
+		{
+			name:     "vanilla-cluster",
+			isOkteto: false,
+			expected: []string{},
+		},
+		{
+			name:     "okteto-cluster",
+			isOkteto: true,
+			expected: []string{
+				"okteto.global",
+				"okteto.dev",
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			okteto.CurrentStore = &okteto.OktetoContextStore{
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {
+						Namespace: "test",
+						IsOkteto:  tc.isOkteto,
+					},
+				},
+				CurrentContext: "test",
+			}
+			assert.Equal(t, tc.expected, getTargetRegistries())
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

This issue came up while testing the `2.16.x` release. When working with vanilla clusters, the CLI will try to reach out to the Okteto Registry and the build fails.

| Before | After |
|--------|-------|
|   <img width="414" alt="before" src="https://github.com/okteto/okteto/assets/2318450/ee4fc939-517d-4ebc-bcf3-c8bddfbdac98">  |  <img width="424" alt="after" src="https://github.com/okteto/okteto/assets/2318450/acab0424-836b-43a5-b5ed-5e65072bcecf">  |

## How to test
1. Clone https://github.com/okteto/movies-with-compose
2. Build this branch and run against the repo "okteto build"
3. Observe how the validation kicks in, instead of a weird connection issue

