### PR TITLE
add local envs for hybrid command

### DIFF
--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -157,7 +157,7 @@ type envsGetter struct {
 	configMapEnvsGetter configMapEnvsGetterInterface
 	secretsEnvsGetter   secretsEnvsGetterInterface
 	imageEnvsGetter     imageEnvsGetterInterface
-	pathGetter          func(string) string
+	getLocalEnvs        func() []string
 }
 
 func newEnvsGetter(hybridCtx *HybridExecCtx) (*envsGetter, error) {
@@ -183,7 +183,7 @@ func newEnvsGetter(hybridCtx *HybridExecCtx) (*envsGetter, error) {
 		imageEnvsGetter: &imageEnvsGetter{
 			imageGetter: registry.NewOktetoRegistry(okteto.Config{}),
 		},
-		pathGetter: os.Getenv,
+		getLocalEnvs: os.Environ,
 	}, nil
 }
 
@@ -217,10 +217,7 @@ func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 		envs = append(envs, fmt.Sprintf("%s=%s", env.Name, env.Value))
 	}
 
-	pathValue := eg.pathGetter("PATH")
-	if pathValue != "" {
-		envs = append(envs, fmt.Sprintf("PATH=%s", pathValue))
-	}
+	envs = append(envs, eg.getLocalEnvs()...)
 
 	return envs, nil
 }

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -163,7 +163,7 @@ func TestGetEnvs(t *testing.T) {
 				configMapEnvsGetter: &tt.fakeConfigMapEnvsGetter,
 				secretsEnvsGetter:   &tt.fakeSecretEnvsGetter,
 				imageEnvsGetter:     &tt.fakeImageEnvsGetter,
-				pathGetter:          func(_ string) string { return "" },
+				getLocalEnvs:        func() []string { return []string{} },
 			}
 
 			envs, err := eg.getEnvs(ctx)

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -163,7 +163,7 @@ func TestGetEnvs(t *testing.T) {
 				configMapEnvsGetter: &tt.fakeConfigMapEnvsGetter,
 				secretsEnvsGetter:   &tt.fakeSecretEnvsGetter,
 				imageEnvsGetter:     &tt.fakeImageEnvsGetter,
-				getLocalEnvs:        func() []string { return []string{} },
+				getDefaultLocalEnvs: func() []string { return []string{} },
 			}
 
 			envs, err := eg.getEnvs(ctx)


### PR DESCRIPTION
# Proposed changes

Fixes #3651

- add local envs to cmd hybrid command
- local envs will have the highest preference if one of its variables is already contained in the config map, image used or in the secrets.
