### PR TITLE
Add os environ to RunOktetoEndpoints

### DIFF
--- a/integration/commands/endpoints.go
+++ b/integration/commands/endpoints.go
@@ -16,6 +16,7 @@ package commands
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 )
 
@@ -30,6 +31,7 @@ type EndpointOptions struct {
 // RunOktetoDeploy runs an okteto deploy command
 func RunOktetoEndpoints(oktetoPath string, endpointsOptions *EndpointOptions) ([]byte, error) {
 	cmd := exec.Command(oktetoPath, "endpoints")
+	cmd.Env = os.Environ()
 	if endpointsOptions.Workdir != "" {
 		cmd.Dir = endpointsOptions.Workdir
 	}


### PR DESCRIPTION
Signed-off-by: Agustín Díaz <agustin.ramiro.diaz@gmail.com>

# Proposed changes

Adds the OS environment variables to ` RunOktetoEndpoints` so that okteto is in `PATH` 

E2E run in circleci: https://app.circleci.com/pipelines/github/okteto/okteto/10543/workflows/38f85c28-e487-4de7-8a2b-5c27c23a7033