### PR TITLE
fix send on closed channel panic in isClean

### DIFF
--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"github.com/go-git/go-git/v5"
+	"os"
 	"os/exec"
 	"strings"
 )
 
 var (
-	errLocalGitCannotGetStatusDubiousOwner    = errors.New("detected dubious ownership in repository")
 	errLocalGitCannotGetStatusTooManyAttempts = errors.New("failed to get status: too many attempts")
 	errLocalGitCannotGetStatusCannotRecover   = errors.New("failed to get status: cannot recover")
 	errLocalGitInvalidStatusOutput            = errors.New("failed to get git status: unexpected status line")
@@ -25,6 +25,7 @@ type LocalExec struct{}
 func (*LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
 	c := exec.CommandContext(ctx, name, arg...)
 	c.Dir = dir
+	c.Env = os.Environ()
 	return c.Output()
 }
 
@@ -53,13 +54,16 @@ func NewLocalGit(gitPath string, exec CommandExecutor) *LocalGit {
 
 // Status returns the status of the repository at the given path
 func (lg *LocalGit) Status(ctx context.Context, dirPath string, fixAttempt int) (git.Status, error) {
-	if fixAttempt > 0 {
+	if fixAttempt > 1 {
 		return git.Status{}, errLocalGitCannotGetStatusTooManyAttempts
 	}
 
-	output, err := lg.exec.RunCommand(ctx, lg.gitPath, "status", "--porcelain", "-z")
+	output, err := lg.exec.RunCommand(ctx, dirPath, lg.gitPath, "status", "--porcelain", "-z")
 	if err != nil {
-		if errors.Is(err, errLocalGitCannotGetStatusDubiousOwner) {
+		var exitError *exec.ExitError
+		errors.As(err, &exitError)
+		exitErr := string(exitError.Stderr)
+		if strings.Contains(exitErr, "detected dubious ownership in repository") {
 			err = lg.FixDubiousOwnershipConfig(dirPath)
 			if err != nil {
 				return git.Status{}, errLocalGitCannotGetStatusCannotRecover
@@ -79,13 +83,15 @@ func (lg *LocalGit) Status(ctx context.Context, dirPath string, fixAttempt int) 
 
 // FixDubiousOwnershipConfig adds the given path to the git config safe.directory to avoid the dubious ownership error
 func (lg *LocalGit) FixDubiousOwnershipConfig(path string) error {
-	_, err := lg.exec.RunCommand(context.Background(), lg.gitPath, "config", "--global", "--add", "safe.directory", path)
+	_, err := lg.exec.RunCommand(context.Background(), path, lg.gitPath, "config", "--global", "--add", "safe.directory", path)
 	return err
 }
 
 // Exists checks if git binary exists in the system
 func (lg *LocalGit) Exists() (string, error) {
-	return lg.exec.LookPath("git")
+	var err error
+	lg.gitPath, err = lg.exec.LookPath("git")
+	return lg.gitPath, err
 }
 
 func (*LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
@@ -93,6 +99,9 @@ func (*LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
 	status := make(map[string]*git.FileStatus, len(lines))
 
 	for _, line := range lines {
+		if line == "" {
+			continue
+		}
 		// line example values can be: "M modified-file.go", "?? new-file.go", etc
 		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", 2)
 		if len(parts) == 2 {


### PR DESCRIPTION
Fix `send on closed channel` error that occurs when we exceed the timeout for git clean status.

This issue can be reproduced locally by changing the `ctxWithTimeout` deadline to 1 millisecond [here](https://github.com/okteto/okteto/blob/master/pkg/repository/git.go#L44).

```
okteto build --progress plain
 !  Calculating git status: git is not installed, for better performances consider installing it
 !  Timeout exceeded calculating git status: assuming dirty commit
 i  Building ‘Dockerfile.okteto’ in tcp://buildkit.qwerty.okteto.dev:443...
panic: send on closed channelgoroutine 23 [running]:
github.com/okteto/okteto/pkg/repository.gitRepoController.isClean.func1()
  github.com/okteto/okteto/pkg/repository/git.go:69 +0x299
created by github.com/okteto/okteto/pkg/repository.gitRepoController.isClean
  github.com/okteto/okteto/pkg/repository/git.go:50 +0x1a5
```


This happens because when we hit the timeout the function returns and we call `defer close(ch)`.  However, the internal go routines is still active. Eventually the goroutine tries to write to `ch` but it's closed so it panics.

The fix is making sure we race `ch` against a `timeoutCh` and write to `ch` in a single place for readability (hence the new `calculateIsClean` func).

One other thing that changed, is that we are now passing a context with a timeout to `worktree.Status`. Before we were passing the top level function context. Not sure if this has any actual effect but it's worth mentioning since this could've been the original issue.

I didn't get into the nitty gritty of preventing `calculateIsClean` and children from blocking forever and assumed that the context deadline is respected. We are passing down the right context with a 1s timeout to `worktree.Status` so if that works it should be ok. Otherwise the goroutine could leak (if calculateIsClean blocks forever).
