### PR TITLE
fix: endpoints should only return the json if the flag specify it

### DIFF
--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -49,7 +49,9 @@ func Endpoints(ctx context.Context) *cobra.Command {
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
 				return err
 			}
-			oktetoLog.Information("Using %s @ %s as context", previewName, okteto.RemoveSchema(okteto.Context().Name))
+			if output != "json" {
+				oktetoLog.Information("Using %s @ %s as context", previewName, okteto.RemoveSchema(okteto.Context().Name))
+			}
 
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster


### PR DESCRIPTION
# Proposed changes

Fixes #3681 

| Before | After |
|--------|-------|
|  <img width="493" alt="Captura de Pantalla 2023-05-31 a las 18 01 36" src="https://github.com/okteto/okteto/assets/25170843/71c3def8-9b0c-46c1-bf21-7c42cb236e81"> |  <img width="494" alt="Captura de Pantalla 2023-05-31 a las 18 04 07" src="https://github.com/okteto/okteto/assets/25170843/51466c87-17c5-413d-890d-5c4871fd3dcd"> |

# Test:

1. Deploy a preview environment
2. Run okteto preview endpoints {{previewName}}-o json