### PR TITLE
fix: variable expansion on buildargs that only have one env

### DIFF
--- a/cmd/build/v2/config_test.go
+++ b/cmd/build/v2/config_test.go
@@ -173,7 +173,7 @@ func TestGetGitCommit(t *testing.T) {
 func TestGetTextToHash(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	afero.WriteFile(fs, "secret", []byte("bar"), 0600)
-
+	t.Setenv("BAR", "bar")
 	type input struct {
 		repo      fakeConfigRepo
 		buildInfo *model.BuildInfo
@@ -263,6 +263,32 @@ func TestGetTextToHash(t *testing.T) {
 				},
 			},
 			expected: "commit:;target:target;build_args:;secrets:secret=secret;context:context;dockerfile:dockerfile;image:image;",
+		},
+		{
+			name: "arg with expansion",
+			input: input{
+				repo: fakeConfigRepo{
+					sha:     "",
+					isClean: true,
+					err:     assert.AnError,
+				},
+				buildInfo: &model.BuildInfo{
+					Args: model.BuildArgs{
+						{
+							Name:  "foo",
+							Value: "$BAR",
+						},
+					},
+					Target: "target",
+					Secrets: model.BuildSecrets{
+						"secret": "secret",
+					},
+					Context:    "context",
+					Dockerfile: "dockerfile",
+					Image:      "image",
+				},
+			},
+			expected: "commit:;target:target;build_args:foo=bar;secrets:secret=secret;context:context;dockerfile:dockerfile;image:image;",
 		},
 	}
 	for _, tc := range tt {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
-	github.com/a8m/envsubst v1.3.0
+	github.com/a8m/envsubst v1.4.2
 	github.com/alessio/shellescape v1.4.1
 	github.com/briandowns/spinner v1.23.0
 	github.com/cheggaaa/pb/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
-github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
-github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
+github.com/a8m/envsubst v1.4.2 h1:4yWIHXOLEJHQEFd4UjrWDrYeYlV7ncFWJOCBRLOZHQg=
+github.com/a8m/envsubst v1.4.2/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -141,7 +141,11 @@ type BuildArg struct {
 }
 
 func (v *BuildArg) String() string {
-	return fmt.Sprintf("%s=%s", v.Name, v.Value)
+	value, err := ExpandEnv(v.Value, true)
+	if err != nil {
+		return fmt.Sprintf("%s=%s", v.Name, v.Value)
+	}
+	return fmt.Sprintf("%s=%s", v.Name, value)
 }
 
 // BuildArgs is a list of arguments used on the build step.

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1057,38 +1057,50 @@ func TestPersistentVolumeEnabled(t *testing.T) {
 }
 
 func Test_ExpandEnv(t *testing.T) {
-	os.Setenv("BAR", "bar")
+	t.Setenv("BAR", "bar")
 	tests := []struct {
-		name   string
-		value  string
-		result string
+		name          string
+		value         string
+		expandIfEmpty bool
+		result        string
 	}{
 		{
-			name:   "no-var",
-			value:  "value",
-			result: "value",
+			name:          "no-var",
+			value:         "value",
+			expandIfEmpty: true,
+			result:        "value",
 		},
 		{
-			name:   "var",
-			value:  "value-${BAR}-value",
-			result: "value-bar-value",
+			name:          "var",
+			value:         "value-${BAR}-value",
+			expandIfEmpty: true,
+			result:        "value-bar-value",
 		},
 		{
-			name:   "default",
-			value:  "value-${FOO:-foo}-value",
-			result: "value-foo-value",
+			name:          "default",
+			value:         "value-${FOO:-foo}-value",
+			expandIfEmpty: true,
+			result:        "value-foo-value",
+		},
+		{
+			name:          "only bar expanded",
+			value:         "${BAR}",
+			expandIfEmpty: true,
+			result:        "bar",
+		},
+		{
+			name:          "only bar not expand if empty",
+			value:         "${FOO}",
+			expandIfEmpty: false,
+			result:        "${FOO}",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := ExpandEnv(tt.value, true)
-			if err != nil {
-				t.Errorf("error in test '%s': %s", tt.name, err.Error())
-			}
-			if result != tt.result {
-				t.Errorf("error in test '%s': '%s', expected: '%s'", tt.name, result, tt.result)
-			}
+			result, err := ExpandEnv(tt.value, tt.expandIfEmpty)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.result, result)
 		})
 	}
 }

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -1325,7 +1325,7 @@ func getBuildArgs(unmarshal func(interface{}) error) (map[string]string, error) 
 	err := unmarshal(&rawList)
 	if err == nil {
 		for _, buildArg := range rawList {
-			value, err := ExpandEnv(buildArg.Value, true)
+			value, err := ExpandEnv(buildArg.Value, false)
 			if err != nil {
 				return nil, err
 			}
@@ -1339,7 +1339,7 @@ func getBuildArgs(unmarshal func(interface{}) error) (map[string]string, error) 
 		return nil, err
 	}
 	for key, value := range rawMap {
-		result[key], err = ExpandEnv(value, true)
+		result[key], err = ExpandEnv(value, false)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -2685,7 +2685,7 @@ func TestBuildArgsUnmarshalling(t *testing.T) {
 			expected: BuildArgs{
 				{
 					Name:  "KEY",
-					Value: "",
+					Value: "$VALUE",
 				},
 			},
 			env: map[string]string{},
@@ -2698,7 +2698,7 @@ func TestBuildArgsUnmarshalling(t *testing.T) {
 			expected: BuildArgs{
 				{
 					Name:  "KEY",
-					Value: "",
+					Value: "$VALUE",
 				},
 				{
 					Name:  "KEY2",


### PR DESCRIPTION
# Proposed changes

Fixes #3686 
Fixes #3684

- Update dependency
- Add unit tests covering a value with a single env var
- Add unit test for getting the build hash with a single env var
- If the value is a single env var on serializer don't expand it

## Tests done
- Using #3684 reproduction steps. Check that the variable is printed inside buildkit
- Check that the build hash changes with different values of the build env var
