### PR TITLE
feat: add preview labels to preview list

### DIFF
--- a/cmd/utils/okteto.go
+++ b/cmd/utils/okteto.go
@@ -51,7 +51,7 @@ func HasAccessToOktetoClusterNamespace(ctx context.Context, namespace string, ok
 		}
 	}
 
-	previewList, err := oktetoClient.Previews().List(ctx)
+	previewList, err := oktetoClient.Previews().List(ctx, []string{})
 	if err != nil {
 		return false, err
 	}

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -44,7 +44,7 @@ func NewFakePreviewClient(response *FakePreviewResponse) *FakePreviewsClient {
 }
 
 // List list namespaces
-func (c *FakePreviewsClient) List(_ context.Context) ([]types.Preview, error) {
+func (c *FakePreviewsClient) List(_ context.Context, _ []string) ([]types.Preview, error) {
 	return c.response.PreviewList, c.response.ErrList
 }
 

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -360,7 +360,7 @@ func SetServerNameOverride(serverNameOverride string) {
 		oktetoLog.Fatalf("invalid server name %q: %s", serverNameOverride, err)
 		return
 	}
-	oktetoLog.Warning("Server name overriden to host=%s port=%s", host, port)
+	oktetoLog.Warning("Server name overridden to host=%s port=%s", host, port)
 	serverName = net.JoinHostPort(host, port)
 }
 

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -82,11 +82,11 @@ type destroyPreviewMutation struct {
 }
 
 type listPreviewQuery struct {
-	Response []previewEnvWithLabels `graphql:"previews(labels: $labels)"`
+	Response []previewEnv `graphql:"previews(labels: $labels)"`
 }
 
 type listPreviewQueryDeprecated struct {
-	Response []previewEnv `graphql:"previews"`
+	Response []deprecatedPreviewEnv `graphql:"previews"`
 }
 
 type listPreviewEndpoints struct {
@@ -132,13 +132,13 @@ type endpointURL struct {
 	Url graphql.String
 }
 
-type previewEnv struct {
+type deprecatedPreviewEnv struct {
 	Id       graphql.String
 	Sleeping graphql.Boolean
 	Scope    graphql.String
 }
 
-type previewEnvWithLabels struct {
+type previewEnv struct {
 	Id            graphql.String
 	Sleeping      graphql.Boolean
 	Scope         graphql.String

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	ErrLabelsFeatureNotSupported = fmt.Errorf("Labels feature not supported in version of this context")
+	ErrLabelsFeatureNotSupported = fmt.Errorf("Labels are not supported in the version of this Okteto context")
 )
 
 type previewClient struct {

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -81,7 +81,7 @@ type destroyPreviewMutation struct {
 	Response previewIDStruct `graphql:"destroyPreview(id: $id)"`
 }
 
-type listPreviewQueryWithLabels struct {
+type listPreviewQuery struct {
 	Response []previewEnvWithLabels `graphql:"previews(labels: $labels)"`
 }
 
@@ -247,7 +247,7 @@ func (c *previewClient) Destroy(ctx context.Context, name string) error {
 
 // ListPreviews list preview environments
 func (c *previewClient) List(ctx context.Context, labels []string) ([]types.Preview, error) {
-	queryStruct := listPreviewQueryWithLabels{}
+	queryStruct := listPreviewQuery{}
 
 	variables := map[string]interface{}{}
 	labelsVariable := make(labelList, 0)

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -305,7 +305,7 @@ func TestListPreview(t *testing.T) {
 			input: input{
 				client: &fakeGraphQLClient{
 					queryResult: &listPreviewQuery{
-						Response: []previewEnvWithLabels{
+						Response: []previewEnv{
 							{
 								Id:       "test",
 								Sleeping: false,
@@ -334,7 +334,7 @@ func TestListPreview(t *testing.T) {
 				labels: []string{"value", "key"},
 				client: &fakeGraphQLClient{
 					queryResult: &listPreviewQuery{
-						Response: []previewEnvWithLabels{
+						Response: []previewEnv{
 							{
 								Id:       "test",
 								Sleeping: false,
@@ -431,7 +431,7 @@ func TestDeprecatedListPreview(t *testing.T) {
 			input: input{
 				client: &fakeGraphQLClient{
 					queryResult: &listPreviewQueryDeprecated{
-						Response: []previewEnv{
+						Response: []deprecatedPreviewEnv{
 							{
 								Id:       "test",
 								Sleeping: false,

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -304,7 +304,7 @@ func TestListPreview(t *testing.T) {
 			name: "no error",
 			input: input{
 				client: &fakeGraphQLClient{
-					queryResult: &listPreviewQueryWithLabels{
+					queryResult: &listPreviewQuery{
 						Response: []previewEnvWithLabels{
 							{
 								Id:       "test",
@@ -333,7 +333,7 @@ func TestListPreview(t *testing.T) {
 			input: input{
 				labels: []string{"value", "key"},
 				client: &fakeGraphQLClient{
-					queryResult: &listPreviewQueryWithLabels{
+					queryResult: &listPreviewQuery{
 						Response: []previewEnvWithLabels{
 							{
 								Id:       "test",
@@ -393,7 +393,7 @@ func TestListPreview(t *testing.T) {
 				labels: []string{"value", "key"},
 				client: &fakeGraphQLClient{
 					queryResult: nil,
-					err:         errors.New("Cannot query field \"previewLabels\" on type \"Preview\""),
+					err:         errors.New("Unknown argument \"labels\" on field \"previews\" of type \"Query\""),
 				},
 			},
 			expected: expected{

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -47,7 +47,7 @@ type NamespaceInterface interface {
 
 // PreviewInterface represents the client that connects to the preview functions
 type PreviewInterface interface {
-	List(ctx context.Context) ([]Preview, error)
+	List(ctx context.Context, labels []string) ([]Preview, error)
 	DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []Variable, labels []string) (*PreviewResponse, error)
 	GetResourcesStatus(ctx context.Context, previewName, devName string) (map[string]string, error)
 	Destroy(ctx context.Context, previewName string) error

--- a/pkg/types/preview.go
+++ b/pkg/types/preview.go
@@ -15,12 +15,13 @@ package types
 
 // Preview represents an Okteto preview environment
 type Preview struct {
-	ID           string        `json:"id" yaml:"id"`
-	Sleeping     bool          `json:"sleeping" yaml:"sleeping"`
-	Scope        string        `json:"scope" yaml:"scope"`
-	GitDeploys   []GitDeploy   `json:"gitDeploys"`
-	Statefulsets []Statefulset `json:"statefulsets"`
-	Deployments  []Deployment  `json:"deployments"`
+	ID            string        `json:"id" yaml:"id"`
+	Sleeping      bool          `json:"sleeping" yaml:"sleeping"`
+	Scope         string        `json:"scope" yaml:"scope"`
+	GitDeploys    []GitDeploy   `json:"gitDeploys"`
+	Statefulsets  []Statefulset `json:"statefulsets"`
+	Deployments   []Deployment  `json:"deployments"`
+	PreviewLabels []string      `json:"previewLabels" yaml:"previewLabels"`
 }
 
 // PreviewResponse represents the response of a deployPreview


### PR DESCRIPTION
# Proposed changes

Fixes #3608 

- Add a label flag to preview list command
- If the backend don't support it, return a user friendly error
- The output shows the labels that a preview has

### Acceptance criteria

- [x]  A user can add several labels as flags
- [x]  The flag —label can be used
- [x]  If the backend return an error, the user must get a friendly error
- [x]  If there is no labels the gql call shouldn’t have any mention to labels
