### PR TITLE
Support for node selector in the docker-compose spec

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -139,6 +139,7 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 				},
 				Spec: apiv1.PodSpec{
 					TerminationGracePeriodSeconds: pointer.Int64Ptr(svc.StopGracePeriod),
+					NodeSelector:                  svc.NodeSelector,
 					Containers: []apiv1.Container{
 						{
 							Name:            svcName,
@@ -213,6 +214,7 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 					TerminationGracePeriodSeconds: pointer.Int64Ptr(svc.StopGracePeriod),
 					InitContainers:                initContainers,
 					Affinity:                      translateAffinity(svc),
+					NodeSelector:                  svc.NodeSelector,
 					Volumes:                       translateVolumes(svc),
 					Containers: []apiv1.Container{
 						{
@@ -263,6 +265,7 @@ func translateJob(svcName string, s *model.Stack) *batchv1.Job {
 					TerminationGracePeriodSeconds: pointer.Int64Ptr(svc.StopGracePeriod),
 					InitContainers:                initContainers,
 					Affinity:                      translateAffinity(svc),
+					NodeSelector:                  svc.NodeSelector,
 					Containers: []apiv1.Container{
 						{
 							Name:            svcName,

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -68,6 +68,10 @@ func Test_translateDeployment(t *testing.T) {
 					"annotation1": "value1",
 					"annotation2": "value2",
 				},
+				NodeSelector: model.Selector{
+					"node1": "value1",
+					"node2": "value2",
+				},
 				Image:           "image",
 				Replicas:        3,
 				StopGracePeriod: 20,
@@ -97,16 +101,18 @@ func Test_translateDeployment(t *testing.T) {
 		model.StackNameLabel:        "stackname",
 		model.StackServiceNameLabel: "svcName",
 	}
-	if !reflect.DeepEqual(result.Labels, labels) {
-		t.Errorf("Wrong deployment labels: '%s'", result.Labels)
-	}
+	assert.Equal(t, result.Labels, labels)
 	annotations := map[string]string{
 		"annotation1": "value1",
 		"annotation2": "value2",
 	}
-	if !reflect.DeepEqual(result.Annotations, annotations) {
-		t.Errorf("Wrong deployment annotations: '%s'", result.Annotations)
+	assert.Equal(t, result.Annotations, annotations)
+	nodeSelector := map[string]string{
+		"node1": "value1",
+		"node2": "value2",
 	}
+	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
+
 	if *result.Spec.Replicas != 3 {
 		t.Errorf("Wrong deployment spec.replicas: '%d'", *result.Spec.Replicas)
 	}
@@ -169,6 +175,10 @@ func Test_translateStatefulSet(t *testing.T) {
 					"annotation1": "value1",
 					"annotation2": "value2",
 				},
+				NodeSelector: model.Selector{
+					"node1": "value1",
+					"node2": "value2",
+				},
 				Image:           "image",
 				Replicas:        3,
 				StopGracePeriod: 20,
@@ -215,14 +225,17 @@ func Test_translateStatefulSet(t *testing.T) {
 		model.StackServiceNameLabel: "svcName",
 	}
 	assert.Equal(t, labels, result.Labels)
-
 	annotations := map[string]string{
 		"annotation1": "value1",
 		"annotation2": "value2",
 	}
-	if !reflect.DeepEqual(result.Annotations, annotations) {
-		t.Errorf("Wrong statefulset annotations: '%s'", result.Annotations)
+	assert.Equal(t, result.Annotations, annotations)
+	nodeSelector := map[string]string{
+		"node1": "value1",
+		"node2": "value2",
 	}
+	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
+
 	if *result.Spec.Replicas != 3 {
 		t.Errorf("Wrong statefulset spec.replicas: '%d'", *result.Spec.Replicas)
 	}
@@ -363,6 +376,10 @@ func Test_translateJobWithoutVolumes(t *testing.T) {
 					"annotation1": "value1",
 					"annotation2": "value2",
 				},
+				NodeSelector: model.Selector{
+					"node1": "value1",
+					"node2": "value2",
+				},
 				Image:           "image",
 				StopGracePeriod: 20,
 				Replicas:        3,
@@ -408,16 +425,17 @@ func Test_translateJobWithoutVolumes(t *testing.T) {
 		model.StackNameLabel:        "stackname",
 		model.StackServiceNameLabel: "svcName",
 	}
-	if !reflect.DeepEqual(result.Labels, labels) {
-		t.Errorf("Wrong job labels: '%s'", result.Labels)
-	}
+	assert.Equal(t, labels, result.Labels)
 	annotations := map[string]string{
 		"annotation1": "value1",
 		"annotation2": "value2",
 	}
-	if !reflect.DeepEqual(result.Annotations, annotations) {
-		t.Errorf("Wrong job annotations: '%s'", result.Annotations)
+	assert.Equal(t, result.Annotations, annotations)
+	nodeSelector := map[string]string{
+		"node1": "value1",
+		"node2": "value2",
 	}
+	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
 	if *result.Spec.Completions != 3 {
 		t.Errorf("Wrong job spec.completions: '%d'", *result.Spec.Completions)
 	}
@@ -496,6 +514,10 @@ func Test_translateJobWithVolumes(t *testing.T) {
 					"annotation1": "value1",
 					"annotation2": "value2",
 				},
+				NodeSelector: model.Selector{
+					"node1": "value1",
+					"node2": "value2",
+				},
 				Image:           "image",
 				StopGracePeriod: 20,
 				Replicas:        3,
@@ -542,13 +564,17 @@ func Test_translateJobWithVolumes(t *testing.T) {
 		model.StackNameLabel:        "stackname",
 		model.StackServiceNameLabel: "svcName",
 	}
-	if !reflect.DeepEqual(result.Labels, labels) {
-		t.Errorf("Wrong job labels: '%s'", result.Labels)
-	}
+	assert.Equal(t, labels, result.Labels)
 	annotations := map[string]string{
 		"annotation1": "value1",
 		"annotation2": "value2",
 	}
+	assert.Equal(t, result.Annotations, annotations)
+	nodeSelector := map[string]string{
+		"node1": "value1",
+		"node2": "value2",
+	}
+	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
 	if !reflect.DeepEqual(result.Annotations, annotations) {
 		t.Errorf("Wrong job annotations: '%s'", result.Annotations)
 	}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -72,6 +72,7 @@ type Service struct {
 	Image           string                `yaml:"image,omitempty"`
 	Labels          Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations     Annotations           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	NodeSelector    Selector              `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
 	Ports           []Port                `yaml:"ports,omitempty"`
 	RestartPolicy   apiv1.RestartPolicy   `yaml:"restart,omitempty"`
 	StopGracePeriod int64                 `yaml:"stop_grace_period,omitempty"`
@@ -694,6 +695,9 @@ func (stack *Stack) mergeServices(otherStack *Stack) *Stack {
 		}
 		if len(svc.Annotations) > 0 {
 			resultSvc.Annotations = svc.Annotations
+		}
+		if len(svc.NodeSelector) > 0 {
+			resultSvc.NodeSelector = svc.NodeSelector
 		}
 		if len(svc.Ports) > 0 {
 			resultSvc.Ports = svc.Ports

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -79,6 +79,7 @@ type ServiceRaw struct {
 	Image                    string                `yaml:"image,omitempty"`
 	Labels                   Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations              Annotations           `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	NodeSelector             Selector              `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
 	MemLimit                 Quantity              `yaml:"mem_limit,omitempty"`
 	MemReservation           Quantity              `yaml:"mem_reservation,omitempty"`
 	Ports                    []PortRaw             `yaml:"ports,omitempty"`
@@ -416,6 +417,7 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 	if svc.Annotations == nil {
 		svc.Annotations = make(Annotations)
 	}
+	svc.NodeSelector = serviceRaw.NodeSelector
 
 	if stack.IsCompose {
 		if len(serviceRaw.Args.Values) > 0 {

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -728,8 +728,9 @@ func TestStack_Merge(t *testing.T) {
 								Value: "ok",
 							},
 						},
-						Labels:      Labels{"test": "ok"},
-						Annotations: Annotations{"test": "ok"},
+						Labels:       Labels{"test": "ok"},
+						Annotations:  Annotations{"test": "ok"},
+						NodeSelector: Selector{"test": "ok"},
 						Ports: []Port{
 							{
 								HostPort:      8080,
@@ -757,8 +758,9 @@ func TestStack_Merge(t *testing.T) {
 								Value: "overwrite",
 							},
 						},
-						Labels:      Labels{"test": "overwrite"},
-						Annotations: Annotations{"test": "overwrite"},
+						Labels:       Labels{"test": "overwrite"},
+						Annotations:  Annotations{"test": "overwrite"},
+						NodeSelector: Selector{"test": "overwrite"},
 						Ports: []Port{
 							{
 								HostPort:      3000,
@@ -786,8 +788,9 @@ func TestStack_Merge(t *testing.T) {
 								Value: "overwrite",
 							},
 						},
-						Labels:      Labels{"test": "overwrite"},
-						Annotations: Annotations{"test": "overwrite"},
+						Labels:       Labels{"test": "overwrite"},
+						Annotations:  Annotations{"test": "overwrite"},
+						NodeSelector: Selector{"test": "overwrite"},
 						Ports: []Port{
 							{
 								HostPort:      3000,


### PR DESCRIPTION
# Proposed changes

This PR adds support for `x-node-selector` in compose files. Node selector [is already supported](https://www.okteto.com/docs/reference/manifest/#nodeselector-mapstringstring-optional) in the dev containers section of okteto manifests