### PR TITLE
Fix depends on when loading stack from file

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -612,7 +612,7 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 	}
 
 	if isEmptyManifestFile(b) {
-		return nil, fmt.Errorf("%w: %w", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrEmptyManifest)
+		return nil, fmt.Errorf("%s: %w", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrEmptyManifest)
 	}
 
 	manifest, err := Read(b)

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -612,7 +612,7 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 	}
 
 	if isEmptyManifestFile(b) {
-		return nil, fmt.Errorf("%w: %s", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrEmptyManifest)
+		return nil, fmt.Errorf("%w: %w", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrEmptyManifest)
 	}
 
 	manifest, err := Read(b)

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -412,7 +412,12 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 		}
 		s, stackErr := LoadStack("", composeFiles, true)
 		if stackErr != nil {
-			return nil, stackErr
+			// if err is from validation, then return the stackErr
+			if errors.Is(stackErr, errDependsOn) {
+				return nil, stackErr
+			}
+			// if not return original manifest err
+			return nil, err
 		}
 		stackManifest.Deploy.ComposeSection.Stack = s
 		if stackManifest.Deploy.ComposeSection.Stack.Name != "" {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -410,12 +410,9 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 		for _, composeInfo := range stackManifest.Deploy.ComposeSection.ComposesInfo {
 			composeFiles = append(composeFiles, composeInfo.File)
 		}
-		s, stackErr := LoadStack("", composeFiles, false)
-
-		// We failed to load a stack file and a manifest file, so we need to return
-		// only the original manifest error
+		s, stackErr := LoadStack("", composeFiles, true)
 		if stackErr != nil {
-			return nil, err
+			return nil, stackErr
 		}
 		stackManifest.Deploy.ComposeSection.Stack = s
 		if stackManifest.Deploy.ComposeSection.Stack.Name != "" {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -387,6 +387,7 @@ func GetManifestV2(manifestPath string) (*Manifest, error) {
 	return nil, discovery.ErrOktetoManifestNotFound
 }
 
+// getManifestFromFile retrieves the manifest from a given file, okteto manifest or docker-compose
 func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 	devManifest, err := getOktetoManifest(manifestPath)
 	if err != nil {
@@ -439,7 +440,8 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 			for _, composeInfo := range devManifest.Deploy.ComposeSection.ComposesInfo {
 				stackFiles = append(stackFiles, composeInfo.File)
 			}
-			s, err := LoadStack("", stackFiles, false)
+			// LoadStack should perform validation of the stack read from the file on compose section
+			s, err := LoadStack("", stackFiles, true)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -836,6 +836,16 @@ sync:
 			composeBytes:  nil,
 			expectedErr:   discovery.ErrOktetoManifestNotFound,
 		},
+		{
+			name:          "manifestPath to a invalid compose file - depends_on error",
+			manifestBytes: nil,
+			composeBytes: []byte(`services:
+  api:
+    image: test
+    depends_on:
+      - frontend`),
+			expectedErr: errDependsOn,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/6669

When reading a compose from a file using `okteto deploy -f docker-compose.yaml` the function that loads the stack was not performing the validation required.

This PR enables validation when the stack is read from file as it is done when inferring the stack when the command is `okteto deploy` and there is no `okteto.yaml` but `docker-compose.yaml`

Depends_on fields point into services within the same compose.

Output is now the same in both cases:

Example using `movies-with-compose` and removing the service `frontend` but leaving `depends_on` at `movies` service.

```
API server listening at: 127.0.0.1:16484
 i  Using teresaromero @ okteto.teresa.dev.okteto.net as context
 x   Service 'movies' depends on service 'frontend' which is undefined.
```