### PR TITLE
Fix context cancelled with reading git status operation

### DIFF
--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -3,10 +3,12 @@ package repository
 import (
 	"context"
 	"errors"
-	"github.com/go-git/go-git/v5"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
+
+	"github.com/go-git/go-git/v5"
 )
 
 var (
@@ -24,6 +26,10 @@ type LocalExec struct{}
 
 func (*LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
 	c := exec.CommandContext(ctx, name, arg...)
+	c.Cancel = func() error {
+		return c.Process.Signal(syscall.SIGTERM)
+	}
+
 	c.Dir = dir
 	c.Env = os.Environ()
 	return c.Output()

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -30,7 +30,7 @@ type LocalExec struct{}
 func (*LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
 	c := exec.CommandContext(ctx, name, arg...)
 	c.Cancel = func() error {
-		oktetoLog.Debugf("terminating %s...", c.String())
+		oktetoLog.Debugf("terminating %s - %s/%s", c.String(), dir, name)
 		if err := c.Process.Signal(syscall.SIGTERM); err != nil {
 			oktetoLog.Debugf("err at signal SIGTERM: %v", err)
 		}
@@ -42,7 +42,7 @@ func (*LocalExec) RunCommand(ctx context.Context, dir string, name string, arg .
 			}
 			oktetoLog.Debugf("reading signal with error %v", err)
 		}
-		oktetoLog.Debugf("killing %s...", c.String())
+		oktetoLog.Debugf("killing %s - %s/%s", c.String(), dir, name)
 		return c.Process.Signal(syscall.SIGKILL)
 	}
 

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -35,7 +35,7 @@ func (*LocalExec) RunCommand(ctx context.Context, dir string, name string, arg .
 			oktetoLog.Debugf("err at signal SIGTERM: %v", err)
 		}
 
-		time.Sleep(5 * time.Second)
+		time.Sleep(3 * time.Second)
 		if err := c.Process.Signal(syscall.Signal(0)); err != nil {
 			if errors.Is(err, os.ErrProcessDone) {
 				return nil

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"os/exec"
+	"runtime"
 	"testing"
 	"time"
 
@@ -205,7 +206,12 @@ func Test_LocalExec_RunCommandWithContextCanceled(t *testing.T) {
 
 	localExec := &LocalExec{}
 	got, err := localExec.RunCommand(ctx, t.TempDir(), "sleep", "3600")
-	assert.ErrorContains(t, err, "signal: terminated")
+
+	if runtime.GOOS != "windows" {
+		assert.EqualError(t, err, "signal: terminated")
+	} else {
+		assert.EqualError(t, err, "exit status 1")
+	}
 	assert.Equal(t, []byte(""), got)
 }
 


### PR DESCRIPTION
# Proposed changes

Fixes: https://github.com/okteto/app/issues/6687

Relates: https://github.com/okteto/okteto/issues/3699

- Add custom Cancel function to `exec.CommandContext` so when the context is cancelled by external functions, the funcion exits with a termination signal instead of kill, that way git can remove the lock file and recover from the cancelation.

EDIT: after research, for windows we have to keep killing the process as there is no termination signal implementation
