### PR TITLE
Show error if deploying services with persistentVolume as `disabled`

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -310,6 +310,8 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
 		if err := config.UpdateStateFile(up.Dev.Name, up.Dev.Namespace, config.Attaching); err != nil {
 			oktetoLog.Infof("error updating state: %s", err.Error())
 		}
+	} else {
+		return fmt.Errorf("'persistentVolume.enabled' must be true to use the 'services' field")
 	}
 
 	oktetoLog.Spinner(msg)


### PR DESCRIPTION
# Proposed changes

Fixes #3437

**Final Output**
_-  If using services with `persistentVolume` as **disabled**:_
![Screenshot from 2023-06-10 13-38-49](https://github.com/okteto/okteto/assets/86051118/e2fc7b3d-a462-4a66-b04c-73ad9f9e2a77)

_- If using services with `persistenVolume` as **enabled**:_
![image](https://github.com/okteto/okteto/assets/86051118/83b8c91c-0a67-4928-9d59-2e02182836b7)

**Additional Information:** 
In the [blog](https://www.okteto.com/blog/develop-django-celery-app-in-kubernetes/) we're mentioning about to take a look at the `okteto.yml` file. However, the `okteto.yml` file doesn't match with the `okteto.yml` present [here](https://github.com/okteto/math). **Port Forwarding field is missing.** _We can raise a PR to add that change as well._ If the field will be missing, the user will have to use the endpoints from Okteto UI than directly from CLI.  Here's how it looks like _with/without_ Port forwarding mentioned:

**Port Forwarding included:**
![image](https://github.com/okteto/okteto/assets/86051118/54cfbf32-b4d9-44a1-8e61-a3bdb44fa95a) 
![image](https://github.com/okteto/okteto/assets/86051118/6428d768-1479-4d6e-9cdd-5b08f4b41c44)

**Port Forwarding not included:**
![image](https://github.com/okteto/okteto/assets/86051118/1e55a735-d8ad-49dc-af0c-6f9eb4f7aa5e)
![image](https://github.com/okteto/okteto/assets/86051118/0cded8e4-5e6e-4e97-bb25-70836aeadd6c)


