### PR TITLE
fix: no optional locks on git read only commands

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -73,7 +73,7 @@ func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
 	timeoutErr := errors.New("timeout exceeded")
 
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(5 * time.Second)
 		close(timeoutCh)
 		cancel()
 		ch <- cleanStatus{false, timeoutErr}

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -73,7 +73,7 @@ func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
 	timeoutErr := errors.New("timeout exceeded")
 
 	go func() {
-		time.Sleep(5 * time.Second)
+		time.Sleep(time.Second)
 		close(timeoutCh)
 		cancel()
 		ch <- cleanStatus{false, timeoutErr}

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -58,7 +58,7 @@ func (lg *LocalGit) Status(ctx context.Context, dirPath string, fixAttempt int) 
 		return git.Status{}, errLocalGitCannotGetStatusTooManyAttempts
 	}
 
-	output, err := lg.exec.RunCommand(ctx, dirPath, lg.gitPath, "status", "--porcelain", "-z")
+	output, err := lg.exec.RunCommand(ctx, dirPath, lg.gitPath, "--no-optional-locks", "status", "--porcelain", "-z")
 	if err != nil {
 		var exitError *exec.ExitError
 		errors.As(err, &exitError)


### PR DESCRIPTION
May resolve:
- https://github.com/okteto/okteto/issues/3699

Complementary or alternative to:
- https://github.com/okteto/okteto/pull/3704

This PR focuses on `git` configuration to avoid creating optional locks
on read only operations, specifically `git status`.

This comes with a cost, as the `.git/index` must be recalculated if it
is not up to date or if it was generated from a different `git` arch
such as running `git status` sequentially from a `linux/amd64` and then
from a `darwin/arm64`.

Because of it, `git` command timeout has been extended to 5 seconds.

This change is complementary to https://github.com/okteto/okteto/pull/3704 as it doesn't touch process
management and signals, so with the current `HEAD`, `git` command will
still be killed if it goes beyond the specified timeout.

`--no-optional-locks` was introduced in `git` v2.15:
- https://github.com/git/git/blob/master/Documentation/RelNotes/2.15.0.txt#L97-L100
- https://github.com/git/git/blob/fe86abd7511a9a6862d5706c6fa1d9b57a63ba09/Documentation/RelNotes/2.15.0.txt#L97-L100

Signed-off-by: Javier Provecho Fernández (Okteto) <jpf@okteto.com>