### PR TITLE
update golang-ci at circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:1.18.0
+      - image: okteto/golang-ci:2.3.0
 
 jobs:
   build-binaries:


### PR DESCRIPTION
# Proposed changes

Update golang-ci to 2.3.0 to support go features from 1.20 at circleci jobs
