### PR TITLE
Execute `okteto destroy --remote` successfully when there is no okteto manifest found

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -49,7 +49,7 @@ const (
 	succesfullyDeployedmsg = "Development environment '%s' successfully deployed"
 )
 
-// Options options for deploy command
+// Options represents options for deploy command
 type Options struct {
 	// ManifestPathFlag is the option -f as introduced by the user when executing this command.
 	// This is stored at the configmap as filename to redeploy from the ui.

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -235,14 +235,11 @@ func (dc *destroyCommand) getDestroyer(ctx context.Context, opts *Options) (dest
 	} else {
 		manifest, err := model.GetManifestV2(opts.ManifestPath)
 		if err != nil {
-			// error will only be available when there is no valid manifest found
-			// hence, we need not to destroy because the manifest would never be deployed
-			// Return the error message
+			// Log error message but application can still be deleted
 			oktetoLog.Infof("could not find manifest file to be executed: %s", err)
 			manifest = &model.Manifest{
 				Destroy: &model.DestroyInfo{},
 			}
-			return nil, err
 		}
 
 		isRemote := utils.LoadBoolean(constants.OktetoDeployRemote)

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -270,7 +270,7 @@ func (dc *destroyCommand) getDestroyer(ctx context.Context, opts *Options) (dest
 		// if the command is executed remotely and destroy section is nil, this will cause a panic
 		// Hence consider the command locally for successful execution.
 		// This will make sure all the resources are deleted.
-		if runInRemote == true && manifest.Destroy == nil {
+		if manifest.Destroy == nil {
 			runInRemote = false
 		}
 

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -266,14 +266,6 @@ func (dc *destroyCommand) getDestroyer(ctx context.Context, opts *Options) (dest
 		}
 		runInRemote := !isRemote && (destroyImage != "" || opts.RunInRemote)
 
-		// destroy section should not be nil whether the command is executed remotely or locally
-		// if the command is executed remotely and destroy section is nil, this will cause a panic
-		// Hence consider the command locally for successful execution.
-		// This will make sure all the resources are deleted.
-		if manifest.Destroy == nil {
-			runInRemote = false
-		}
-
 		if runInRemote {
 			destroyer = newRemoteDestroyer(manifest)
 			oktetoLog.Info("Destroying remotely...")

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -104,9 +104,12 @@ type remoteDestroyCommand struct {
 func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
 	fs := afero.NewOsFs()
 	builder := remoteBuild.NewBuilderFromScratch()
+	if manifest.Destroy == nil {
+		manifest.Destroy = &model.DestroyInfo{}
+	}
 	return &remoteDestroyCommand{
 		builder:              builder,
-		destroyImage:         "",
+		destroyImage:         manifest.Destroy.Image,
 		fs:                   fs,
 		workingDirectoryCtrl: filesystem.NewOsWorkingDirectoryCtrl(),
 		temporalCtrl:         filesystem.NewTemporalDirectoryCtrl(fs),

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -106,7 +106,7 @@ func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
 	builder := remoteBuild.NewBuilderFromScratch()
 	return &remoteDestroyCommand{
 		builder:              builder,
-		destroyImage:         manifest.Destroy.Image,
+		destroyImage:         "",
 		fs:                   fs,
 		workingDirectoryCtrl: filesystem.NewOsWorkingDirectoryCtrl(),
 		temporalCtrl:         filesystem.NewTemporalDirectoryCtrl(fs),

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package destroy
 
 import (

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -524,14 +524,14 @@ func GetInferredManifest(cwd string) (*Manifest, error) {
 		}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Found helm chart on %s", chartPath)
 		tags := inferHelmTags(chartPath)
-		command := fmt.Sprintf("helm upgrade --install ${%s} %s %s", constants.OktetoAutodiscoveryReleaseName, chartPath, tags)
+		deployHelm := fmt.Sprintf("helm upgrade --install ${%s} %s %s", constants.OktetoAutodiscoveryReleaseName, chartPath, tags)
 		chartManifest := &Manifest{
 			Type: ChartType,
 			Deploy: &DeployInfo{
 				Commands: []DeployCommand{
 					{
-						Name:    command,
-						Command: command,
+						Name:    deployHelm,
+						Command: deployHelm,
 					},
 				},
 			},


### PR DESCRIPTION
# Proposed changes

Fixes #3656 

![image](https://github.com/okteto/okteto/assets/86051118/2e2e25c7-9646-4a31-b841-1b9ecded47e0)

**Additional Information:**

1. **Why is the panic occurring?**

- In the [directory](https://github.com/ifbyol/test-pipeline), we don't have any `okteto.yml` file. Okteto was able to deploy because of the `k8s.yml` file and executed the command `kubectl apply -f...` that is [mentioned here](https://github.com/okteto/okteto/blob/master/pkg/model/manifest.go#L554). it applied the commands successfully and hence was able to deploy. 

- When it comes to destroy, okteto tried to look for okteto manifet such as `okteto.yml` but in the repository, `okteto-custom.yml` was present. Hence it detected that [no okteto manifest was found](https://github.com/okteto/okteto/blob/master/pkg/discovery/manifest.go#L24). However, the K8s manifest was there but there were no commands on how to delete the services produced by k8s manifest. Generally, we have Okteto manifest mentioning how to destroy services produced by k8s manifest but here `okteto-custom.yml` doesn't fit the naming convention for the okteto manifest.

2. **Have you tested your changes on some other application that contains both `okteto.yml` and `k8s.yml`?**

- Yes, I've tried testing changes on [this go application](https://github.com/okteto/go-getting-started) that contains both `k8s.yml` and `okteto.yml`. The changes run well as expected. Here's the attached image:
![Screenshot from 2023-06-22 11-11-42](https://github.com/okteto/okteto/assets/86051118/4efdcc48-5d32-439f-a2f9-8990f4c01ff3)

3. **Is there anything else you'd like to add?**

- I think we may need to add separate commands to destroy services generated by _compose, helm_ when no okteto manifest has been detected. The application will be deployed but will execute panic when destroying if there is no okteto manifest and no command specified on how to delete services generated by _compose, helm etc,_
