### PR TITLE
Update the log message when no endpoints are available

### DIFF
--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -227,7 +227,7 @@ func (dc *EndpointGetter) showEndpoints(ctx context.Context, opts *EndpointsOpti
 		}
 	default:
 		if len(eps) == 0 {
-			oktetoLog.Printf("There are no available endpoints for '%s'\n", opts.Name)
+			oktetoLog.Information("There are no available endpoints for '%s'.\n    Follow this link to know more about how to create public endpoints for your application:\n    https://www.okteto.com/docs/cloud/ssl/", opts.Name)
 		} else {
 			oktetoLog.Information("Endpoints available:")
 			oktetoLog.Printf("  - %s\n", strings.Join(eps, "\n  - "))


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/okteto/issues/3719

- Updates the message to mention redirecting to [this](https://www.okteto.com/docs/cloud/ssl/) when no endpoints are provided.
![Screenshot from 2023-06-23 19-14-38](https://github.com/okteto/okteto/assets/86051118/bbae08fc-bca0-4fbc-b9c0-5e1e1dbdf504)

