### PR TITLE
Don't copy ca-certs on deploy image

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -48,15 +48,11 @@ const (
 	dockerfileTemplate     = `
 FROM {{ .OktetoCLIImage }} as okteto-cli
 
-FROM alpine as certs
-RUN apk update && apk add ca-certificates
-
 FROM {{ .InstallerImage }} as installer
 
 FROM {{ .UserDeployImage }} as deploy
 
 ENV PATH="${PATH}:/okteto/bin"
-COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 COPY --from=installer /app/bin/* /okteto/bin/
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -38,13 +38,9 @@ FROM {{ .OktetoCLIImage }} as okteto-cli
 
 FROM {{ .InstallerImage }} as installer
 
-FROM alpine as certs
-RUN apk update && apk add ca-certificates
-
 FROM {{ .UserDestroyImage }} as deploy
 
 ENV PATH="${PATH}:/okteto/bin"
-COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 COPY --from=installer /app/bin/* /okteto/bin/
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 


### PR DESCRIPTION
Since we pass the [right certificate](https://github.com/okteto/okteto/pull/3618) on `okteto deploy --remote` , there is no need to copy `ca-certificates` on the deploy image at runtime.
The user is responsible of adding the right certificates to her image if needed.