### PR TITLE
Use ARG instead of ENV to pass metadata for "--remote"

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -114,7 +114,7 @@ func (*OktetoBuilder) IsV1() bool {
 
 // Build builds the images defined by a manifest
 func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions) error {
-	if utils.LoadBoolean(constants.OKtetoDeployRemote) {
+	if utils.LoadBoolean(constants.OktetoDeployRemote) {
 		// Since the local build has already been built,
 		// we have the environment variables set and we can skip this code
 		return nil

--- a/cmd/deploy/cfghandler.go
+++ b/cmd/deploy/cfghandler.go
@@ -54,7 +54,7 @@ func newDefaultConfigMapHandler(provider okteto.K8sClientProvider) *defaultConfi
 }
 
 func NewConfigmapHandler(provider okteto.K8sClientProvider) configMapHandler {
-	if utils.LoadBoolean(constants.OKtetoDeployRemote) {
+	if utils.LoadBoolean(constants.OktetoDeployRemote) {
 		return newDeployInsideDeployConfigMapHandler()
 	}
 	return newDefaultConfigMapHandler(provider)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -194,7 +194,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				Builder:            buildv2.NewBuilderFromScratch(),
 				DeployWaiter:       NewDeployWaiter(k8sClientProvider),
 				EndpointGetter:     NewEndpointGetter,
-				isRemote:           utils.LoadBoolean(constants.OKtetoDeployRemote),
+				isRemote:           utils.LoadBoolean(constants.OktetoDeployRemote),
 				CfgMapHandler:      NewConfigmapHandler(k8sClientProvider),
 				Fs:                 afero.NewOsFs(),
 				PipelineCMD:        pc,
@@ -530,7 +530,7 @@ func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, b
 
 	// isDeployRemote represents wheather the process is comming from a remote deploy
 	// if true it should get the local deployer
-	isDeployRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
+	isDeployRemote := utils.LoadBoolean(constants.OktetoDeployRemote)
 
 	// remote deployment should be done when flag RunInRemote is active OR deploy.image is fulfilled
 	if !isDeployRemote && (opts.RunInRemote || opts.Manifest.Deploy.Image != "") {

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -271,7 +271,7 @@ func TestCreateDockerfile(t *testing.T) {
 				},
 			},
 			expected: expected{
-				dockerfileName: filepath.Clean("/test/deploy"),
+				dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
 			},
 		},
 	}
@@ -371,7 +371,7 @@ func Test_getOktetoCLIVersion(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.cliImageEnv != "" {
-				t.Setenv(constants.OKtetoDeployRemoteImage, tt.cliImageEnv)
+				t.Setenv(constants.OktetoDeployRemoteImage, tt.cliImageEnv)
 			}
 
 			version := getOktetoCLIVersion(tt.versionString)

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -244,7 +244,7 @@ func (dc *destroyCommand) getDestroyer(ctx context.Context, opts *Options) (dest
 			}
 		}
 
-		isRemote := utils.LoadBoolean(constants.OKtetoDeployRemote)
+		isRemote := utils.LoadBoolean(constants.OktetoDeployRemote)
 
 		destroyImage := ""
 		if manifest.Destroy != nil {

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -296,10 +296,9 @@ func TestCreateDockerfile(t *testing.T) {
 		err            error
 	}
 	var tests = []struct {
-		name            string
-		config          config
-		expected        expected
-		actionNameValue string
+		name     string
+		config   config
+		expected expected
 	}{
 		{
 			name: "OS can't access working directory",
@@ -319,9 +318,8 @@ func TestCreateDockerfile(t *testing.T) {
 				opts: &Options{},
 			},
 			expected: expected{
-				dockerfileName: filepath.Clean("/test/deploy"),
+				dockerfileName: filepath.Clean("/test/Dockerfile.destroy"),
 			},
-			actionNameValue: "test",
 		},
 	}
 
@@ -334,7 +332,6 @@ func TestCreateDockerfile(t *testing.T) {
 				workingDirectoryCtrl: wdCtrl,
 				registry:             newFakeRegistry(),
 			}
-			t.Setenv(model.OktetoActionNameEnvVar, tt.actionNameValue)
 			dockerfileName, err := rdc.createDockerfile("/test", tt.config.opts)
 			assert.ErrorIs(t, err, tt.expected.err)
 			assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
@@ -343,7 +340,7 @@ func TestCreateDockerfile(t *testing.T) {
 				_, err = rdc.fs.Stat(filepath.Join("/test", dockerfileTemporalNane))
 				assert.NoError(t, err)
 				content, _ := afero.ReadFile(rdc.fs, filepath.Join("/test", dockerfileTemporalNane))
-				assert.True(t, strings.Contains(string(content), fmt.Sprintf("ENV %s %s", model.OktetoActionNameEnvVar, tt.actionNameValue)))
+				assert.True(t, strings.Contains(string(content), fmt.Sprintf("ARG %s", model.OktetoActionNameEnvVar)))
 			}
 
 		})
@@ -419,7 +416,7 @@ func Test_getOktetoCLIVersion(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.cliImageEnv != "" {
-				t.Setenv(constants.OKtetoDeployRemoteImage, tt.cliImageEnv)
+				t.Setenv(constants.OktetoDeployRemoteImage, tt.cliImageEnv)
 			}
 
 			version := getOktetoCLIVersion(tt.versionString)

--- a/cmd/utils/executor/executor.go
+++ b/cmd/utils/executor/executor.go
@@ -59,7 +59,7 @@ func NewExecutor(output string, runWithoutBash bool, dir string) *Executor {
 	}
 
 	shell := "bash"
-	if utils.LoadBoolean(constants.OKtetoDeployRemote) {
+	if utils.LoadBoolean(constants.OktetoDeployRemote) {
 		shell = "sh"
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -50,11 +50,20 @@ const (
 	// TimeFormat is the format to use when storing timestamps as a string
 	TimeFormat = "2006-01-02T15:04:05"
 
-	// OKtetoDeployRemote defines if deployment is executed remotely
-	OKtetoDeployRemote = "OKTETO_DEPLOY_REMOTE"
+	// OktetoDeployRemote defines if deployment is executed remotely
+	OktetoDeployRemote = "OKTETO_DEPLOY_REMOTE"
 
-	// OKtetoDeployRemoteImage defines okteto cli image used for deploy an environment remotely
-	OKtetoDeployRemoteImage = "OKTETO_REMOTE_CLI_IMAGE"
+	// OktetoTlsCertBase64 defines the TLS certificate in base64 for --remote
+	OktetoTlsCertBase64EnvVar = "OKTETO_TLS_CERT_BASE64"
+
+	// OktetoInternalServerName defines the internal server name for --remote
+	OktetoInternalServerNameEnvVar = "INTERNAL_SERVER_NAME"
+
+	// OktetoInvalidateCacheEnvVar defines a ramdom number to invalidate the "--remote" cache
+	OktetoInvalidateCacheEnvVar = "OKTETO_INVALIDATE_CACHE"
+
+	// OktetoDeployRemoteImage defines okteto cli image used for deploy an environment remotely
+	OktetoDeployRemoteImage = "OKTETO_REMOTE_CLI_IMAGE"
 
 	// OktetoCLIImageForRemoteTemplate defines okteto CLI image template to use for remote deployments
 	OktetoCLIImageForRemoteTemplate = "okteto/okteto:%s"

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -47,7 +47,7 @@ func NewRepository(path string) Repository {
 
 	var controller repositoryInterface = newGitRepoController()
 	// check if we are inside a remote deploy
-	if v := os.Getenv(constants.OKtetoDeployRemote); v != "" {
+	if v := os.Getenv(constants.OktetoDeployRemote); v != "" {
 		sha := os.Getenv(constants.OktetoGitCommitEnvVar)
 		controller = newOktetoRemoteRepoController(sha)
 	}

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -15,9 +15,10 @@ package repository
 
 import (
 	"context"
-	"github.com/go-git/go-git/v5"
 	"net/url"
 	"testing"
+
+	"github.com/go-git/go-git/v5"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/okteto/okteto/pkg/constants"
@@ -113,7 +114,7 @@ func TestNewRepo(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(constants.OktetoGitCommitEnvVar, tc.GitCommit)
-			t.Setenv(constants.OKtetoDeployRemote, string(tc.remoteDeploy))
+			t.Setenv(constants.OktetoDeployRemote, string(tc.remoteDeploy))
 			r := NewRepository("https://my-repo/okteto/okteto")
 			assert.Equal(t, "/okteto/okteto", r.url.Path)
 			assert.IsType(t, tc.expectedControl, r.control)


### PR DESCRIPTION
This PR refactors the `Dockerfile` generation for `--remote` to pass information using `ARG`instead of `ENV`. This way, sensible information like the okteto token, is not in plain in the dynamic Dockerfile.

