### PR TITLE
Always create ".dockerignore" for "okteto destroy"

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -116,7 +116,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "deploy [service...]",
-		Short: "Execute locally the list of commands specified in the 'deploy' section of your okteto manifest",
+		Short: "Execute the list of commands specified in the 'deploy' section of your okteto manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// validate cmd options
 			if options.Dependencies && !okteto.IsOkteto() {

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -256,12 +256,7 @@ func (rd *remoteDeployCommand) createDockerignore(cwd, tmpDir string) error {
 			return err
 		}
 	}
-	err := afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
 }
 
 func getDeployFlags(opts *Options) []string {

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -297,7 +297,7 @@ func TestCreateDockerfile(t *testing.T) {
 	}
 }
 
-func TestCreateDockerignoreIfNeeded(t *testing.T) {
+func TestCreateDockerignore(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	tempDir := "/temp"
 

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -216,7 +216,7 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 		return "", err
 	}
 
-	err = rd.createDockerignoreIfNeeded(cwd, tempDir)
+	err = rd.createDockerignore(cwd, tempDir)
 	if err != nil {
 		return "", err
 	}
@@ -228,7 +228,7 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 
 }
 
-func (rd *remoteDestroyCommand) createDockerignoreIfNeeded(cwd, tmpDir string) error {
+func (rd *remoteDestroyCommand) createDockerignore(cwd, tmpDir string) error {
 	dockerignoreContent := []byte(``)
 	dockerignoreFilePath := filepath.Join(cwd, oktetoDockerignoreName)
 	if _, err := rd.fs.Stat(dockerignoreFilePath); err != nil {
@@ -242,12 +242,7 @@ func (rd *remoteDestroyCommand) createDockerignoreIfNeeded(cwd, tmpDir string) e
 			return err
 		}
 	}
-	err := afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return afero.WriteFile(rd.fs, fmt.Sprintf("%s/%s", tmpDir, ".dockerignore"), dockerignoreContent, 0600)
 }
 
 func getDestroyFlags(opts *Options) []string {

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -347,7 +347,7 @@ func TestCreateDockerfile(t *testing.T) {
 	}
 }
 
-func TestCreateDockerignoreIfNeeded(t *testing.T) {
+func TestCreateDockerignore(t *testing.T) {
 	fs := afero.NewMemMapFs()
 
 	dockerignoreWd := "/test/"
@@ -378,7 +378,7 @@ func TestCreateDockerignoreIfNeeded(t *testing.T) {
 				fs:       fs,
 				registry: newFakeRegistry(),
 			}
-			err := rdc.createDockerignoreIfNeeded(tt.config.wd, "/temp")
+			err := rdc.createDockerignore(tt.config.wd, "/temp")
 			assert.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
Similarly to what we did [here](https://github.com/okteto/okteto/pull/3539) for `okteto deploy --remote`, we should create an empty `.dockerignore` file for `okteto destroy --remote` if needed