### PR TITLE
refactor: add metadata to exec analytics for mode

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -37,6 +37,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	defaultDevMode = "sync"
+)
+
 // execFlags is the input of the user to exec command
 type execFlags struct {
 	manifestPath     string
@@ -94,9 +98,15 @@ func Exec() *cobra.Command {
 				err = executeExec(ctx, dev, execFlags.commandToExecute)
 			}
 
+			mode := dev.Mode
+			if mode == "" {
+				mode = defaultDevMode
+			}
+
 			analytics.TrackExec(&analytics.TrackExecMetadata{
 				FirstArgIsDev: manifest.Dev.HasDev(args[0]),
 				Success:       err == nil,
+				Mode:          mode,
 			})
 
 			if oktetoErrors.IsNotFound(err) {

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -217,12 +217,14 @@ func TrackDurationActivateUp(durationActivateUp time.Duration) {
 type TrackExecMetadata struct {
 	FirstArgIsDev bool
 	Success       bool
+	Mode          string
 }
 
 // TrackExec sends a tracking event to mixpanel when the user runs the exec command
 func TrackExec(m *TrackExecMetadata) {
 	props := map[string]interface{}{
 		"isFirstArgDev": m.FirstArgIsDev,
+		"mode":          m.Mode,
 	}
 	track(execEvent, m.Success, props)
 }


### PR DESCRIPTION
# Proposed changes

This PR implements the analytics described at https://github.com/okteto/app/issues/6493

In order to track if exec command is run with hybrid or sync mode, we add to props this information.