### PR TITLE
Remove git credentials from debug logs

### DIFF
--- a/pkg/devenvironment/name.go
+++ b/pkg/devenvironment/name.go
@@ -82,12 +82,12 @@ func (n NameInferer) InferNameFromDevEnvsAndRepository(ctx context.Context, repo
 		optsRepo := repository.NewRepository(repoURL)
 		cmapRepo := repository.NewRepository(repo)
 		if !optsRepo.IsEqual(cmapRepo) {
-			oktetoLog.Infof("configmap %s with repo %s doesn't match with found repo %s", cmap.Name, repo, repoURL)
+			oktetoLog.Infof("configmap %s with repo %s doesn't match with found repo %s", cmap.Name, cmapRepo.GetAnonymizedRepo(), repoURL)
 			continue
 		}
 
 		if filename := cmap.Data["filename"]; filename != manifestPath {
-			oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", filename, repo, manifestPath)
+			oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", filename, cmapRepo.GetAnonymizedRepo(), manifestPath)
 			continue
 		}
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -44,8 +44,9 @@ type repositoryURL struct {
 
 // String is a custom implementation for the url where User is removed
 func (r repositoryURL) String() string {
-	r.URL.User = nil
-	return r.URL.String()
+	repo := r.URL
+	repo.User = nil
+	return repo.String()
 }
 
 func getURLFromPath(path string) repositoryURL {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -89,3 +89,18 @@ func (r Repository) IsEqual(otherRepo Repository) bool {
 func cleanPath(path string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(path, "/"), ".git")
 }
+
+// GetAnonymizedRepo returns a clean repo url string without sensible information
+func (r Repository) GetAnonymizedRepo() string {
+	gitURL := r.url.String()
+
+	parsedRepo, err := giturls.Parse(gitURL)
+	if err != nil {
+		return ""
+	}
+
+	if parsedRepo.User.Username() != "" {
+		parsedRepo.User = nil
+	}
+	return parsedRepo.String()
+}

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -324,3 +324,20 @@ func Test_getURLFromPath(t *testing.T) {
 		})
 	}
 }
+
+func Test_String(t *testing.T) {
+	r := &repositoryURL{
+		url.URL{
+			Scheme: "http",
+			Host:   "okteto.com",
+			Path:   "docs",
+			User:   url.UserPassword("test", "password"),
+		},
+	}
+
+	expected := "http://okteto.com/docs"
+	got := r.String()
+
+	assert.Equal(t, expected, got)
+	assert.NotNil(t, r.URL.User)
+}

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
+	giturls "github.com/whilp/git-urls"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/okteto/okteto/pkg/constants"
@@ -215,6 +216,45 @@ func TestCleanPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := cleanPath(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_GetAnonymizedRepo(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		expected string
+		repo     string
+	}{
+		{
+			name:     "https repo without credentials",
+			repo:     "https://github.com/okteto/okteto",
+			expected: "https://github.com/okteto/okteto",
+		},
+		{
+			name:     "ssh repo",
+			repo:     "git@github.com:okteto/okteto.git",
+			expected: "ssh://github.com/okteto/okteto.git",
+		},
+		{
+			name:     "https repo with credentials",
+			repo:     "https://git:PASSWORD@github.com/okteto/okteto",
+			expected: "https://github.com/okteto/okteto",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoURL, err := giturls.Parse(tt.repo)
+			assert.NoError(t, err)
+
+			repo := Repository{
+				url: repoURL,
+			}
+			got := repo.GetAnonymizedRepo()
+
+			assert.Equal(t, tt.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3560 

In order to display de repo url without user information, new method attached to `Repository` and use it for displying the logs.
