### PR TITLE
Fix integration hybrid

### DIFF
--- a/cmd/up/exec_unix.go
+++ b/cmd/up/exec_unix.go
@@ -34,7 +34,6 @@ func (he *hybridExecutor) GetCommandToExec(ctx context.Context, cmd []string) (*
 
 	c.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid:    true,
-		Foreground: true,
 	}
 
 	return c, nil

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -927,18 +927,23 @@ func (up *upContext) shutdown() {
 }
 
 func (up *upContext) shutdownHybridMode() {
-	if up.hybridCommand != nil {
-		pid := up.hybridCommand.Process.Pid
-		if existProcess(pid) {
-			if err := killProcess(pid); err != nil {
-				oktetoLog.Warning("failed to stop gracefully local process related to command executed in hybrid mode: %s", err.Error())
-			}
+	if up.hybridCommand == nil {
+		return
+	}
+	if up.hybridCommand.Process == nil {
+		return
+	}
 
-			waitTimeout := 15 * time.Second
-			hasFinished := hasHybridCommandFinished(pid, waitTimeout)
-			if !hasFinished {
-				oktetoLog.Warning("timeout waiting to finish hybrid command gracefully")
-			}
+	pid := up.hybridCommand.Process.Pid
+	if existProcess(pid) {
+		if err := killProcess(pid); err != nil {
+			oktetoLog.Warning("failed to stop gracefully local process related to command executed in hybrid mode: %s", err.Error())
+		}
+
+		waitTimeout := 15 * time.Second
+		hasFinished := hasHybridCommandFinished(pid, waitTimeout)
+		if !hasFinished {
+			oktetoLog.Warning("timeout waiting to finish hybrid command gracefully")
 		}
 	}
 }

--- a/integration/commands/dev.go
+++ b/integration/commands/dev.go
@@ -99,7 +99,13 @@ func RunOktetoUpAndWait(oktetoPath string, upOptions *UpOptions) error {
 		return fmt.Errorf("okteto up failed to start: %s", err)
 	}
 
-	return cmd.Wait()
+	err := cmd.Wait()
+	if err != nil {
+		log.Printf("okteto up failed: %v", err)
+		log.Printf("okteto up output err: \n%s", string(out.Bytes()))
+		return err
+	}
+	return nil
 }
 
 func getUpCmd(oktetoPath string, upOptions *UpOptions) *exec.Cmd {


### PR DESCRIPTION
# Proposed changes

When introducing https://github.com/okteto/okteto/pull/3683 at master the integration test failed.
The cause identified where 2:
- nil pointer when Process is nil when shutingdown
- Foreground property at SysProcAttr (after long investigation i found that using this property caused the binary for the shell to not work properly)

This changes have been also tested with the hybrid feature, this means the functionality is still working.

Also added logs in case of error for the Hybrid integration as the error shown at the test was not clear enough

