### PR TITLE
[Fix] [Pull-First-Approach] Search first in dev registry (Option 2/2)

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -59,6 +59,7 @@ type oktetoBuilderConfigInterface interface {
 	GetBuildHash(*model.BuildInfo) string
 	GetGitCommit() string
 	IsOkteto() bool
+	IsClean() (bool, error)
 }
 
 // OktetoBuilder builds the images

--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -84,7 +84,12 @@ func (oc oktetoBuilderConfig) GetGitCommit() string {
 	return commitSHA
 }
 
-// GetBuildTag returns a sha hash of the build info and the commit sha
+// IsClean checks if the repository is clean
+func (oc oktetoBuilderConfig) IsClean() (bool, error) {
+	return oc.repository.IsClean()
+}
+
+// GetBuildHash returns a sha hash of the build info and the commit sha
 func (oc oktetoBuilderConfig) GetBuildHash(buildInfo *model.BuildInfo) string {
 	commitSHA, err := oc.repository.GetSHA()
 	if err != nil {

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -40,7 +40,7 @@ func getTargetRegistries() []string {
 	registries := []string{}
 
 	if okteto.IsOkteto() {
-		registries = append(registries, constants.GlobalRegistry, constants.DevRegistry)
+		registries = append(registries, constants.DevRegistry, constants.GlobalRegistry)
 	}
 
 	return registries

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -216,8 +216,8 @@ func TestImageTaggerGetPossibleHashImages(t *testing.T) {
 			name: "sha",
 			sha:  "sha",
 			expectedImages: []string{
-				"okteto.global/test-test:sha",
 				"okteto.dev/test-test:sha",
+				"okteto.global/test-test:sha",
 			},
 		},
 	}
@@ -244,8 +244,8 @@ func TestImageTaggerWithVolumesGetPossibleHashImages(t *testing.T) {
 			name: "sha",
 			sha:  "sha",
 			expectedImages: []string{
-				"okteto.global/test-test:okteto-with-volume-mounts-sha",
 				"okteto.dev/test-test:okteto-with-volume-mounts-sha",
+				"okteto.global/test-test:okteto-with-volume-mounts-sha",
 			},
 		},
 	}
@@ -267,18 +267,18 @@ func TestImageTaggerGetPossibleTags(t *testing.T) {
 			name: "no sha",
 			sha:  "",
 			expectedImages: []string{
-				"okteto.global/test-test:okteto",
 				"okteto.dev/test-test:okteto",
+				"okteto.global/test-test:okteto",
 			},
 		},
 		{
 			name: "sha",
 			sha:  "sha",
 			expectedImages: []string{
-				"okteto.global/test-test:sha",
 				"okteto.dev/test-test:sha",
-				"okteto.global/test-test:okteto",
+				"okteto.global/test-test:sha",
 				"okteto.dev/test-test:okteto",
+				"okteto.global/test-test:okteto",
 			},
 		},
 	}
@@ -300,18 +300,18 @@ func TestImageTaggerWithVolumesGetPossibleTags(t *testing.T) {
 			name: "no sha",
 			sha:  "",
 			expectedImages: []string{
-				"okteto.global/test-test:okteto-with-volume-mounts",
 				"okteto.dev/test-test:okteto-with-volume-mounts",
+				"okteto.global/test-test:okteto-with-volume-mounts",
 			},
 		},
 		{
 			name: "sha",
 			sha:  "sha",
 			expectedImages: []string{
-				"okteto.global/test-test:okteto-with-volume-mounts-sha",
 				"okteto.dev/test-test:okteto-with-volume-mounts-sha",
-				"okteto.global/test-test:okteto-with-volume-mounts",
+				"okteto.global/test-test:okteto-with-volume-mounts-sha",
 				"okteto.dev/test-test:okteto-with-volume-mounts",
+				"okteto.global/test-test:okteto-with-volume-mounts",
 			},
 		},
 	}
@@ -338,8 +338,8 @@ func Test_getTargetRegistries(t *testing.T) {
 			name:     "okteto-cluster",
 			isOkteto: true,
 			expected: []string{
-				"okteto.global",
 				"okteto.dev",
+				"okteto.global",
 			},
 		},
 	}


### PR DESCRIPTION
⚠️ WIP: This is a different approach to https://github.com/okteto/okteto/pull/3750 which skips the call to the `okteto.dev` registry for dirty commits. 

# Proposed changes

Fixes https://github.com/okteto/app/issues/6710

## How to reproduce the bug

1. Use context: `demo.okteto.dev`
2. Clone https://github.com/okteto/movies-with-helm
3. Build the CLI from `master` or use the latest release (`2.16.3`), and run `okteto build` in `movies-with-helm`
4. Notice how the image is being built successfully (it's probably already built, and it's okay)
5. Now make a change (eg `echo hi > hi.txt`)
6. Run again `okteto build` and notice the cmd succeeding again
7. Now run `okteto deploy`, wait until complete, then go to the UI
8. Inspect the YAML of the movies API deployment, search for the `image:` and notice that it's using an image from the `okteto` namespace instead of your own, example `image: registry.demo.okteto.dev/okteto/movies-with-helm....`).

The `image:` should have been pointing to your own namespace, because by making the repo dirty, and building a new image, you now have a tag for that change but it wasn't used at deploy time.

## How to test the fix

1. Using this branch, build the CLI
2. Using the same repository `movies-with-helm` and keeping the change you made run the new version of the CLI
3. Check again the `image:` property in the Dashboard and notice how it now shows: `image: registry.demo.okteto.dev/<your namespace>/movies-with-helm-api...`

