### PR TITLE
add envs from manifest to local process

### DIFF
--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -214,6 +214,10 @@ func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 
 	envs = append(envs, eg.getDefaultLocalEnvs()...)
 
+	for _, env := range eg.dev.Environment {
+		envs = append(envs, fmt.Sprintf("%s=%s", env.Name, env.Value))
+	}
+
 	return envs, nil
 }
 

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -185,18 +185,6 @@ func newEnvsGetter(hybridCtx *HybridExecCtx) (*envsGetter, error) {
 func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 	var envs []string
 
-	configMapEnvs, err := eg.configMapEnvsGetter.getEnvsFromConfigMap(ctx, eg.name, eg.namespace, eg.client)
-	if err != nil {
-		return nil, err
-	}
-	envs = append(envs, configMapEnvs...)
-
-	secretsEnvs, err := eg.secretsEnvsGetter.getEnvsFromSecrets(ctx)
-	if err != nil {
-		return nil, err
-	}
-	envs = append(envs, secretsEnvs...)
-
 	app, err := apps.Get(ctx, eg.dev, eg.namespace, eg.client)
 	if err != nil {
 		return nil, err
@@ -207,6 +195,18 @@ func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	envs = append(envs, imageEnvs...)
+
+	secretsEnvs, err := eg.secretsEnvsGetter.getEnvsFromSecrets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	envs = append(envs, secretsEnvs...)
+
+	configMapEnvs, err := eg.configMapEnvsGetter.getEnvsFromConfigMap(ctx, eg.name, eg.namespace, eg.client)
+	if err != nil {
+		return nil, err
+	}
+	envs = append(envs, configMapEnvs...)
 
 	for _, env := range apps.GetDevContainer(app.PodSpec(), "").Env {
 		envs = append(envs, fmt.Sprintf("%s=%s", env.Name, env.Value))

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -41,6 +41,7 @@ func TestGetEnvs(t *testing.T) {
 	tests := []struct {
 		name                    string
 		expectedEnvs            []string
+		dev                     *model.Dev
 		client                  *fake.Clientset
 		fakeConfigMapEnvsGetter fakeGetter
 		fakeSecretEnvsGetter    fakeGetter
@@ -67,6 +68,10 @@ func TestGetEnvs(t *testing.T) {
 					},
 				},
 			}),
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
 		},
 		{
 			name:                    "only envs from secrets",
@@ -90,6 +95,10 @@ func TestGetEnvs(t *testing.T) {
 					},
 				},
 			}),
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
 		},
 		{
 			name: "only envs from image",
@@ -118,6 +127,10 @@ func TestGetEnvs(t *testing.T) {
 			fakeSecretEnvsGetter:    fakeGetter{},
 			fakeImageEnvsGetter:     fakeGetter{envs: []string{"FROMIMAGE=VALUE1"}},
 			expectedEnvs:            []string{"FROMIMAGE=VALUE1"},
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
 		},
 		{
 			name: "only envs from pod",
@@ -147,16 +160,51 @@ func TestGetEnvs(t *testing.T) {
 			fakeSecretEnvsGetter:    fakeGetter{},
 			fakeImageEnvsGetter:     fakeGetter{},
 			expectedEnvs:            []string{"FROMPOD=VALUE1"},
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+		{
+			name: "only envs from environment section in manifest",
+			client: fake.NewSimpleClientset(&appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Env: []v1.EnvVar{},
+								},
+							},
+						},
+					},
+				},
+			}),
+			fakeConfigMapEnvsGetter: fakeGetter{},
+			fakeSecretEnvsGetter:    fakeGetter{},
+			fakeImageEnvsGetter:     fakeGetter{},
+			expectedEnvs:            []string{"FROMENVSECTION=VALUE1"},
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+				Environment: model.Environment{
+					model.EnvVar{
+						Name:  "FROMENVSECTION",
+						Value: "VALUE1",
+					},
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			eg := envsGetter{
-				dev: &model.Dev{
-					Name:      "test",
-					Namespace: "test",
-				},
+				dev:                 tt.dev,
 				name:                "test",
 				namespace:           "test",
 				client:              tt.client,

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -363,6 +363,9 @@ func TestGetEnvForHybridModeWithProperPriority(t *testing.T) {
 		},
 	}
 
+	// acording to exec.Cmd.Env docs, if cmd.Env contains duplicate environment keys, only the last
+	// value in the slice for each duplicate key is used so most priority values needs to be add
+	// at the end of the list
 	expectedEnvsSortedByPriority := []string{
 		"ENVFROMIMAGE=FROMIMAGEVALUE",
 		"ENVFROMSECRET=FROMSECRETVALUE",

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -739,6 +739,7 @@ func (d *Dev) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				Selector    Selector          `json:"selector,omitempty" yaml:"selector,omitempty"`
 				Forward     []forward.Forward `json:"forward,omitempty" yaml:"forward,omitempty"`
 				Environment Environment       `json:"environment,omitempty" yaml:"environment,omitempty"`
+				EnvFiles    EnvFiles          `json:"envFiles,omitempty" yaml:"envFiles,omitempty"`
 				Command     Command           `json:"command,omitempty" yaml:"command,omitempty"`
 				Reverse     []Reverse         `json:"reverse,omitempty" yaml:"reverse,omitempty"`
 				Mode        string            `json:"mode,omitempty" yaml:"mode,omitempty"`


### PR DESCRIPTION
# Proposed changes
- support `envFiles` field for hybrid dev
- add envs from `environment` field into local process

Fixes #[6715](https://github.com/okteto/app/issues/6715)
