### PR TITLE
Mount ssh agent in remote deploy

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -74,8 +74,6 @@ type Options struct {
 	Timeout    time.Duration
 
 	ShowCTA bool
-
-	SshIdentityKey string
 }
 
 // DeployCommand defines the config for deploying an app
@@ -264,7 +262,6 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
-	cmd.Flags().StringVarP(&options.SshIdentityKey, "identity-file", "i", "", "the identity key to use for ssh sessions")
 	cmd.Flags().BoolVarP(&options.Build, "build", "", false, "force build of images when deploying the development environment")
 	cmd.Flags().BoolVarP(&options.Dependencies, "dependencies", "", false, "deploy the dependencies from manifest")
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -74,6 +74,8 @@ type Options struct {
 	Timeout    time.Duration
 
 	ShowCTA bool
+
+	SshIdentityKey string
 }
 
 // DeployCommand defines the config for deploying an app
@@ -262,6 +264,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
+	cmd.Flags().StringVarP(&options.SshIdentityKey, "identity-file", "i", "", "the identity key to use for ssh sessions")
 	cmd.Flags().BoolVarP(&options.Build, "build", "", false, "force build of images when deploying the development environment")
 	cmd.Flags().BoolVarP(&options.Dependencies, "dependencies", "", false, "deploy the dependencies from manifest")
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -186,11 +186,16 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	}
 
 	if sshSock != "" {
-		knownHostsPath := filepath.Join(home, ".ssh", "known_hosts")
-		oktetoLog.Debugf("reading known hosts from %s", knownHostsPath)
-		sshSession := types.BuildSshSession{Id: "remote", Target: sshSock}
-		buildOptions.SshSessions = append(buildOptions.SshSessions, sshSession)
-		buildOptions.Secrets = append(buildOptions.Secrets, fmt.Sprintf("id=known_hosts,src=%s", knownHostsPath))
+		if _, err := os.Stat(sshSock); err != nil {
+			oktetoLog.Debugf("Not mounting ssh agent. Error reading socket: %s", err.Error())
+			sshSock = ""
+		} else {
+			knownHostsPath := filepath.Join(home, ".ssh", "known_hosts")
+			oktetoLog.Debugf("reading known hosts from %s", knownHostsPath)
+			sshSession := types.BuildSshSession{Id: "remote", Target: sshSock}
+			buildOptions.SshSessions = append(buildOptions.SshSessions, sshSession)
+			buildOptions.Secrets = append(buildOptions.Secrets, fmt.Sprintf("id=known_hosts,src=%s", knownHostsPath))
+		}
 	} else {
 		oktetoLog.Debug("no ssh agent found. Not mouting ssh-agent for build")
 	}

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -90,7 +90,6 @@ type dockerfileTemplateProperties struct {
 	GitCommitArgName       string
 	InvalidateCacheArgName string
 	DeployFlags            string
-	KnownSshHosts          []string
 }
 
 type remoteDeployCommand struct {
@@ -187,9 +186,11 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	}
 
 	if sshSock != "" {
+		knownHostsPath := filepath.Join(home, ".ssh", "known_hosts")
+		oktetoLog.Debugf("reading known hosts from %s", knownHostsPath)
 		sshSession := types.BuildSshSession{Id: "remote", Target: sshSock}
 		buildOptions.SshSessions = append(buildOptions.SshSessions, sshSession)
-		buildOptions.Secrets = append(buildOptions.Secrets, fmt.Sprintf("id=known_hosts,src=%s/.ssh/known_hosts", home))
+		buildOptions.Secrets = append(buildOptions.Secrets, fmt.Sprintf("id=known_hosts,src=%s", knownHostsPath))
 	} else {
 		oktetoLog.Debug("no ssh agent found. Not mouting ssh-agent for build")
 	}
@@ -247,7 +248,6 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		GitCommitArgName:       constants.OktetoGitCommitEnvVar,
 		InvalidateCacheArgName: constants.OktetoInvalidateCacheEnvVar,
 		DeployFlags:            strings.Join(getDeployFlags(opts), " "),
-		KnownSshHosts:          []string{"github.com", "gitlab.com"},
 	}
 
 	dockerfile, err := rd.fs.Create(filepath.Join(tmpDir, dockerfileTemporalName))

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -72,7 +72,7 @@ ARG {{ .GitCommitArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
 RUN --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
-  echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
+  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
   okteto deploy --log-output=json --server-name="${{ .InternalServerName }}" {{ .DeployFlags }}
 `
 )

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -171,8 +171,9 @@ func TestRemoteDeployWithSshAgent(t *testing.T) {
 	home, _ := homedir.Dir()
 
 	assertContains := func(o *types.BuildOptions) {
+		knownHostsPath := filepath.Join(home, ".ssh", "known_hosts")
 		assert.Contains(t, o.SshSessions, types.BuildSshSession{Id: "remote", Target: socket})
-		assert.Contains(t, o.Secrets, fmt.Sprintf("id=known_hosts,src=%s/.ssh/known_hosts", home))
+		assert.Contains(t, o.Secrets, fmt.Sprintf("id=known_hosts,src=%s", knownHostsPath))
 	}
 
 	envvarName := fmt.Sprintf("TEST_SOCKET_%s", os.Getenv("RANDOM"))

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -15,10 +15,13 @@ package deploy
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/mitchellh/go-homedir"
 	v2 "github.com/okteto/okteto/cmd/build/v2"
 	"github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/constants"
@@ -32,10 +35,14 @@ import (
 )
 
 type fakeBuilder struct {
-	err error
+	err           error
+	assertOptions func(o *types.BuildOptions)
 }
 
-func (f fakeBuilder) Build(_ context.Context, _ *types.BuildOptions) error {
+func (f fakeBuilder) Build(_ context.Context, opts *types.BuildOptions) error {
+	if f.assertOptions != nil {
+		f.assertOptions(opts)
+	}
 	return f.err
 }
 
@@ -140,7 +147,7 @@ func TestRemoteTest(t *testing.T) {
 				builderV2: &v2.OktetoBuilder{
 					Registry: newFakeRegistry(),
 				},
-				builderV1:            fakeBuilder{tt.config.builderErr},
+				builderV1:            fakeBuilder{err: tt.config.builderErr},
 				fs:                   fs,
 				workingDirectoryCtrl: wdCtrl,
 				temporalCtrl:         tempCreator,
@@ -156,6 +163,47 @@ func TestRemoteTest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRemoteDeployWithSshAgent(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	socket := "my-socket-file"
+	home, _ := homedir.Dir()
+
+	assertContains := func(o *types.BuildOptions) {
+		assert.Contains(t, o.SshSessions, types.BuildSshSession{Id: "remote", Target: socket})
+		assert.Contains(t, o.Secrets, fmt.Sprintf("id=known_hosts,src=%s/.ssh/known_hosts", home))
+	}
+
+	envvarName := fmt.Sprintf("TEST_SOCKET_%s", os.Getenv("RANDOM"))
+
+	os.Setenv(envvarName, socket)
+	defer func() {
+		t.Logf("cleaning up %s envvar", envvarName)
+		os.Unsetenv(envvarName)
+	}()
+	rdc := remoteDeployCommand{
+		sshAuthSockEnvvar: envvarName,
+		builderV2: &v2.OktetoBuilder{
+			Registry: newFakeRegistry(),
+		},
+		builderV1:            fakeBuilder{assertOptions: assertContains},
+		fs:                   fs,
+		workingDirectoryCtrl: filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/")),
+		temporalCtrl:         filesystem.NewTemporalDirectoryCtrl(fs),
+		clusterMetadata: func(context.Context) (*types.ClusterMetadata, error) {
+			return &types.ClusterMetadata{}, nil
+		},
+	}
+
+	err := rdc.deploy(context.Background(), &Options{
+		Manifest: &model.Manifest{
+			Deploy: &model.DeployInfo{
+				Image: "test-image",
+			},
+		},
+	})
+	assert.NoError(t, err)
 }
 
 func TestGetDeployFlags(t *testing.T) {

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -90,8 +90,11 @@ type remoteDestroyCommand struct {
 	registry             remoteBuild.OktetoRegistryInterface
 	clusterMetadata      func(context.Context) (*types.ClusterMetadata, error)
 
-	// defaults to SSH_AUTH_SOCK. Provided mostly for testing
+	// sshAuthSockEnvvar is the default for SSH_AUTH_SOCK. Provided mostly for testing
 	sshAuthSockEnvvar string
+
+	// knownHostsPath  is the default known_hosts file path. Provided mostly for testing
+	knownHostsPath string
 }
 
 func newRemoteDestroyer(manifest *model.Manifest) *remoteDestroyCommand {
@@ -179,11 +182,26 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	}
 
 	if sshSock != "" {
-		knownHostsPath := filepath.Join(home, ".ssh", "known_hosts")
-		oktetoLog.Debugf("reading known hosts from %s", knownHostsPath)
-		sshSession := types.BuildSshSession{Id: "remote", Target: sshSock}
-		buildOptions.SshSessions = append(buildOptions.SshSessions, sshSession)
-		buildOptions.Secrets = append(buildOptions.Secrets, fmt.Sprintf("id=known_hosts,src=%s", knownHostsPath))
+		if _, err := os.Stat(sshSock); err != nil {
+			oktetoLog.Debugf("Not mounting ssh agent. Error reading socket: %s", err.Error())
+			sshSock = ""
+		} else {
+			sshSession := types.BuildSshSession{Id: "remote", Target: sshSock}
+			buildOptions.SshSessions = append(buildOptions.SshSessions, sshSession)
+		}
+
+		// TODO: check if ~/.ssh/config exists and has UserKnownHostsFile defined
+		knownHostsPath := rd.knownHostsPath
+		if knownHostsPath == "" {
+			knownHostsPath = filepath.Join(home, ".ssh", "known_hosts")
+		}
+		if _, err := os.Stat(knownHostsPath); err != nil {
+			oktetoLog.Debugf("Not know_hosts file. Error reading file: %s", err.Error())
+		} else {
+			oktetoLog.Debugf("reading known hosts from %s", knownHostsPath)
+			buildOptions.Secrets = append(buildOptions.Secrets, fmt.Sprintf("id=known_hosts,src=%s", knownHostsPath))
+		}
+
 	} else {
 		oktetoLog.Debug("no ssh agent found. Not mouting ssh-agent for build")
 	}

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -60,7 +60,7 @@ ARG {{ .GitCommitArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
 RUN --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
-  echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
+  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
   okteto destroy --log-output=json --server-name="${{ .InternalServerName }}" {{ .DestroyFlags }}
 `
 )

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -15,6 +15,16 @@ package types
 
 import "github.com/okteto/okteto/pkg/model"
 
+// BuildSshSession is a reference to an ssh session which translates to a
+// --mount=ssh,id={id} argument in a buildkit run.
+// More info here: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypessh
+type BuildSshSession struct {
+	// Id is the name of the key for the mount. Defaults to "default"
+	Id string
+	// Target is the ssh-agent socket to mount the path to a *.pem file
+	Target string
+}
+
 // BuildOptions define the options available for build
 type BuildOptions struct {
 	BuildArgs     []string
@@ -34,6 +44,8 @@ type BuildOptions struct {
 	// CommandArgs comes from the user input on the command
 	CommandArgs  []string
 	EnableStages bool
+
+	SshSessions []BuildSshSession
 
 	Manifest *model.Manifest
 }


### PR DESCRIPTION
Mounts the ssh agent in the remote deploy command allowing to clone private repos and make authenticated ssh operations.

There are a few things pending (see below) but wanted to open early to get feedback

## Testing

Prior to this change this doesn't work:

```Dockerfile
FROM okteto/pipeline-runner:1.0.3
```
```yaml
build:
  base:
    image: okteto.dev/my-repo:latest

deploy:
  image: okteto.dev/my-repo:latest
  commands:
    - git clone git@github.com:maroshii/okteto-tester.git
```

```bash
$ okteto deploy --remote
 i  Using fran @ okteto.fran.dev.okteto.net as context
 i  Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'
 i  Running stage 'git clone git@github.com:maroshii/okteto-tester.git'
Cloning into 'okteto-tester'...
Host key verification failed.
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
 x  Error executing command 'git clone git@github.com:maroshii/okteto-tester.git': exit status 128
```

After this change:

```bash
$ okteto deploy --remote
 i  Using fran @ okteto.fran.dev.okteto.net as context
 i  Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'
 i  Running stage 'git clone git@github.com:maroshii/okteto-tester.git'
Executing command 'git clone git@github.com:maroshii/okteto-tester.git'...
Cloning into 'okteto-tester'...
Command 'git clone git@github.com:maroshii/okteto-tester.git' successfully executed
 i  Endpoints available:
  - https://hello-world-fran.fran.dev.okteto.net/
 ✓  Development environment 'okteto-tester' successfully deployed
 i  Run 'okteto up' to activate your development container
```

## Open Questions

- [x] How should we add known hosts? Currently github.com and gitlab.com are hardcoded but we should support other hosts that may be needed
- [x] Should we automatically mount `$HOME/.ssh/id_rsa` if `SSH_AUTH_SOCK` is empty? I think no but it was listed in the requirement

## Pending

- [x] Add ~same logic `okteto destroy --remote`
- [x] Write tests
