### PR TITLE
place exec command in foreground when hybrid mode

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -227,6 +227,8 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 				return err
 			}
 
+			cmd.SysProcAttr.Foreground = true
+
 			return executor.RunCommand(cmd)
 		}
 


### PR DESCRIPTION
## Context
when a command that requires interaction is executed on a dev environment in hybrid mode, the user does not get interaction with the command.

<img width="622" alt="Captura de Pantalla 2023-06-28 a las 13 01 31" src="https://github.com/okteto/okteto/assets/22500940/cef104b0-34be-4e95-87c0-e62f7f8f58c6">


# Proposed changes
- place exec command in foreground
<img width="643" alt="Captura de Pantalla 2023-06-28 a las 13 05 04" src="https://github.com/okteto/okteto/assets/22500940/837605c7-0362-45cf-bbea-d29ee63d6b20">
