### PR TITLE
Improve "cannot create pid" error message

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -606,7 +606,14 @@ func (up *upContext) start() error {
 
 	if err := up.pidController.create(); err != nil {
 		oktetoLog.Infof("failed to create pid file for %s - %s: %s", up.Dev.Namespace, up.Dev.Name, err)
-		return fmt.Errorf("couldn't create pid file for %s - %s", up.Dev.Namespace, up.Dev.Name)
+
+		return oktetoErrors.UserError{
+			E: fmt.Errorf("couldn't create a pid file for %s - %s", up.Dev.Namespace, up.Dev.Name),
+			Hint: `This error can occur if the ".okteto" folder in your home has misconfigured permissions.
+    To resolve, try 'sudo chown -R <your-user>: ~/.okteto'
+
+    Alternatively, check the permissions of that directory and its content to ensure your user has write permissions.`,
+		}
 	}
 
 	defer up.pidController.delete()


### PR DESCRIPTION
# Proposed changes

I've hit this error today and it took me some time to figure out why it was failing.

It was caused accidentally because I've used `sudo` to run some okteto commands which I then interrupted leaving an orphan `okteto.pid` owned by `root`, so that any following command was failing.

Besides spitting out an error here, we culd offer the user an actionable suggestion to heal and solve the situation.

It might be sligly different for Windows but I think as a generic advice, the one I've used could be sufficient for solving this error in most scenarios.. Let me know your thought on:

1. The approach used / style of comms
2. The actual suggested fix

| Before | After |
|--------|-------|
|    <img width="450" alt="Screenshot 2023-06-15 at 17 55 35" src="https://github.com/okteto/okteto/assets/2318450/765b3b24-9372-4bae-a7a5-44ef83b6b176">    |    <img width="450" alt="Screenshot 2023-06-15 at 17 55 28" src="https://github.com/okteto/okteto/assets/2318450/c01abe8a-6be1-4b32-9787-2eebe27300dc">   |




