### PR TITLE
Add "scope" to the `okteto preview deploy` command metric

### DIFF
--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -104,7 +104,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 
 func (pw *Command) ExecuteDeployPreview(ctx context.Context, opts *DeployOptions) error {
 	resp, err := pw.deployPreview(ctx, opts)
-	analytics.TrackPreviewDeploy(err == nil)
+	analytics.TrackPreviewDeploy(err == nil, opts.scope)
 	if err != nil {
 		return err
 	}

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -122,8 +122,11 @@ func TrackDeleteNamespace(success bool) {
 }
 
 // TrackPreviewDeploy sends a tracking event to mixpanel when the creates a preview environment
-func TrackPreviewDeploy(success bool) {
-	track(previewDeployEvent, success, nil)
+func TrackPreviewDeploy(success bool, scope string) {
+	props := map[string]interface{}{
+		"scope": scope,
+	}
+	track(previewDeployEvent, success, props)
 }
 
 // TrackPreviewDestroy sends a tracking event to mixpanel when the deletes a preview environment


### PR DESCRIPTION
Having the `scope` in the preview deploy event helps to understand how people are using this feature