### PR TITLE
add implementation to retrieve cmap variables when running in remote

### DIFF
--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -38,6 +38,7 @@ type DeployOptions struct {
 	Token            string
 	Name             string
 	Variables        string
+	IsRemote         bool
 }
 
 // DestroyOptions defines the options that can be added to a deploy command
@@ -181,6 +182,9 @@ func getDeployCmd(oktetoPath string, deployOptions *DeployOptions) *exec.Cmd {
 	}
 	if deployOptions.Variables != "" {
 		cmd.Args = append(cmd.Args, "--var", deployOptions.Variables)
+	}
+	if deployOptions.IsRemote {
+		cmd.Args = append(cmd.Args, "--remote")
 	}
 	cmd.Env = os.Environ()
 	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -49,6 +49,7 @@ type DestroyOptions struct {
 	OktetoHome   string
 	Token        string
 	Name         string
+	IsRemote     bool
 }
 
 // RunOktetoDeploy runs an okteto deploy command
@@ -139,6 +140,9 @@ func getDestroyCmd(oktetoPath string, destroyOptions *DestroyOptions) *exec.Cmd 
 	}
 	if destroyOptions.Namespace != "" {
 		cmd.Args = append(cmd.Args, "--namespace", destroyOptions.Namespace)
+	}
+	if destroyOptions.IsRemote {
+		cmd.Args = append(cmd.Args, "--remote")
 	}
 	cmd.Env = os.Environ()
 	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {


### PR DESCRIPTION
# Context

when a variable is printed in deploy section using remote deploy feature it is not masked as expected. This is because implementation related to retrieve variables from config map in remote deploy mode is empty

Fixes #3735

# Proposed changes
- add implementation about retrieve variables from configmap when deploy is running remotely

# How to check the fix

1. Using latest CLI release
2. clone https://github.com/okteto/movies
3. set deploy section as:
````yaml
deploy:
  - name: test
    command: echo $TEST
````
4. run `okteto deploy --remote --var TEST=111`
5. Value should be masked