### PR TITLE
add dev mode annotation (sync or hybrid)

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -23,7 +23,7 @@ const (
 	OktetoURLAnnotation = "dev.okteto.com/url"
 
 	// OktetoDevModeAnnotation indicates the development mode in use (sync or hybrid)
-	OktetoDevModeAnnotation = "dev.okteto.com/mode"
+	OktetoDevModeAnnotation = "dev.okteto.com/dev-mode"
 
 	// OktetoExtension identifies the okteto extension in kubeconfig files
 	OktetoExtension = "okteto"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -22,6 +22,9 @@ const (
 	// OktetoURLAnnotation indicates the okteto cluster public url
 	OktetoURLAnnotation = "dev.okteto.com/url"
 
+	// OktetoDevModeAnnotation indicates the development mode in use (sync or hybrid)
+	OktetoDevModeAnnotation = "dev.okteto.com/mode"
+
 	// OktetoExtension identifies the okteto extension in kubeconfig files
 	OktetoExtension = "okteto"
 

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -74,6 +74,8 @@ func (tr *Translation) translate() error {
 
 	tr.App.ObjectMeta().Annotations[model.AppReplicasAnnotation] = strconv.Itoa(int(replicas))
 	tr.App.ObjectMeta().Labels[constants.DevLabel] = "true"
+	tr.App.ObjectMeta().Annotations[constants.OktetoDevModeAnnotation] = tr.Dev.Mode
+	tr.DevApp.ObjectMeta().Annotations[constants.OktetoDevModeAnnotation] = tr.Dev.Mode
 	tr.App.SetReplicas(0)
 
 	for k, v := range tr.Dev.Metadata.Annotations {
@@ -134,6 +136,7 @@ func (tr *Translation) DevModeOff() error {
 	delete(tr.App.TemplateObjectMeta().Annotations, model.OktetoStignoreAnnotation)
 	delete(tr.App.ObjectMeta().Annotations, model.OktetoSyncAnnotation)
 	delete(tr.App.TemplateObjectMeta().Annotations, model.OktetoSyncAnnotation)
+	delete(tr.App.ObjectMeta().Annotations, constants.OktetoDevModeAnnotation)
 
 	for k := range tr.Dev.Metadata.Annotations {
 		delete(tr.App.ObjectMeta().Annotations, k)

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -395,7 +395,7 @@ services:
 		t.Fatalf("Wrong d1 pod labels: '%v'", tr1.App.TemplateObjectMeta().Labels)
 
 	}
-	expectedAnnotations := map[string]string{model.AppReplicasAnnotation: "3", "key1": "value1"}
+	expectedAnnotations := map[string]string{model.AppReplicasAnnotation: "3", "key1": "value1", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr1.App.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong d1 annotations: '%v'", tr1.App.ObjectMeta().Annotations)
 	}
@@ -429,7 +429,7 @@ services:
 	if !reflect.DeepEqual(tr1.DevApp.TemplateObjectMeta().Labels, expectedPodLabels) {
 		t.Fatalf("Wrong dev d1 pod labels: '%v'", tr1.DevApp.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{"key1": "value1"}
+	expectedAnnotations = map[string]string{"key1": "value1", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr1.DevApp.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong dev d1 annotations: '%v'", tr1.DevApp.ObjectMeta().Annotations)
 	}
@@ -552,7 +552,7 @@ services:
 	if !reflect.DeepEqual(tr2.App.TemplateObjectMeta().Labels, d2Orig.Spec.Template.Labels) {
 		t.Fatalf("Wrong d2 pod labels: '%v'", tr2.App.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{model.AppReplicasAnnotation: "3", "key2": "value2"}
+	expectedAnnotations = map[string]string{model.AppReplicasAnnotation: "3", "key2": "value2", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr2.App.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong d2 annotations: '%v'", tr2.App.ObjectMeta().Annotations)
 	}
@@ -577,7 +577,7 @@ services:
 	if !reflect.DeepEqual(tr2.DevApp.TemplateObjectMeta().Labels, expectedPodLabels) {
 		t.Fatalf("Wrong dev d2 pod labels: '%v'", tr2.DevApp.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{"key2": "value2"}
+	expectedAnnotations = map[string]string{"key2": "value2", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr2.DevApp.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong dev d2 annotations: '%v'", tr2.DevApp.ObjectMeta().Annotations)
 	}
@@ -1795,7 +1795,7 @@ services:
 	if !reflect.DeepEqual(tr1.App.TemplateObjectMeta().Labels, sfs1Orig.Spec.Template.Labels) {
 		t.Fatalf("Wrong sfs1 pod labels: '%v'", tr1.App.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations := map[string]string{model.AppReplicasAnnotation: "2", "key1": "value1"}
+	expectedAnnotations := map[string]string{model.AppReplicasAnnotation: "2", "key1": "value1", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr1.App.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong sfs1 annotations: '%v'", tr1.App.ObjectMeta().Annotations)
 	}
@@ -1821,7 +1821,7 @@ services:
 	if !reflect.DeepEqual(tr1.DevApp.TemplateObjectMeta().Labels, expectedPodLabels) {
 		t.Fatalf("Wrong dev sfs1 pod labels: '%v'", tr1.DevApp.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{"key1": "value1"}
+	expectedAnnotations = map[string]string{"key1": "value1", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr1.DevApp.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong dev sfs1 annotations: '%v'", tr1.DevApp.ObjectMeta().Annotations)
 	}
@@ -1946,7 +1946,7 @@ services:
 	if !reflect.DeepEqual(tr2.App.TemplateObjectMeta().Labels, sfs2Orig.Spec.Template.Labels) {
 		t.Fatalf("Wrong sfs2 pod labels: '%v'", tr2.App.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{model.AppReplicasAnnotation: "3", "key2": "value2"}
+	expectedAnnotations = map[string]string{model.AppReplicasAnnotation: "3", "key2": "value2", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr2.App.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong sfs2 annotations: '%v'", tr2.App.ObjectMeta().Annotations)
 	}
@@ -1971,7 +1971,7 @@ services:
 	if !reflect.DeepEqual(tr2.DevApp.TemplateObjectMeta().Labels, expectedPodLabels) {
 		t.Fatalf("Wrong dev sfs2 pod labels: '%v'", tr2.DevApp.TemplateObjectMeta().Labels)
 	}
-	expectedAnnotations = map[string]string{"key2": "value2"}
+	expectedAnnotations = map[string]string{"key2": "value2", constants.OktetoDevModeAnnotation: constants.OktetoSyncModeFieldValue}
 	if !reflect.DeepEqual(tr2.DevApp.ObjectMeta().Annotations, expectedAnnotations) {
 		t.Fatalf("Wrong dev sfs2 annotations: '%v'", tr2.DevApp.ObjectMeta().Annotations)
 	}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -773,6 +773,8 @@ func (d *Dev) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		dev.Workdir = localDir
 		dev.Image.Name = "busybox"
 
+	} else {
+		dev.Mode = constants.OktetoSyncModeFieldValue
 	}
 
 	*d = Dev(dev)

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model/forward"
 	"github.com/stretchr/testify/assert"
@@ -1113,6 +1114,7 @@ dev:
 				External:     externalresource.ExternalResourceSection{},
 				Dev: map[string]*Dev{
 					"test-1": {
+						Mode: constants.OktetoSyncModeFieldValue,
 						Name: "test-1",
 						Sync: Sync{
 							RescanInterval: 300,
@@ -1176,7 +1178,6 @@ dev:
 						},
 						Environment: Environment{},
 						Volumes:     []Volume{},
-						Mode:        "sync",
 					},
 					"test-2": {
 						Name: "test-2",
@@ -1242,7 +1243,7 @@ dev:
 						},
 						Environment: Environment{},
 						Volumes:     []Volume{},
-						Mode:        "sync",
+						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
 			},
@@ -1327,7 +1328,7 @@ sync:
 						},
 						Environment: Environment{},
 						Volumes:     []Volume{},
-						Mode:        "sync",
+						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
 			},
@@ -1434,6 +1435,7 @@ services:
 									Annotations: Annotations{},
 								},
 								Volumes: []Volume{},
+								Mode:    constants.OktetoSyncModeFieldValue,
 							},
 						},
 						InitContainer: InitContainer{
@@ -1449,7 +1451,7 @@ services:
 						},
 						Environment: Environment{},
 						Volumes:     []Volume{},
-						Mode:        "sync",
+						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
 			},
@@ -1546,7 +1548,7 @@ dev:
 						},
 						Environment: Environment{},
 						Volumes:     []Volume{},
-						Mode:        "sync",
+						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
 			},
@@ -1635,7 +1637,7 @@ dev:
 						},
 						Environment: Environment{},
 						Volumes:     []Volume{},
-						Mode:        "sync",
+						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 					"test-2": {
 						Name: "test-2",
@@ -1701,7 +1703,7 @@ dev:
 						},
 						Environment: Environment{},
 						Volumes:     []Volume{},
-						Mode:        "sync",
+						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
 			},
@@ -1868,7 +1870,7 @@ command: ["sh", "-c", "yarn start"]
 reverse:
   - 8080:8080`),
 			expected: &Dev{
-				Mode:    "hybrid",
+				Mode:    constants.OktetoHybridModeFieldValue,
 				Workdir: wd,
 				Selector: Selector{
 					"app.kubernetes.io/part-of":   "okteto",
@@ -1924,7 +1926,7 @@ sync:
 forward:
   - 2345:2345`),
 			expected: &Dev{
-				Mode: "sync",
+				Mode: constants.OktetoSyncModeFieldValue,
 				Selector: Selector{
 					"app.kubernetes.io/part-of":   "okteto",
 					"app.kubernetes.io/component": "api",
@@ -1988,6 +1990,7 @@ sync:
 forward:
   - 2345:2345`),
 			expected: &Dev{
+				Mode: constants.OktetoSyncModeFieldValue,
 				Selector: Selector{
 					"app.kubernetes.io/part-of":   "okteto",
 					"app.kubernetes.io/component": "producer",


### PR DESCRIPTION
# Context
when a dev environment starts the backend doesn't have the possibility to know which mode is in use. Available dev modes are `sync` or `hybrid`.

# Proposed changes
- add `dev.okteto.com/mode` to app and dev app to make available dev mode in use for the backend
- delete annotation when dev mode off.

Fixes #3653 

# How to test changes
1. develop in https://github.com/okteto/movies by running `okteto up api` 
2. check that development `api` and `api-okteto` have annotations `dev.okteto.com/mode = sync`
3. run `okteto down api` and check that annotation is removed
