### PR TITLE
Update go to 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,10 +194,10 @@ jobs:
             go test ./...
       - run:
           name: Upgrade kubectl
-          command: choco install kubernetes-cli
+          command: choco install kubernetes-cli -y
       - run:
           name: Upgrade helm
-          command: choco install kubernetes-helm
+          command: choco install kubernetes-helm -y
       - attach_workspace:
           at: .\artifacts
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
       - checkout
       - run:
           name: Check Golang version
-          command: choco version golang
+          command: go version
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -182,7 +182,7 @@ jobs:
       - checkout
       - run:
           name: Check Golang version
-          command: choco version golang
+          command: go version
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ aliases:
   - &release-branch-regex /^release-\d+\.\d+$/
 version: 2.1
 orbs:
-  win: circleci/windows@2.1.0
+  win: circleci/windows@5.0.0
 commands:
   integration-actions:
     steps:
@@ -52,7 +52,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:1.18.0
+      - image: okteto/golang-ci:2.3.1
 
 jobs:
   build-binaries:
@@ -103,8 +103,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Upgrade Golang
-          command: choco upgrade golang --version 1.18
+          name: Check Golang version
+          command: choco version golang
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -181,8 +181,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Upgrade Golang
-          command: choco upgrade golang --version 1.18
+          name: Check Golang version
+          command: choco version golang
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -207,13 +207,13 @@ jobs:
           command: |
             new-item $HOME\.okteto -itemtype "directory" -force
             new-item $HOME\.okteto\.noanalytics -itemtype "file" -value "noanalytics" -force
-            & 'C:\Users\circleci\project\artifacts\bin\okteto.exe' login --token $env:API_STAGING_TOKEN
-            & 'C:\Users\circleci\project\artifacts\bin\okteto.exe' kubeconfig
+            & "$($HOME)\project\artifacts\bin\okteto.exe" login --token $env:API_STAGING_TOKEN
+            & "$($HOME)\project\artifacts\bin\okteto.exe" kubeconfig
       - run:
           name: Run deprecated integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: 'C:\Users\circleci\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
@@ -223,7 +223,7 @@ jobs:
           name: Run build integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: 'C:\Users\circleci\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
@@ -231,7 +231,7 @@ jobs:
           name: Run deploy integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: 'C:\Users\circleci\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
@@ -239,7 +239,7 @@ jobs:
           name: Run up integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: 'C:\Users\circleci\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
           name: Run deprecated integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: 'C:\Users\circleci.PACKER-64370BA5\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
@@ -223,7 +223,7 @@ jobs:
           name: Run build integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: 'C:\Users\circleci.PACKER-64370BA5\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
@@ -231,7 +231,7 @@ jobs:
           name: Run deploy integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: 'C:\Users\circleci.PACKER-64370BA5\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
@@ -239,7 +239,7 @@ jobs:
           name: Run up integration tests
           environment:
             - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_PATH: '${HOME}\project\artifacts\bin\okteto.exe'
+            - OKTETO_PATH: 'C:\Users\circleci.PACKER-64370BA5\project\artifacts\bin\okteto.exe'
             - OKTETO_SKIP_CLEANUP: 'true'
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: 1.18
+  go: 1.20
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
   errcheck:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ ARG KUBECTL_VERSION=1.22.17
 ARG HELM_VERSION=3.12.1
 ARG KUSTOMIZE_VERSION=5.0.0
 
-FROM golang:1.19.6-bullseye as kubectl-builder
+FROM golang:1.20-bullseye as kubectl-builder
 ARG KUBECTL_VERSION
 RUN curl -sLf --retry 3 -o kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     cp kubectl /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl && \
     /usr/local/bin/kubectl version --client=true
 
-FROM golang:1.19.6-bullseye as helm-builder
+FROM golang:1.20-bullseye as helm-builder
 ARG HELM_VERSION
 RUN curl -sLf --retry 3 -o helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
     mkdir -p helm && tar -C helm -xf helm.tar.gz && \
@@ -19,14 +19,14 @@ RUN curl -sLf --retry 3 -o helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}
     chmod +x /usr/local/bin/helm && \
     /usr/local/bin/helm version
 
-FROM golang:1.19.6-bullseye as kustomize-builder
+FROM golang:1.20-bullseye as kustomize-builder
 ARG KUSTOMIZE_VERSION
 RUN curl -sLf --retry 3 -o kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz \
     && tar -xvzf kustomize.tar.gz -C /usr/local/bin \
     && chmod +x /usr/local/bin/kustomize \
     && /usr/local/bin/kustomize version
 
-FROM golang:1.18-buster as builder
+FROM golang:1.20-buster as builder
 WORKDIR /okteto
 
 ENV CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@ VERSION_STRING := $(shell git rev-parse --short HEAD)
 endif
 
 BINDIR    := $(CURDIR)/bin
-PLATFORMS := linux/amd64/okteto-Linux-x86_64 darwin/amd64/okteto-Darwin-x86_64 windows/amd64/okteto.exe linux/arm64/okteto-Linux-arm64 darwin/arm64/okteto-Darwin-arm64
-BUILDCOMMAND := go build -trimpath -ldflags "-s -w -X github.com/okteto/okteto/pkg/config.VersionString=${VERSION_STRING}" -tags "osusergo netgo static_build"
+PLATFORMS := linux/amd64/okteto-Linux-x86_64/osusergo*netgo*static_build darwin/amd64/okteto-Darwin-x86_64/osusergo*netgo*static_build windows/amd64/okteto.exe/osusergo*static_build linux/arm64/okteto-Linux-arm64/osusergo*netgo*static_build darwin/arm64/okteto-Darwin-arm64/osusergo*netgo*static_build
+BUILDCOMMAND := go build -trimpath -ldflags "-s -w -X github.com/okteto/okteto/pkg/config.VersionString=${VERSION_STRING}"
 temp = $(subst /, ,$@)
 os = $(word 1, $(temp))
 arch = $(word 2, $(temp))
 label = $(word 3, $(temp))
+tags = $(subst *, ,$(word 4, $(temp)))
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
@@ -21,9 +22,8 @@ endif
 
 .PHONY: release
 build-all: $(PLATFORMS)
-
 $(PLATFORMS):
-	GOOS=$(os) GOARCH=$(arch) CGO_ENABLED=0 $(BUILDCOMMAND) -o "bin/$(label)"
+	GOOS=$(os) GOARCH=$(arch) CGO_ENABLED=0 $(BUILDCOMMAND) -tags "$(tags)" -o "bin/$(label)"
 	$(SHACOMMAND) "bin/$(label)" > "bin/$(label).sha256"
 
 .PHONY: latest

--- a/contributing.md
+++ b/contributing.md
@@ -94,7 +94,7 @@ If a pull request does not have one of these labels checks will fail and PR merg
 
 ## Development Guide
 
-Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.18](https://go.dev/doc/go1.18). It uses go modules for dependency management.
+Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.20](https://go.dev/doc/go1.20). It uses go modules for dependency management.
 
 ### Building
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/okteto/okteto
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1


### PR DESCRIPTION
# Proposed changes

This PR updates the go version of the project. 

- Add the tags for each os since Windows no longer can be built using `netgo`. For more information see this [gh issue](https://github.com/golang/go/issues/57757)
- This is the pipeline executing all the e2e tests on windows: https://app.circleci.com/pipelines/github/okteto/okteto/10897/workflows/d7bc3916-24de-4a31-8668-8c9db2805032/jobs/34211
- Updates the contribution guides to point from 1.18 to 1.20
- Update go.mod to point to 1.20
- Update the Dockerfile to build with go 1.20
- Update golangci go version
