### PR TITLE
feat(build): expand image before build

### DIFF
--- a/cmd/build/v1/build.go
+++ b/cmd/build/v1/build.go
@@ -16,6 +16,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"github.com/okteto/okteto/pkg/model"
 	"path/filepath"
 
 	"github.com/okteto/okteto/cmd/utils"
@@ -92,6 +93,12 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 		oktetoLog.Information("%s using your local docker daemon", buildMsg)
 	} else {
 		oktetoLog.Information("%s in %s...", buildMsg, okteto.Context().Builder)
+	}
+
+	var err error
+	options.Tag, err = model.ExpandEnv(options.Tag, true)
+	if err != nil {
+		return err
 	}
 
 	if err := bc.Builder.Run(ctx, options); err != nil {

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1063,43 +1063,56 @@ func Test_ExpandEnv(t *testing.T) {
 		value         string
 		expandIfEmpty bool
 		result        string
+		expectedErr   error
 	}{
+		{
+			name:          "broken var - missing closing curly bracket",
+			value:         "value-${BAR",
+			expandIfEmpty: true,
+			result:        "",
+			expectedErr:   fmt.Errorf("error expanding environment on 'value-${BAR': closing brace expected"),
+		},
 		{
 			name:          "no-var",
 			value:         "value",
 			expandIfEmpty: true,
 			result:        "value",
+			expectedErr:   nil,
 		},
 		{
 			name:          "var",
 			value:         "value-${BAR}-value",
 			expandIfEmpty: true,
 			result:        "value-bar-value",
+			expectedErr:   nil,
 		},
 		{
 			name:          "default",
 			value:         "value-${FOO:-foo}-value",
 			expandIfEmpty: true,
 			result:        "value-foo-value",
+			expectedErr:   nil,
 		},
 		{
 			name:          "only bar expanded",
 			value:         "${BAR}",
 			expandIfEmpty: true,
 			result:        "bar",
+			expectedErr:   nil,
 		},
 		{
 			name:          "only bar not expand if empty",
 			value:         "${FOO}",
 			expandIfEmpty: false,
 			result:        "${FOO}",
+			expectedErr:   nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := ExpandEnv(tt.value, tt.expandIfEmpty)
-			assert.NoError(t, err)
+			assert.Equal(t, err, tt.expectedErr)
 			assert.Equal(t, tt.result, result)
 		})
 	}


### PR DESCRIPTION
# Proposed changes

Expand build image just before doing the actual build to make sure if we use `depends_on` and other vars coming from other services, it won't break that behavioir. 

Fixes https://github.com/okteto/okteto/issues/3780

## How to reproduce the bug

- Follow steps in the [issue](https://github.com/okteto/okteto/issues/3780)

## How to test the fix

- Build this branch, run against the example in the issue
- Notice how the CLI can successfully build the image now
- Also, notice that the expansion is done just before the build maintaining the original manifest so that if the user uses variables coming from other builds, it won't break. To verify this, you can use the following manifest:

```yaml
build:
  api2:
    context: .
  k8s-status-api:
    image: okteto.dev/k8s-status-api:${OKTETO_BUILD_API2_TAG}
    context: .
    depends_on:
      - api2
```
- In this case, the CLI will build `api2` first, and when building `k8s-status-api`, it will replace `${OKTETO_BUILD_API2_TAG}` with the actual tag built from `api2`.