### PR TITLE
Compute hash for divert annotation to limit the size of the annotation

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -110,8 +110,11 @@ const (
 	// OktetoDivertHeaderName the default header name used by okteto to divert traffic
 	OktetoDivertHeaderName = "okteto-divert"
 
-	//OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
-	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
+	// OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s"
+
+	// OktetoDeprecatedDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+	OktetoDeprecatedDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
 
 	//OktetoHybridModeFieldValue represents the hybrid mode field value
 	OktetoHybridModeFieldValue = "hybrid"

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -52,7 +52,7 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Labels:    map[string]string{"l1": "v1"},
 					Annotations: map[string]string{
 						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy"}`,
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy"}`,
 					},
 				},
 			},
@@ -75,7 +75,7 @@ func Test_translateDivertVirtualService(t *testing.T) {
 					Labels:    map[string]string{"l1": "v1"},
 					Annotations: map[string]string{
 						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","routes":["one-route","another-route"]}`,
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy","routes":["one-route","another-route"]}`,
 					},
 				},
 			},
@@ -116,7 +116,28 @@ func Test_restoreDivertVirtualService(t *testing.T) {
 					Namespace: "staging",
 					Annotations: map[string]string{
 						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
+						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
+					},
+				},
+			},
+			expected: &istioV1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "service-a",
+					Namespace:   "staging",
+					Labels:      map[string]string{"l1": "v1"},
+					Annotations: map[string]string{"a1": "v1"},
+				},
+			},
+		},
+		{
+			name: "clean-deprecated-divert-annotation",
+			vs: &istioV1beta1.VirtualService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "service-a",
+					Namespace: "staging",
+					Annotations: map[string]string{
+						"a1": "v1",
+						fmt.Sprintf(constants.OktetoDeprecatedDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
 					},
 				},
 			},


### PR DESCRIPTION
Users of divert are reporting that the annotation we set in virtual services might get too long:
```
Invalid value: "divert.okteto.com/<<namespace-name>>-<<dev-environment-name>>": name part must be no more than 63 characters
```
This is because the annotation length isn't fixed. It's a combination of the namespace name, and the dev environment name. And the preview environment name can get too long, especially in preview environments.

This PR computes a hash of those value to always create a fixed length for this annotation. The code is backward compatible because on destruction, we remove the old and new values of the annotation.

I added a unit tests covering the missing case.