### PR TITLE
fix: context switch regression

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -292,9 +292,6 @@ func getLoggedUserContext(ctx context.Context, c *ContextCommand, ctxOptions *Co
 
 	userContext, err := c.getUserContext(ctx, ctxOptions.Namespace)
 	if err != nil {
-		if oktetoErrors.IsNotFound(err) {
-
-		}
 		return nil, err
 	}
 
@@ -357,6 +354,7 @@ func (c ContextCommand) getUserContext(ctx context.Context, ns string) (*types.U
 			}
 
 			if oktetoErrors.IsNotFound(err) {
+				// fallback to personal namesapce using empty string as param
 				userContext, err = client.User().GetContext(ctx, "")
 				if err != nil {
 					return nil, err

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -567,8 +567,6 @@ func TestGetUserContext(t *testing.T) {
 	for _, tc := range tt {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			fakeOktetoClient := &client.FakeOktetoClient{
 				Namespace: client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
 				Users:     client.NewFakeUsersClient(user, tc.input.userErr...),

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -32,7 +32,9 @@ func (c *FakeUserClient) GetContext(_ context.Context, ns string) (*types.UserCo
 	if c.err != nil && len(c.err) > 0 {
 		err := c.err[0]
 		c.err = c.err[1:]
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return c.userCtx, nil

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -59,8 +59,8 @@ func (e NotLoggedError) Error() string {
 	return fmt.Sprintf(ErrNotLogged, e.Context)
 }
 
-func (e NotLoggedError) Unwrap() error {
-	return notLogged
+func (NotLoggedError) Unwrap() error {
+	return ErrNotLoggedMsg
 }
 
 var (
@@ -68,7 +68,7 @@ var (
 	ErrCommandFailed = errors.New("command execution failed")
 
 	// notLogged is raised when the user is not logged in okteto
-	notLogged = errors.New("user is not logged in okteto")
+	ErrNotLoggedMsg = errors.New("user is not logged in okteto")
 
 	// ErrNotLogged is raised when we can't get the user token
 	ErrNotLogged = "your token is invalid. Please run 'okteto context use %s' and try again"

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -49,9 +49,26 @@ const (
 	InvalidDockerfile = "invalid Dockerfile"
 )
 
+// NotLoggedError is raised when the user is not logged in okteto
+type NotLoggedError struct {
+	Context string
+}
+
+// Error returns the error message
+func (e NotLoggedError) Error() string {
+	return fmt.Sprintf(ErrNotLogged, e.Context)
+}
+
+func (e NotLoggedError) Unwrap() error {
+	return notLogged
+}
+
 var (
 	// ErrCommandFailed is raised when the command execution failed
 	ErrCommandFailed = errors.New("command execution failed")
+
+	// notLogged is raised when the user is not logged in okteto
+	notLogged = errors.New("user is not logged in okteto")
 
 	// ErrNotLogged is raised when we can't get the user token
 	ErrNotLogged = "your token is invalid. Please run 'okteto context use %s' and try again"


### PR DESCRIPTION
# Proposed changes

Fixes #3334 regression caused by #3343 introduced in [CLI release 2.16.0](https://github.com/okteto/okteto/releases/tag/2.16.0)

The bug was introduced as part of the multicluster fixes. We end up going with another approach but this part of the code was a nice to have (always send the namespace the user will be working on) regarding if the user was running in multicluster or single cluster.

I've tested it with different commands (context and namespace)

Also I've added an unit test for the code that part where we were not covering the errors that we could face and the scenario that we fixed. 

| Before | After |
|--------|-------|
|   <img width="989" alt="Captura de Pantalla 2023-07-06 a las 18 23 53" src="https://github.com/okteto/okteto/assets/25170843/13c892ad-a911-4e59-9b5e-a2d193be3780">  |  <img width="916" alt="Captura de Pantalla 2023-07-06 a las 18 24 25" src="https://github.com/okteto/okteto/assets/25170843/fc4daf9e-60e2-4bbe-81a8-1314b7aa2ee3"> |




