### PR TITLE
fix publish okteto release for windows

### DIFF
--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -186,17 +186,17 @@
 
                 if [ "$tag" = "$latest" ]; then
                         gsutil -m rsync "gs://$BIN_BUCKET_NAME" "gs://$BIN_BUCKET_ROOT_WITH_CHAN"
+                        
+                        if [ "$is_oficial_release" = true ] ; then
+                                # upload artifacts to bucket root (gs://downloads.okteto.com/cli)
+                                echo "Syncing artifacts from $BIN_PATH with $BIN_BUCKET_ROOT"
+                                gsutil -m rsync -r "$BIN_PATH" "gs://$BIN_BUCKET_ROOT"
+                        fi
                 fi
 
                 gsutil -m -h "Cache-Control: no-store" -h "Content-Type: text/plain" cp "${version_file}" "gs://${VERSIONS_BUCKET_FILENAME}"
                 echo "${chan} channel updated with ${tag}"
         done
-
-        if [ "$is_oficial_release" = true ] ; then
-                 # upload artifacts to bucket root (gs://downloads.okteto.com/cli)
-                echo "Syncing artifacts from $BIN_PATH with $BIN_BUCKET_ROOT"
-                gsutil -m rsync -r "$BIN_PATH" "gs://$BIN_BUCKET_ROOT"
-        fi
 
         ################################################################################
         # Update Github Release

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -128,6 +128,8 @@
                 fi
         fi
 
+        BIN_BUCKET_ROOT="downloads.okteto.com/cli"
+        
         for chan in "${CHANNELS[@]}"; do
                 echo "---------------------------------------------------------------------------------"
                 tag="${RELEASE_TAG:-"$PSEUDO_TAG"}"
@@ -140,7 +142,7 @@
                 # BIN_BUCKET_NAME is the name of the bucket where the binaries are stored.
                 # Starting at Okteto CLI 2.0, all these binaries are publicly accessible at:
                 # https://downloads.okteto.com/cli/<channel>/<tag>
-                BIN_BUCKET_ROOT="downloads.okteto.com/cli"
+                
                 BIN_BUCKET_ROOT_WITH_CHAN="${BIN_BUCKET_ROOT}/${chan}"
                 BIN_BUCKET_NAME="${BIN_BUCKET_ROOT_WITH_CHAN}/${tag}"
 

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -102,6 +102,7 @@
         # If the channel is unknown the release will fail
         CHANNELS=
 
+        IS_OFICIAL_RELEASE=false
         # dev releases don't have tags
         if [ "$RELEASE_TAG" = "" ]; then
                 CHANNELS=("dev")
@@ -112,7 +113,7 @@
                 # Stable releases are added to all channel
                 if [ -z "$prerel" ]; then
                         CHANNELS=("stable" "beta" "dev")
-
+                        IS_OFICIAL_RELEASE=true
                 elif [[ $prerel =~ $beta_prerel_regex ]]; then
                         CHANNELS=("beta" "dev")
 
@@ -138,8 +139,9 @@
                 # BIN_BUCKET_NAME is the name of the bucket where the binaries are stored.
                 # Starting at Okteto CLI 2.0, all these binaries are publicly accessible at:
                 # https://downloads.okteto.com/cli/<channel>/<tag>
-                BIN_BUCKET_ROOT="downloads.okteto.com/cli/${chan}"
-                BIN_BUCKET_NAME="${BIN_BUCKET_ROOT}/${tag}"
+                BIN_BUCKET_ROOT="downloads.okteto.com/cli"
+                BIN_BUCKET_ROOT_WITH_CHAN="${BIN_BUCKET_ROOT}/${chan}"
+                BIN_BUCKET_NAME="${BIN_BUCKET_ROOT_WITH_CHAN}/${tag}"
 
                 # VERSIONS_BUCKET_FILENAME are all the available versions for a release channel.
                 # This is also publicly accessible at:
@@ -180,12 +182,18 @@
                 latest="$(tail -n1 "${version_file}")"
 
                 if [ "$tag" = "$latest" ]; then
-                        gsutil -m rsync "gs://$BIN_BUCKET_NAME" "gs://$BIN_BUCKET_ROOT"
+                        gsutil -m rsync "gs://$BIN_BUCKET_NAME" "gs://$BIN_BUCKET_ROOT_WITH_CHAN"
                 fi
 
                 gsutil -m -h "Cache-Control: no-store" -h "Content-Type: text/plain" cp "${version_file}" "gs://${VERSIONS_BUCKET_FILENAME}"
                 echo "${chan} channel updated with ${tag}"
         done
+
+        if [ "$IS_OFICIAL_RELEASE" = true ] ; then
+                 # upload artifacts to bucket root (https://downloads.okteto.com/cli)
+                echo "Syncing artifacts from $BIN_PATH with $BIN_BUCKET_ROOT"
+                gsutil -m rsync -r "$BIN_PATH" "gs://$BIN_BUCKET_ROOT"
+        fi
 
         ################################################################################
         # Update Github Release

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -103,7 +103,7 @@
         CHANNELS=
 
         is_oficial_release=false
-        
+
         # dev releases don't have tags
         if [ "$RELEASE_TAG" = "" ]; then
                 CHANNELS=("dev")
@@ -191,7 +191,7 @@
         done
 
         if [ "$is_oficial_release" = true ] ; then
-                 # upload artifacts to bucket root (https://downloads.okteto.com/cli)
+                 # upload artifacts to bucket root (gs://downloads.okteto.com/cli)
                 echo "Syncing artifacts from $BIN_PATH with $BIN_BUCKET_ROOT"
                 gsutil -m rsync -r "$BIN_PATH" "gs://$BIN_BUCKET_ROOT"
         fi

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -102,7 +102,8 @@
         # If the channel is unknown the release will fail
         CHANNELS=
 
-        IS_OFICIAL_RELEASE=false
+        is_oficial_release=false
+        
         # dev releases don't have tags
         if [ "$RELEASE_TAG" = "" ]; then
                 CHANNELS=("dev")
@@ -113,7 +114,7 @@
                 # Stable releases are added to all channel
                 if [ -z "$prerel" ]; then
                         CHANNELS=("stable" "beta" "dev")
-                        IS_OFICIAL_RELEASE=true
+                        is_oficial_release=true
                 elif [[ $prerel =~ $beta_prerel_regex ]]; then
                         CHANNELS=("beta" "dev")
 
@@ -189,7 +190,7 @@
                 echo "${chan} channel updated with ${tag}"
         done
 
-        if [ "$IS_OFICIAL_RELEASE" = true ] ; then
+        if [ "$is_oficial_release" = true ] ; then
                  # upload artifacts to bucket root (https://downloads.okteto.com/cli)
                 echo "Syncing artifacts from $BIN_PATH with $BIN_BUCKET_ROOT"
                 gsutil -m rsync -r "$BIN_PATH" "gs://$BIN_BUCKET_ROOT"


### PR DESCRIPTION
# Context
new okteto release binaries related to windows are not available since okteto CLI `2.3.3`, instead of that these binaries are under the channel `stable` using `https://downloads.okteto.com/cli/stable/okteto.exe`.

# Proposed changes
add built artifacts into the proper bucket folder in order to make public stable releases on windows using `https://downloads.okteto.com/cli/okteto.exe` url

Fixes #https://github.com/okteto/app/issues/6414

