### PR TITLE
Initialize registrytoken command as docker credentials helper

### DIFF
--- a/cmd/registrytoken/registrytoken.go
+++ b/cmd/registrytoken/registrytoken.go
@@ -1,0 +1,69 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registrytoken
+
+import (
+	"context"
+	"os"
+
+	contextCMD "github.com/okteto/okteto/cmd/context"
+
+	"github.com/okteto/okteto/pkg/auth/dockercredentials"
+	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+type regCreds struct {
+	okteto.Config
+}
+
+func (r regCreds) GetRegistryCredentials(host string) (string, string, error) {
+	return r.GetExternalRegistryCredentials(host)
+}
+
+func RegistryToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registrytoken",
+		Short: "docker credentials helper for private registries registered in okteto",
+		Long: `Acts as a docker credentials helper printing out private registry credentials previously configured in okteto:
+
+Usage: echo gcr.io | okteto registrytoken get
+
+More info about docker credentials helpers here: https://github.com/docker/docker-credential-helpers
+  `,
+		Hidden:    true,
+		ValidArgs: []string{"get"},
+		Args:      cobra.OnlyValidArgs,
+	}
+
+	cmd.RunE = func(_ *cobra.Command, args []string) error {
+		action := args[0]
+		ctx := context.Background()
+		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{})
+		if err != nil {
+			return err
+		}
+		conf := okteto.Config{}
+		if !conf.IsOktetoCluster() {
+			return errors.ErrContextIsNotOktetoCluster
+		}
+		h := dockercredentials.NewOktetoClusterHelper(regCreds{conf})
+		return credentials.HandleCommand(h, action, os.Stdin, os.Stdout)
+	}
+
+	return cmd
+}

--- a/cmd/registrytoken/registrytoken.go
+++ b/cmd/registrytoken/registrytoken.go
@@ -53,8 +53,7 @@ More info about docker credentials helpers here: https://github.com/docker/docke
 	cmd.RunE = func(_ *cobra.Command, args []string) error {
 		action := args[0]
 		ctx := context.Background()
-		err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{})
-		if err != nil {
+		if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
 			return err
 		}
 		conf := okteto.Config{}

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/preview"
+	"github.com/okteto/okteto/cmd/registrytoken"
 	"github.com/okteto/okteto/cmd/stack"
 	"github.com/okteto/okteto/cmd/up"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -124,6 +125,8 @@ func main() {
 	root.AddCommand(contextCMD.Context())
 	root.AddCommand(cmd.Kubeconfig())
 	root.AddCommand(kubetoken.KubeToken())
+	root.AddCommand(registrytoken.RegistryToken())
+
 	root.AddCommand(build.Build(ctx))
 
 	root.AddCommand(namespace.Namespace(ctx))

--- a/pkg/auth/dockercredentials/helper.go
+++ b/pkg/auth/dockercredentials/helper.go
@@ -1,0 +1,44 @@
+package dockercredentials
+
+import (
+	"errors"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+type RegistryCredentialsGetter interface {
+	GetRegistryCredentials(host string) (string, string, error)
+}
+
+type OktetoClusterHelper struct {
+	getter RegistryCredentialsGetter
+}
+
+var _ credentials.Helper = (*OktetoClusterHelper)(nil)
+
+func NewOktetoClusterHelper(getter RegistryCredentialsGetter) *OktetoClusterHelper {
+	return &OktetoClusterHelper{getter: getter}
+}
+
+// Add appends credentials to the store.
+func (och *OktetoClusterHelper) Add(*credentials.Credentials) error {
+	return ErrNotImplemented
+}
+
+// Delete removes credentials from the store.
+func (och *OktetoClusterHelper) Delete(serverURL string) error {
+	return ErrNotImplemented
+}
+
+// Get retrieves credentials from the store.
+// It returns username and secret as strings.
+func (och *OktetoClusterHelper) Get(serverURL string) (string, string, error) {
+	return och.getter.GetRegistryCredentials(serverURL)
+}
+
+// List returns the stored serverURLs and their associated usernames.
+func (och *OktetoClusterHelper) List() (map[string]string, error) {
+	return nil, ErrNotImplemented
+}

--- a/pkg/auth/dockercredentials/helper.go
+++ b/pkg/auth/dockercredentials/helper.go
@@ -1,3 +1,15 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package dockercredentials
 
 import (


### PR DESCRIPTION
Creates a new (hidden) command that can be used as a [docker credentials helper](https://github.com/docker/docker-credential-helpers):

```golang
echo "1234567890.dkr.ecr.us-east-2.amazonaws.com" | okteto registrytoken get
{"ServerURL": "1234567890.dkr.ecr.us-east-2.amazonaws.com", "Username": "AWS", "Secret": "eyJwZqwer......"}
```