### PR TITLE
feat: add `--output` flag for `okteto preview list`

### DIFF
--- a/cmd/preview/list_test.go
+++ b/cmd/preview/list_test.go
@@ -1,0 +1,143 @@
+package preview
+
+import (
+	"context"
+	"fmt"
+	"github.com/okteto/okteto/internal/test/client"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_listPreview(t *testing.T) {
+	ctx := context.Background()
+	opts := ListFlags{}
+	var tests = []struct {
+		name           string
+		previews       []types.Preview
+		expectedResult []PreviewOutput
+		expectedErr    error
+	}{
+		{
+			name: "List all previews",
+			previews: []types.Preview{
+				{
+					ID:            "test",
+					PreviewLabels: []string{"label-1", "label-2"},
+				},
+				{
+					ID:            "test-1",
+					PreviewLabels: []string{"label-3"},
+				},
+				{
+					ID:            "test-2",
+					Sleeping:      true,
+					PreviewLabels: []string{"-"},
+				},
+			},
+			expectedResult: []PreviewOutput{
+				{
+					Name:     "test",
+					Scope:    "",
+					Sleeping: false,
+					Labels:   []string{"label-1", "label-2"},
+				},
+				{
+					Name:     "test-1",
+					Scope:    "",
+					Sleeping: false,
+					Labels:   []string{"label-3"},
+				},
+				{
+					Name:     "test-2",
+					Scope:    "",
+					Sleeping: true,
+					Labels:   []string{"-"},
+				},
+			},
+		},
+		{
+			name:           "error retrieving preview list",
+			previews:       nil,
+			expectedResult: nil,
+			expectedErr:    fmt.Errorf("error retrieving previews"),
+		},
+		{
+			name:           "user error retrieving preview list",
+			previews:       nil,
+			expectedResult: nil,
+			expectedErr: oktetoErrors.UserError{
+				E:    fmt.Errorf("error retrieving previews"),
+				Hint: "please try again",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			okteto.CurrentStore = &okteto.OktetoContextStore{
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {
+						Name:     "test",
+						Token:    "test",
+						IsOkteto: true,
+						UserID:   "1",
+					},
+				},
+				CurrentContext: "test",
+			}
+			usr := &types.User{
+				Token: "test",
+			}
+			fakeOktetoClient := &client.FakeOktetoClient{
+				Preview: client.NewFakePreviewClient(&client.FakePreviewResponse{PreviewList: tt.previews, ErrList: tt.expectedErr}),
+				Users:   client.NewFakeUsersClient(usr),
+			}
+			result, err := getPreviewOutput(ctx, opts, fakeOktetoClient)
+			if tt.expectedErr != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, result, tt.expectedResult)
+			}
+		})
+	}
+}
+
+func Test_PreviewListOutputValidation(t *testing.T) {
+	var tests = []struct {
+		name        string
+		output      ListFlags
+		expectedErr error
+	}{
+		{
+			name: "ouput format is yaml",
+			output: ListFlags{
+				output: "yaml",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "output format is json",
+			output: ListFlags{
+				output: "json",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "output format is not valid",
+			output: ListFlags{
+				output: "xml",
+			},
+			expectedErr: fmt.Errorf("output format is not accepted. Value must be one of: ['json', 'yaml']"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOutput(tt.output.output)
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes #3772

![image](https://github.com/okteto/okteto/assets/86051118/f79327fa-6da1-4d85-bf70-f26d35fd1525)

- Added the `--output` flag for `json` & `yaml` to `okteto preview list` command
- Added the test cases to check whether the output format is correct 