### PR TITLE
fix: fail if dev mode is not valid

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -210,6 +210,9 @@ var (
 
 	// ErrTimeout is raised when an operation has timed out
 	ErrTimeout = fmt.Errorf("operation timed out")
+
+	//ErrDevModeNotValid is raised when development mode in manifest is not 'sync' nor 'hybrid'
+	ErrDevModeNotValid = errors.New("development mode not valid. Value must be one of: ['sync', 'hybrid']")
 )
 
 // IsAlreadyExists raised if the Kubernetes API returns AlreadyExists

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kballard/go-shellquote"
 	"github.com/okteto/okteto/pkg/cache"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/externalresource"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model/forward"
@@ -790,16 +791,25 @@ func (d *Dev) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	mode := &modeInfo{}
 	err := unmarshal(mode)
 	if err != nil {
-		if mode.Mode == constants.OktetoHybridModeFieldValue {
-			hybridModeDev := &hybridModeInfo{}
-			err := unmarshal(hybridModeDev)
-			if err != nil {
-				return err
-			}
 
-			warningMsg := hybridModeDev.warnHybridUnsupportedFields()
-			if warningMsg != "" {
-				oktetoLog.Warning(warningMsg)
+		switch mode.Mode {
+		case "", constants.OktetoSyncModeFieldValue:
+		case constants.OktetoHybridModeFieldValue:
+			{
+				hybridModeDev := &hybridModeInfo{}
+				err := unmarshal(hybridModeDev)
+				if err != nil {
+					return err
+				}
+
+				warningMsg := hybridModeDev.warnHybridUnsupportedFields()
+				if warningMsg != "" {
+					oktetoLog.Warning(warningMsg)
+				}
+			}
+		default:
+			{
+				return errors.ErrDevModeNotValid
 			}
 		}
 	}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -15,13 +15,14 @@ package model
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/externalresource"
@@ -2095,6 +2096,21 @@ forward:
 					Image: "okteto/bin:1.4.2",
 				},
 			},
+		},
+		{
+			name: "no valid mode return error",
+			input: []byte(`
+mode: invalid-mode
+selector:
+  app.kubernetes.io/part-of: okteto
+  app.kubernetes.io/component: producer
+image: okteto/golang:1
+command: sh
+sync:
+  - ./producer:/usr/src/app
+forward:
+  - 2345:2345`),
+			expected: nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Context
when a development mode is neither `sync` nor `hybrid`, we use `sync` mode as default. We should inform the user that the mode is not correct instead fallback `sync` mode.

# Proposed changes
- raise an error if development mode is not `sync` nor `hybrid``
- add test covering new logic

Fixes #3778

# How to test it
1. create a manifest with an invalid development mode:
``````yaml
dev:
  frontend:
    mode: synco-invalid
    image: okteto/node:18
    sync:
      - ./frontend:/app
    workdir: /app
    command: ["bash"]
``````
2. Check error is raised:
<img width="501" alt="Captura de Pantalla 2023-07-10 a las 14 32 03" src="https://github.com/okteto/okteto/assets/22500940/daa81200-7edd-4a9a-a171-059776bfdf5f">
