### PR TITLE
[Hybrid] Support additional Dev fields

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -210,7 +210,12 @@ func (up *upContext) activate() error {
 		durationActivateUp := time.Since(up.StartTime)
 		analytics.TrackDurationActivateUp(durationActivateUp)
 
-		up.CommandResult <- up.RunCommand(ctx, up.Dev.Command.Values)
+		cmd := up.Dev.Command.Values
+
+		if len(up.Dev.Args.Values) > 0 {
+			cmd = append(cmd, up.Dev.Args.Values...)
+		}
+		up.CommandResult <- up.RunCommand(ctx, cmd)
 	}()
 
 	prevError := up.waitUntilExitOrInterruptOrApply(ctx)

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -210,12 +210,7 @@ func (up *upContext) activate() error {
 		durationActivateUp := time.Since(up.StartTime)
 		analytics.TrackDurationActivateUp(durationActivateUp)
 
-		cmd := up.Dev.Command.Values
-
-		if len(up.Dev.Args.Values) > 0 {
-			cmd = append(cmd, up.Dev.Args.Values...)
-		}
-		up.CommandResult <- up.RunCommand(ctx, cmd)
+		up.CommandResult <- up.RunCommand(ctx, up.Dev.Command.Values)
 	}()
 
 	prevError := up.waitUntilExitOrInterruptOrApply(ctx)

--- a/integration/k8s-client.go
+++ b/integration/k8s-client.go
@@ -48,6 +48,10 @@ func getClientConfig(kubeconfigPaths []string, kubeContext string) clientcmd.Cli
 	)
 }
 
+func GetPodsBySelector(ctx context.Context, ns, selector string, client kubernetes.Interface) (*corev1.PodList, error) {
+	return client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})
+}
+
 // GetService returns a service given a namespace and a name
 func GetService(ctx context.Context, ns, name string, client kubernetes.Interface) (*corev1.Service, error) {
 	return client.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -122,7 +121,6 @@ func TestUpUsingHybridMode(t *testing.T) {
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
-	log.Printf("Using kubeconfig: '%s'", filepath.Join(dir, ".kube", "config"))
 
 	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), hybridManifest))
 	require.NoError(t, writeFile(filepath.Join(dir, "docker-compose.yml"), hybridCompose))

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -50,6 +50,8 @@ dev:
         e2e/test-1: annotation-1
       labels:
         custom.label/e2e: "true"
+    annotations:
+      deprecated.annotation.format: deprecated-annotation-1
 `
 	hybridCompose = `services:
  svc:
@@ -143,10 +145,14 @@ func TestUpUsingHybridMode(t *testing.T) {
 	// Get deployment and check for annotations and labels
 	deploy, err := integration.GetDeployment(context.Background(), testNamespace, "svc", c)
 	require.NoError(t, err)
-	require.Equal(t, constants.OktetoHybridModeFieldValue, deploy.Annotations[constants.OktetoDevModeAnnotation])
 
-	// TODO: understand why this Label is not getting set
-	//require.Equal(t, "true", deploy.Annotations["custom.label/e2e"])
+	pods, err := integration.GetPodsBySelector(context.Background(), testNamespace, "stack.okteto.com/service=svc", c)
+	require.NoError(t, err)
+
+	require.Equal(t, constants.OktetoHybridModeFieldValue, deploy.Annotations[constants.OktetoDevModeAnnotation])
+	require.Equal(t, "annotation-1", deploy.Annotations["e2e/test-1"])
+	require.Equal(t, "deprecated-annotation-1", deploy.Annotations["deprecated.annotation.format"])
+	require.Equal(t, "true", pods.Items[0].Labels["custom.label/e2e"])
 
 	// Test okteto down command
 	down1Opts := &commands.DownOptions{

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -59,7 +59,7 @@ dev:
 
 	svcDockerfile = `FROM busybox
 ENV ENV_IN_IMAGE value_from_image`
-	envFile      = `VALUE_OF_ARG2=value-of-arg2`
+	envFile      = `TEST_ENV_FILE_VAR1=from-file-1`
 	localProcess = `
 #!/bin/bash
 
@@ -70,6 +70,11 @@ fi
 
 if [ "$TEST_ENV_VAR1" != "test-value1" ]; then
   echo "TEST_ENV_VAR1 should be 'test-value1', got '$TEST_ENV_VAR1' instead"
+  exit 1
+fi
+
+if [ "$TEST_ENV_FILE_VAR1" != "from-file-1" ]; then
+  echo "TEST_ENV_FILE_VAR1 should be 'from-file-1', got '$TEST_ENV_FILE_VAR1' instead"
   exit 1
 fi
 

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -38,12 +38,9 @@ dev:
     context: svc
     namespace: user
     mode: hybrid
-    command: ./checker.sh
+    command: bash ./checker.sh
     reverse:
     - 8080:8080
-    args:
-    - value-of-arg1
-    - $VALUE_OF_ARG2
     envFiles:
     - .env
     environment:
@@ -66,18 +63,8 @@ ENV ENV_IN_IMAGE value_from_image`
 	localProcess = `
 #!/bin/bash
 
-if [ "$#" -ne 2 ]; then
-  echo "Total arguments count should be 2, got $# instead"
-  exit 1
-fi
-
-if [ "$1" != "value-of-arg1" ]; then
-  echo "First argument should be 'value-of-arg1', got '$1' instead"
-  exit 1
-fi
-
-if [ "$2" != "value-of-arg2" ]; then
-  echo "Second argument should be 'value-of-arg2', got '$2' instead"
+if [ "$#" -ne 0 ]; then
+  echo "This script does not accept any argument, got $# instead"
   exit 1
 fi
 

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -121,6 +122,7 @@ func TestUpUsingHybridMode(t *testing.T) {
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
+	log.Printf("Using kubeconfig: '%s'", filepath.Join(dir, ".kube", "config"))
 
 	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), hybridManifest))
 	require.NoError(t, writeFile(filepath.Join(dir, "docker-compose.yml"), hybridCompose))

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -60,7 +60,7 @@ dev:
   - ENV_IN_POD=value_from_pod`
 
 	svcDockerfile = `FROM busybox
-ENV ANOTHER_ENV value_from_image`
+ENV ENV_IN_IMAGE value_from_image`
 	envFile      = `TEST_ENV_FILE_VAR1=from-file-1`
 	localProcess = `#!/bin/bash
 set -e


### PR DESCRIPTION
# Proposed changes

Fixes #3739

With this PR I've tested all manifest properties that should also work for services in Hybrid mode, as specified in #3739.

Most of them are already working out of the box with recent changes that we made in https://github.com/okteto/okteto/pull/3764, so, as part of this PR, I am mainly extending E2E tests to cover for fields:

- `envFiles`
- `environment`
- `metadata.annotations`
- `metadata.labels`
- `annotations` 

Sure, here's the information as a table:

| Fields                | Status                                                 |
|-----------------------|--------------------------------------------------------|
| annotations           | Works ✅                                               |
| container             | Works ✅                                               |
| args                  | Not implemented in sync either. Moved to separate issue: [Link](https://github.com/okteto/okteto/issues/3836) |
| probes                | Works ✅ |
| interface             | Works ✅ |
| remote                | Works ✅                                               |
| timeout               | Not working properly for sync either (Created dedicated issue: [Link](https://github.com/okteto/okteto/issues/3849)) |
| metadata.annotations  | Works ✅                                               |
| metadata.labels       | Works ✅                                               |
| autocreate            | Works ✅                                               |
| envFiles              | Works ✅                                               |
| environment           | Works ✅                                               |
| healthchecks          | Should work, but deprecated                            |
| labels                | Should work, but deprecated                            |

## How to test

I've tested manually all of those with the ✅  - for some of them I was able to modify the e2e test to include those in the automated test.

See passing E2E tests for Windows: https://app.circleci.com/pipelines/github/okteto/okteto/11166/workflows/0c8e7538-0a87-4537-8cdb-8ac1c0169a90/jobs/35422