### PR TITLE
Add docker-credential-okteto to cli image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN chmod +x /okteto/bin/okteto
 # Test
 RUN /okteto/bin/okteto version
 
+COPY docker-credential-okteto /okteto/bin/docker-credential-okteto
+
 FROM alpine:3
 
 RUN apk add --no-cache bash ca-certificates
@@ -50,6 +52,8 @@ COPY --from=helm-builder /usr/local/bin/helm /usr/local/bin/helm
 COPY --from=kustomize-builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 
 COPY --from=builder /okteto/bin/okteto /usr/local/bin/okteto
+COPY --from=builder /okteto/bin/docker-credential-okteto /usr/local/bin/docker-credential-okteto
+
 
 ENV OKTETO_DISABLE_SPINNER=true
 

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -89,6 +89,26 @@ func Build(ctx context.Context) *cobra.Command {
 				return err
 			}
 
+			if okteto.IsOkteto() && options.Tag != "" {
+				oc, err := okteto.NewOktetoClient()
+				if err != nil {
+					return err
+				}
+				reg, _ := bc.Registry.GetRegistryAndRepo(options.Tag)
+				creds, err := oc.User().GetRegistryCredentials(ctx, reg)
+				if err != nil {
+					return err
+				}
+				registryWithAuth := registry.
+					NewOktetoRegistry(okteto.Config{}).
+					WithBasicAuthFor(reg, creds.Username, creds.Password)
+
+				bc.Registry = registryWithAuth
+				bc.Builder = &build.OktetoBuilder{
+					Registry: registryWithAuth,
+				}
+			}
+
 			builder, err := bc.getBuilder(options)
 			if err != nil {
 				return err

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -89,26 +89,6 @@ func Build(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if okteto.IsOkteto() && options.Tag != "" {
-				oc, err := okteto.NewOktetoClient()
-				if err != nil {
-					return err
-				}
-				reg, _ := bc.Registry.GetRegistryAndRepo(options.Tag)
-				creds, err := oc.User().GetRegistryCredentials(ctx, reg)
-				if err != nil {
-					return err
-				}
-				registryWithAuth := registry.
-					NewOktetoRegistry(okteto.Config{}).
-					WithBasicAuthFor(reg, creds.Username, creds.Password)
-
-				bc.Registry = registryWithAuth
-				bc.Builder = &build.OktetoBuilder{
-					Registry: registryWithAuth,
-				}
-			}
-
 			builder, err := bc.getBuilder(options)
 			if err != nil {
 				return err

--- a/cmd/registrytoken/registrytoken.go
+++ b/cmd/registrytoken/registrytoken.go
@@ -1,0 +1,68 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registrytoken
+
+import (
+	"context"
+	"os"
+
+	contextCMD "github.com/okteto/okteto/cmd/context"
+
+	"github.com/okteto/okteto/pkg/auth/dockercredentials"
+	"github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+type regCreds struct {
+	okteto.Config
+}
+
+func (r regCreds) GetRegistryCredentials(host string) (string, string, error) {
+	return r.GetExternalRegistryCredentials(host)
+}
+
+func RegistryToken() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "registrytoken",
+		Short: "docker credentials helper for private registries registered in okteto",
+		Long: `Acts as a docker credentials helper printing out private registry credentials previously configured in okteto:
+
+Usage: echo gcr.io | okteto registrytoken get
+
+More info about docker credentials helpers here: https://github.com/docker/docker-credential-helpers
+  `,
+		Hidden:    true,
+		ValidArgs: []string{"get"},
+		Args:      cobra.OnlyValidArgs,
+	}
+
+	cmd.RunE = func(_ *cobra.Command, args []string) error {
+		action := args[0]
+		ctx := context.Background()
+		if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
+			return err
+		}
+		conf := okteto.Config{}
+		if !conf.IsOktetoCluster() {
+			return errors.ErrContextIsNotOktetoCluster
+		}
+		h := dockercredentials.NewOktetoClusterHelper(regCreds{conf})
+		return credentials.HandleCommand(h, action, os.Stdin, os.Stdout)
+	}
+
+	return cmd
+}

--- a/docker-credential-okteto
+++ b/docker-credential-okteto
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# docker-credential-okteto is a docker credentials helper that allows docker to
+# authenticate against private registries defined in Okteto
+cat | okteto registrytoken "${1}"

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -49,10 +49,10 @@ func (c *FakeUserClient) GetClusterCertificate(_ context.Context, cluster, ns st
 	return nil, nil
 }
 
-func (c *FakeUserClient) GetClusterMetadata(ctx context.Context, ns string) (types.ClusterMetadata, error) {
+func (c *FakeUserClient) GetClusterMetadata(_ context.Context, _ string) (types.ClusterMetadata, error) {
 	return types.ClusterMetadata{}, nil
 }
 
-func (c *FakeUserClient) GetRegistryCredentials(ctx context.Context, registry string) (dockertypes.AuthConfig, error) {
+func (c *FakeUserClient) GetRegistryCredentials(_ context.Context, _ string) (dockertypes.AuthConfig, error) {
 	return dockertypes.AuthConfig{}, nil
 }

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -14,6 +14,7 @@ package client
 import (
 	"context"
 
+	dockertypes "github.com/docker/cli/cli/config/types"
 	"github.com/okteto/okteto/pkg/types"
 )
 
@@ -50,4 +51,8 @@ func (c *FakeUserClient) GetClusterCertificate(_ context.Context, cluster, ns st
 
 func (c *FakeUserClient) GetClusterMetadata(ctx context.Context, ns string) (types.ClusterMetadata, error) {
 	return types.ClusterMetadata{}, nil
+}
+
+func (c *FakeUserClient) GetRegistryCredentials(ctx context.Context, registry string) (dockertypes.AuthConfig, error) {
+	return dockertypes.AuthConfig{}, nil
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/preview"
+	"github.com/okteto/okteto/cmd/registrytoken"
 	"github.com/okteto/okteto/cmd/stack"
 	"github.com/okteto/okteto/cmd/up"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -124,6 +125,8 @@ func main() {
 	root.AddCommand(contextCMD.Context())
 	root.AddCommand(cmd.Kubeconfig())
 	root.AddCommand(kubetoken.KubeToken())
+	root.AddCommand(registrytoken.RegistryToken())
+
 	root.AddCommand(build.Build(ctx))
 
 	root.AddCommand(namespace.Namespace(ctx))

--- a/pkg/auth/dockercredentials/helper.go
+++ b/pkg/auth/dockercredentials/helper.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package dockercredentials
+
+import (
+	"errors"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+type RegistryCredentialsGetter interface {
+	GetRegistryCredentials(host string) (string, string, error)
+}
+
+type OktetoClusterHelper struct {
+	getter RegistryCredentialsGetter
+}
+
+var _ credentials.Helper = (*OktetoClusterHelper)(nil)
+
+func NewOktetoClusterHelper(getter RegistryCredentialsGetter) *OktetoClusterHelper {
+	return &OktetoClusterHelper{getter: getter}
+}
+
+// Add appends credentials to the store.
+func (och *OktetoClusterHelper) Add(*credentials.Credentials) error {
+	return ErrNotImplemented
+}
+
+// Delete removes credentials from the store.
+func (och *OktetoClusterHelper) Delete(serverURL string) error {
+	return ErrNotImplemented
+}
+
+// Get retrieves credentials from the store.
+// It returns username and secret as strings.
+func (och *OktetoClusterHelper) Get(serverURL string) (string, string, error) {
+	return och.getter.GetRegistryCredentials(serverURL)
+}
+
+// List returns the stored serverURLs and their associated usernames.
+func (och *OktetoClusterHelper) List() (map[string]string, error) {
+	return nil, ErrNotImplemented
+}

--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/types"
-	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"google.golang.org/grpc"
@@ -32,7 +31,7 @@ import (
 
 var oktetoRegistry = ""
 
-func newDockerAndOktetoAuthProvider(registryURL, username, password string, stderr io.Writer) session.Attachable {
+func newDockerAndOktetoAuthProvider(registryURL, username, password string, stderr io.Writer) *authProvider {
 	result := &authProvider{
 		config: config.LoadDefaultConfigFile(stderr),
 	}
@@ -45,8 +44,15 @@ func newDockerAndOktetoAuthProvider(registryURL, username, password string, stde
 	return result
 }
 
+type externalRegistryCredentialFunc func(ctx context.Context, host string) (types.AuthConfig, error)
+
 type authProvider struct {
 	config *configfile.ConfigFile
+
+	// externalAuth is an external registry credentials getter that live
+	// outside of the configfile. It is used to load external auth data without
+	// going through the target config file store
+	externalAuth externalRegistryCredentialFunc
 
 	// The need for this mutex is not well understood.
 	// Without it, the docker cli on OS X hangs when
@@ -71,12 +77,12 @@ func (*authProvider) VerifyTokenAuthority(_ context.Context, _ *auth.VerifyToken
 	return nil, status.Errorf(codes.Unimplemented, "method VerifyTokenAuthority not implemented")
 }
 
-func (ap *authProvider) Credentials(_ context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
-	res := &auth.CredentialsResponse{}
+func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
 	if req.Host == oktetoRegistry {
-		res.Username = ap.config.AuthConfigs[oktetoRegistry].Username
-		res.Secret = ap.config.AuthConfigs[oktetoRegistry].Password
-		return res, nil
+		return &auth.CredentialsResponse{
+			Username: ap.config.AuthConfigs[oktetoRegistry].Username,
+			Secret:   ap.config.AuthConfigs[oktetoRegistry].Password,
+		}, nil
 	}
 
 	ap.mu.Lock()
@@ -88,17 +94,32 @@ func (ap *authProvider) Credentials(_ context.Context, req *auth.CredentialsRequ
 	if err != nil {
 		if isErrCredentialsHelperNotAccessible(err) {
 			oktetoLog.Infof("could not access %s defined in %s", ap.config.CredentialsStore, ap.config.Filename)
-			return res, nil
+			return &auth.CredentialsResponse{}, nil
 		}
 
 		return nil, err
 	}
 	if ac.IdentityToken != "" {
-		res.Secret = ac.IdentityToken
-	} else {
-		res.Username = ac.Username
-		res.Secret = ac.Password
+		return &auth.CredentialsResponse{
+			Secret: ac.IdentityToken,
+		}, nil
 	}
+
+	res := &auth.CredentialsResponse{
+		Username: ac.Username,
+		Secret:   ac.Password,
+	}
+
+	// local credentials takes precedence over cluster defined credentials
+	if ap.externalAuth != nil && (res.Username == "" || res.Secret == "") {
+		if auth, err := ap.externalAuth(ctx, req.Host); err != nil {
+			oktetoLog.Debugf("failed to load external auth for %s: %w", req.Host, err.Error())
+		} else {
+			res.Username = auth.Username
+			res.Secret = auth.Password
+		}
+	}
+
 	return res, nil
 }
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -48,9 +48,7 @@ type OktetoBuilderInterface interface {
 }
 
 // OktetoBuilder runs the build of an image
-type OktetoBuilder struct {
-	Registry registry.OktetoRegistry
-}
+type OktetoBuilder struct{}
 
 // OktetoRegistryInterface checks if an image is at the registry
 type OktetoRegistryInterface interface {
@@ -160,11 +158,7 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 	}
 
 	if err == nil && buildOptions.Tag != "" {
-		reg := ob.Registry
-		if reg == (registry.OktetoRegistry{}) {
-			reg = registry.NewOktetoRegistry(okteto.Config{})
-		}
-		if _, err := reg.GetImageTagWithDigest(buildOptions.Tag); err != nil {
+		if _, err := registry.NewOktetoRegistry(okteto.Config{}).GetImageTagWithDigest(buildOptions.Tag); err != nil {
 			oktetoLog.Yellow(`Failed to push '%s' metadata to the registry:
 	  %s,
 	  Retrying ...`, buildOptions.Tag, err.Error())

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -90,7 +90,6 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 	attachable := []session.Attachable{}
 	if okteto.IsOkteto() {
 		ap := newDockerAndOktetoAuthProvider(okteto.Context().Registry, okteto.Context().UserID, okteto.Context().Token, os.Stderr)
-		ap.externalAuth = (&okteto.RegistryCredentialsReader{}).ClusterCredentials
 		attachable = append(attachable, ap)
 	} else {
 		attachable = append(attachable, authprovider.NewDockerAuthProvider(os.Stderr))

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -89,7 +89,9 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 	}
 	attachable := []session.Attachable{}
 	if okteto.IsOkteto() {
-		attachable = append(attachable, newDockerAndOktetoAuthProvider(okteto.Context().Registry, okteto.Context().UserID, okteto.Context().Token, os.Stderr))
+		ap := newDockerAndOktetoAuthProvider(okteto.Context().Registry, okteto.Context().UserID, okteto.Context().Token, os.Stderr)
+		ap.externalAuth = (&okteto.RegistryCredentialsReader{}).ClusterCredentials
+		attachable = append(attachable, ap)
 	} else {
 		attachable = append(attachable, authprovider.NewDockerAuthProvider(os.Stderr))
 	}

--- a/pkg/okteto/config.go
+++ b/pkg/okteto/config.go
@@ -13,7 +13,10 @@
 
 package okteto
 
-import "crypto/x509"
+import (
+	"context"
+	"crypto/x509"
+)
 
 type Config struct{}
 
@@ -27,3 +30,6 @@ func (Config) GetContextCertificate() (*x509.Certificate, error) { return GetCon
 func (Config) IsInsecureSkipTLSVerifyPolicy() bool               { return Context().IsInsecure }
 func (Config) GetServerNameOverride() string                     { return GetServerNameOverride() }
 func (Config) GetContextName() string                            { return Context().Name }
+func (Config) GetExternalRegistryCredentials(registryHost string) (string, string, error) {
+	return GetExternalRegistryCredentials(context.TODO(), registryHost)
+}

--- a/pkg/okteto/registry_credentials.go
+++ b/pkg/okteto/registry_credentials.go
@@ -1,0 +1,32 @@
+package okteto
+
+import (
+	"context"
+
+	dockertypes "github.com/docker/cli/cli/config/types"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/types"
+)
+
+type RegistryCredentialsReader struct {
+	OktetoClient types.UserInterface
+}
+
+func (rcr *RegistryCredentialsReader) ClusterCredentials(ctx context.Context, host string) (dockertypes.AuthConfig, error) {
+	if !IsOkteto() {
+		return dockertypes.AuthConfig{}, nil
+	}
+
+	c := rcr.OktetoClient
+
+	if c == nil {
+		fullClient, err := NewOktetoClient()
+		if err != nil {
+			oktetoLog.Debugf("failed to create okteto client for getting registry credentials: %s", err.Error())
+			return dockertypes.AuthConfig{}, err
+		}
+		c = fullClient.User()
+	}
+
+	return c.GetRegistryCredentials(ctx, host)
+}

--- a/pkg/okteto/registry_credentials.go
+++ b/pkg/okteto/registry_credentials.go
@@ -2,31 +2,34 @@ package okteto
 
 import (
 	"context"
+	"strings"
 
-	dockertypes "github.com/docker/cli/cli/config/types"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/types"
 )
 
-type RegistryCredentialsReader struct {
-	OktetoClient types.UserInterface
-}
-
-func (rcr *RegistryCredentialsReader) ClusterCredentials(ctx context.Context, host string) (dockertypes.AuthConfig, error) {
+func GetExternalRegistryCredentials(ctx context.Context, registryOrImage string) (string, string, error) {
 	if !IsOkteto() {
-		return dockertypes.AuthConfig{}, nil
+		return "", "", nil
+	}
+	c, err := NewOktetoClient()
+	if err != nil {
+		oktetoLog.Debugf("failed to create okteto client for getting registry credentials: %s", err.Error())
+		return "", "", err
 	}
 
-	c := rcr.OktetoClient
+	registry := registryOrImage
+	registry = strings.TrimPrefix(registry, "https://")
+	registry = strings.TrimPrefix(registry, "http://")
 
-	if c == nil {
-		fullClient, err := NewOktetoClient()
-		if err != nil {
-			oktetoLog.Debugf("failed to create okteto client for getting registry credentials: %s", err.Error())
-			return dockertypes.AuthConfig{}, err
-		}
-		c = fullClient.User()
+	switch {
+	case strings.HasPrefix(registry, "index.docker.io/v2"):
+		registry = "https://index.docker.io/v2/"
+	case strings.HasPrefix(registry, "index.docker.io/v1"):
+		registry = "https://index.docker.io/v1/"
+	case strings.HasPrefix(registry, "index.docker.io"):
+		registry = "https://index.docker.io/v1/"
 	}
 
-	return c.GetRegistryCredentials(ctx, host)
+	ac, err := c.User().GetRegistryCredentials(ctx, registry)
+	return ac.Username, ac.Password, err
 }

--- a/pkg/okteto/registry_credentials.go
+++ b/pkg/okteto/registry_credentials.go
@@ -2,19 +2,22 @@ package okteto
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"strings"
 
+	dockertypes "github.com/docker/cli/cli/config/types"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
-func GetExternalRegistryCredentials(ctx context.Context, registryOrImage string) (string, string, error) {
-	if !IsOkteto() {
+type externalRegistryCredentialsReader struct {
+	getter   func(ctx context.Context, host string) (dockertypes.AuthConfig, error)
+	isOkteto bool
+}
+
+func (r *externalRegistryCredentialsReader) read(ctx context.Context, registryOrImage string) (string, string, error) {
+	if !r.isOkteto {
 		return "", "", nil
-	}
-	c, err := NewOktetoClient()
-	if err != nil {
-		oktetoLog.Debugf("failed to create okteto client for getting registry credentials: %s", err.Error())
-		return "", "", err
 	}
 
 	registry := registryOrImage
@@ -28,8 +31,28 @@ func GetExternalRegistryCredentials(ctx context.Context, registryOrImage string)
 		registry = "https://index.docker.io/v1/"
 	case strings.HasPrefix(registry, "index.docker.io"):
 		registry = "https://index.docker.io/v1/"
+	default:
+		u, err := url.Parse(fmt.Sprintf("//%s", registry))
+		if err != nil {
+			oktetoLog.Debugf("invalid registry host: %s", err.Error())
+			return "", "", err
+		}
+		registry = u.Host
 	}
 
-	ac, err := c.User().GetRegistryCredentials(ctx, registry)
+	ac, err := r.getter(ctx, registry)
 	return ac.Username, ac.Password, err
+}
+
+func GetExternalRegistryCredentials(ctx context.Context, registryOrImage string) (string, string, error) {
+	c, err := NewOktetoClient()
+	if err != nil {
+		oktetoLog.Debugf("failed to create okteto client for getting registry credentials: %s", err.Error())
+		return "", "", err
+	}
+	r := &externalRegistryCredentialsReader{
+		isOkteto: IsOkteto(),
+		getter:   c.User().GetRegistryCredentials,
+	}
+	return r.read(ctx, registryOrImage)
 }

--- a/pkg/okteto/registry_credentials_test.go
+++ b/pkg/okteto/registry_credentials_test.go
@@ -1,0 +1,143 @@
+package okteto
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	dockertypes "github.com/docker/cli/cli/config/types"
+	"github.com/stretchr/testify/require"
+)
+
+type getFn func(ctx context.Context, host string) (dockertypes.AuthConfig, error)
+
+func TestExternalRegistryCredentialsOK(t *testing.T) {
+	defaultV1 := "https://index.docker.io/v1/"
+	defaultV2 := "https://index.docker.io/v2/"
+
+	spyOnAndExpect := func(expected string) getFn {
+		return func(ctx context.Context, host string) (dockertypes.AuthConfig, error) {
+			require.Equal(t, expected, host)
+			return dockertypes.AuthConfig{
+				Username: "user",
+				Password: "pass",
+			}, nil
+		}
+
+	}
+
+	tt := []struct {
+		input    string
+		getter   getFn
+		expected [2]string
+	}{
+		// default hub v1 registry
+		{
+			input:  "index.docker.io",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "index.docker.io/v1",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "index.docker.io/v1/",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "https://index.docker.io",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "http://index.docker.io",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "https://index.docker.io/v1",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "http://index.docker.io/v1",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "https://index.docker.io/v1/",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		{
+			input:  "http://index.docker.io/v1/",
+			getter: spyOnAndExpect(defaultV1),
+		},
+		// v2 hub registry
+		{
+			input:  "index.docker.io/v2",
+			getter: spyOnAndExpect(defaultV2),
+		},
+		{
+			input:  "index.docker.io/v2/",
+			getter: spyOnAndExpect(defaultV2),
+		},
+		{
+			input:  "https://index.docker.io/v2",
+			getter: spyOnAndExpect(defaultV2),
+		},
+		{
+			input:  "http://index.docker.io/v2",
+			getter: spyOnAndExpect(defaultV2),
+		},
+		{
+			input:  "https://index.docker.io/v2/",
+			getter: spyOnAndExpect(defaultV2),
+		},
+		{
+			input:  "http://index.docker.io/v2/",
+			getter: spyOnAndExpect(defaultV2),
+		},
+		{
+			input:  "http://index.docker.io/v2/",
+			getter: spyOnAndExpect(defaultV2),
+		},
+		// external registries
+		{
+			input:  "https://gcr.io",
+			getter: spyOnAndExpect("gcr.io"),
+		},
+		{
+			input:  "http://gcr.io",
+			getter: spyOnAndExpect("gcr.io"),
+		},
+		{
+			input:  "https://gcr.io/qwerty",
+			getter: spyOnAndExpect("gcr.io"),
+		},
+		{
+			input:  "https://gcr.io/qwerty/nested/path/12345",
+			getter: spyOnAndExpect("gcr.io"),
+		},
+		{
+			input:  "some-extranous-host/with-strange-path",
+			getter: spyOnAndExpect("some-extranous-host"),
+		},
+		{
+			input:  "https://gcr.io?with=query-string#and-fragment",
+			getter: spyOnAndExpect("gcr.io"),
+		},
+	}
+
+	ctx := context.Background()
+	for i, tc := range tt {
+		name := fmt.Sprintf("check%v", i)
+		t.Run(name, func(t *testing.T) {
+			r := externalRegistryCredentialsReader{
+				isOkteto: true,
+				getter:   tc.getter,
+			}
+			user, pass, err := r.read(ctx, tc.input)
+			require.NoError(t, err)
+			require.Equal(t, "user", user)
+			require.Equal(t, "pass", pass)
+		})
+
+	}
+
+}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -136,7 +136,7 @@ func (f fakeClientConfig) IsInsecureSkipTLSVerifyPolicy() bool               { r
 func (f fakeClientConfig) GetContextCertificate() (*x509.Certificate, error) { return f.cert, nil }
 func (f fakeClientConfig) GetServerNameOverride() string                     { return f.serverName }
 func (f fakeClientConfig) GetContextName() string                            { return f.contextName }
-func (f fakeClientConfig) GetExternalRegistryCredentials(registryHost string) (string, string, error) {
+func (f fakeClientConfig) GetExternalRegistryCredentials(_ string) (string, string, error) {
 	return f.externalRegistryCredentials[0], f.externalRegistryCredentials[1], nil
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
@@ -36,6 +35,7 @@ type configInterface interface {
 	GetContextCertificate() (*x509.Certificate, error)
 	GetServerNameOverride() string
 	GetContextName() string
+	GetExternalRegistryCredentials(registryHost string) (string, string, error)
 }
 
 // OktetoRegistry represents the registry
@@ -58,19 +58,6 @@ func NewOktetoRegistry(config configInterface) OktetoRegistry {
 		imageCtrl: NewImageCtrl(config),
 		config:    config,
 	}
-}
-
-func (or OktetoRegistry) WithBasicAuthFor(registry, username, password string) OktetoRegistry {
-	if username == "" || password == "" {
-		oktetoLog.Debug("skipping basic auth for registry: '%s'. Both username and password must be defined")
-		return or
-	}
-	clone := NewOktetoRegistry(or.config)
-	clone.client = newOktetoRegistryClient(or.config).WithExternalAuth(registry, &authn.Basic{
-		Username: username,
-		Password: password,
-	})
-	return clone
 }
 
 func (or OktetoRegistry) GetImageTagWithDigest(image string) (string, error) {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -33,6 +33,7 @@ type FakeConfig struct {
 	ContextCertificate          *x509.Certificate
 	ServerName                  string
 	ContextName                 string
+	externalRegistryCredentials [2]string
 }
 
 func (fc FakeConfig) IsOktetoCluster() bool               { return fc.IsOktetoClusterCfg }
@@ -47,6 +48,9 @@ func (fc FakeConfig) GetContextCertificate() (*x509.Certificate, error) {
 }
 func (fc FakeConfig) GetServerNameOverride() string { return fc.ServerName }
 func (fc FakeConfig) GetContextName() string        { return fc.ContextName }
+func (f FakeConfig) GetExternalRegistryCredentials(registryHost string) (string, string, error) {
+	return f.externalRegistryCredentials[0], f.externalRegistryCredentials[1], nil
+}
 
 func TestGetImageTagWithDigest(t *testing.T) {
 	type expected struct {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -48,7 +48,7 @@ func (fc FakeConfig) GetContextCertificate() (*x509.Certificate, error) {
 }
 func (fc FakeConfig) GetServerNameOverride() string { return fc.ServerName }
 func (fc FakeConfig) GetContextName() string        { return fc.ContextName }
-func (f FakeConfig) GetExternalRegistryCredentials(registryHost string) (string, string, error) {
+func (f FakeConfig) GetExternalRegistryCredentials(_ string) (string, string, error) {
 	return f.externalRegistryCredentials[0], f.externalRegistryCredentials[1], nil
 }
 

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -13,7 +13,9 @@
 
 package types
 
-import "github.com/okteto/okteto/pkg/model"
+import (
+	"github.com/okteto/okteto/pkg/model"
+)
 
 // BuildSshSession is a reference to an ssh session which translates to a
 // --mount=ssh,id={id} argument in a buildkit run.

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -16,6 +16,8 @@ package types
 import (
 	"context"
 	"time"
+
+	dockertypes "github.com/docker/cli/cli/config/types"
 )
 
 // OktetoInterface represents the client that connects to the backend to create API calls
@@ -33,6 +35,7 @@ type UserInterface interface {
 	GetContext(ctx context.Context, ns string) (*UserContext, error)
 	GetClusterCertificate(ctx context.Context, cluster, ns string) ([]byte, error)
 	GetClusterMetadata(ctx context.Context, ns string) (ClusterMetadata, error)
+	GetRegistryCredentials(ctx context.Context, host string) (dockertypes.AuthConfig, error)
 }
 
 // NamespaceInterface represents the client that connects to the namespace functions


### PR DESCRIPTION
Creates an executable file that should be used as a docker credential helper.

For now, this is not added locally to the user path meaning that it won't work locally since the UX for this needs to be decided. TL;DR: `~/.docker/config.json`  reads this executable automatically

However, this works out of the box in `--remote` deploy because all binaries in `/usr/local/bin/*` are already copied to the target image. After this change this should work:

```yaml
deploy:
  commands:
    - echo my-registry.com | docker-credential-okteto get
```
