### PR TITLE
fix(up): skip deploy properly if deploy and depencencies are empty

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -284,8 +284,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	oktetoLog.Debug("found okteto manifest")
 	dc.PipelineType = deployOptions.Manifest.Type
 
-	dependenciesEmpty := deployOptions.Manifest.Dependencies == nil || len(deployOptions.Manifest.Dependencies) == 0
-	if deployOptions.Manifest.Deploy == nil && dependenciesEmpty {
+	if deployOptions.Manifest.Deploy == nil && !deployOptions.Manifest.HasDependencies() {
 		return oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands
 	}
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -284,9 +284,11 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	oktetoLog.Debug("found okteto manifest")
 	dc.PipelineType = deployOptions.Manifest.Type
 
-	if deployOptions.Manifest.Deploy == nil && deployOptions.Manifest.Dependencies == nil {
+	dependenciesEmpty := deployOptions.Manifest.Dependencies == nil || len(deployOptions.Manifest.Dependencies) == 0
+	if deployOptions.Manifest.Deploy == nil && dependenciesEmpty {
 		return oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands
 	}
+
 	if len(deployOptions.servicesToDeploy) > 0 && deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection == nil {
 		return oktetoErrors.ErrDeployCantDeploySvcsIfNotCompose
 	}

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -345,7 +345,8 @@ func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
 
 	err := c.RunDeploy(ctx, opts)
 
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands)
+
 	// No command was executed
 	assert.Len(t, e.executed, 0)
 	// Proxy wasn't started

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -287,8 +287,8 @@ func Up() *cobra.Command {
 					Err:                    err,
 				})
 
-				// only allow error.ErrManifestFoundButNoDeployCommands to go forward - autocreate property will deploy the app
-				if err != nil && !errors.Is(err, oktetoErrors.ErrManifestFoundButNoDeployCommands) {
+				// only allow error.ErrManifestFoundButNoDeployAndDependenciesCommands to go forward - autocreate property will deploy the app
+				if err != nil && !errors.Is(err, oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands) {
 					return err
 				}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -157,9 +157,6 @@ var (
 	// ErrNoServicesinOktetoManifest raised when no services are defined in the okteto manifest
 	ErrNoServicesinOktetoManifest = fmt.Errorf("'okteto restart' is only supported when using the field 'services'")
 
-	// ErrManifestFoundButNoDeployCommands raised when a manifest is found but no deploy commands are defined
-	ErrManifestFoundButNoDeployCommands = errors.New("found okteto manifest, but no deploy commands where defined")
-
 	// ErrManifestFoundButNoDeployAndDependenciesCommands raised when a manifest is found but no deploy or dependencies commands are defined
 	ErrManifestFoundButNoDeployAndDependenciesCommands = errors.New("found okteto manifest, but no deploy or dependencies commands were defined")
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1331,6 +1331,14 @@ func (m *Manifest) setManifestDefaultsFromDev() {
 	}
 }
 
+// HasDependencies returns true if the manifest has dependencies
+func (m *Manifest) HasDependencies() bool {
+	if m.Dependencies == nil {
+		return false
+	}
+	return len(m.Dependencies) > 0
+}
+
 // HasDev checks if manifestDevs has a dev name as key
 func (d ManifestDevs) HasDev(name string) bool {
 	_, ok := d[name]

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -731,6 +731,44 @@ func TestSetManifestDefaultsFromDev(t *testing.T) {
 	}
 }
 
+func TestHasDependencies(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest Manifest
+		expected bool
+	}{
+		{
+			name: "nil dependencies",
+			manifest: Manifest{
+				Dependencies: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "empty dependencies",
+			manifest: Manifest{
+				Dependencies: make(ManifestDependencies, 0),
+			},
+			expected: false,
+		},
+		{
+			name: "has dependencies",
+			manifest: Manifest{
+				Dependencies: ManifestDependencies{
+					"test": &Dependency{},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.manifest.HasDependencies())
+		})
+	}
+}
+
 func TestSetBuildDefaults(t *testing.T) {
 
 	tests := []struct {


### PR DESCRIPTION
# Proposed changes

Fixes #3812

This PR is fixing the unwanted behaviour introduced in https://github.com/okteto/okteto/pull/3614, causing the `up` cmd to fail in scenarios where the ServiceAccount used did not have permissions to create a configmap. Howerver, creating a configmap is not a thing the cmd should do, in fact the code didn't stop where it was supposed to.

## How to test

Refer to the issue #3812 for instructions on how to test it, or feel free to reach out to me to test it together because it might take a while to setup the environment.