### PR TITLE
Update info messages for hybrid `okteto up`

### DIFF
--- a/cmd/up/forwards.go
+++ b/cmd/up/forwards.go
@@ -28,7 +28,11 @@ import (
 )
 
 func (up *upContext) forwards(ctx context.Context) error {
-	oktetoLog.Spinner("Configuring SSH tunnel to your development container...")
+	msg := "Configuring SSH tunnel to your development container..."
+	if up.Dev.IsHybridModeEnabled() {
+		msg = "Configuring reverse tunnel to your development environment..."
+	}
+	oktetoLog.Spinner(msg)
 	oktetoLog.StartSpinner()
 	defer oktetoLog.StopSpinner()
 

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -61,7 +61,11 @@ func (up *upContext) sync(ctx context.Context) error {
 		return err
 	}
 
-	oktetoLog.Success("Files synchronized")
+	msg := "Files synchronized"
+	if up.Dev.IsHybridModeEnabled() {
+		msg = "Reverse tunnel configured"
+	}
+	oktetoLog.Success(msg)
 
 	elapsed := time.Since(start)
 	analytics.TrackDurationInitialSync(elapsed)
@@ -88,9 +92,11 @@ func (up *upContext) sync(ctx context.Context) error {
 }
 
 func (up *upContext) startSyncthing(ctx context.Context) error {
-	oktetoLog.Spinner("Starting the file synchronization service...")
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
+	if !up.Dev.IsHybridModeEnabled() {
+		oktetoLog.Spinner("Starting the file synchronization service...")
+		oktetoLog.StartSpinner()
+		defer oktetoLog.StopSpinner()
+	}
 
 	if err := config.UpdateStateFile(up.Dev.Name, up.Dev.Namespace, config.StartingSync); err != nil {
 		return err
@@ -112,7 +118,10 @@ func (up *upContext) startSyncthing(ctx context.Context) error {
 		return up.checkOktetoStartError(ctx, "Failed to connect to the synchronization service")
 	}
 
-	oktetoLog.Spinner("Scanning file system...")
+	if !up.Dev.IsHybridModeEnabled() {
+		oktetoLog.Spinner("Scanning file system...")
+	}
+
 	if err := up.Sy.WaitForScanning(ctx, true); err != nil {
 		return err
 	}
@@ -125,9 +134,11 @@ func (up *upContext) startSyncthing(ctx context.Context) error {
 }
 
 func (up *upContext) synchronizeFiles(ctx context.Context) error {
-	oktetoLog.Spinner("Synchronizing your files...")
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
+	if !up.Dev.IsHybridModeEnabled() {
+		oktetoLog.Spinner("Synchronizing your files...")
+		oktetoLog.StartSpinner()
+		defer oktetoLog.StopSpinner()
+	}
 
 	progressBar := utils.NewSyncthingProgressBar(40)
 	defer progressBar.Finish()


### PR DESCRIPTION
# Proposed changes

Fixes #3773 

When running `okteto up` in `hybrid` mode we were displaying spinners with messages that are not applicable for this new mode.

This PR adds conditions to show one spinner or the other depending on the mode used for run `okteto up`

Screen recording, first the changes, after how it was. Have in mind currently there is a bug where the remote terminal is not shown when running `up` so that is why at the end of the command there is no terminal.

https://github.com/okteto/okteto/assets/40767058/5f62cb22-c840-4d13-a468-b563a7d621bc



