### PR TITLE
Add dockerconfig in remote commands

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -71,6 +71,10 @@ WORKDIR /okteto/src
 ARG {{ .GitCommitArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
+RUN \
+  mkdir -p $HOME/.docker && \
+  echo '{"credsStore":"okteto"}' > $HOME/.docker/config.json
+
 RUN --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
   okteto deploy --log-output=json --server-name="${{ .InternalServerName }}" {{ .DeployFlags }}

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -72,6 +72,10 @@ WORKDIR /okteto/src
 ARG {{ .GitCommitArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
+RUN \
+  mkdir -p $HOME/.docker && \
+  echo '{"credsStore":"okteto"}' > $HOME/.docker/config.json
+
 RUN --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
   okteto destroy --log-output=json --server-name="${{ .InternalServerName }}" {{ .DestroyFlags }}


### PR DESCRIPTION
Allows to access private images through docker config in remote deploy/destroy commands.

Given this manifest:

```yaml
deploy:
  image: aquasec/trivy
  commands:
    - trivy i 987654321.dkr.ecr.us-east-2.amazonaws.com/alpine-dev 
```
and doing a remote deploy/destroy:

```
okteto deploy|destroy --remote
```

Before this change:

```
Executing command 'trivy i 987654321.dkr.ecr.us-east-2.amazonaws.com/alpine'...
2023-07-13T13:53:09.526Z        INFO    Need to update DB
2023-07-13T13:53:09.526Z        INFO    DB Repository: ghcr.io/aquasecurity/trivy-db
2023-07-13T13:53:09.526Z        INFO    Downloading DB...
2023-07-13T13:53:13.707Z        INFO    Secret scanning is enabled
2023-07-13T13:53:13.707Z        INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-07-13T13:53:13.707Z        INFO    Please see also https://aquasecurity.github.io/trivy/v0.43/docs/scanner/secret/#recommendation for faster secret detection
2023-07-13T13:53:14.058Z        FATAL   image scan error: scan error: unable to initialize a scanner: unable to initialize a docker scanner: 4 errors occurred:
        * unable to inspect the image (987654321.dkr.ecr.us-east-2.amazonaws.com/alpine): Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
        * containerd socket not found: /run/containerd/containerd.sock
        * unable to initialize Podman client: no podman socket found: stat podman/podman.sock: no such file or directory
        * GET https://987654321.dkr.ecr.us-east-2.amazonaws.com/v2/alpine/manifests/latest: unexpected status code 401 Unauthorized: Not Authorized
 x  Error executing command 'trivy i 987654321.dkr.ecr.us-east-2.amazonaws.com/alpine': exit status 1
```

After this change:

```
2023-07-13T13:50:21.579Z        INFO    Downloading DB...
2023-07-13T13:50:25.576Z        INFO    Secret scanning is enabled
2023-07-13T13:50:25.576Z        INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-07-13T13:50:25.576Z        INFO    Please see also https://aquasecurity.github.io/trivy/v0.43/docs/scanner/secret/#recommendation for faster secret detection
2023-07-13T13:50:29.230Z        INFO    Detected OS: alpine
2023-07-13T13:50:29.230Z        INFO    Detecting Alpine vulnerabilities...
2023-07-13T13:50:29.233Z        INFO    Number of language-specific files: 0
987654321.dkr.ecr.us-east-2.amazonaws.com/alpine (alpine 3.18.2)
=======================================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
Command 'trivy i 987654321.dkr.ecr.us-east-2.amazonaws.com/alpine' successfully executed
```

# Why this works

`trivy` attempts to authenticate via credentials stored in a docker config.json file. The one we are injecting to the builds defaults to using our new okteto helper command via `credsStore=okteto`. Docker credentials helpers assumes there's an executable in the path named `docker-credential-okteto`  and executes it and reads the credentials from there. It is this file [here](https://github.com/okteto/okteto/blob/master/docker-credential-okteto) that we now add to the cli image and copy over to the deploy/destroy image.


