### PR TITLE
fix:infer name with default okteto manifest

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -442,7 +442,7 @@ func (o *DeployOptions) setDefaults() error {
 			return err
 		}
 		inferer := devenvironment.NewNameInferer(c)
-		o.Name = inferer.InferNameFromDevEnvsAndRepository(context.Background(), o.Repository, okteto.Context().Namespace, o.File)
+		o.Name = inferer.InferNameFromDevEnvsAndRepository(context.Background(), o.Repository, okteto.Context().Namespace, o.File, "")
 	}
 
 	currentRepoURL, err := model.GetRepositoryURL(cwd)

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -236,7 +236,7 @@ func (o *DestroyOptions) setDefaults() error {
 		}
 		inferer := devenvironment.NewNameInferer(c)
 		// okteto pipeline destroy doesn't have a -f flag to specify the path, so we pass empty string
-		o.Name = inferer.InferNameFromDevEnvsAndRepository(context.Background(), repo, okteto.Context().Namespace, "")
+		o.Name = inferer.InferNameFromDevEnvsAndRepository(context.Background(), repo, okteto.Context().Namespace, "", "")
 	}
 
 	if o.Namespace == "" {

--- a/pkg/devenvironment/name.go
+++ b/pkg/devenvironment/name.go
@@ -28,11 +28,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-	// defaultOktetoFilename is the default name of the manifest file
-	defaultOktetoFilename = "okteto.yml"
-)
-
 // DeprecatedInferName infers the dev environment name from the folder received as parameter.
 // It is deprecated as it doesn't take into account deployed dev environments to get the non-sanitized name.
 // This is only being effectively used in push command, which will be deleted in the next major version

--- a/pkg/devenvironment/name.go
+++ b/pkg/devenvironment/name.go
@@ -147,6 +147,8 @@ func (n NameInferer) InferName(ctx context.Context, cwd, namespace, manifestPath
 	if err != nil {
 		oktetoLog.Infof("could not get relative path for %s: %s", discoveredFile, err.Error())
 	}
+	// We need to sanitize paths to be UNIX style, as the ones in the configmaps are
+	sanitizedFile := filepath.ToSlash(discoveredFile)
 
-	return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath, discoveredFile)
+	return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath, sanitizedFile)
 }

--- a/pkg/devenvironment/name.go
+++ b/pkg/devenvironment/name.go
@@ -19,10 +19,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/okteto/okteto/pkg/discovery"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/repository"
+	"github.com/spf13/afero"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -49,6 +51,7 @@ func DeprecatedInferName(cwd string) string {
 type NameInferer struct {
 	k8s              kubernetes.Interface
 	getRepositoryURL func(string) (string, error)
+	fs               afero.Fs
 }
 
 // NewNameInferer allows to create a new instance of a name inferer
@@ -56,13 +59,14 @@ func NewNameInferer(k8s kubernetes.Interface) NameInferer {
 	return NameInferer{
 		k8s:              k8s,
 		getRepositoryURL: model.GetRepositoryURL,
+		fs:               afero.NewOsFs(),
 	}
 }
 
 // InferNameFromDevEnvsAndRepository it infers the name from the development environments deployed in the specified namespace
 // or from the git repository URL if no dev environment is found.
 // `manifestPath` is needed because we compare it with the one in dev environments to see if it is the dev environment we look for
-func (n NameInferer) InferNameFromDevEnvsAndRepository(ctx context.Context, repoURL, namespace, manifestPath string) string {
+func (n NameInferer) InferNameFromDevEnvsAndRepository(ctx context.Context, repoURL, namespace, manifestPath, discoveredFile string) string {
 	labelSelector := fmt.Sprintf("%s=true", model.GitDeployLabel)
 
 	oktetoLog.Infof("found repository url %s", repoURL)
@@ -91,22 +95,20 @@ func (n NameInferer) InferNameFromDevEnvsAndRepository(ctx context.Context, repo
 			continue
 		}
 
-		filename := cmap.Data["filename"]
-
+		cmapFilename := cmap.Data["filename"]
 		// If the manifestPath is not the default one, we compare it with the one in the configmap
-
-		if manifestPath != filename {
+		if manifestPath != cmapFilename {
 			if manifestPath == "" {
-				// If manifestPath is empty and filename is not equal to defaultOktetoFilename,
+				// If manifestPath is empty and filename is not equal to one of the default okteto name,
 				// log a message indicating the mismatch between the configmap and the provided manifest.
-				if filename != defaultOktetoFilename {
-					oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", filename, cmapRepo.GetAnonymizedRepo(), manifestPath)
+				if cmapFilename != discoveredFile {
+					oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
 					continue
 				}
 			} else {
 				// If manifestPath is not empty and filename is not the same as manifestPath,
 				// log a message indicating the mismatch between the configmap and the provided manifest.
-				oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", filename, cmapRepo.GetAnonymizedRepo(), manifestPath)
+				oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
 				continue
 			}
 		}
@@ -142,5 +144,14 @@ func (n NameInferer) InferName(ctx context.Context, cwd, namespace, manifestPath
 		return filepath.Base(cwd)
 	}
 
-	return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath)
+	discoveredFile, err := discovery.GetOktetoManifestPathWithFilesystem(cwd, n.fs)
+	if err != nil {
+		oktetoLog.Info("could not detect okteto manifest file")
+	}
+	discoveredFile, err = filepath.Rel(cwd, discoveredFile)
+	if err != nil {
+		oktetoLog.Infof("could not get relative path for %s: %s", discoveredFile, err.Error())
+	}
+
+	return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath, discoveredFile)
 }

--- a/pkg/devenvironment/name_test.go
+++ b/pkg/devenvironment/name_test.go
@@ -115,8 +115,8 @@ func TestInferName(t *testing.T) {
 			devEnvs:            getDevEnvironmentConfigMaps(),
 			ns:                 "test",
 			manifestPath:       "",
-			cwd:                filepath.Clean("/tmp/my-dev-env"),
-			oktetoManifestPath: filepath.Clean(".okteto/okteto.yml"),
+			cwd:                "/tmp/my-dev-env",
+			oktetoManifestPath: ".okteto/okteto.yml",
 			expectedName:       "single dev name with .okteto/okteto.yml filename saved",
 		},
 		{
@@ -127,8 +127,8 @@ func TestInferName(t *testing.T) {
 			devEnvs:            getDevEnvironmentConfigMaps(),
 			ns:                 "test",
 			manifestPath:       "",
-			cwd:                filepath.Clean("/tmp/my-dev-env"),
-			oktetoManifestPath: filepath.Clean(".okteto/okteto.yaml"),
+			cwd:                "/tmp/my-dev-env",
+			oktetoManifestPath: ".okteto/okteto.yaml",
 			expectedName:       "single dev name with .okteto/okteto.yaml filename saved",
 		},
 	}

--- a/pkg/devenvironment/name_test.go
+++ b/pkg/devenvironment/name_test.go
@@ -2,7 +2,6 @@ package devenvironment
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -101,9 +100,6 @@ func TestInferName(t *testing.T) {
 				getRepositoryURL: tt.getRepositoryURL,
 			}
 
-			if "with-non-matching-criteria-but-default-one-dev" == tt.name {
-				fmt.Println("here")
-			}
 			result := inferer.InferName(ctx, tt.cwd, tt.ns, tt.manifestPath)
 			require.Equal(t, tt.expectedName, result)
 		})
@@ -170,10 +166,6 @@ func TestInferNameFromDevEnvsAndRepository(t *testing.T) {
 				getRepositoryURL: func(s string) (string, error) {
 					return "", assert.AnError
 				},
-			}
-
-			if tt.name == "without-matching-criteria-but-default-one-dev" {
-				fmt.Println("here")
 			}
 
 			result := inferer.InferNameFromDevEnvsAndRepository(ctx, tt.repositoryURL, tt.ns, tt.manifestPath)

--- a/pkg/devenvironment/name_test.go
+++ b/pkg/devenvironment/name_test.go
@@ -2,7 +2,6 @@ package devenvironment
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -142,7 +141,7 @@ func TestInferName(t *testing.T) {
 				fs:               afero.NewMemMapFs(),
 			}
 
-			inferer.fs.Create(filepath.Clean(fmt.Sprintf("/tmp/my-dev-env/%s", tt.oktetoManifestPath)))
+			inferer.fs.Create(filepath.Clean(filepath.Join(tt.cwd, tt.oktetoManifestPath)))
 			result := inferer.InferName(ctx, tt.cwd, tt.ns, tt.manifestPath)
 			require.Equal(t, tt.expectedName, result)
 		})


### PR DESCRIPTION
# Proposed changes

Fixes #3748 

- Add a new check while infering the name
- If the flag name is empty and the cmap filename is the default manifest we assign the name to it

## Before and after:


| Before | After |
|--------|-------|
|  ![image](https://github.com/okteto/okteto/assets/25170843/633f2df6-893f-49b4-acc8-f56c8cefd35e)   |  <img width="399" alt="Captura de pantalla 2023-07-14 a las 10 38 34" src="https://github.com/okteto/okteto/assets/25170843/2ebe32c0-9ae2-4598-af42-98326e55858f"> |


## Reproduction steps
1. Deploy the Catalog item `Oktaco Shop` in `demo.okteto.dev` adding `okteto.yml` as manifestPath
2. Clone https://github.com/okteto/external-resources-tf-aws locally: `git clone https://github.com/okteto/external-resources-tf-aws locally`
3. Run `okteto up`