### PR TITLE
fix: show context message on okteto build

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -81,7 +81,6 @@ func Build(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.CommandArgs = args
 			bc := NewBuildCommand()
-
 			// The context must be loaded before reading manifest. Otherwise,
 			// secrets will not be resolved when GetManifest is called and
 			// the manifest will load empty values.
@@ -170,11 +169,12 @@ func (*Command) loadContext(ctx context.Context, options *types.BuildOptions) er
 	ctxOpts := &contextCMD.ContextOptions{
 		Context:   options.K8sContext,
 		Namespace: options.Namespace,
+		Show:      true,
 	}
 
 	// before calling the context command, there is need to retrieve the context and
 	// namespace through the given manifest. If the manifest is a Dockerfile, this
-	// information cannot be extracted so call to GetContextResource is skkiped.
+	// information cannot be extracted so call to GetContextResource is skipped.
 	if err := validateDockerfile(options.File); err != nil {
 		ctxResource, err := model.GetContextResource(options.File)
 		if err != nil && !errors.Is(err, discovery.ErrOktetoManifestNotFound) {


### PR DESCRIPTION
Fixes: #3823


![253727889-1868b2cd-ee70-4ea5-97df-b9a6ac30345d](https://github.com/okteto/okteto/assets/86051118/fd83cdd7-8bf0-4944-9478-835a9c80e316)
