### PR TITLE
fix: command unmarshal wrapping command

### DIFF
--- a/cmd/up/exec_unix.go
+++ b/cmd/up/exec_unix.go
@@ -8,14 +8,13 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strings"
 	"syscall"
 )
 
 func (he *hybridExecutor) GetCommandToExec(ctx context.Context, cmd []string) (*exec.Cmd, error) {
 	var c *exec.Cmd
 	if runtime.GOOS != "windows" {
-		c = exec.Command("bash", "-c", strings.Join(cmd, " "))
+		c = exec.Command(cmd[0], cmd[1:]...)
 	} else {
 		binary, err := expandExecutableInCurrentDirectory(cmd[0], he.workdir)
 		if err != nil {
@@ -33,7 +32,7 @@ func (he *hybridExecutor) GetCommandToExec(ctx context.Context, cmd []string) (*
 	c.Dir = he.workdir
 
 	c.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:    true,
+		Setpgid: true,
 	}
 
 	return c, nil

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -241,20 +241,22 @@ func (e Entrypoint) MarshalYAML() (interface{}, error) {
 func (c *Command) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var multi []string
 	err := unmarshal(&multi)
-	if err != nil {
-		var single string
-		err := unmarshal(&single)
-		if err != nil {
-			return err
-		}
-		if strings.Contains(single, " ") {
-			c.Values = []string{"sh", "-c", single}
-		} else {
-			c.Values = []string{single}
-		}
-	} else {
+	if err == nil {
 		c.Values = multi
+		return nil
 	}
+
+	var single string
+	err = unmarshal(&single)
+	if err != nil {
+		return err
+	}
+
+	cmd, err := shellquote.Split(single)
+	if err != nil {
+		return err
+	}
+	c.Values = cmd
 	return nil
 }
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -252,11 +252,11 @@ func (c *Command) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	cmd, err := shellquote.Split(single)
-	if err != nil {
-		return err
+	if strings.Contains(single, " ") {
+		c.Values = []string{"sh", "-c", single}
+	} else {
+		c.Values = []string{single}
 	}
-	c.Values = cmd
 	return nil
 }
 
@@ -736,11 +736,36 @@ type hybridModeInfo struct {
 	Selector    Selector          `json:"selector,omitempty" yaml:"selector,omitempty"`
 	Forward     []forward.Forward `json:"forward,omitempty" yaml:"forward,omitempty"`
 	Environment Environment       `json:"environment,omitempty" yaml:"environment,omitempty"`
-	Command     Command           `json:"command,omitempty" yaml:"command,omitempty"`
+	Command     hybridCommand     `json:"command,omitempty" yaml:"command,omitempty"`
 	Reverse     []Reverse         `json:"reverse,omitempty" yaml:"reverse,omitempty"`
 	Mode        string            `json:"mode,omitempty" yaml:"mode,omitempty"`
 
 	UnsupportedFields map[string]interface{} `yaml:",inline" json:"-"`
+}
+
+type hybridCommand Command
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (hc *hybridCommand) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var multi []string
+	err := unmarshal(&multi)
+	if err == nil {
+		hc.Values = multi
+		return nil
+	}
+
+	var single string
+	err = unmarshal(&single)
+	if err != nil {
+		return err
+	}
+
+	cmd, err := shellquote.Split(single)
+	if err != nil {
+		return err
+	}
+	hc.Values = cmd
+	return nil
 }
 
 var hybridUnsupportedFields = []string{

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -192,12 +192,12 @@ func TestCommandUnmarshalling(t *testing.T) {
 		{
 			"single-space",
 			[]byte("start.sh arg"),
-			Command{Values: []string{"sh", "-c", "start.sh arg"}},
+			Command{Values: []string{"start.sh", "arg"}},
 		},
 		{
 			"double-command",
 			[]byte("mkdir myproject && cd myproject"),
-			Command{Values: []string{"sh", "-c", "mkdir myproject && cd myproject"}},
+			Command{Values: []string{"mkdir", "myproject", "&&", "cd", "myproject"}},
 		},
 		{
 			"multiple",
@@ -214,9 +214,7 @@ func TestCommandUnmarshalling(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("didn't unmarshal correctly. Actual %+v, Expected %+v", result, tt.expected)
-			}
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3777

- Fix serializer to not wrap the command around "sh -c"
- Use `shelquote.Split` instead of splitting by whitespace. This has the advantage of having args with double quotes as a single arg instead of several ones which could cause errors
