### PR TITLE
fix: build args flags populated into buildkit

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -286,7 +286,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 	args := []model.BuildArg{}
 	optionsBuildArgs := map[string]string{}
 	for _, arg := range o.BuildArgs {
-		splittedArg := strings.SplitN(strings.Trim(arg, "\""), "=", 2)
+		splittedArg := strings.SplitN(arg, "=", 2)
 		if len(splittedArg) == 1 {
 			optionsBuildArgs[splittedArg[0]] = ""
 			args = append(args, model.BuildArg{

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -287,10 +287,19 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 	optionsBuildArgs := map[string]string{}
 	for _, arg := range o.BuildArgs {
 		splittedArg := strings.SplitN(strings.Trim(arg, "\""), "=", 2)
-		optionsBuildArgs[splittedArg[0]] = splittedArg[1]
-		args = append(args, model.BuildArg{
-			Name: splittedArg[0], Value: splittedArg[1],
-		})
+		if len(splittedArg) == 1 {
+			optionsBuildArgs[splittedArg[0]] = ""
+			args = append(args, model.BuildArg{
+				Name: splittedArg[0], Value: "",
+			})
+		} else if len(splittedArg) == 2 {
+			optionsBuildArgs[splittedArg[0]] = splittedArg[1]
+			args = append(args, model.BuildArg{
+				Name: splittedArg[0], Value: splittedArg[1],
+			})
+		} else {
+			oktetoLog.Infof("invalid build-arg '%s'", arg)
+		}
 	}
 
 	for _, e := range b.Args {

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -371,6 +371,68 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				OutputMode: "tty",
 			},
 		},
+		{
+			name:        "empty build arg",
+			serviceName: "service",
+			buildInfo: &model.BuildInfo{
+				Args: model.BuildArgs{
+					{
+						Name:  "arg1",
+						Value: "value2",
+					},
+				},
+			},
+			initialOpts: &types.BuildOptions{
+				BuildArgs: []string{
+					"arg1=\"\"",
+				},
+			},
+			isOkteto: true,
+			mr: mockRegistry{
+				isOktetoRegistry: true,
+				registry:         "okteto.dev",
+				repo:             "movies-service",
+			},
+			expected: &types.BuildOptions{
+				BuildArgs: []string{
+					namespaceEnvVar.String(),
+					"arg1=",
+				},
+				Tag:        "okteto.dev/movies-service:okteto",
+				OutputMode: "tty",
+			},
+		},
+		{
+			name:        "only key",
+			serviceName: "service",
+			buildInfo: &model.BuildInfo{
+				Args: model.BuildArgs{
+					{
+						Name:  "arg1",
+						Value: "value2",
+					},
+				},
+			},
+			initialOpts: &types.BuildOptions{
+				BuildArgs: []string{
+					"arg1",
+				},
+			},
+			isOkteto: true,
+			mr: mockRegistry{
+				isOktetoRegistry: true,
+				registry:         "okteto.dev",
+				repo:             "movies-service",
+			},
+			expected: &types.BuildOptions{
+				BuildArgs: []string{
+					namespaceEnvVar.String(),
+					"arg1=",
+				},
+				Tag:        "okteto.dev/movies-service:okteto",
+				OutputMode: "tty",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -316,6 +316,61 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				OutputMode: "tty",
 			},
 		},
+		{
+			name:        "has-platform-option",
+			serviceName: "service",
+			buildInfo:   &model.BuildInfo{},
+			initialOpts: &types.BuildOptions{
+				BuildArgs: []string{
+					"arg1=value1",
+				},
+			},
+			isOkteto: true,
+			mr: mockRegistry{
+				isOktetoRegistry: true,
+				registry:         "okteto.dev",
+				repo:             "movies-service",
+			},
+			expected: &types.BuildOptions{
+				BuildArgs: []string{
+					namespaceEnvVar.String(),
+					"arg1=value1",
+				},
+				Tag:        "okteto.dev/movies-service:okteto",
+				OutputMode: "tty",
+			},
+		},
+		{
+			name:        "has-platform-option",
+			serviceName: "service",
+			buildInfo: &model.BuildInfo{
+				Args: model.BuildArgs{
+					{
+						Name:  "arg1",
+						Value: "value2",
+					},
+				},
+			},
+			initialOpts: &types.BuildOptions{
+				BuildArgs: []string{
+					"\"arg1=value1\"",
+				},
+			},
+			isOkteto: true,
+			mr: mockRegistry{
+				isOktetoRegistry: true,
+				registry:         "okteto.dev",
+				repo:             "movies-service",
+			},
+			expected: &types.BuildOptions{
+				BuildArgs: []string{
+					namespaceEnvVar.String(),
+					"arg1=value1",
+				},
+				Tag:        "okteto.dev/movies-service:okteto",
+				OutputMode: "tty",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -341,68 +341,6 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			},
 		},
 		{
-			name:        "has-platform-option",
-			serviceName: "service",
-			buildInfo: &model.BuildInfo{
-				Args: model.BuildArgs{
-					{
-						Name:  "arg1",
-						Value: "value2",
-					},
-				},
-			},
-			initialOpts: &types.BuildOptions{
-				BuildArgs: []string{
-					"\"arg1=value1\"",
-				},
-			},
-			isOkteto: true,
-			mr: mockRegistry{
-				isOktetoRegistry: true,
-				registry:         "okteto.dev",
-				repo:             "movies-service",
-			},
-			expected: &types.BuildOptions{
-				BuildArgs: []string{
-					namespaceEnvVar.String(),
-					"arg1=value1",
-				},
-				Tag:        "okteto.dev/movies-service:okteto",
-				OutputMode: "tty",
-			},
-		},
-		{
-			name:        "empty build arg",
-			serviceName: "service",
-			buildInfo: &model.BuildInfo{
-				Args: model.BuildArgs{
-					{
-						Name:  "arg1",
-						Value: "value2",
-					},
-				},
-			},
-			initialOpts: &types.BuildOptions{
-				BuildArgs: []string{
-					"arg1=\"\"",
-				},
-			},
-			isOkteto: true,
-			mr: mockRegistry{
-				isOktetoRegistry: true,
-				registry:         "okteto.dev",
-				repo:             "movies-service",
-			},
-			expected: &types.BuildOptions{
-				BuildArgs: []string{
-					namespaceEnvVar.String(),
-					"arg1=",
-				},
-				Tag:        "okteto.dev/movies-service:okteto",
-				OutputMode: "tty",
-			},
-		},
-		{
 			name:        "only key",
 			serviceName: "service",
 			buildInfo: &model.BuildInfo{


### PR DESCRIPTION
# Proposed changes

Fixes #3746 

- build arg flags were not being populated to buildkit instances. This PR fixes that
- If the build arg is passed as flag surrounded by double quotes, this PR cleans those double quotes and generate the correct build arg
- If there is a flag that conflicts with manifest build arg the one in the build arg flag takes precedence
- Added unit test covering the new scenarios. Previous scenarios keeps the same so we don't need to modify them

## Tests:
Copy the following Dockerfile
```Dockerfile
ARG MY_BUILD_ARG=alpine
FROM $MY_BUILD_ARG
```
Create the following `okteto.yml`
```yaml
build:
  web:
    context: .
    args:
      MY_BUILD_ARG: ubuntu
```
Run `ok build --progress plain --no-cache --build-arg "MY_BUILD_ARG=plzwork` and check that it fails because the image is not found