### PR TITLE
Added gracefull fail in case of malformed docker-compose.yml

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -191,7 +191,7 @@ var (
 	ErrInvalidManifest = errors.New("invalid manifest")
 
 	// ErrServiceEmpty is raised whenever service is empty in docker-compose
-	ErrServiceEmpty = errors.New("Service cannot be empty")
+	ErrServiceEmpty = errors.New("service cannot be empty")
 
 	// ErrEmptyManifest is raised when cannot detected content to read in manifest
 	ErrEmptyManifest = errors.New("no content detected for okteto.yml file")

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -190,7 +190,7 @@ var (
 	// ErrInvalidManifest is raised when cannot unmarshal manifest properly
 	ErrInvalidManifest = errors.New("invalid manifest")
 
-	//  ErrServiceEmpty is raised whenever service is empty in docker-compose
+	// ErrServiceEmpty is raised whenever service is empty in docker-compose
 	ErrServiceEmpty = errors.New("Service cannot be empty")
 
 	// ErrEmptyManifest is raised when cannot detected content to read in manifest

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -190,6 +190,9 @@ var (
 	// ErrInvalidManifest is raised when cannot unmarshal manifest properly
 	ErrInvalidManifest = errors.New("invalid manifest")
 
+	//  ErrServiceEmpty is raised whenever service is empty in docker-compose
+	ErrServiceEmpty = errors.New("Service cannot be empty")
+
 	// ErrEmptyManifest is raised when cannot detected content to read in manifest
 	ErrEmptyManifest = errors.New("no content detected for okteto.yml file")
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -417,8 +417,7 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 			if errors.Is(stackErr, errDependsOn) {
 				return nil, stackErr
 			}
-			// if not return original manifest err
-			return nil, err
+			return nil, stackErr
 		}
 		stackManifest.Deploy.ComposeSection.Stack = s
 		if stackManifest.Deploy.ComposeSection.Stack.Name != "" {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -417,7 +417,12 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 			if errors.Is(stackErr, errDependsOn) {
 				return nil, stackErr
 			}
-			return nil, stackErr
+
+			if strings.Contains(stackErr.Error(), oktetoErrors.ErrServiceEmpty.Error()) {
+				return nil, stackErr
+			}
+			// if not return original manifest err
+			return nil, err
 		}
 		stackManifest.Deploy.ComposeSection.Stack = s
 		if stackManifest.Deploy.ComposeSection.Stack.Name != "" {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -418,7 +418,7 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 				return nil, stackErr
 			}
 
-			if strings.Contains(stackErr.Error(), oktetoErrors.ErrServiceEmpty.Error()) {
+			if errors.Is(stackErr, oktetoErrors.ErrServiceEmpty) {
 				return nil, stackErr
 			}
 			// if not return original manifest err

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -843,6 +843,14 @@ func Test_getManifestFromFile(t *testing.T) {
     image: test`),
 		},
 		{
+			name:          "manifestPath to a invalid compose file with empty service",
+			manifestBytes: nil,
+			composeBytes: []byte(`services:
+  test:
+          `),
+			expectedErr: oktetoErrors.ErrServiceEmpty,
+		},
+		{
 			name:          "manifestPath to empty okteto manifest, no compose file",
 			manifestBytes: []byte(``),
 			composeBytes:  nil,

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -347,6 +347,9 @@ func ReadStack(bytes []byte, isCompose bool) (*Stack, error) {
 			_, _ = sb.WriteString("    See https://okteto.com/docs/reference/compose/ for details")
 			return nil, errors.New(sb.String())
 		}
+		if errors.Is(err, oktetoErrors.ErrServiceEmpty) {
+			return nil, err
+		}
 
 		msg := strings.Replace(err.Error(), "yaml: unmarshal errors:", "invalid compose manifest:", 1)
 		msg = strings.TrimSuffix(msg, "in type model.Stack")

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -1629,7 +1629,7 @@ func validateExtensions(stack StackRaw) error {
 
 	for svcName, svc := range stack.Services {
 		if svc == nil {
-			return fmt.Errorf("%s: %w", oktetoErrors.ErrInvalidManifest, fmt.Errorf("Service %s is empty", svcName))
+			return fmt.Errorf("%s: %w", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrServiceEmpty)
 		}
 		for extension := range svc.Extensions {
 			nonValidFields = append(nonValidFields, fmt.Sprintf("services[%s].%s", svcName, extension))

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kballard/go-shellquote"
 	"github.com/okteto/okteto/pkg/cache"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/model/forward"
 	apiv1 "k8s.io/api/core/v1"
@@ -1627,6 +1628,9 @@ func validateExtensions(stack StackRaw) error {
 	}
 
 	for svcName, svc := range stack.Services {
+		if svc == nil {
+			return fmt.Errorf("%s: %w", oktetoErrors.ErrInvalidManifest, fmt.Errorf("Service %s is empty", svcName))
+		}
 		for extension := range svc.Extensions {
 			nonValidFields = append(nonValidFields, fmt.Sprintf("services[%s].%s", svcName, extension))
 		}

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -886,6 +886,12 @@ func Test_validateCommandArgs(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:        "COMPOSE-service-empty",
+			manifest:    []byte("services:\n  app:\n"),
+			isCompose:   true,
+			expectedErr: true,
+		},
+		{
 			name:        "STACK-only-entrypoint",
 			manifest:    []byte("services:\n  app:\n    entrypoint: [\"/usr/bin/rpk\", \"redpanda\"]\n    image: okteto/vote:1"),
 			isCompose:   false,


### PR DESCRIPTION
Fixes #3440 

Currently, a panic occurs when running okteto deploy -f ./docker-compose.yml on a docker-compose.yml where a service is empty. This PR adds changes for Okteto deploy to fail gracefully in this case.