### PR TITLE
Add CA to kubeconfig in insecure mode

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -191,6 +191,9 @@ func (c *ContextCommand) UseContext(ctx context.Context, ctxOptions *ContextOpti
 			currentCtx.Namespace = currentCtx.PersonalNamespace
 		}
 
+		currentCtx := ctxStore.Contexts[ctxOptions.Context]
+		currentCtx.IsStoredAsInsecure = okteto.IsInsecureSkipTLSVerifyPolicy()
+
 		if err := c.OktetoContextWriter.Write(); err != nil {
 			return err
 		}

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -61,21 +61,22 @@ var (
 
 // OktetoContext contains the information related to an okteto context
 type OktetoContext struct {
-	Name              string               `json:"name" yaml:"name,omitempty"`
-	UserID            string               `json:"id,omitempty" yaml:"id,omitempty"`
-	Username          string               `json:"username,omitempty" yaml:"username,omitempty"`
-	Token             string               `json:"token,omitempty" yaml:"token,omitempty"`
-	Namespace         string               `json:"namespace" yaml:"namespace,omitempty"`
-	Cfg               *clientcmdapi.Config `json:"-" yaml:"-"`
-	Builder           string               `json:"builder,omitempty" yaml:"builder,omitempty"`
-	Registry          string               `json:"registry,omitempty" yaml:"registry,omitempty"`
-	Certificate       string               `json:"certificate,omitempty" yaml:"certificate,omitempty"`
-	PersonalNamespace string               `json:"personalNamespace,omitempty" yaml:"personalNamespace,omitempty"`
-	GlobalNamespace   string               `json:"-" yaml:"-"`
-	Analytics         bool                 `json:"-" yaml:"-"`
-	ClusterType       string               `json:"-" yaml:"-"`
-	IsOkteto          bool                 `json:"isOkteto,omitempty" yaml:"isOkteto,omitempty"`
-	IsInsecure        bool                 `json:"isInsecure,omitempty" yaml:"isInsecure,omitempty"`
+	Name               string               `json:"name" yaml:"name,omitempty"`
+	UserID             string               `json:"id,omitempty" yaml:"id,omitempty"`
+	Username           string               `json:"username,omitempty" yaml:"username,omitempty"`
+	Token              string               `json:"token,omitempty" yaml:"token,omitempty"`
+	Namespace          string               `json:"namespace" yaml:"namespace,omitempty"`
+	Cfg                *clientcmdapi.Config `json:"-" yaml:"-"`
+	Builder            string               `json:"builder,omitempty" yaml:"builder,omitempty"`
+	Registry           string               `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Certificate        string               `json:"certificate,omitempty" yaml:"certificate,omitempty"`
+	PersonalNamespace  string               `json:"personalNamespace,omitempty" yaml:"personalNamespace,omitempty"`
+	GlobalNamespace    string               `json:"-" yaml:"-"`
+	Analytics          bool                 `json:"-" yaml:"-"`
+	ClusterType        string               `json:"-" yaml:"-"`
+	IsOkteto           bool                 `json:"isOkteto,omitempty" yaml:"isOkteto,omitempty"`
+	IsStoredAsInsecure bool                 `json:"isInsecure,omitempty" yaml:"isInsecure,omitempty"`
+	IsInsecure         bool                 `json:"-" yaml:"-"`
 }
 
 // OktetoContextViewer contains info to show
@@ -273,19 +274,22 @@ func HasBeenLogged(oktetoURL string) bool {
 func AddOktetoContext(name string, u *types.User, namespace, personalNamespace string) {
 	CurrentStore = ContextStore()
 	name = strings.TrimSuffix(name, "/")
-	CurrentStore.Contexts[name] = &OktetoContext{
-		Name:              name,
-		UserID:            u.ID,
-		Username:          u.ExternalID,
-		Token:             u.Token,
-		Namespace:         namespace,
-		PersonalNamespace: personalNamespace,
-		GlobalNamespace:   u.GlobalNamespace,
-		Builder:           u.Buildkit,
-		Registry:          u.Registry,
-		Certificate:       u.Certificate,
-		Analytics:         u.Analytics,
+	current := CurrentStore.Contexts[name]
+	if current == nil {
+		current = &OktetoContext{}
 	}
+	current.Name = name
+	current.UserID = u.ID
+	current.Username = u.ExternalID
+	current.Token = u.Token
+	current.Namespace = namespace
+	current.PersonalNamespace = personalNamespace
+	current.GlobalNamespace = u.GlobalNamespace
+	current.Builder = u.Buildkit
+	current.Registry = u.Registry
+	current.Certificate = u.Certificate
+	current.Analytics = u.Analytics
+
 	CurrentStore.CurrentContext = name
 }
 

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -274,10 +274,10 @@ func HasBeenLogged(oktetoURL string) bool {
 func AddOktetoContext(name string, u *types.User, namespace, personalNamespace string) {
 	CurrentStore = ContextStore()
 	name = strings.TrimSuffix(name, "/")
-	current := CurrentStore.Contexts[name]
-	if current == nil {
-		current = &OktetoContext{}
+	if CurrentStore.Contexts[name] == nil {
+		CurrentStore.Contexts[name] = &OktetoContext{}
 	}
+	current := CurrentStore.Contexts[name]
 	current.Name = name
 	current.UserID = u.ID
 	current.Username = u.ExternalID


### PR DESCRIPTION
Fixes `okteto kubeconfig` when using okteto self signed certificates.

When using self signed certs, the backend doesn't return the CA so the kube config file generated is not valid producing the following output:

```
...
Unable to connect to the server: tls: failed to verify certificate: x509: “*.{SUBDOMAIN}” certificate is not standards compliant
```

This PR adds the context certificate to the kubeconfig is the cluster is "insecure"

# How to test

Run you dev environment with self sign certificates by making these changes:
```
UPGRADE_DEV_ARGS="--set wildcardCertificate.create=true" make upgrade-dev 
```

Check that you get a cert error when accessing https://okteto.{me}.dev.okteto.net on the browser

Build the cli from master and run:

```
bin/okteto context use okteto.{me}.dev.okteto.net
bin/okteto kubeconfig
kubectl get pods
```

You should get:

```
Unable to connect to the server: tls: failed to verify certificate: x509: “*.{SUBDOMAIN}” certificate is not standards compliant
```

Switch to this branch, re-build the cli and re-run:

```
bin/okteto context use okteto.{me}.dev.okteto.net
bin/okteto kubeconfig
kubectl get pods
```

You should now get:

```
No resources found in {me} namespace.
```

# Changes

Note that this change is in the critical path (context), so everything else should keep working in the same way it was. It's a sensitive change because prior to this change, we were reading the context from the file and overriding it in memory and discarding those values, so the json unmarshal was useless (at least in all the paths I tested). This requires a thorough review to understand that this "fix" doesn't break something else and why it was the way and still functioning correctly.

This can be tested by adding a property to one of the contexts in the context file and also adding it to the `OktetoContext` struct with the correct unmarshal. That property would ALWAYS have the golang zero value and never be included correctly in the context. This PR also fixes that.


