### PR TITLE
Add .git to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 /docs
 /integration
 /.circleci
+/.git
 /.github
 /.vscode


### PR DESCRIPTION
# Proposed changes

While trying to `okteto build` the image I've found that it was transferring a huge context. Turns out it was transferring the .git folder 