### PR TITLE
track deploy and destroy on remote

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -90,7 +90,7 @@ type DeployCommand struct {
 	Fs                 afero.Fs
 	DivertDriver       divert.Driver
 	PipelineCMD        pipelineCMD.PipelineDeployerInterface
-	AnalyticsTracker   *analytics.AnalyticsTracker
+	AnalyticsTracker   DeployAnalyticsTracker
 
 	PipelineType       model.Archetype
 	isRemote           bool

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -204,6 +204,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				Fs:                 afero.NewOsFs(),
 				PipelineCMD:        pc,
 				runningInInstaller: config.RunningInInstaller(),
+				AnalyticsTracker:   analytics.NewAnalyticsTracker(),
 			}
 			startTime := time.Now()
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -606,8 +606,8 @@ func (dc *DeployCommand) trackDeploy(manifest *model.Manifest, runInRemoteFlag b
 			}
 		}
 
-		hasDependencySection = manifest.IsV2 && len(manifest.Dependencies) > 0
-		hasBuildSection = manifest.IsV2 && len(manifest.Build) > 0
+		hasDependencySection = manifest.HasDependencies()
+		hasBuildSection = manifest.HasBuildSection()
 	}
 
 	dc.AnalyticsTracker.TrackDeploy(analytics.DeployMetadata{

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/divert"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/registry"
@@ -1110,4 +1111,57 @@ func TestDeployOnlyDependencies(t *testing.T) {
 	err := c.RunDeploy(ctx, opts)
 
 	assert.NoError(t, err)
+}
+
+func TestTrackDeploy(t *testing.T) {
+	tt := []struct {
+		name       string
+		manifest   *model.Manifest
+		remoteFlag bool
+		commandErr error
+	}{
+		{
+			name:       "error tracking deploy",
+			commandErr: assert.AnError,
+		},
+		{
+			name: "successful with V2",
+			manifest: &model.Manifest{
+				IsV2: true,
+				Deploy: &model.DeployInfo{
+					Commands: []model.DeployCommand{
+						{
+							Name:    "test",
+							Command: "test",
+						},
+					},
+				},
+			},
+			remoteFlag: true,
+		},
+		{
+			name: "successful with compose",
+			manifest: &model.Manifest{
+				IsV2: true,
+				Deploy: &model.DeployInfo{
+					ComposeSection: &model.ComposeSectionInfo{
+						ComposesInfo: model.ComposeInfoList{},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			dc := &DeployCommand{
+				AnalyticsTracker: &analytics.AnalyticsTracker{
+					TrackFn: func(_ string, _ bool, _ map[string]interface{}) {
+						return
+					},
+				},
+			}
+
+			dc.trackDeploy(tc.manifest, tc.remoteFlag, time.Now(), tc.commandErr)
+		})
+	}
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1113,6 +1113,10 @@ func TestDeployOnlyDependencies(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+type fakeTracker struct{}
+
+func (*fakeTracker) TrackDeploy(dm analytics.DeployMetadata) {}
+
 func TestTrackDeploy(t *testing.T) {
 	tt := []struct {
 		name       string
@@ -1154,11 +1158,7 @@ func TestTrackDeploy(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			dc := &DeployCommand{
-				AnalyticsTracker: &analytics.AnalyticsTracker{
-					TrackFn: func(_ string, _ bool, _ map[string]interface{}) {
-						return
-					},
-				},
+				AnalyticsTracker: &fakeTracker{},
 			}
 
 			dc.trackDeploy(tc.manifest, tc.remoteFlag, time.Now(), tc.commandErr)

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -16,9 +16,14 @@ package destroy
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/cmd/utils/executor"
+	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
@@ -32,9 +37,6 @@ import (
 	oktetoPath "github.com/okteto/okteto/pkg/path"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 const (
@@ -76,6 +78,11 @@ type Options struct {
 type destroyInterface interface {
 	destroy(context.Context, *Options) error
 }
+
+type destroyAnalyticsTracker interface {
+	TrackDestroy(metadata analytics.DestroyMetadata)
+}
+
 type destroyCommand struct {
 	getManifest func(path string) (*model.Manifest, error)
 
@@ -86,6 +93,7 @@ type destroyCommand struct {
 	ConfigMapHandler  configMapHandler
 	oktetoClient      *okteto.OktetoClient
 	buildCtrl         buildCtrl
+	analyticsTracker  destroyAnalyticsTracker
 }
 
 // Destroy destroys the dev application defined by the manifest
@@ -179,6 +187,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 				k8sClientProvider: okteto.NewK8sClientProvider(),
 				oktetoClient:      okClient,
 				buildCtrl:         newBuildCtrl(options.Name),
+				analyticsTracker:  analytics.NewAnalyticsTracker(),
 			}
 
 			kubeconfigPath := getTempKubeConfigFile(options.Name)
@@ -193,7 +202,18 @@ func Destroy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			return destroyer.destroy(ctx, options)
+			err = destroyer.destroy(ctx, options)
+
+			metadata := &analytics.DestroyMetadata{
+				Success: err == nil,
+			}
+			if _, ok := destroyer.(*localDestroyAllCommand); ok {
+				metadata.IsDestroyAll = true
+			} else if _, ok := destroyer.(*remoteDestroyCommand); ok {
+				metadata.IsRemote = true
+			}
+			c.analyticsTracker.TrackDestroy(*metadata)
+			return err
 		},
 	}
 

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
-	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/divert"
@@ -55,7 +54,6 @@ func (ld *localDestroyCommand) destroy(ctx context.Context, opts *Options) error
 			oktetoLog.Success("Development environment '%s' successfully destroyed", opts.Name)
 		}
 	}
-	analytics.TrackDestroy(err == nil, opts.DestroyAll)
 
 	return err
 }

--- a/cmd/preview/list_test.go
+++ b/cmd/preview/list_test.go
@@ -3,12 +3,13 @@ package preview
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/okteto/okteto/internal/test/client"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_listPreview(t *testing.T) {
@@ -113,7 +114,7 @@ func Test_PreviewListOutputValidation(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "ouput format is yaml",
+			name: "output format is yaml",
 			output: ListFlags{
 				output: "yaml",
 			},

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -54,7 +54,7 @@ func (up *upContext) activate() error {
 	up.Forwarder = nil
 	defer func() {
 		if up.Dev.IsHybridModeEnabled() {
-			// interrupt signal handler already performs a gracefull shutdown
+			// interrupt signal handler already performs a graceful shutdown
 			if !up.interruptReceived {
 				up.shutdown()
 			}

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -363,7 +363,7 @@ func TestGetEnvForHybridModeWithProperPriority(t *testing.T) {
 		},
 	}
 
-	// acording to exec.Cmd.Env docs, if cmd.Env contains duplicate environment keys, only the last
+	// according to exec.Cmd.Env docs, if cmd.Env contains duplicate environment keys, only the last
 	// value in the slice for each duplicate key is used so most priority values needs to be add
 	// at the end of the list
 	expectedEnvsSortedByPriority := []string{

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -589,8 +589,8 @@ func (up *upContext) deployApp(ctx context.Context) error {
 		PipelineType:           up.Manifest.Type,
 		DeployType:             "automatic",
 		IsPreview:              os.Getenv(model.OktetoCurrentDeployBelongsToPreview) == "true",
-		HasDependenciesSection: up.Manifest.IsV2 && len(up.Manifest.Dependencies) > 0,
-		HasBuildSection:        up.Manifest.IsV2 && len(up.Manifest.Build) > 0,
+		HasDependenciesSection: up.Manifest.HasDependenciesSection(),
+		HasBuildSection:        up.Manifest.HasBuildSection(),
 		Err:                    err,
 		IsRemote:               up.Manifest.IsV2 && up.Manifest.Deploy.Image != "",
 	})

--- a/docs/how-to-run-tests.md
+++ b/docs/how-to-run-tests.md
@@ -15,6 +15,7 @@ On this document we will cover how to run unit tests and e2e tests locally
   - [How to run pre-commit on your local branch](#how-to-run-pre-commit-on-your-local-branch)
     - [Install pre-commit](#install-pre-commit)
     - [How to run pre-commit locally](#how-to-run-pre-commit-locally)
+  - [How to run e2e tests from a PR?](#how-to-run-e2e-tests-from-a-pr)
 
 ## How to run unit tests locally?
 
@@ -137,3 +138,12 @@ You'll need to set your working directory on the root of your Okteto CLI project
 ```bash
 pre-commit run --all-files
 ```
+
+
+## How to run e2e tests from a PR?
+
+Use the following labels to trigger integration test on this branch:
+
+- `run-e2e`: triggers the workflow for unix and windows
+- `run-e2e-unix`: triggers the workflow for unix
+- `run-e2e-windows`: triggers the workflow just for windows

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -58,7 +58,7 @@ for x in ENV_IN_POD,value_from_pod ENV_IN_IMAGE,value_from_image ; do
     echo "env '$name' not found. Expected value '$value'"
     exit 1
   fi
-done 
+done
 
 echo "!Successful envs check!"
 exit 0`

--- a/pkg/analytics/analyticstracker.go
+++ b/pkg/analytics/analyticstracker.go
@@ -18,6 +18,7 @@ func NewAnalyticsTracker() *AnalyticsTracker {
 	}
 }
 
+// DeployMetadata contains the metadata of a deploy event
 type DeployMetadata struct {
 	Success                bool
 	IsOktetoRepo           bool
@@ -31,6 +32,7 @@ type DeployMetadata struct {
 	IsRemote               bool
 }
 
+// TrackDeploy sends a tracking event to mixpanel when the user deploys from command okteto deploy
 func (a *AnalyticsTracker) TrackDeploy(metadata DeployMetadata) {
 	if metadata.PipelineType == "" {
 		metadata.PipelineType = "pipeline"
@@ -49,4 +51,20 @@ func (a *AnalyticsTracker) TrackDeploy(metadata DeployMetadata) {
 		props["error"] = metadata.Err.Error()
 	}
 	a.TrackFn(deployEvent, metadata.Success, props)
+}
+
+// DestroyMetadata contains the metadata of a destroy event
+type DestroyMetadata struct {
+	Success      bool
+	IsDestroyAll bool
+	IsRemote     bool
+}
+
+// TrackDestroy sends a tracking event to mixpanel when the user destroys a pipeline from local
+func (a *AnalyticsTracker) TrackDestroy(metadata DestroyMetadata) {
+	props := map[string]any{
+		"isDestroyAll": metadata.IsDestroyAll,
+		"isRemote":     metadata.IsRemote,
+	}
+	a.TrackFn(destroyEvent, metadata.Success, props)
 }

--- a/pkg/analytics/analyticstracker.go
+++ b/pkg/analytics/analyticstracker.go
@@ -1,0 +1,52 @@
+package analytics
+
+import (
+	"time"
+
+	"github.com/okteto/okteto/pkg/model"
+)
+
+const deployEvent = "Deploy"
+
+type AnalyticsTracker struct {
+	TrackFn func(event string, success bool, props map[string]interface{})
+}
+
+func NewAnalyticsTracker() *AnalyticsTracker {
+	return &AnalyticsTracker{
+		TrackFn: track,
+	}
+}
+
+type DeployMetadata struct {
+	Success                bool
+	IsOktetoRepo           bool
+	Err                    error
+	Duration               time.Duration
+	PipelineType           model.Archetype
+	DeployType             string
+	IsPreview              bool
+	HasDependenciesSection bool
+	HasBuildSection        bool
+	IsRemote               bool
+}
+
+func (a *AnalyticsTracker) TrackDeploy(metadata DeployMetadata) {
+	if metadata.PipelineType == "" {
+		metadata.PipelineType = "pipeline"
+	}
+	props := map[string]any{
+		"pipelineType":           metadata.PipelineType,
+		"isOktetoRepository":     metadata.IsOktetoRepo,
+		"duration":               metadata.Duration.Seconds(),
+		"deployType":             metadata.DeployType,
+		"isPreview":              metadata.IsPreview,
+		"hasDependenciesSection": metadata.HasDependenciesSection,
+		"hasBuildSection":        metadata.HasBuildSection,
+		"isRemote":               metadata.IsRemote,
+	}
+	if metadata.Err != nil {
+		props["error"] = metadata.Err.Error()
+	}
+	a.TrackFn(deployEvent, metadata.Success, props)
+}

--- a/pkg/analytics/analyticstracker_test.go
+++ b/pkg/analytics/analyticstracker_test.go
@@ -1,0 +1,130 @@
+package analytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockEvent struct {
+	event   string
+	success bool
+	props   map[string]any
+}
+
+func TestDeployTracker(t *testing.T) {
+	tt := []struct {
+		name     string
+		metadata DeployMetadata
+		expected mockEvent
+	}{
+		{
+			name: "all fields set",
+			metadata: DeployMetadata{
+				Success:                true,
+				IsOktetoRepo:           true,
+				Err:                    nil,
+				Duration:               1,
+				PipelineType:           "pipeline",
+				DeployType:             "deploy",
+				IsPreview:              true,
+				HasDependenciesSection: true,
+				HasBuildSection:        true,
+				IsRemote:               true,
+			},
+			expected: mockEvent{
+				event:   deployEvent,
+				success: true,
+				props: map[string]any{
+					"pipelineType":           "pipeline",
+					"isOktetoRepository":     true,
+					"duration":               1.0,
+					"deployType":             "deploy",
+					"isPreview":              true,
+					"hasDependenciesSection": true,
+					"hasBuildSection":        true,
+					"isRemote":               true,
+				},
+			},
+		},
+		{
+			name: "pipeline type not set",
+			metadata: DeployMetadata{
+				Success:                true,
+				IsOktetoRepo:           true,
+				Err:                    nil,
+				Duration:               1,
+				PipelineType:           "",
+				DeployType:             "deploy",
+				IsPreview:              true,
+				HasDependenciesSection: true,
+				HasBuildSection:        true,
+				IsRemote:               true,
+			},
+			expected: mockEvent{
+				event:   deployEvent,
+				success: true,
+				props: map[string]any{
+					"pipelineType":           "pipeline",
+					"isOktetoRepository":     true,
+					"duration":               1.0,
+					"deployType":             "deploy",
+					"isPreview":              true,
+					"hasDependenciesSection": true,
+					"hasBuildSection":        true,
+					"isRemote":               true,
+				},
+			},
+		},
+		{
+			name: "error set",
+			metadata: DeployMetadata{
+				Success:                true,
+				IsOktetoRepo:           true,
+				Err:                    assert.AnError,
+				Duration:               1,
+				PipelineType:           "",
+				DeployType:             "deploy",
+				IsPreview:              true,
+				HasDependenciesSection: true,
+				HasBuildSection:        true,
+				IsRemote:               true,
+			},
+			expected: mockEvent{
+				event:   deployEvent,
+				success: true,
+				props: map[string]any{
+					"pipelineType":           "pipeline",
+					"isOktetoRepository":     true,
+					"duration":               1.0,
+					"deployType":             "deploy",
+					"isPreview":              true,
+					"hasDependenciesSection": true,
+					"hasBuildSection":        true,
+					"isRemote":               true,
+					"error":                  assert.AnError,
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			eventReceived := &mockEvent{}
+			tracker := AnalyticsTracker{
+				TrackFn: func(event string, success bool, props map[string]any) {
+					eventReceived = &mockEvent{
+						event:   event,
+						success: success,
+						props:   props,
+					}
+				},
+			}
+
+			tracker.TrackDeploy(tc.metadata)
+
+			assert.Equal(t, tc.expected.event, eventReceived.event)
+			assert.Equal(t, tc.expected.success, eventReceived.success)
+			assert.Equal(t, tc.expected.props, eventReceived.props)
+		})
+	}
+}

--- a/pkg/analytics/deploy.go
+++ b/pkg/analytics/deploy.go
@@ -40,5 +40,5 @@ func (a *AnalyticsTracker) TrackDeploy(metadata DeployMetadata) {
 	if metadata.Err != nil {
 		props["error"] = metadata.Err.Error()
 	}
-	a.TrackFn(deployEvent, metadata.Success, props)
+	a.trackFn(deployEvent, metadata.Success, props)
 }

--- a/pkg/analytics/deploy.go
+++ b/pkg/analytics/deploy.go
@@ -8,16 +8,6 @@ import (
 
 const deployEvent = "Deploy"
 
-type AnalyticsTracker struct {
-	TrackFn func(event string, success bool, props map[string]interface{})
-}
-
-func NewAnalyticsTracker() *AnalyticsTracker {
-	return &AnalyticsTracker{
-		TrackFn: track,
-	}
-}
-
 // DeployMetadata contains the metadata of a deploy event
 type DeployMetadata struct {
 	Success                bool
@@ -51,20 +41,4 @@ func (a *AnalyticsTracker) TrackDeploy(metadata DeployMetadata) {
 		props["error"] = metadata.Err.Error()
 	}
 	a.TrackFn(deployEvent, metadata.Success, props)
-}
-
-// DestroyMetadata contains the metadata of a destroy event
-type DestroyMetadata struct {
-	Success      bool
-	IsDestroyAll bool
-	IsRemote     bool
-}
-
-// TrackDestroy sends a tracking event to mixpanel when the user destroys a pipeline from local
-func (a *AnalyticsTracker) TrackDestroy(metadata DestroyMetadata) {
-	props := map[string]any{
-		"isDestroyAll": metadata.IsDestroyAll,
-		"isRemote":     metadata.IsRemote,
-	}
-	a.TrackFn(destroyEvent, metadata.Success, props)
 }

--- a/pkg/analytics/deploy_test.go
+++ b/pkg/analytics/deploy_test.go
@@ -107,7 +107,7 @@ func TestDeployTracker(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			eventReceived := &mockEvent{}
 			tracker := AnalyticsTracker{
-				TrackFn: func(event string, success bool, props map[string]any) {
+				trackFn: func(event string, success bool, props map[string]any) {
 					eventReceived = &mockEvent{
 						event:   event,
 						success: success,

--- a/pkg/analytics/deploy_test.go
+++ b/pkg/analytics/deploy_test.go
@@ -8,12 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockEvent struct {
-	event   string
-	success bool
-	props   map[string]any
-}
-
 func TestDeployTracker(t *testing.T) {
 	tt := []struct {
 		name     string
@@ -123,80 +117,6 @@ func TestDeployTracker(t *testing.T) {
 			}
 
 			tracker.TrackDeploy(tc.metadata)
-
-			assert.Equal(t, tc.expected.event, eventReceived.event)
-			assert.Equal(t, tc.expected.success, eventReceived.success)
-			assert.Equal(t, tc.expected.props, eventReceived.props)
-		})
-	}
-}
-
-func TestDestroyTracker(t *testing.T) {
-	tt := []struct {
-		name     string
-		metadata DestroyMetadata
-		expected mockEvent
-	}{
-		{
-			name: "success destroy",
-			metadata: DestroyMetadata{
-				Success: true,
-			},
-			expected: mockEvent{
-				event:   destroyEvent,
-				success: true,
-				props: map[string]any{
-					"isDestroyAll": false,
-					"isRemote":     false,
-				},
-			},
-		},
-		{
-			name: "success destroy on remote",
-			metadata: DestroyMetadata{
-				Success:  true,
-				IsRemote: true,
-			},
-			expected: mockEvent{
-				event:   destroyEvent,
-				success: true,
-				props: map[string]any{
-					"isDestroyAll": false,
-					"isRemote":     true,
-				},
-			},
-		},
-		{
-			name: "fail destroy all",
-			metadata: DestroyMetadata{
-				Success:      false,
-				IsRemote:     false,
-				IsDestroyAll: true,
-			},
-			expected: mockEvent{
-				event:   destroyEvent,
-				success: false,
-				props: map[string]any{
-					"isDestroyAll": true,
-					"isRemote":     false,
-				},
-			},
-		},
-	}
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			eventReceived := &mockEvent{}
-			tracker := AnalyticsTracker{
-				TrackFn: func(event string, success bool, props map[string]any) {
-					eventReceived = &mockEvent{
-						event:   event,
-						success: success,
-						props:   props,
-					}
-				},
-			}
-
-			tracker.TrackDestroy(tc.metadata)
 
 			assert.Equal(t, tc.expected.event, eventReceived.event)
 			assert.Equal(t, tc.expected.success, eventReceived.success)

--- a/pkg/analytics/destroy.go
+++ b/pkg/analytics/destroy.go
@@ -1,0 +1,17 @@
+package analytics
+
+// DestroyMetadata contains the metadata of a destroy event
+type DestroyMetadata struct {
+	Success      bool
+	IsDestroyAll bool
+	IsRemote     bool
+}
+
+// TrackDestroy sends a tracking event to mixpanel when the user destroys a pipeline from local
+func (a *AnalyticsTracker) TrackDestroy(metadata DestroyMetadata) {
+	props := map[string]any{
+		"isDestroyAll": metadata.IsDestroyAll,
+		"isRemote":     metadata.IsRemote,
+	}
+	a.TrackFn(destroyEvent, metadata.Success, props)
+}

--- a/pkg/analytics/destroy.go
+++ b/pkg/analytics/destroy.go
@@ -13,5 +13,5 @@ func (a *AnalyticsTracker) TrackDestroy(metadata DestroyMetadata) {
 		"isDestroyAll": metadata.IsDestroyAll,
 		"isRemote":     metadata.IsRemote,
 	}
-	a.TrackFn(destroyEvent, metadata.Success, props)
+	a.trackFn(destroyEvent, metadata.Success, props)
 }

--- a/pkg/analytics/destroy_test.go
+++ b/pkg/analytics/destroy_test.go
@@ -1,0 +1,81 @@
+package analytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDestroyTracker(t *testing.T) {
+	tt := []struct {
+		name     string
+		metadata DestroyMetadata
+		expected mockEvent
+	}{
+		{
+			name: "success destroy",
+			metadata: DestroyMetadata{
+				Success: true,
+			},
+			expected: mockEvent{
+				event:   destroyEvent,
+				success: true,
+				props: map[string]any{
+					"isDestroyAll": false,
+					"isRemote":     false,
+				},
+			},
+		},
+		{
+			name: "success destroy on remote",
+			metadata: DestroyMetadata{
+				Success:  true,
+				IsRemote: true,
+			},
+			expected: mockEvent{
+				event:   destroyEvent,
+				success: true,
+				props: map[string]any{
+					"isDestroyAll": false,
+					"isRemote":     true,
+				},
+			},
+		},
+		{
+			name: "fail destroy all",
+			metadata: DestroyMetadata{
+				Success:      false,
+				IsRemote:     false,
+				IsDestroyAll: true,
+			},
+			expected: mockEvent{
+				event:   destroyEvent,
+				success: false,
+				props: map[string]any{
+					"isDestroyAll": true,
+					"isRemote":     false,
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			eventReceived := &mockEvent{}
+			tracker := AnalyticsTracker{
+				TrackFn: func(event string, success bool, props map[string]any) {
+					eventReceived = &mockEvent{
+						event:   event,
+						success: success,
+						props:   props,
+					}
+				},
+			}
+
+			tracker.TrackDestroy(tc.metadata)
+
+			assert.Equal(t, tc.expected.event, eventReceived.event)
+			assert.Equal(t, tc.expected.success, eventReceived.success)
+			assert.Equal(t, tc.expected.props, eventReceived.props)
+		})
+	}
+}

--- a/pkg/analytics/destroy_test.go
+++ b/pkg/analytics/destroy_test.go
@@ -62,7 +62,7 @@ func TestDestroyTracker(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			eventReceived := &mockEvent{}
 			tracker := AnalyticsTracker{
-				TrackFn: func(event string, success bool, props map[string]any) {
+				trackFn: func(event string, success bool, props map[string]any) {
 					eventReceived = &mockEvent{
 						event:   event,
 						success: success,

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -333,6 +333,7 @@ type TrackDeployMetadata struct {
 	IsPreview              bool
 	HasDependenciesSection bool
 	HasBuildSection        bool
+	IsRemote               bool
 }
 
 // TrackDeploy sends a tracking event to mixpanel when the user deploys a pipeline
@@ -348,6 +349,7 @@ func TrackDeploy(m TrackDeployMetadata) {
 		"isPreview":              m.IsPreview,
 		"hasDependenciesSection": m.HasDependenciesSection,
 		"hasBuildSection":        m.HasBuildSection,
+		"isRemote":               m.IsRemote,
 	}
 	if m.Err != nil {
 		props["error"] = m.Err.Error()

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -322,14 +322,6 @@ func TrackDestroyStack(success bool) {
 	track(destroyStackEvent, success, nil)
 }
 
-// TrackDestroy sends a tracking event to mixpanel when the user destroys a pipeline from local
-func TrackDestroy(success bool, isDestroyAll bool) {
-	props := map[string]interface{}{
-		"isDestroyAll": isDestroyAll,
-	}
-	track(destroyEvent, success, props)
-}
-
 // TrackLogin sends a tracking event to mixpanel when the user logs in
 func TrackLogin(success bool) {
 	track(loginEvent, success, nil)

--- a/pkg/analytics/tracker.go
+++ b/pkg/analytics/tracker.go
@@ -1,0 +1,11 @@
+package analytics
+
+type AnalyticsTracker struct {
+	TrackFn func(event string, success bool, props map[string]interface{})
+}
+
+func NewAnalyticsTracker() *AnalyticsTracker {
+	return &AnalyticsTracker{
+		TrackFn: track,
+	}
+}

--- a/pkg/analytics/tracker.go
+++ b/pkg/analytics/tracker.go
@@ -1,11 +1,11 @@
 package analytics
 
 type AnalyticsTracker struct {
-	TrackFn func(event string, success bool, props map[string]interface{})
+	trackFn func(event string, success bool, props map[string]interface{})
 }
 
 func NewAnalyticsTracker() *AnalyticsTracker {
 	return &AnalyticsTracker{
-		TrackFn: track,
+		trackFn: track,
 	}
 }

--- a/pkg/analytics/tracker_test.go
+++ b/pkg/analytics/tracker_test.go
@@ -1,0 +1,7 @@
+package analytics
+
+type mockEvent struct {
+	event   string
+	success bool
+	props   map[string]any
+}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1180,7 +1180,7 @@ func Test_Manifest_HasDeploySection(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "m.IsV2 && m.Deploy.Commands is emtpy",
+			name: "m.IsV2 && m.Deploy.Commands is empty",
 			manifest: &Manifest{
 				IsV2: true,
 				Deploy: &DeployInfo{

--- a/pkg/okteto/secrets_test.go
+++ b/pkg/okteto/secrets_test.go
@@ -467,7 +467,7 @@ func TestGetClusterMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "pipelineRunnerImage cant be empty",
+			name: "pipelineRunnerImage can't be empty",
 			cfg: input{
 				client: &fakeGraphQLClient{
 					queryResult: &metadataQuery{

--- a/scripts/ci/release.sh
+++ b/scripts/ci/release.sh
@@ -129,7 +129,7 @@
         fi
 
         BIN_BUCKET_ROOT="downloads.okteto.com/cli"
-        
+
         for chan in "${CHANNELS[@]}"; do
                 echo "---------------------------------------------------------------------------------"
                 tag="${RELEASE_TAG:-"$PSEUDO_TAG"}"
@@ -142,7 +142,7 @@
                 # BIN_BUCKET_NAME is the name of the bucket where the binaries are stored.
                 # Starting at Okteto CLI 2.0, all these binaries are publicly accessible at:
                 # https://downloads.okteto.com/cli/<channel>/<tag>
-                
+
                 BIN_BUCKET_ROOT_WITH_CHAN="${BIN_BUCKET_ROOT}/${chan}"
                 BIN_BUCKET_NAME="${BIN_BUCKET_ROOT_WITH_CHAN}/${tag}"
 
@@ -186,7 +186,7 @@
 
                 if [ "$tag" = "$latest" ]; then
                         gsutil -m rsync "gs://$BIN_BUCKET_NAME" "gs://$BIN_BUCKET_ROOT_WITH_CHAN"
-                        
+
                         if [ "$is_oficial_release" = true ] ; then
                                 # upload artifacts to bucket root (gs://downloads.okteto.com/cli)
                                 echo "Syncing artifacts from $BIN_PATH with $BIN_BUCKET_ROOT"


### PR DESCRIPTION
# Proposed changes

Fixes #3646 

## Deploy

- Created `isRemoteDeployer` in order to know if it's running on remote or locally at several points of the code
- Created `DeployAnalyticsTracker` interface in order to mock the calls in the deploy command(tested that it can not throw a panic since I don't know how to test with this module correctly)
- Added the `isRemote` property in deploy command
- Added the `isRemote` property in deploy from up command
- Added tests for the analytics.Deploy

## Destroy

- Created `DestroyAnalyticsTracker` interface in order to mock the calls in the destroy command
- Added the `isRemote` property in destroy command
- Added tests for the analytics.Destroy
- I had to cast the destroyer to `destroyAll` and `destroyRemote` to get the right analytics

## Bug fixes

- Found that we were only tracking events for destroy locally. Now tracks all the different destroy methods(all, remote, local)

## Tests done

- Debugging check that the destroy metadata is correctly injected
- Debugging check that the deploy metadata is correctly injected

Both test I have not send new data to mixpanel


### Related issues

As part of the testing I found that the mixpanel package that we were using is outdated. I created https://github.com/okteto/okteto/issues/3847 to track and address this issue

