### PR TITLE
Run e2e tests from PR labels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ workflows:
     when:
       equal: [ "run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
     jobs:
-      - build-binaries:
+      - build-binaries
       - run-windows-e2e-test:
           requires:
             - build-binaries
@@ -524,7 +524,7 @@ workflows:
     when:
       equal: [ "run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
     jobs:
-      - build-binaries:
+      - build-binaries
       - test-integration:
           requires:
             - build-binaries
@@ -533,7 +533,7 @@ workflows:
     when:
       equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
-      - build-binaries:
+      - build-binaries
       - test-integration:
           requires:
             - build-binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,8 +349,16 @@ workflows:
                 - master
   test:
     when:
-      not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+      or:
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - or:
+            - not:
+                equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
+            - not:
+                equal: [ "run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+            - not:
+                equal: [ "run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,23 @@ aliases:
   - &release-regex /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
   - &release-branch-regex /^release-\d+\.\d+$/
 version: 2.1
+
+parameters:
+  # The following parameters are filled by GH Actions to run CircleCI jobs
+  GHA_Actor:
+    type: string
+    default: ""
+  GHA_Action:
+    type: string
+    default: ""
+  GHA_Event:
+    type: string
+    default: ""
+  GHA_Meta:
+    type: string
+    default: ""
+
+
 orbs:
   win: circleci/windows@5.0.0
 commands:
@@ -494,3 +511,32 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
+
+  run-windows-e2e:
+    when:
+        equal: [ "run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-binaries:
+      - run-windows-e2e-test:
+          requires:
+            - build-binaries
+  run-unix-e2e-tests:
+    when:
+        equal: [ "run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-binaries:
+      - test-integration:
+          requires:
+            - build-binaries
+  
+  run-e2e-tests:
+   when:
+        equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-binaries:
+      - test-integration:
+          requires:
+            - build-binaries
+      - run-windows-e2e-test:
+          requires:
+            - build-binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,7 +530,7 @@ workflows:
             - build-binaries
   
   run-e2e-tests:
-   when:
+    when:
         equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,7 +514,7 @@ workflows:
 
   run-windows-e2e:
     when:
-        equal: [ "run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+      equal: [ "run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries:
       - run-windows-e2e-test:
@@ -522,7 +522,7 @@ workflows:
             - build-binaries
   run-unix-e2e-tests:
     when:
-        equal: [ "run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+      equal: [ "run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries:
       - test-integration:
@@ -531,7 +531,7 @@ workflows:
   
   run-e2e-tests:
     when:
-        equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
+      equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries:
       - test-integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ workflows:
                 - master
   test:
     when:
-      or:
+      and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,13 +349,8 @@ workflows:
                 - master
   test:
     when:
-      and:
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not:
-            matches:
-              pattern: "^run-e2e.*"
-              value: << pipeline.parameters.GHA_Meta >>
+      not:
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - build-binaries:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,13 +352,10 @@ workflows:
       and:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - or:
-            - not:
-                equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
-            - not:
-                equal: [ "run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-            - not:
-                equal: [ "run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+        - not:
+            matches:
+              pattern: "^run-e2e.*"
+              value: << pipeline.parameters.GHA_Meta >>
     jobs:
       - build-binaries:
           filters:

--- a/.github/workflows/run-circleci-from-label.yml
+++ b/.github/workflows/run-circleci-from-label.yml
@@ -2,25 +2,29 @@ name: Run CircleCI from label
 
 on:
   pull_request:
-    types: [ labeled ]
+    types: 
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
 
 jobs:
   run-e2e-windows:
-    if: ${{ github.event.label.name == 'run-e2e-windows' }}
+    if: contains(github.event.pull_request.labels.*.name, 'run-e2e-windows') && !contains(github.event.pull_request.labels.*.name, 'run-e2e')
     runs-on: ubuntu-latest
     steps:
     - name: Run a one-line script
       run: echo Running e2e tests on Windows
 
   run-e2e-unix:
-    if: ${{ github.event.label.name == 'run-e2e-unix' }}
+    if: contains(github.event.pull_request.labels.*.name, 'run-e2e-unix') && !contains(github.event.pull_request.labels.*.name, 'run-e2e')
     runs-on: ubuntu-latest
     steps:
     - name: Run a one-line script
       run: echo Running e2e tests on Unix
 
   run-e2e:
-    if: ${{ github.event.label.name == 'run-e2e' }}
+    if: contains(github.event.pull_request.labels.*.name, 'run-e2e') 
     runs-on: ubuntu-latest
     steps:
     - name: Run a one-line script

--- a/.github/workflows/run-circleci-from-label.yml
+++ b/.github/workflows/run-circleci-from-label.yml
@@ -1,0 +1,27 @@
+name: Run CircleCI from label
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  run-e2e-windows:
+    if: ${{ github.event.label.name == 'run-e2e-windows' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run a one-line script
+      run: echo Running e2e tests on Windows
+
+  run-e2e-windows:
+    if: ${{ github.event.label.name == 'run-e2e-unix' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run a one-line script
+      run: echo Running e2e tests on Unix
+
+  run-e2e:
+    if: ${{ github.event.label.name == 'run-e2e' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run a one-line script
+      run: echo Running e2e tests on Windows and Unix

--- a/.github/workflows/run-circleci-from-label.yml
+++ b/.github/workflows/run-circleci-from-label.yml
@@ -13,19 +13,31 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'run-e2e-windows') && !contains(github.event.pull_request.labels.*.name, 'run-e2e')
     runs-on: ubuntu-latest
     steps:
-    - name: Run a one-line script
-      run: echo Running e2e tests on Windows
+      - name: Run Windows e2e tests on CircleCI
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        with:
+          GHA_Meta: "run-e2e-unix"
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
 
   run-e2e-unix:
     if: contains(github.event.pull_request.labels.*.name, 'run-e2e-unix') && !contains(github.event.pull_request.labels.*.name, 'run-e2e')
     runs-on: ubuntu-latest
     steps:
-    - name: Run a one-line script
-      run: echo Running e2e tests on Unix
+      - name: Run UNIX e2e tests on CircleCI
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        with:
+          GHA_Meta: "run-e2e-windows"
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
 
   run-e2e:
     if: contains(github.event.pull_request.labels.*.name, 'run-e2e') 
     runs-on: ubuntu-latest
     steps:
-    - name: Run a one-line script
-      run: echo Running e2e tests on Windows and Unix
+      - name: Run e2e tests on CircleCI
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        with:
+          GHA_Meta: "run-e2e"
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}

--- a/.github/workflows/run-circleci-from-label.yml
+++ b/.github/workflows/run-circleci-from-label.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Run a one-line script
       run: echo Running e2e tests on Windows
 
-  run-e2e-windows:
+  run-e2e-unix:
     if: ${{ github.event.label.name == 'run-e2e-unix' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-circleci-from-label.yml
+++ b/.github/workflows/run-circleci-from-label.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run Windows e2e tests on CircleCI
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         with:
-          GHA_Meta: "run-e2e-unix"
+          GHA_Meta: "run-e2e-windows"
         env:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
 
@@ -27,7 +27,7 @@ jobs:
       - name: Run UNIX e2e tests on CircleCI
         uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         with:
-          GHA_Meta: "run-e2e-windows"
+          GHA_Meta: "run-e2e-unix"
         env:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
 


### PR DESCRIPTION
# Proposed changes

Fixes #3826 

## Proposed changes

- Add github action to detect when a label has been added to the PR (Unable to do it directly with CircleCI)
- If `run-e2e` label is present with `run-e2e-unix` or `run-e2e-windows` it will only be executed the `run-e2e` workflow