### PR TITLE
fix (linter): enable gosimple

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters-settings:
 # All possible linters can be found here
 linters:
   disable:
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
@@ -25,6 +24,7 @@ linters:
     - unused
   enable:
     - errcheck
+    - gosimple
 # Enabled by your configuration linters:
 # deadcode: Finds unused code [fast: false, auto-fix: false]
 # gosimple (megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -89,7 +89,7 @@ func (nc *NamespaceCommand) Create(ctx context.Context, opts *CreateOptions) err
 		Context:      okteto.Context().Name,
 	}
 
-	if opts.SetCurrentNs == true {
+	if opts.SetCurrentNs {
 		ctxOptions.Save = true
 		ctxOptions.Show = true
 	} else {

--- a/integration/commands/dev.go
+++ b/integration/commands/dev.go
@@ -101,7 +101,7 @@ func RunOktetoUpAndWaitWithOutput(oktetoPath string, upOptions *UpOptions) (byte
 	err := cmd.Wait()
 	if err != nil {
 		log.Printf("okteto up failed: %v", err)
-		log.Printf("okteto up output err: \n%s", string(out.Bytes()))
+		log.Printf("okteto up output err: \n%s", out.String())
 		return out, err
 	}
 	return out, nil


### PR DESCRIPTION
# Proposed changes

Fixes partly #3828

- Enable gosimple on golangciyaml
- Fixes the bugs reported by the linter