### PR TITLE
fix: preview output json

### DIFF
--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -14,9 +14,11 @@
 package preview
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -46,11 +48,19 @@ func Endpoints(ctx context.Context) *cobra.Command {
 				return err
 			}
 
+			jsonContextBuffer := bytes.NewBuffer([]byte{})
+			if output == "json" {
+				oktetoLog.SetOutput(jsonContextBuffer)
+			}
+
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.ContextOptions{}); err != nil {
 				return err
 			}
 			if output != "json" {
 				oktetoLog.Information("Using %s @ %s as context", previewName, okteto.RemoveSchema(okteto.Context().Name))
+			} else {
+				oktetoLog.Info(jsonContextBuffer.String())
+				oktetoLog.SetOutput(os.Stdout)
 			}
 
 			if !okteto.IsOkteto() {


### PR DESCRIPTION
# Proposed changes

Fixes #3860 

- Save the logs that should appear while initializing the context
- Print them as information messages on the log file if the ouptut is json

## Before and after:

| Before | After |
|--------|-------|
| <img width="727" alt="Captura de pantalla 2023-07-31 a las 13 53 24" src="https://github.com/okteto/okteto/assets/25170843/a7992f24-6013-4dd0-8934-0c2d05a71f25">  | <img width="690" alt="Captura de pantalla 2023-07-31 a las 13 54 19" src="https://github.com/okteto/okteto/assets/25170843/52bcfc0d-b4ea-45d8-82df-20112fe5278c"> |


## Reproduction steps
1. Set Secret `KEY` on okteto cloud settings
2. Create a local environment variable `$KEY` with different value
3. Run `okteto preview deploy issue-USERNAME --scope personal --branch master --repository https://github.com/okteto/movies`
4. execute "okteto preview endpoints issue-USERNAME -ojson
