### PR TITLE
Up event refactor

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -150,7 +150,7 @@ func (up *upContext) activate() error {
 		if lastPodUID != up.Pod.UID {
 			cause = analytics.ReconnectCauseDevPodRecreated
 		}
-		analytics.TrackReconnect(true, cause)
+		up.analyticsTracker.TrackReconnect(true, cause)
 	}
 
 	up.isRetry = true
@@ -208,7 +208,7 @@ func (up *upContext) activate() error {
 		}
 		printDisplayContext(up)
 		durationActivateUp := time.Since(up.StartTime)
-		analytics.TrackDurationActivateUp(durationActivateUp)
+		up.analyticsTracker.TrackDurationActivateUp(durationActivateUp)
 
 		up.CommandResult <- up.RunCommand(ctx, up.Dev.Command.Values)
 	}()

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -150,7 +150,7 @@ func (up *upContext) activate() error {
 		if lastPodUID != up.Pod.UID {
 			cause = analytics.ReconnectCauseDevPodRecreated
 		}
-		up.analyticsTracker.TrackReconnect(true, cause)
+		up.analyticsMeta.AddReconnect(cause)
 	}
 
 	up.isRetry = true

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -176,6 +176,7 @@ func (up *upContext) activate() error {
 		return err
 	}
 
+	// success means all context is ready to run the activation
 	up.success = true
 
 	go func() {

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -209,7 +209,7 @@ func (up *upContext) activate() error {
 		}
 		printDisplayContext(up)
 		durationActivateUp := time.Since(up.StartTime)
-		up.analyticsTracker.TrackDurationActivateUp(durationActivateUp)
+		up.analyticsMeta.AddActivateDuration(durationActivateUp)
 
 		up.CommandResult <- up.RunCommand(ctx, up.Dev.Command.Values)
 	}()

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/cmd/utils"
-	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -146,11 +145,11 @@ func (up *upContext) activate() error {
 	}
 
 	if up.isRetry {
-		cause := analytics.ReconnectCauseDefault
 		if lastPodUID != up.Pod.UID {
-			cause = analytics.ReconnectCauseDevPodRecreated
+			up.analyticsMeta.ReconnectDevPodRecreated()
+		} else {
+			up.analyticsMeta.ReconnectDefault()
 		}
-		up.analyticsMeta.AddReconnect(cause)
 	}
 
 	up.isRetry = true
@@ -209,7 +208,7 @@ func (up *upContext) activate() error {
 		}
 		printDisplayContext(up)
 		durationActivateUp := time.Since(up.StartTime)
-		up.analyticsMeta.AddActivateDuration(durationActivateUp)
+		up.analyticsMeta.ActivateDuration(durationActivateUp)
 
 		up.CommandResult <- up.RunCommand(ctx, up.Dev.Command.Values)
 	}()

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/cmd/utils"
-	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/config"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -68,7 +67,7 @@ func (up *upContext) sync(ctx context.Context) error {
 	oktetoLog.Success(msg)
 
 	elapsed := time.Since(start)
-	analytics.TrackDurationInitialSync(elapsed)
+	up.analyticsTracker.TrackDurationInitialSync(elapsed)
 	maxDuration := time.Duration(1) * time.Minute
 	if elapsed > maxDuration {
 		minutes := elapsed / time.Minute
@@ -177,7 +176,7 @@ func (up *upContext) synchronizeFiles(ctx context.Context) error {
 	}()
 
 	if err := up.Sy.WaitForCompletion(ctx, reporter); err != nil {
-		analytics.TrackSyncError()
+		up.analyticsTracker.TrackSyncError()
 		switch err {
 		case oktetoErrors.ErrLostSyncthing:
 			return err

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -67,7 +67,7 @@ func (up *upContext) sync(ctx context.Context) error {
 	oktetoLog.Success(msg)
 
 	elapsed := time.Since(start)
-	up.analyticsMeta.AddInitialSyncDuration(elapsed)
+	up.analyticsMeta.InitialSyncDuration(elapsed)
 	maxDuration := time.Duration(1) * time.Minute
 	if elapsed > maxDuration {
 		minutes := elapsed / time.Minute
@@ -176,14 +176,14 @@ func (up *upContext) synchronizeFiles(ctx context.Context) error {
 	}()
 
 	if err := up.Sy.WaitForCompletion(ctx, reporter); err != nil {
-		up.analyticsMeta.AddErrSync()
+		up.analyticsMeta.ErrSync()
 		switch err {
 		case oktetoErrors.ErrLostSyncthing:
 			return err
 		case oktetoErrors.ErrInsufficientSpace:
 			return up.getInsufficientSpaceError(err)
 		case oktetoErrors.ErrNeedsResetSyncError:
-			up.analyticsMeta.AddErrResetDatabase()
+			up.analyticsMeta.ErrResetDatabase()
 			return oktetoErrors.UserError{
 				E:    fmt.Errorf("the synchronization service state is inconsistent"),
 				Hint: `Try running 'okteto up --reset' to reset the synchronization service`,

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -67,7 +67,7 @@ func (up *upContext) sync(ctx context.Context) error {
 	oktetoLog.Success(msg)
 
 	elapsed := time.Since(start)
-	up.analyticsTracker.TrackDurationInitialSync(elapsed)
+	up.analyticsMeta.AddInitialSyncDuration(elapsed)
 	maxDuration := time.Duration(1) * time.Minute
 	if elapsed > maxDuration {
 		minutes := elapsed / time.Minute

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -183,6 +183,7 @@ func (up *upContext) synchronizeFiles(ctx context.Context) error {
 		case oktetoErrors.ErrInsufficientSpace:
 			return up.getInsufficientSpaceError(err)
 		case oktetoErrors.ErrNeedsResetSyncError:
+			up.analyticsMeta.AddErrResetDatabase()
 			return oktetoErrors.UserError{
 				E:    fmt.Errorf("the synchronization service state is inconsistent"),
 				Hint: `Try running 'okteto up --reset' to reset the synchronization service`,

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -176,7 +176,7 @@ func (up *upContext) synchronizeFiles(ctx context.Context) error {
 	}()
 
 	if err := up.Sy.WaitForCompletion(ctx, reporter); err != nil {
-		up.analyticsTracker.TrackSyncError()
+		up.analyticsMeta.AddErrSync()
 		switch err {
 		case oktetoErrors.ErrLostSyncthing:
 			return err

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/moby/term"
+	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/model/forward"
@@ -65,6 +66,7 @@ type upContext struct {
 	Fs                    afero.Fs
 	hybridCommand         *exec.Cmd
 	interruptReceived     bool
+	analyticsTracker      *analytics.AnalyticsTracker
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -67,7 +67,7 @@ type upContext struct {
 	hybridCommand         *exec.Cmd
 	interruptReceived     bool
 	analyticsTracker      *analytics.AnalyticsTracker
-	analyticsMeta         *analytics.UpMetadata
+	analyticsMeta         *analytics.UpMetricsMetadata
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -67,6 +67,7 @@ type upContext struct {
 	hybridCommand         *exec.Cmd
 	interruptReceived     bool
 	analyticsTracker      *analytics.AnalyticsTracker
+	analyticsMeta         *analytics.UpMetadata
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -633,7 +633,7 @@ func (up *upContext) start() error {
 
 	pidFileCh := make(chan error, 1)
 
-	analytics.TrackUp(analytics.TrackUpMetadata{
+	up.analyticsTracker.TrackUp(analytics.TrackUpMetadata{
 		IsInteractive:          up.Dev.IsInteractive(),
 		IsOktetoRepository:     utils.IsOktetoRepo(),
 		IsV2:                   up.Manifest.IsV2,

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -633,16 +633,12 @@ func (up *upContext) start() error {
 
 	pidFileCh := make(chan error, 1)
 
-	up.analyticsTracker.TrackUp(analytics.TrackUpMetadata{
-		IsInteractive:          up.Dev.IsInteractive(),
-		IsOktetoRepository:     utils.IsOktetoRepo(),
-		IsV2:                   up.Manifest.IsV2,
-		HasDependenciesSection: up.Manifest.HasDependenciesSection(),
-		HasBuildSection:        up.Manifest.HasBuildSection(),
-		HasDeploySection:       up.Manifest.HasDeploySection(),
-		HasReverse:             len(up.Dev.Reverse) > 0,
-		Mode:                   up.Dev.Mode,
-	})
+	upMetadata := analytics.NewTrackUpMetadata()
+	upMetadata.AddManifestProps(up.Manifest)
+	upMetadata.AddDevProps(up.Dev)
+	upMetadata.AddRepositoryProps(utils.IsOktetoRepo())
+
+	up.analyticsTracker.TrackUp(true, upMetadata)
 
 	go up.activateLoop()
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -240,7 +240,7 @@ func Up() *cobra.Command {
 			}
 
 			analyticsTracker := analytics.NewAnalyticsTracker()
-			upMeta := analytics.NewUpMetadata()
+			upMeta := analytics.NewUpMetricsMetadata()
 
 			// when cmd up finishes, send the event
 			// metadata retrieved during the run of the cmd

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -116,6 +116,7 @@ func Up() *cobra.Command {
 			checkLocalWatchesConfiguration()
 
 			ctx := context.Background()
+			analyticsTracker := analytics.NewAnalyticsTracker()
 
 			if upOptions.ManifestPath != "" {
 				// if path is absolute, its transformed to rel from root
@@ -240,14 +241,15 @@ func Up() *cobra.Command {
 			}
 
 			up := &upContext{
-				Manifest:       oktetoManifest,
-				Dev:            nil,
-				Exit:           make(chan error, 1),
-				resetSyncthing: upOptions.Reset,
-				StartTime:      time.Now(),
-				Registry:       registry.NewOktetoRegistry(okteto.Config{}),
-				Options:        upOptions,
-				Fs:             afero.NewOsFs(),
+				Manifest:         oktetoManifest,
+				Dev:              nil,
+				Exit:             make(chan error, 1),
+				resetSyncthing:   upOptions.Reset,
+				StartTime:        time.Now(),
+				Registry:         registry.NewOktetoRegistry(okteto.Config{}),
+				Options:          upOptions,
+				Fs:               afero.NewOsFs(),
+				analyticsTracker: analyticsTracker,
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {
@@ -569,7 +571,7 @@ func (up *upContext) deployApp(ctx context.Context) error {
 		PipelineCMD:        pc,
 		DeployWaiter:       deploy.NewDeployWaiter(k8sClientProvider),
 		EndpointGetter:     deploy.NewEndpointGetter,
-		AnalyticsTracker:   analytics.NewAnalyticsTracker(),
+		AnalyticsTracker:   up.analyticsTracker,
 	}
 
 	startTime := time.Now()

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -639,9 +639,9 @@ func (up *upContext) start() error {
 
 	pidFileCh := make(chan error, 1)
 
-	up.analyticsMeta.AddManifestProps(up.Manifest)
-	up.analyticsMeta.AddDevProps(up.Dev)
-	up.analyticsMeta.AddRepositoryProps(utils.IsOktetoRepo())
+	up.analyticsMeta.ManifestProps(up.Manifest)
+	up.analyticsMeta.DevProps(up.Dev)
+	up.analyticsMeta.RepositoryProps(utils.IsOktetoRepo())
 
 	go up.activateLoop()
 
@@ -895,7 +895,7 @@ func (up *upContext) shutdown() {
 
 	oktetoLog.Infof("starting shutdown sequence")
 	if !up.success {
-		up.analyticsMeta.SetFailActivate()
+		up.analyticsMeta.FailActivate()
 	}
 
 	if up.Cancel != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -896,7 +896,7 @@ func (up *upContext) shutdown() {
 
 	oktetoLog.Infof("starting shutdown sequence")
 	if !up.success {
-		analytics.TrackUpError(true)
+		up.analyticsTracker.TrackUpError(true)
 	}
 
 	if up.Cancel != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -897,7 +897,7 @@ func (up *upContext) shutdown() {
 
 	oktetoLog.Infof("starting shutdown sequence")
 	if !up.success {
-		up.analyticsTracker.TrackUpError(true)
+		up.analyticsMeta.SetFailActivate()
 	}
 
 	if up.Cancel != nil {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -250,6 +250,7 @@ func Up() *cobra.Command {
 				Options:          upOptions,
 				Fs:               afero.NewOsFs(),
 				analyticsTracker: analyticsTracker,
+				analyticsMeta:    analytics.NewUpMetadata(),
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {
@@ -633,12 +634,11 @@ func (up *upContext) start() error {
 
 	pidFileCh := make(chan error, 1)
 
-	upMetadata := analytics.NewTrackUpMetadata()
-	upMetadata.AddManifestProps(up.Manifest)
-	upMetadata.AddDevProps(up.Dev)
-	upMetadata.AddRepositoryProps(utils.IsOktetoRepo())
+	up.analyticsMeta.AddManifestProps(up.Manifest)
+	up.analyticsMeta.AddDevProps(up.Dev)
+	up.analyticsMeta.AddRepositoryProps(utils.IsOktetoRepo())
 
-	up.analyticsTracker.TrackUp(true, upMetadata)
+	up.analyticsTracker.TrackUp(true, up.analyticsMeta)
 
 	go up.activateLoop()
 

--- a/pkg/analytics/deploy.go
+++ b/pkg/analytics/deploy.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analytics
 
 import (

--- a/pkg/analytics/destroy.go
+++ b/pkg/analytics/destroy.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analytics
 
 // DestroyMetadata contains the metadata of a destroy event

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -35,7 +35,6 @@ const (
 	mixpanelToken = "92fe782cdffa212d8f03861fbf1ea301"
 
 	manifestHasChangedEvent  = "Manifest Has Changed"
-	durationInitialSyncEvent = "Initial Sync Duration Time"
 	downEvent                = "Down"
 	downVolumesEvent         = "DownVolumes"
 	pushEvent                = "Push"

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -34,14 +34,8 @@ const (
 	// This is mixpanel's public token, is needed to send analytics to the project
 	mixpanelToken = "92fe782cdffa212d8f03861fbf1ea301"
 
-	upEvent                  = "Up"
-	upErrorEvent             = "Up Error"
 	manifestHasChangedEvent  = "Manifest Has Changed"
-	durationActivateUpEvent  = "Up Duration Time"
-	reconnectEvent           = "Reconnect"
 	durationInitialSyncEvent = "Initial Sync Duration Time"
-	syncErrorEvent           = "Sync Error"
-	syncResetDatabase        = "Sync Reset Database"
 	downEvent                = "Down"
 	downVolumesEvent         = "DownVolumes"
 	pushEvent                = "Push"
@@ -133,87 +127,9 @@ func TrackPreviewDestroy(success bool) {
 	track(previewDestroyEvent, success, nil)
 }
 
-const (
-	// ReconnectCauseDefault is the default cause for a reconnection
-	ReconnectCauseDefault = "unrecognised"
-
-	// ReconnectCauseDevPodRecreated is cause when pods UID change between retrys
-	ReconnectCauseDevPodRecreated = "dev-pod-recreated"
-)
-
-// TrackReconnect sends a tracking event to mixpanel when the development container reconnect
-func TrackReconnect(success bool, cause string) {
-	props := map[string]interface{}{
-		"cause": cause,
-	}
-	track(reconnectEvent, success, props)
-}
-
-// TrackSyncError sends a tracking event to mixpanel when the init sync fails
-func TrackSyncError() {
-	track(syncErrorEvent, false, nil)
-}
-
-// TrackDurationInitialSync sends a tracking event to mixpanel with initial sync duration
-func TrackDurationInitialSync(durationInitialSync time.Duration) {
-	props := map[string]interface{}{
-		"duration": durationInitialSync,
-	}
-	track(durationInitialSyncEvent, true, props)
-}
-
-// TrackResetDatabase sends a tracking event to mixpanel when the syncthing database is reset
-func TrackResetDatabase(success bool) {
-	track(syncResetDatabase, success, nil)
-}
-
-// TrackUpMetadata defines the properties an up can have
-type TrackUpMetadata struct {
-	IsV2                   bool
-	ManifestType           model.Archetype
-	IsInteractive          bool
-	IsOktetoRepository     bool
-	HasDependenciesSection bool
-	HasBuildSection        bool
-	HasDeploySection       bool
-	Success                bool
-	HasReverse             bool
-	IsHybridDev            bool
-	Mode                   string
-}
-
-// TrackUp sends a tracking event to mixpanel when the user activates a development container
-func TrackUp(m TrackUpMetadata) {
-	props := map[string]interface{}{
-		"isInteractive":          m.IsInteractive,
-		"isV2":                   m.IsV2,
-		"manifestType":           m.ManifestType,
-		"isOktetoRepository":     m.IsOktetoRepository,
-		"hasDependenciesSection": m.HasDependenciesSection,
-		"hasBuildSection":        m.HasBuildSection,
-		"hasDeploySection":       m.HasDeploySection,
-		"hasReverse":             m.HasReverse,
-		"mode":                   m.Mode,
-	}
-	track(upEvent, m.Success, props)
-}
-
-// TrackUpError sends a tracking event to mixpanel when the okteto up command fails
-func TrackUpError(success bool) {
-	track(upErrorEvent, success, nil)
-}
-
 // TrackManifestHasChanged sends a tracking event to mixpanel when the okteto up command fails because manifest has changed
 func TrackManifestHasChanged(success bool) {
 	track(manifestHasChangedEvent, success, nil)
-}
-
-// TrackDurationActivateUp sends a tracking event to mixpanel of the time that has elapsed in the execution of up
-func TrackDurationActivateUp(durationActivateUp time.Duration) {
-	props := map[string]interface{}{
-		"duration": durationActivateUp,
-	}
-	track(durationActivateUpEvent, true, props)
 }
 
 // TrackExecMetadata is the metadata added to execEvent

--- a/pkg/analytics/tracker.go
+++ b/pkg/analytics/tracker.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analytics
 
 type AnalyticsTracker struct {

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package analytics
 
 import (

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -30,6 +30,7 @@ type UpMetadata struct {
 	ReconnectCause         string
 	ErrSync                bool
 	ErrResetDatabase       bool
+	Success                bool
 }
 
 func NewUpMetadata() *UpMetadata {
@@ -109,7 +110,11 @@ func (u *UpMetadata) AddErrResetDatabase() {
 	u.ErrResetDatabase = true
 }
 
+func (u *UpMetadata) CommandSuccess() {
+	u.Success = true
+}
+
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
-func (a *AnalyticsTracker) TrackUp(success bool, m *UpMetadata) {
-	a.trackFn(upEvent, success, m.toProps())
+func (a *AnalyticsTracker) TrackUp(m *UpMetadata) {
+	a.trackFn(upEvent, m.Success, m.toProps())
 }

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -31,7 +31,7 @@ type TrackUpMetadata struct {
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
-func TrackUp(m TrackUpMetadata) {
+func (a *AnalyticsTracker) TrackUp(m TrackUpMetadata) {
 	props := map[string]interface{}{
 		"isInteractive":          m.IsInteractive,
 		"isV2":                   m.IsV2,

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -9,7 +9,6 @@ import (
 const (
 	// Event that tracks when a user activates a development container
 	upEvent           = "Up"
-	syncErrorEvent    = "Sync Error"
 	syncResetDatabase = "Sync Reset Database"
 )
 
@@ -30,6 +29,7 @@ type UpMetadata struct {
 	InitialSyncDuration    time.Duration
 	IsReconnect            bool
 	ReconnectCause         string
+	ErrSync                bool
 }
 
 func NewUpMetadata() *UpMetadata {
@@ -52,6 +52,7 @@ func (u *UpMetadata) toProps() map[string]interface{} {
 		"initialSyncDurationSeconds": u.InitialSyncDuration.Seconds(),
 		"isReconnect":                u.IsReconnect,
 		"reconnectCause":             u.ReconnectCause,
+		"errSync":                    u.ErrSync,
 	}
 }
 
@@ -99,14 +100,13 @@ func (u *UpMetadata) AddReconnect(cause string) {
 	u.ReconnectCause = cause
 }
 
+func (u *UpMetadata) AddErrSync() {
+	u.ErrSync = true
+}
+
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
 func (a *AnalyticsTracker) TrackUp(success bool, m *UpMetadata) {
 	a.trackFn(upEvent, success, m.toProps())
-}
-
-// TrackSyncError sends a tracking event to mixpanel when the init sync fails
-func (a *AnalyticsTracker) TrackSyncError() {
-	a.trackFn(syncErrorEvent, false, nil)
 }
 
 // TrackResetDatabase sends a tracking event to mixpanel when the syncthing database is reset

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -46,10 +46,12 @@ type UpMetricsMetadata struct {
 	success                bool
 }
 
+// NewUpMetricsMetadata returns an empty instance of UpMetricsMetadata
 func NewUpMetricsMetadata() *UpMetricsMetadata {
 	return &UpMetricsMetadata{}
 }
 
+// toProps transforms UpMetricsMetadata into a map to be able to send it to mixpanel
 func (u *UpMetricsMetadata) toProps() map[string]interface{} {
 	return map[string]interface{}{
 		"isInteractive":              u.isInteractive,
@@ -71,7 +73,8 @@ func (u *UpMetricsMetadata) toProps() map[string]interface{} {
 	}
 }
 
-func (u *UpMetricsMetadata) AddManifestProps(m *model.Manifest) {
+// ManifestProps adds the tracking properties of the repository manifest
+func (u *UpMetricsMetadata) ManifestProps(m *model.Manifest) {
 	u.isV2 = m.IsV2
 	u.manifestType = m.Type
 	u.hasDependenciesSection = m.HasDependenciesSection()
@@ -79,50 +82,65 @@ func (u *UpMetricsMetadata) AddManifestProps(m *model.Manifest) {
 	u.hasDeploySection = m.HasDeploySection()
 }
 
-func (u *UpMetricsMetadata) AddDevProps(d *model.Dev) {
+// DevProps adds the tracking properties of the service development manifest
+func (u *UpMetricsMetadata) DevProps(d *model.Dev) {
 	u.hasReverse = len(d.Reverse) > 0
 	u.mode = d.Mode
 	u.isInteractive = d.IsInteractive()
 
 }
 
-func (u *UpMetricsMetadata) AddRepositoryProps(isOktetoRepository bool) {
+// RepositoryProps adds the tracking properties of the repository
+func (u *UpMetricsMetadata) RepositoryProps(isOktetoRepository bool) {
 	u.isOktetoRepository = isOktetoRepository
 }
 
-func (u *UpMetricsMetadata) SetFailActivate() {
+// FailActivate sets to true the property failActivate
+func (u *UpMetricsMetadata) FailActivate() {
 	u.failActivate = true
 }
 
-func (u *UpMetricsMetadata) AddActivateDuration(duration time.Duration) {
+// ActivateDuration adds the duration of up activation
+func (u *UpMetricsMetadata) ActivateDuration(duration time.Duration) {
 	u.activateDuration = duration
 }
 
-func (u *UpMetricsMetadata) AddInitialSyncDuration(duration time.Duration) {
+// InitialSyncDuration adds the duration of the initial sync
+func (u *UpMetricsMetadata) InitialSyncDuration(duration time.Duration) {
 	u.initialSyncDuration = duration
 }
 
 const (
-	// ReconnectCauseDefault is the default cause for a reconnection
-	ReconnectCauseDefault = "unrecognised"
+	// reconnectCauseDefault is the default cause for a reconnection
+	reconnectCauseDefault = "unrecognised"
 
-	// ReconnectCauseDevPodRecreated is cause when pods UID change between retrys
-	ReconnectCauseDevPodRecreated = "dev-pod-recreated"
+	// reconnectCauseDevPodRecreated is cause when pods UID change between retrys
+	reconnectCauseDevPodRecreated = "dev-pod-recreated"
 )
 
-func (u *UpMetricsMetadata) AddReconnect(cause string) {
+// ReconnectDefault sets to true the property isReconnect and adds the cause "unrecognised"
+func (u *UpMetricsMetadata) ReconnectDefault() {
 	u.isReconnect = true
-	u.reconnectCause = cause
+	u.reconnectCause = reconnectCauseDefault
 }
 
-func (u *UpMetricsMetadata) AddErrSync() {
+// ReconnectDevPodRecreated sets to true the property isReconnect and adds the cause "dev-pod-recreated"
+func (u *UpMetricsMetadata) ReconnectDevPodRecreated() {
+	u.isReconnect = true
+	u.reconnectCause = reconnectCauseDevPodRecreated
+}
+
+// ErrSync sets to true the property errSync
+func (u *UpMetricsMetadata) ErrSync() {
 	u.errSync = true
 }
 
-func (u *UpMetricsMetadata) AddErrResetDatabase() {
+// ErrResetDatabase sets to true the property errResetDatabase
+func (u *UpMetricsMetadata) ErrResetDatabase() {
 	u.errResetDatabase = true
 }
 
+// CommandSuccess sets to true the property success
 func (u *UpMetricsMetadata) CommandSuccess() {
 	u.success = true
 }

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -9,7 +9,6 @@ import (
 const (
 	// Event that tracks when a user activates a development container
 	upEvent                  = "Up"
-	durationActivateUpEvent  = "Up Duration Time"
 	durationInitialSyncEvent = "Initial Sync Duration Time"
 	reconnectEvent           = "Reconnect"
 	syncErrorEvent           = "Sync Error"
@@ -29,6 +28,7 @@ type UpMetadata struct {
 	IsHybridDev            bool
 	Mode                   string
 	FailActivate           bool
+	ActivateDuration       time.Duration
 }
 
 func NewUpMetadata() *UpMetadata {
@@ -37,16 +37,17 @@ func NewUpMetadata() *UpMetadata {
 
 func (u *UpMetadata) toProps() map[string]interface{} {
 	return map[string]interface{}{
-		"isInteractive":          u.IsInteractive,
-		"isV2":                   u.IsV2,
-		"manifestType":           u.ManifestType,
-		"isOktetoRepository":     u.IsOktetoRepository,
-		"hasDependenciesSection": u.HasDependenciesSection,
-		"hasBuildSection":        u.HasBuildSection,
-		"hasDeploySection":       u.HasDeploySection,
-		"hasReverse":             u.HasReverse,
-		"mode":                   u.Mode,
-		"failActivate":           u.FailActivate,
+		"isInteractive":           u.IsInteractive,
+		"isV2":                    u.IsV2,
+		"manifestType":            u.ManifestType,
+		"isOktetoRepository":      u.IsOktetoRepository,
+		"hasDependenciesSection":  u.HasDependenciesSection,
+		"hasBuildSection":         u.HasBuildSection,
+		"hasDeploySection":        u.HasDeploySection,
+		"hasReverse":              u.HasReverse,
+		"mode":                    u.Mode,
+		"failActivate":            u.FailActivate,
+		"activateDurationSeconds": u.ActivateDuration.Seconds(),
 	}
 }
 
@@ -71,6 +72,10 @@ func (u *UpMetadata) AddRepositoryProps(isOktetoRepository bool) {
 
 func (u *UpMetadata) SetFailActivate() {
 	u.FailActivate = true
+}
+
+func (u *UpMetadata) AddActivateDuration(duration time.Duration) {
+	u.ActivateDuration = duration
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
@@ -105,14 +110,6 @@ func (a *AnalyticsTracker) TrackDurationInitialSync(durationInitialSync time.Dur
 		"duration": durationInitialSync,
 	}
 	a.trackFn(durationInitialSyncEvent, true, props)
-}
-
-// TrackDurationActivateUp sends a tracking event to mixpanel of the time that has elapsed in the execution of up
-func (a *AnalyticsTracker) TrackDurationActivateUp(durationActivateUp time.Duration) {
-	props := map[string]interface{}{
-		"duration": durationActivateUp,
-	}
-	a.trackFn(durationActivateUpEvent, true, props)
 }
 
 // TrackResetDatabase sends a tracking event to mixpanel when the syncthing database is reset

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -24,8 +24,8 @@ const (
 	upEvent = "Up"
 )
 
-// UpMetadata defines the properties an up can have
-type UpMetadata struct {
+// UpMetricsMetadata defines the properties of the Up event we want to track
+type UpMetricsMetadata struct {
 	isV2                   bool
 	manifestType           model.Archetype
 	isInteractive          bool
@@ -46,11 +46,11 @@ type UpMetadata struct {
 	success                bool
 }
 
-func NewUpMetadata() *UpMetadata {
-	return &UpMetadata{}
+func NewUpMetricsMetadata() *UpMetricsMetadata {
+	return &UpMetricsMetadata{}
 }
 
-func (u *UpMetadata) toProps() map[string]interface{} {
+func (u *UpMetricsMetadata) toProps() map[string]interface{} {
 	return map[string]interface{}{
 		"isInteractive":              u.isInteractive,
 		"isV2":                       u.isV2,
@@ -71,7 +71,7 @@ func (u *UpMetadata) toProps() map[string]interface{} {
 	}
 }
 
-func (u *UpMetadata) AddManifestProps(m *model.Manifest) {
+func (u *UpMetricsMetadata) AddManifestProps(m *model.Manifest) {
 	u.isV2 = m.IsV2
 	u.manifestType = m.Type
 	u.hasDependenciesSection = m.HasDependenciesSection()
@@ -79,26 +79,26 @@ func (u *UpMetadata) AddManifestProps(m *model.Manifest) {
 	u.hasDeploySection = m.HasDeploySection()
 }
 
-func (u *UpMetadata) AddDevProps(d *model.Dev) {
+func (u *UpMetricsMetadata) AddDevProps(d *model.Dev) {
 	u.hasReverse = len(d.Reverse) > 0
 	u.mode = d.Mode
 	u.isInteractive = d.IsInteractive()
 
 }
 
-func (u *UpMetadata) AddRepositoryProps(isOktetoRepository bool) {
+func (u *UpMetricsMetadata) AddRepositoryProps(isOktetoRepository bool) {
 	u.isOktetoRepository = isOktetoRepository
 }
 
-func (u *UpMetadata) SetFailActivate() {
+func (u *UpMetricsMetadata) SetFailActivate() {
 	u.failActivate = true
 }
 
-func (u *UpMetadata) AddActivateDuration(duration time.Duration) {
+func (u *UpMetricsMetadata) AddActivateDuration(duration time.Duration) {
 	u.activateDuration = duration
 }
 
-func (u *UpMetadata) AddInitialSyncDuration(duration time.Duration) {
+func (u *UpMetricsMetadata) AddInitialSyncDuration(duration time.Duration) {
 	u.initialSyncDuration = duration
 }
 
@@ -110,24 +110,24 @@ const (
 	ReconnectCauseDevPodRecreated = "dev-pod-recreated"
 )
 
-func (u *UpMetadata) AddReconnect(cause string) {
+func (u *UpMetricsMetadata) AddReconnect(cause string) {
 	u.isReconnect = true
 	u.reconnectCause = cause
 }
 
-func (u *UpMetadata) AddErrSync() {
+func (u *UpMetricsMetadata) AddErrSync() {
 	u.errSync = true
 }
 
-func (u *UpMetadata) AddErrResetDatabase() {
+func (u *UpMetricsMetadata) AddErrResetDatabase() {
 	u.errResetDatabase = true
 }
 
-func (u *UpMetadata) CommandSuccess() {
+func (u *UpMetricsMetadata) CommandSuccess() {
 	u.success = true
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
-func (a *AnalyticsTracker) TrackUp(m *UpMetadata) {
+func (a *AnalyticsTracker) TrackUp(m *UpMetricsMetadata) {
 	a.trackFn(upEvent, m.success, m.toProps())
 }

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -9,7 +9,6 @@ import (
 const (
 	// Event that tracks when a user activates a development container
 	upEvent                  = "Up"
-	upErrorEvent             = "Up Error"
 	durationActivateUpEvent  = "Up Duration Time"
 	durationInitialSyncEvent = "Initial Sync Duration Time"
 	reconnectEvent           = "Reconnect"
@@ -29,6 +28,7 @@ type UpMetadata struct {
 	HasReverse             bool
 	IsHybridDev            bool
 	Mode                   string
+	FailActivate           bool
 }
 
 func NewUpMetadata() *UpMetadata {
@@ -46,6 +46,7 @@ func (u *UpMetadata) toProps() map[string]interface{} {
 		"hasDeploySection":       u.HasDeploySection,
 		"hasReverse":             u.HasReverse,
 		"mode":                   u.Mode,
+		"failActivate":           u.FailActivate,
 	}
 }
 
@@ -68,14 +69,13 @@ func (u *UpMetadata) AddRepositoryProps(isOktetoRepository bool) {
 	u.IsOktetoRepository = isOktetoRepository
 }
 
+func (u *UpMetadata) SetFailActivate() {
+	u.FailActivate = true
+}
+
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
 func (a *AnalyticsTracker) TrackUp(success bool, m *UpMetadata) {
 	a.trackFn(upEvent, success, m.toProps())
-}
-
-// TrackUpError sends a tracking event to mixpanel when the okteto up command fails
-func (a *AnalyticsTracker) TrackUpError(success bool) {
-	a.trackFn(upErrorEvent, success, nil)
 }
 
 const (

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -43,12 +43,12 @@ func (a *AnalyticsTracker) TrackUp(m TrackUpMetadata) {
 		"hasReverse":             m.HasReverse,
 		"mode":                   m.Mode,
 	}
-	track(upEvent, m.Success, props)
+	a.trackFn(upEvent, m.Success, props)
 }
 
 // TrackUpError sends a tracking event to mixpanel when the okteto up command fails
-func TrackUpError(success bool) {
-	track(upErrorEvent, success, nil)
+func (a *AnalyticsTracker) TrackUpError(success bool) {
+	a.trackFn(upErrorEvent, success, nil)
 }
 
 const (
@@ -60,35 +60,35 @@ const (
 )
 
 // TrackReconnect sends a tracking event to mixpanel when the development container reconnect
-func TrackReconnect(success bool, cause string) {
+func (a *AnalyticsTracker) TrackReconnect(success bool, cause string) {
 	props := map[string]interface{}{
 		"cause": cause,
 	}
-	track(reconnectEvent, success, props)
+	a.trackFn(reconnectEvent, success, props)
 }
 
 // TrackSyncError sends a tracking event to mixpanel when the init sync fails
-func TrackSyncError() {
-	track(syncErrorEvent, false, nil)
+func (a *AnalyticsTracker) TrackSyncError() {
+	a.trackFn(syncErrorEvent, false, nil)
 }
 
 // TrackDurationInitialSync sends a tracking event to mixpanel with initial sync duration
-func TrackDurationInitialSync(durationInitialSync time.Duration) {
+func (a *AnalyticsTracker) TrackDurationInitialSync(durationInitialSync time.Duration) {
 	props := map[string]interface{}{
 		"duration": durationInitialSync,
 	}
-	track(durationInitialSyncEvent, true, props)
+	a.trackFn(durationInitialSyncEvent, true, props)
+}
+
+// TrackDurationActivateUp sends a tracking event to mixpanel of the time that has elapsed in the execution of up
+func (a *AnalyticsTracker) TrackDurationActivateUp(durationActivateUp time.Duration) {
+	props := map[string]interface{}{
+		"duration": durationActivateUp,
+	}
+	a.trackFn(durationActivateUpEvent, true, props)
 }
 
 // TrackResetDatabase sends a tracking event to mixpanel when the syncthing database is reset
 func TrackResetDatabase(success bool) {
 	track(syncResetDatabase, success, nil)
-}
-
-// TrackDurationActivateUp sends a tracking event to mixpanel of the time that has elapsed in the execution of up
-func TrackDurationActivateUp(durationActivateUp time.Duration) {
-	props := map[string]interface{}{
-		"duration": durationActivateUp,
-	}
-	track(durationActivateUpEvent, true, props)
 }

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -8,11 +8,10 @@ import (
 
 const (
 	// Event that tracks when a user activates a development container
-	upEvent                  = "Up"
-	durationInitialSyncEvent = "Initial Sync Duration Time"
-	reconnectEvent           = "Reconnect"
-	syncErrorEvent           = "Sync Error"
-	syncResetDatabase        = "Sync Reset Database"
+	upEvent           = "Up"
+	reconnectEvent    = "Reconnect"
+	syncErrorEvent    = "Sync Error"
+	syncResetDatabase = "Sync Reset Database"
 )
 
 // UpMetadata defines the properties an up can have
@@ -29,6 +28,7 @@ type UpMetadata struct {
 	Mode                   string
 	FailActivate           bool
 	ActivateDuration       time.Duration
+	InitialSyncDuration    time.Duration
 }
 
 func NewUpMetadata() *UpMetadata {
@@ -37,17 +37,18 @@ func NewUpMetadata() *UpMetadata {
 
 func (u *UpMetadata) toProps() map[string]interface{} {
 	return map[string]interface{}{
-		"isInteractive":           u.IsInteractive,
-		"isV2":                    u.IsV2,
-		"manifestType":            u.ManifestType,
-		"isOktetoRepository":      u.IsOktetoRepository,
-		"hasDependenciesSection":  u.HasDependenciesSection,
-		"hasBuildSection":         u.HasBuildSection,
-		"hasDeploySection":        u.HasDeploySection,
-		"hasReverse":              u.HasReverse,
-		"mode":                    u.Mode,
-		"failActivate":            u.FailActivate,
-		"activateDurationSeconds": u.ActivateDuration.Seconds(),
+		"isInteractive":              u.IsInteractive,
+		"isV2":                       u.IsV2,
+		"manifestType":               u.ManifestType,
+		"isOktetoRepository":         u.IsOktetoRepository,
+		"hasDependenciesSection":     u.HasDependenciesSection,
+		"hasBuildSection":            u.HasBuildSection,
+		"hasDeploySection":           u.HasDeploySection,
+		"hasReverse":                 u.HasReverse,
+		"mode":                       u.Mode,
+		"failActivate":               u.FailActivate,
+		"activateDurationSeconds":    u.ActivateDuration.Seconds(),
+		"initialSyncDurationSeconds": u.InitialSyncDuration.Seconds(),
 	}
 }
 
@@ -78,6 +79,10 @@ func (u *UpMetadata) AddActivateDuration(duration time.Duration) {
 	u.ActivateDuration = duration
 }
 
+func (u *UpMetadata) AddInitialSyncDuration(duration time.Duration) {
+	u.InitialSyncDuration = duration
+}
+
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
 func (a *AnalyticsTracker) TrackUp(success bool, m *UpMetadata) {
 	a.trackFn(upEvent, success, m.toProps())
@@ -102,14 +107,6 @@ func (a *AnalyticsTracker) TrackReconnect(success bool, cause string) {
 // TrackSyncError sends a tracking event to mixpanel when the init sync fails
 func (a *AnalyticsTracker) TrackSyncError() {
 	a.trackFn(syncErrorEvent, false, nil)
-}
-
-// TrackDurationInitialSync sends a tracking event to mixpanel with initial sync duration
-func (a *AnalyticsTracker) TrackDurationInitialSync(durationInitialSync time.Duration) {
-	props := map[string]interface{}{
-		"duration": durationInitialSync,
-	}
-	a.trackFn(durationInitialSyncEvent, true, props)
 }
 
 // TrackResetDatabase sends a tracking event to mixpanel when the syncthing database is reset

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -22,6 +22,12 @@ import (
 const (
 	// Event that tracks when a user activates a development container
 	upEvent = "Up"
+
+	// reconnectCauseDefault is the default cause for a reconnection
+	reconnectCauseDefault = "unrecognised"
+
+	// reconnectCauseDevPodRecreated is cause when pods UID change between retrys
+	reconnectCauseDevPodRecreated = "dev-pod-recreated"
 )
 
 // UpMetricsMetadata defines the properties of the Up event we want to track
@@ -108,14 +114,6 @@ func (u *UpMetricsMetadata) ActivateDuration(duration time.Duration) {
 func (u *UpMetricsMetadata) InitialSyncDuration(duration time.Duration) {
 	u.initialSyncDuration = duration
 }
-
-const (
-	// reconnectCauseDefault is the default cause for a reconnection
-	reconnectCauseDefault = "unrecognised"
-
-	// reconnectCauseDevPodRecreated is cause when pods UID change between retrys
-	reconnectCauseDevPodRecreated = "dev-pod-recreated"
-)
 
 // ReconnectDefault sets to true the property isReconnect and adds the cause "unrecognised"
 func (u *UpMetricsMetadata) ReconnectDefault() {

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -1,0 +1,94 @@
+package analytics
+
+import (
+	"time"
+
+	"github.com/okteto/okteto/pkg/model"
+)
+
+const (
+	upEvent                 = "Up"
+	upErrorEvent            = "Up Error"
+	durationActivateUpEvent = "Up Duration Time"
+	reconnectEvent          = "Reconnect"
+	syncErrorEvent          = "Sync Error"
+	syncResetDatabase       = "Sync Reset Database"
+)
+
+// TrackUpMetadata defines the properties an up can have
+type TrackUpMetadata struct {
+	IsV2                   bool
+	ManifestType           model.Archetype
+	IsInteractive          bool
+	IsOktetoRepository     bool
+	HasDependenciesSection bool
+	HasBuildSection        bool
+	HasDeploySection       bool
+	Success                bool
+	HasReverse             bool
+	IsHybridDev            bool
+	Mode                   string
+}
+
+// TrackUp sends a tracking event to mixpanel when the user activates a development container
+func TrackUp(m TrackUpMetadata) {
+	props := map[string]interface{}{
+		"isInteractive":          m.IsInteractive,
+		"isV2":                   m.IsV2,
+		"manifestType":           m.ManifestType,
+		"isOktetoRepository":     m.IsOktetoRepository,
+		"hasDependenciesSection": m.HasDependenciesSection,
+		"hasBuildSection":        m.HasBuildSection,
+		"hasDeploySection":       m.HasDeploySection,
+		"hasReverse":             m.HasReverse,
+		"mode":                   m.Mode,
+	}
+	track(upEvent, m.Success, props)
+}
+
+// TrackUpError sends a tracking event to mixpanel when the okteto up command fails
+func TrackUpError(success bool) {
+	track(upErrorEvent, success, nil)
+}
+
+const (
+	// ReconnectCauseDefault is the default cause for a reconnection
+	ReconnectCauseDefault = "unrecognised"
+
+	// ReconnectCauseDevPodRecreated is cause when pods UID change between retrys
+	ReconnectCauseDevPodRecreated = "dev-pod-recreated"
+)
+
+// TrackReconnect sends a tracking event to mixpanel when the development container reconnect
+func TrackReconnect(success bool, cause string) {
+	props := map[string]interface{}{
+		"cause": cause,
+	}
+	track(reconnectEvent, success, props)
+}
+
+// TrackSyncError sends a tracking event to mixpanel when the init sync fails
+func TrackSyncError() {
+	track(syncErrorEvent, false, nil)
+}
+
+// TrackDurationInitialSync sends a tracking event to mixpanel with initial sync duration
+func TrackDurationInitialSync(durationInitialSync time.Duration) {
+	props := map[string]interface{}{
+		"duration": durationInitialSync,
+	}
+	track(durationInitialSyncEvent, true, props)
+}
+
+// TrackResetDatabase sends a tracking event to mixpanel when the syncthing database is reset
+func TrackResetDatabase(success bool) {
+	track(syncResetDatabase, success, nil)
+}
+
+// TrackDurationActivateUp sends a tracking event to mixpanel of the time that has elapsed in the execution of up
+func TrackDurationActivateUp(durationActivateUp time.Duration) {
+	props := map[string]interface{}{
+		"duration": durationActivateUp,
+	}
+	track(durationActivateUpEvent, true, props)
+}

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -13,24 +13,24 @@ const (
 
 // UpMetadata defines the properties an up can have
 type UpMetadata struct {
-	IsV2                   bool
-	ManifestType           model.Archetype
-	IsInteractive          bool
-	IsOktetoRepository     bool
-	HasDependenciesSection bool
-	HasBuildSection        bool
-	HasDeploySection       bool
-	HasReverse             bool
-	IsHybridDev            bool
-	Mode                   string
-	FailActivate           bool
-	ActivateDuration       time.Duration
-	InitialSyncDuration    time.Duration
-	IsReconnect            bool
-	ReconnectCause         string
-	ErrSync                bool
-	ErrResetDatabase       bool
-	Success                bool
+	isV2                   bool
+	manifestType           model.Archetype
+	isInteractive          bool
+	isOktetoRepository     bool
+	hasDependenciesSection bool
+	hasBuildSection        bool
+	hasDeploySection       bool
+	hasReverse             bool
+	isHybridDev            bool
+	mode                   string
+	failActivate           bool
+	activateDuration       time.Duration
+	initialSyncDuration    time.Duration
+	isReconnect            bool
+	reconnectCause         string
+	errSync                bool
+	errResetDatabase       bool
+	success                bool
 }
 
 func NewUpMetadata() *UpMetadata {
@@ -39,54 +39,54 @@ func NewUpMetadata() *UpMetadata {
 
 func (u *UpMetadata) toProps() map[string]interface{} {
 	return map[string]interface{}{
-		"isInteractive":              u.IsInteractive,
-		"isV2":                       u.IsV2,
-		"manifestType":               u.ManifestType,
-		"isOktetoRepository":         u.IsOktetoRepository,
-		"hasDependenciesSection":     u.HasDependenciesSection,
-		"hasBuildSection":            u.HasBuildSection,
-		"hasDeploySection":           u.HasDeploySection,
-		"hasReverse":                 u.HasReverse,
-		"mode":                       u.Mode,
-		"failActivate":               u.FailActivate,
-		"activateDurationSeconds":    u.ActivateDuration.Seconds(),
-		"initialSyncDurationSeconds": u.InitialSyncDuration.Seconds(),
-		"isReconnect":                u.IsReconnect,
-		"reconnectCause":             u.ReconnectCause,
-		"errSync":                    u.ErrSync,
-		"errResetDatabase":           u.ErrResetDatabase,
+		"isInteractive":              u.isInteractive,
+		"isV2":                       u.isV2,
+		"manifestType":               u.manifestType,
+		"isOktetoRepository":         u.isOktetoRepository,
+		"hasDependenciesSection":     u.hasDependenciesSection,
+		"hasBuildSection":            u.hasBuildSection,
+		"hasDeploySection":           u.hasDeploySection,
+		"hasReverse":                 u.hasReverse,
+		"mode":                       u.mode,
+		"failActivate":               u.failActivate,
+		"activateDurationSeconds":    u.activateDuration.Seconds(),
+		"initialSyncDurationSeconds": u.initialSyncDuration.Seconds(),
+		"isReconnect":                u.isReconnect,
+		"reconnectCause":             u.reconnectCause,
+		"errSync":                    u.errSync,
+		"errResetDatabase":           u.errResetDatabase,
 	}
 }
 
 func (u *UpMetadata) AddManifestProps(m *model.Manifest) {
-	u.IsV2 = m.IsV2
-	u.ManifestType = m.Type
-	u.HasDependenciesSection = m.HasDependenciesSection()
-	u.HasBuildSection = m.HasBuildSection()
-	u.HasDeploySection = m.HasDeploySection()
+	u.isV2 = m.IsV2
+	u.manifestType = m.Type
+	u.hasDependenciesSection = m.HasDependenciesSection()
+	u.hasBuildSection = m.HasBuildSection()
+	u.hasDeploySection = m.HasDeploySection()
 }
 
 func (u *UpMetadata) AddDevProps(d *model.Dev) {
-	u.HasReverse = len(d.Reverse) > 0
-	u.Mode = d.Mode
-	u.IsInteractive = d.IsInteractive()
+	u.hasReverse = len(d.Reverse) > 0
+	u.mode = d.Mode
+	u.isInteractive = d.IsInteractive()
 
 }
 
 func (u *UpMetadata) AddRepositoryProps(isOktetoRepository bool) {
-	u.IsOktetoRepository = isOktetoRepository
+	u.isOktetoRepository = isOktetoRepository
 }
 
 func (u *UpMetadata) SetFailActivate() {
-	u.FailActivate = true
+	u.failActivate = true
 }
 
 func (u *UpMetadata) AddActivateDuration(duration time.Duration) {
-	u.ActivateDuration = duration
+	u.activateDuration = duration
 }
 
 func (u *UpMetadata) AddInitialSyncDuration(duration time.Duration) {
-	u.InitialSyncDuration = duration
+	u.initialSyncDuration = duration
 }
 
 const (
@@ -98,23 +98,23 @@ const (
 )
 
 func (u *UpMetadata) AddReconnect(cause string) {
-	u.IsReconnect = true
-	u.ReconnectCause = cause
+	u.isReconnect = true
+	u.reconnectCause = cause
 }
 
 func (u *UpMetadata) AddErrSync() {
-	u.ErrSync = true
+	u.errSync = true
 }
 
 func (u *UpMetadata) AddErrResetDatabase() {
-	u.ErrResetDatabase = true
+	u.errResetDatabase = true
 }
 
 func (u *UpMetadata) CommandSuccess() {
-	u.Success = true
+	u.success = true
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
 func (a *AnalyticsTracker) TrackUp(m *UpMetadata) {
-	a.trackFn(upEvent, m.Success, m.toProps())
+	a.trackFn(upEvent, m.success, m.toProps())
 }

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -17,8 +17,8 @@ const (
 	syncResetDatabase        = "Sync Reset Database"
 )
 
-// TrackUpMetadata defines the properties an up can have
-type TrackUpMetadata struct {
+// UpMetadata defines the properties an up can have
+type UpMetadata struct {
 	IsV2                   bool
 	ManifestType           model.Archetype
 	IsInteractive          bool
@@ -31,11 +31,11 @@ type TrackUpMetadata struct {
 	Mode                   string
 }
 
-func NewTrackUpMetadata() *TrackUpMetadata {
-	return &TrackUpMetadata{}
+func NewUpMetadata() *UpMetadata {
+	return &UpMetadata{}
 }
 
-func (u *TrackUpMetadata) toProps() map[string]interface{} {
+func (u *UpMetadata) toProps() map[string]interface{} {
 	return map[string]interface{}{
 		"isInteractive":          u.IsInteractive,
 		"isV2":                   u.IsV2,
@@ -49,7 +49,7 @@ func (u *TrackUpMetadata) toProps() map[string]interface{} {
 	}
 }
 
-func (u *TrackUpMetadata) AddManifestProps(m *model.Manifest) {
+func (u *UpMetadata) AddManifestProps(m *model.Manifest) {
 	u.IsV2 = m.IsV2
 	u.ManifestType = m.Type
 	u.HasDependenciesSection = m.HasDependenciesSection()
@@ -57,19 +57,19 @@ func (u *TrackUpMetadata) AddManifestProps(m *model.Manifest) {
 	u.HasDeploySection = m.HasDeploySection()
 }
 
-func (u *TrackUpMetadata) AddDevProps(d *model.Dev) {
+func (u *UpMetadata) AddDevProps(d *model.Dev) {
 	u.HasReverse = len(d.Reverse) > 0
 	u.Mode = d.Mode
 	u.IsInteractive = d.IsInteractive()
 
 }
 
-func (u *TrackUpMetadata) AddRepositoryProps(isOktetoRepository bool) {
+func (u *UpMetadata) AddRepositoryProps(isOktetoRepository bool) {
 	u.IsOktetoRepository = isOktetoRepository
 }
 
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
-func (a *AnalyticsTracker) TrackUp(success bool, m *TrackUpMetadata) {
+func (a *AnalyticsTracker) TrackUp(success bool, m *UpMetadata) {
 	a.trackFn(upEvent, success, m.toProps())
 }
 

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -7,12 +7,13 @@ import (
 )
 
 const (
-	upEvent                 = "Up"
-	upErrorEvent            = "Up Error"
-	durationActivateUpEvent = "Up Duration Time"
-	reconnectEvent          = "Reconnect"
-	syncErrorEvent          = "Sync Error"
-	syncResetDatabase       = "Sync Reset Database"
+	upEvent                  = "Up"
+	upErrorEvent             = "Up Error"
+	durationActivateUpEvent  = "Up Duration Time"
+	durationInitialSyncEvent = "Initial Sync Duration Time"
+	reconnectEvent           = "Reconnect"
+	syncErrorEvent           = "Sync Error"
+	syncResetDatabase        = "Sync Reset Database"
 )
 
 // TrackUpMetadata defines the properties an up can have

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -8,8 +8,7 @@ import (
 
 const (
 	// Event that tracks when a user activates a development container
-	upEvent           = "Up"
-	syncResetDatabase = "Sync Reset Database"
+	upEvent = "Up"
 )
 
 // UpMetadata defines the properties an up can have
@@ -30,6 +29,7 @@ type UpMetadata struct {
 	IsReconnect            bool
 	ReconnectCause         string
 	ErrSync                bool
+	ErrResetDatabase       bool
 }
 
 func NewUpMetadata() *UpMetadata {
@@ -53,6 +53,7 @@ func (u *UpMetadata) toProps() map[string]interface{} {
 		"isReconnect":                u.IsReconnect,
 		"reconnectCause":             u.ReconnectCause,
 		"errSync":                    u.ErrSync,
+		"errResetDatabase":           u.ErrResetDatabase,
 	}
 }
 
@@ -104,12 +105,11 @@ func (u *UpMetadata) AddErrSync() {
 	u.ErrSync = true
 }
 
+func (u *UpMetadata) AddErrResetDatabase() {
+	u.ErrResetDatabase = true
+}
+
 // TrackUp sends a tracking event to mixpanel when the user activates a development container
 func (a *AnalyticsTracker) TrackUp(success bool, m *UpMetadata) {
 	a.trackFn(upEvent, success, m.toProps())
-}
-
-// TrackResetDatabase sends a tracking event to mixpanel when the syncthing database is reset
-func TrackResetDatabase(success bool) {
-	track(syncResetDatabase, success, nil)
 }

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -87,7 +87,6 @@ func (u *UpMetricsMetadata) DevProps(d *model.Dev) {
 	u.hasReverse = len(d.Reverse) > 0
 	u.mode = d.Mode
 	u.isInteractive = d.IsInteractive()
-
 }
 
 // RepositoryProps adds the tracking properties of the repository

--- a/pkg/analytics/up_test.go
+++ b/pkg/analytics/up_test.go
@@ -1,0 +1,429 @@
+package analytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UpMetricsMetadata_ManifestProps(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest *model.Manifest
+		expected *UpMetricsMetadata
+	}{
+		{
+			name: "manifest with build section",
+			manifest: &model.Manifest{
+				IsV2: true,
+				Build: model.ManifestBuild{
+					"service": &model.BuildInfo{
+						Context: "service",
+					},
+				},
+			},
+			expected: &UpMetricsMetadata{
+				isV2:            true,
+				hasBuildSection: true,
+			},
+		},
+		{
+			name: "manifest with dependencies section",
+			manifest: &model.Manifest{
+				IsV2: true,
+				Dependencies: model.ManifestDependencies{
+					"service": &model.Dependency{},
+				},
+			},
+			expected: &UpMetricsMetadata{
+				isV2:                   true,
+				hasDependenciesSection: true,
+			},
+		},
+		{
+			name: "manifest with deploy section",
+			manifest: &model.Manifest{
+				IsV2: true,
+				Deploy: &model.DeployInfo{
+					Commands: []model.DeployCommand{
+						{
+							Name:    "my command",
+							Command: "echo test",
+						},
+					},
+				},
+			},
+			expected: &UpMetricsMetadata{
+				isV2:             true,
+				hasDeploySection: true,
+			},
+		},
+		{
+			name: "manifest type",
+			manifest: &model.Manifest{
+				Type: model.OktetoManifestType,
+			},
+			expected: &UpMetricsMetadata{
+				manifestType: "manifest",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &UpMetricsMetadata{}
+			m.ManifestProps(tt.manifest)
+			assert.Equal(t, tt.expected, m)
+		})
+	}
+
+}
+
+func Test_UpMetricsMetadata_DevProps(t *testing.T) {
+	tests := []struct {
+		name     string
+		dev      *model.Dev
+		expected *UpMetricsMetadata
+	}{
+		{
+			name: "dev interactive sync mode",
+			dev: &model.Dev{
+				Mode: "sync",
+			},
+			expected: &UpMetricsMetadata{
+				mode:          "sync",
+				isInteractive: true,
+			},
+		},
+		{
+			name: "dev interactive hybrid mode",
+			dev: &model.Dev{
+				Mode: "hybrid",
+			},
+			expected: &UpMetricsMetadata{
+				mode:          "hybrid",
+				isInteractive: true,
+			},
+		},
+		{
+			name: "dev interactive",
+			dev:  &model.Dev{},
+			expected: &UpMetricsMetadata{
+				isInteractive: true,
+			},
+		},
+		{
+			name: "dev not interactive",
+			dev: &model.Dev{
+				Command: model.Command{
+					Values: []string{"yarn start"},
+				},
+			},
+			expected: &UpMetricsMetadata{},
+		},
+		{
+			name: "dev interactive with reverse",
+			dev: &model.Dev{
+				Reverse: []model.Reverse{
+					{
+						Remote: 8080,
+						Local:  8080,
+					},
+				},
+			},
+			expected: &UpMetricsMetadata{
+				hasReverse:    true,
+				isInteractive: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &UpMetricsMetadata{}
+			m.DevProps(tt.dev)
+			assert.Equal(t, tt.expected, m)
+		})
+	}
+
+}
+
+func Test_UpMetricsMetadata_RepositoryProps(t *testing.T) {
+	tests := []struct {
+		name               string
+		isOktetoRepository bool
+		expected           *UpMetricsMetadata
+	}{
+		{
+			name:               "is okteto repository",
+			isOktetoRepository: true,
+			expected: &UpMetricsMetadata{
+				isOktetoRepository: true,
+			},
+		},
+		{
+			name:               "is not okteto repository",
+			isOktetoRepository: false,
+			expected: &UpMetricsMetadata{
+				isOktetoRepository: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &UpMetricsMetadata{}
+			m.RepositoryProps(tt.isOktetoRepository)
+			assert.Equal(t, tt.expected, m)
+		})
+	}
+}
+
+func Test_UpMetricsMetadata_ReconnectDefault(t *testing.T) {
+	m := &UpMetricsMetadata{}
+	m.ReconnectDefault()
+	assert.Equal(t, &UpMetricsMetadata{
+		isReconnect:    true,
+		reconnectCause: "unrecognised",
+	}, m)
+}
+
+func Test_UpMetricsMetadata_ReconnectDevPodRecreated(t *testing.T) {
+	m := &UpMetricsMetadata{}
+	m.ReconnectDevPodRecreated()
+	assert.Equal(t, &UpMetricsMetadata{
+		isReconnect:    true,
+		reconnectCause: "dev-pod-recreated",
+	}, m)
+}
+
+func Test_UpMetricsMetadata_Errors(t *testing.T) {
+	m := &UpMetricsMetadata{}
+	m.ErrSync()
+	m.ErrResetDatabase()
+	m.FailActivate()
+	assert.Equal(t, &UpMetricsMetadata{
+		errSync:          true,
+		errResetDatabase: true,
+		failActivate:     true,
+	}, m)
+}
+
+func Test_UpMetricsMetadata_CommandSuccess(t *testing.T) {
+	m := &UpMetricsMetadata{}
+	m.CommandSuccess()
+	assert.Equal(t, &UpMetricsMetadata{
+		success: true,
+	}, m)
+}
+
+func Test_UpTracker(t *testing.T) {
+	tests := []struct {
+		name     string
+		meta     UpMetricsMetadata
+		expected mockEvent
+	}{
+		{
+			name: "empty event",
+			meta: UpMetricsMetadata{},
+			expected: mockEvent{
+				event:   "Up",
+				success: false,
+				props: map[string]interface{}{
+					"activateDurationSeconds":    float64(0),
+					"errResetDatabase":           false,
+					"errSync":                    false,
+					"failActivate":               false,
+					"hasBuildSection":            false,
+					"hasDependenciesSection":     false,
+					"hasDeploySection":           false,
+					"hasReverse":                 false,
+					"initialSyncDurationSeconds": float64(0),
+					"isInteractive":              false,
+					"isOktetoRepository":         false,
+					"isReconnect":                false,
+					"isV2":                       false,
+					"manifestType":               model.Archetype(""),
+					"mode":                       "",
+					"reconnectCause":             "",
+				},
+			},
+		},
+		{
+			name: "command success empty event",
+			meta: UpMetricsMetadata{
+				success: true,
+			},
+			expected: mockEvent{
+				event:   "Up",
+				success: true,
+				props: map[string]interface{}{
+					"activateDurationSeconds":    float64(0),
+					"errResetDatabase":           false,
+					"errSync":                    false,
+					"failActivate":               false,
+					"hasBuildSection":            false,
+					"hasDependenciesSection":     false,
+					"hasDeploySection":           false,
+					"hasReverse":                 false,
+					"initialSyncDurationSeconds": float64(0),
+					"isInteractive":              false,
+					"isOktetoRepository":         false,
+					"isReconnect":                false,
+					"isV2":                       false,
+					"manifestType":               model.Archetype(""),
+					"mode":                       "",
+					"reconnectCause":             "",
+				},
+			},
+		},
+		{
+			name: "command success all fields",
+			meta: UpMetricsMetadata{
+				isV2:                   true,
+				manifestType:           model.OktetoManifestType,
+				isInteractive:          true,
+				isOktetoRepository:     true,
+				hasDependenciesSection: true,
+				hasBuildSection:        true,
+				hasDeploySection:       true,
+				hasReverse:             true,
+				isHybridDev:            true,
+				mode:                   "sync",
+				activateDuration:       1 * time.Minute,
+				initialSyncDuration:    1 * time.Minute,
+				success:                true,
+			},
+			expected: mockEvent{
+				event:   "Up",
+				success: true,
+				props: map[string]interface{}{
+					"activateDurationSeconds":    float64(60),
+					"errResetDatabase":           false,
+					"errSync":                    false,
+					"failActivate":               false,
+					"hasBuildSection":            true,
+					"hasDependenciesSection":     true,
+					"hasDeploySection":           true,
+					"hasReverse":                 true,
+					"initialSyncDurationSeconds": float64(60),
+					"isInteractive":              true,
+					"isOktetoRepository":         true,
+					"isReconnect":                false,
+					"isV2":                       true,
+					"manifestType":               model.Archetype("manifest"),
+					"mode":                       "sync",
+					"reconnectCause":             "",
+				},
+			},
+		},
+		{
+			name: "command not success with errors",
+			meta: UpMetricsMetadata{
+				isV2:                   true,
+				manifestType:           model.OktetoManifestType,
+				isInteractive:          true,
+				isOktetoRepository:     true,
+				hasDependenciesSection: true,
+				hasBuildSection:        true,
+				hasDeploySection:       true,
+				hasReverse:             true,
+				isHybridDev:            true,
+				mode:                   "sync",
+				activateDuration:       1 * time.Minute,
+				initialSyncDuration:    1 * time.Minute,
+				success:                false,
+				errSync:                true,
+				errResetDatabase:       true,
+				failActivate:           true,
+			},
+			expected: mockEvent{
+				event:   "Up",
+				success: false,
+				props: map[string]interface{}{
+					"activateDurationSeconds":    float64(60),
+					"errResetDatabase":           true,
+					"errSync":                    true,
+					"failActivate":               true,
+					"hasBuildSection":            true,
+					"hasDependenciesSection":     true,
+					"hasDeploySection":           true,
+					"hasReverse":                 true,
+					"initialSyncDurationSeconds": float64(60),
+					"isInteractive":              true,
+					"isOktetoRepository":         true,
+					"isReconnect":                false,
+					"isV2":                       true,
+					"manifestType":               model.Archetype("manifest"),
+					"mode":                       "sync",
+					"reconnectCause":             "",
+				},
+			},
+		},
+		{
+			name: "command success all fields with reconnect",
+			meta: UpMetricsMetadata{
+				isV2:                   true,
+				manifestType:           model.OktetoManifestType,
+				isInteractive:          true,
+				isOktetoRepository:     true,
+				hasDependenciesSection: true,
+				hasBuildSection:        true,
+				hasDeploySection:       true,
+				hasReverse:             true,
+				isHybridDev:            true,
+				mode:                   "sync",
+				activateDuration:       1 * time.Minute,
+				initialSyncDuration:    1 * time.Minute,
+				success:                true,
+				isReconnect:            true,
+				reconnectCause:         reconnectCauseDefault,
+			},
+			expected: mockEvent{
+				event:   "Up",
+				success: true,
+				props: map[string]interface{}{
+					"activateDurationSeconds":    float64(60),
+					"errResetDatabase":           false,
+					"errSync":                    false,
+					"failActivate":               false,
+					"hasBuildSection":            true,
+					"hasDependenciesSection":     true,
+					"hasDeploySection":           true,
+					"hasReverse":                 true,
+					"initialSyncDurationSeconds": float64(60),
+					"isInteractive":              true,
+					"isOktetoRepository":         true,
+					"isReconnect":                true,
+					"isV2":                       true,
+					"manifestType":               model.Archetype("manifest"),
+					"mode":                       "sync",
+					"reconnectCause":             "unrecognised",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventMeta := &mockEvent{}
+			tracker := AnalyticsTracker{
+				trackFn: func(event string, success bool, props map[string]interface{}) {
+					eventMeta = &mockEvent{
+						event:   event,
+						success: success,
+						props:   props,
+					}
+				},
+			}
+
+			tracker.TrackUp(&tt.meta)
+			assert.Equal(t, tt.expected.event, eventMeta.event)
+			assert.Equal(t, tt.expected.success, eventMeta.success)
+			assert.Equal(t, tt.expected.props, eventMeta.props)
+		})
+
+	}
+}

--- a/pkg/syncthing/completion.go
+++ b/pkg/syncthing/completion.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/okteto/okteto/pkg/analytics"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
@@ -77,7 +76,6 @@ func (s *Syncthing) WaitForCompletion(ctx context.Context, reporter chan float64
 			reporter <- wfc.progress
 
 			if wfc.needsDatabaseReset() {
-				analytics.TrackResetDatabase(true)
 				return oktetoErrors.ErrNeedsResetSyncError
 			}
 


### PR DESCRIPTION
# Proposed changes

Partially Fixes #3644 

This PR changes the way we send the `Up` event to our mixpanel platform. Currently we triggered an event during the run of the `up` command, instead of wrapping up the metadata and sending all when the command ends.

This PR tracks metadata and sends the event at the end, either its been successful or not. 
Note that `success` property was always sent `false` since `1.13.11` with this change the meaning of `success` is fixed, so only when there has been an error it will be `false`.

The events that where tracking conditions on the running command are now props, so this can be measured within the event triggered.

Changes:

- Remove all `up` event functions and const to its own file `up.go` under `analytics` pkg
- `TrackUp` is triggered when the command stops, either because an error or because its success. Also a panic in the code will trigger the event to be sent.
- Created `UpMetadata` methods to keep adding the information into the struct

Events that are now props inside the `Up` event
  - `Up Error` event is now prop `failActivate`
  - `Up Duration Time` event is now prop `activateDurationSeconds` and its tracked in seconds, currently it was being sent as a timestamp of duration which was not possible to interpret at mixpanel
  - `Initial Sync Duration Time `event is now prop `initialSyncDurationSeconds`, also tracked in seconds, same as previous it was sent as timestamp
  - `Sync Error` event is now prop `errSync`
  - `Sync Reset Database` event is now prop `errResetDatabase`
  - `Reconnect` event is now prop `isReconnect` and `reconnectCause` with a string of the cause


### Tests

After changes, compiled the binary and running the command up. With the version tag of the build, check at mixpanel the event and props where getting correctly.
- Force a panic , event is sent success false
- Force exit with error, event is sent success false
- Exit normally, event is send success true

### Mixpanel update

Take in mind that this change is reflected with newer versions of CLI when this is released. Any dashboard using the Up event and others should be updated