### PR TITLE
fix panic when displayer has no cancel function

### DIFF
--- a/cmd/utils/displayer/json.go
+++ b/cmd/utils/displayer/json.go
@@ -43,14 +43,17 @@ func newJSONDisplayer(stdout, stderr io.Reader) *jsonDisplayer {
 		stderrScanner = bufio.NewScanner(stderr)
 	}
 
+	commandContext, cancel := context.WithCancel(context.Background())
+
 	return &jsonDisplayer{
-		stdoutScanner: stdoutScanner,
-		stderrScanner: stderrScanner,
+		stdoutScanner:  stdoutScanner,
+		stderrScanner:  stderrScanner,
+		commandContext: commandContext,
+		cancel:         cancel,
 	}
 }
 
 func (d *jsonDisplayer) Display(_ string) {
-	d.commandContext, d.cancel = context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	wgDelta := 0
 	if d.stdoutScanner != nil {

--- a/cmd/utils/displayer/plain.go
+++ b/cmd/utils/displayer/plain.go
@@ -43,14 +43,17 @@ func newPlainDisplayer(stdout, stderr io.Reader) *plainDisplayer {
 		stderrScanner = bufio.NewScanner(stderr)
 	}
 
+	commandContext, cancel := context.WithCancel(context.Background())
+
 	return &plainDisplayer{
-		stdoutScanner: stdoutScanner,
-		stderrScanner: stderrScanner,
+		stdoutScanner:  stdoutScanner,
+		stderrScanner:  stderrScanner,
+		commandContext: commandContext,
+		cancel:         cancel,
 	}
 }
 
 func (d *plainDisplayer) Display(_ string) {
-	d.commandContext, d.cancel = context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	wgDelta := 0
 	if d.stdoutScanner != nil {

--- a/cmd/utils/displayer/tty.go
+++ b/cmd/utils/displayer/tty.go
@@ -47,17 +47,20 @@ func newTTYDisplayer(stdout, stderr io.Reader) *ttyDisplayer {
 		stderrScanner = bufio.NewScanner(stderr)
 	}
 
+	commandContext, cancel := context.WithCancel(context.Background())
+
 	return &ttyDisplayer{
-		stdoutScanner: stdoutScanner,
-		stderrScanner: stderrScanner,
-		screenbuf:     screenbuf.New(os.Stdout),
+		stdoutScanner:  stdoutScanner,
+		stderrScanner:  stderrScanner,
+		screenbuf:      screenbuf.New(os.Stdout),
+		commandContext: commandContext,
+		cancel:         cancel,
 
 		linesToDisplay: []string{},
 	}
 }
 
 func (d *ttyDisplayer) Display(_ string) {
-	d.commandContext, d.cancel = context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	wgDelta := 0
 	if d.stdoutScanner != nil {

--- a/cmd/utils/executor/executor.go
+++ b/cmd/utils/executor/executor.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -86,6 +87,11 @@ func (e *Executor) Execute(cmdInfo model.DeployCommand, env []string) error {
 	}
 
 	if err := e.displayer.startCommand(cmd); err != nil {
+		if execErr, ok := err.(*exec.Error); ok {
+			if execErr != nil && execErr.Name == e.shell {
+				return fmt.Errorf("%w: \"%s\" is a required dependency for executing the command", err, e.shell)
+			}
+		}
 		return err
 	}
 


### PR DESCRIPTION
# Proposed changes

- declare cancel function before start command to avoid panics 2819e5a486cf125f6ca6ad0441dc65a701ecd170
- add message about required shells bd10752562fcb85ec3fd8c3654c302428aae89a9

Fixes #3854 

## How looks like

`okteto deploy --no-bash`

| Before | After |
|----------|----------|
| <img width="1011" alt="Captura de Pantalla 2023-08-07 a las 13 35 04" src="https://github.com/okteto/okteto/assets/22500940/7240f5d0-d484-4309-b689-75a4d724a6db">| <img width="827" alt="Captura de Pantalla 2023-08-07 a las 13 34 12" src="https://github.com/okteto/okteto/assets/22500940/382ef43d-9cfd-45dc-8496-18e7ac75206c">|

`okteto deploy`

| Before | After |
|----------|----------|
|![Captura de Pantalla 2023-08-07 a las 13 45 30](https://github.com/okteto/okteto/assets/22500940/542330ca-df5f-49ad-a35e-76f6fc2ef560)| ![Captura de Pantalla 2023-08-07 a las 13 44 12](https://github.com/okteto/okteto/assets/22500940/7375b800-9e2a-496e-a55a-ef8d37d5679e)|

to be able to repro the last case I've tested it over Powershell so the output format is not so friendly but the case is covered by the message ` "bash": executable file not found in <ugly format (ignore it)> "bash" is a required dependency for executing the command`
