### PR TITLE
Add support for deleting multiple context

### DIFF
--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -30,9 +30,8 @@ func DeleteCMD() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Args:  utils.MinimumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#delete"),
-		Short: "Delete multiple contexts",
+		Short: "Delete one or more contexts",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			analytics.TrackDeleteMultipleContexts(len(args))
 			for _, arg := range args {
 				arg = okteto.AddSchema(arg)
 				arg = strings.TrimSuffix(arg, "/")
@@ -40,6 +39,7 @@ func DeleteCMD() *cobra.Command {
 					return err
 				}
 			}
+			analytics.TrackContextDelete(len(args))
 			return nil
 		},
 	}

--- a/cmd/context/delete_test.go
+++ b/cmd/context/delete_test.go
@@ -28,19 +28,32 @@ func Test_deleteContext(t *testing.T) {
 	var tests = []struct {
 		name         string
 		ctxStore     *okteto.OktetoContextStore
-		toDelete     string
+		toDelete     []string
 		afterContext string
 		expectedErr  bool
 	}{
 		{
-			name: "deleting existing context",
+			name: "deleting one existing context",
 			ctxStore: &okteto.OktetoContextStore{
 				CurrentContext: "test",
 				Contexts: map[string]*okteto.OktetoContext{
 					"test": {},
 				},
 			},
-			toDelete:     "test",
+			toDelete:     []string{"test"},
+			afterContext: "",
+			expectedErr:  false,
+		},
+		{
+			name: "deleting more than one existing context",
+			ctxStore: &okteto.OktetoContextStore{
+				CurrentContext: "test1",
+				Contexts: map[string]*okteto.OktetoContext{
+					"test1": {},
+					"test2": {},
+				},
+			},
+			toDelete:     []string{"test1", "test2"},
 			afterContext: "",
 			expectedErr:  false,
 		},
@@ -52,8 +65,20 @@ func Test_deleteContext(t *testing.T) {
 					"test": {},
 				},
 			},
-			toDelete:     "non-existing-test",
+			toDelete:     []string{"non-existing-test"},
 			afterContext: "test",
+			expectedErr:  true,
+		},
+		{
+			name: "deleting one existing and one non existing context",
+			ctxStore: &okteto.OktetoContextStore{
+				CurrentContext: "test",
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {},
+				},
+			},
+			toDelete:     []string{"test", "non-existing-test"},
+			afterContext: "",
 			expectedErr:  true,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/creack/pty v1.1.18 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/docker-credential-helpers v0.6.4
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
@@ -113,7 +114,7 @@ require (
 	github.com/gofrs/flock v0.8.0 // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4-0.20210608040537-544b4180ac70 // indirect
@@ -149,7 +150,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/miekg/pkcs11 v1.0.3 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -224,9 +225,12 @@ require (
 )
 
 require (
+	github.com/hashicorp/go-multierror v1.1.1
 	istio.io/api v0.0.0-20221013011440-bc935762d2b9
 	istio.io/client-go v1.15.3
 )
+
+require github.com/hashicorp/errwrap v1.0.0 // indirect
 
 replace (
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -666,6 +666,7 @@ github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO0
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -681,6 +682,7 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -290,7 +290,7 @@ func TrackBuildPullError(oktetoBuilkitURL string, success bool) {
 // TrackContextDelete sends a tracking event to mixpanel indicating one or more context have been deleted
 func TrackContextDelete(ctxs int) {
 	props := map[string]interface{}{
-		"hasMoreThanOneContext": ctxs,
+		"totalContextsDeleted": ctxs,
 	}
 	track(deleteContexts, true, props)
 }

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -62,6 +62,7 @@ const (
 	disableEvent             = "Disable Analytics"
 	stackNotSupportedField   = "Stack Field Not Supported"
 	buildPullErrorEvent      = "BuildPullError"
+	deleteMultipleContexts   = "Delete Multiple Contexts"
 )
 
 var (
@@ -284,6 +285,14 @@ func TrackBuildPullError(oktetoBuilkitURL string, success bool) {
 		"oktetoBuilkitURL": oktetoBuilkitURL,
 	}
 	track(buildPullErrorEvent, success, props)
+}
+
+// TrackDeleteMultipleContexts sends a tracking event to mixpanel indicating whether more than one context is deleted
+func TrackDeleteMultipleContexts(ctxs int) {
+	props := map[string]interface{}{
+		"hasMoreThanOneContext": ctxs > 1,
+	}
+	track(deleteMultipleContexts, true, props)
 }
 
 func track(event string, success bool, props map[string]interface{}) {

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -288,11 +288,11 @@ func TrackBuildPullError(oktetoBuilkitURL string, success bool) {
 }
 
 // TrackContextDelete sends a tracking event to mixpanel indicating one or more context have been deleted
-func TrackContextDelete(ctxs int) {
+func TrackContextDelete(ctxs int, success bool) {
 	props := map[string]interface{}{
 		"totalContextsDeleted": ctxs,
 	}
-	track(deleteContexts, true, props)
+	track(deleteContexts, success, props)
 }
 
 func track(event string, success bool, props map[string]interface{}) {

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -287,12 +287,12 @@ func TrackBuildPullError(oktetoBuilkitURL string, success bool) {
 	track(buildPullErrorEvent, success, props)
 }
 
-// TrackContextDelete sends a tracking event to mixpanel indicating whether more than one context is deleted
+// TrackContextDelete sends a tracking event to mixpanel indicating one or more context have been deleted
 func TrackContextDelete(ctxs int) {
 	props := map[string]interface{}{
-		"hasMoreThanOneContext": ctxs > 1,
+		"hasMoreThanOneContext": ctxs,
 	}
-	track(deleteMultipleContexts, true, props)
+	track(deleteContexts, true, props)
 }
 
 func track(event string, success bool, props map[string]interface{}) {

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -62,7 +62,7 @@ const (
 	disableEvent             = "Disable Analytics"
 	stackNotSupportedField   = "Stack Field Not Supported"
 	buildPullErrorEvent      = "BuildPullError"
-	deleteMultipleContexts   = "Delete Multiple Contexts"
+	deleteContexts           = "Contexts Deletion"
 )
 
 var (
@@ -287,8 +287,8 @@ func TrackBuildPullError(oktetoBuilkitURL string, success bool) {
 	track(buildPullErrorEvent, success, props)
 }
 
-// TrackDeleteMultipleContexts sends a tracking event to mixpanel indicating whether more than one context is deleted
-func TrackDeleteMultipleContexts(ctxs int) {
+// TrackContextDelete sends a tracking event to mixpanel indicating whether more than one context is deleted
+func TrackContextDelete(ctxs int) {
 	props := map[string]interface{}{
 		"hasMoreThanOneContext": ctxs > 1,
 	}


### PR DESCRIPTION
# Proposed changes

Fixes #3857  (issue)

Support deletion of multiple context and adding analytic for tracking if more than context is deleted using the command.

## Changes
* Adding for loop in `DeleteCmd` to loop through all `args` and move existing logic inside
* Add `TrackDeleteMultipleContexts` in `track.go` to track if more than one context is deleted
