### PR TITLE
Add exec to kubeconfig when okteto context init

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ jobs:
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
             go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
             go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
       - run:
@@ -253,6 +254,7 @@ jobs:
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
       - run:
           name: Run up integration tests
@@ -262,6 +264,7 @@ jobs:
             - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
             go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
       - store_artifacts:
           path: C:\Users\circleci\.okteto

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -100,15 +100,10 @@ func updateCfgAuthInfoWithExec(okCtx *okteto.OktetoContext) {
 		okCtx.Cfg.AuthInfos[okCtx.UserID].Token = ""
 	}
 
-	okCtx.Cfg.AuthInfos[okCtx.UserID].Exec = getExecConfigForContextAndNamespace(okCtx.Name, okCtx.Namespace)
-}
-
-// getExecConfigForContextAndNamespace returns ExecConfig with kubetoken command including namespace and context flags
-func getExecConfigForContextAndNamespace(context, namespace string) *clientcmdapi.ExecConfig {
-	return &clientcmdapi.ExecConfig{
+	okCtx.Cfg.AuthInfos[okCtx.UserID].Exec = &clientcmdapi.ExecConfig{
 		APIVersion:         "client.authentication.k8s.io/v1",
 		Command:            "okteto",
-		Args:               []string{"kubetoken", "--context", context, "--namespace", namespace},
+		Args:               []string{"kubetoken", "--context", okCtx.Name, "--namespace", okCtx.Namespace},
 		InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
 		InteractiveMode:    "Never",
 		ProvideClusterInfo: true,

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -26,16 +26,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-var (
-	oktetoExecConfig = &clientcmdapi.ExecConfig{
-		APIVersion:      "client.authentication.k8s.io/v1",
-		Command:         "okteto",
-		Args:            []string{"kubetoken"},
-		InstallHint:     "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
-		InteractiveMode: "IfAvailable",
-	}
-)
-
 // UpdateKubeconfigCMD all contexts managed by okteto
 func UpdateKubeconfigCMD() *cobra.Command {
 	cmd := &cobra.Command{
@@ -106,5 +96,17 @@ func updateUserAuthInfoWithExec(okCtx *okteto.OktetoContext, userID string) {
 		okCtx.Cfg.AuthInfos[userID].Token = ""
 	}
 
-	okCtx.Cfg.AuthInfos[userID].Exec = oktetoExecConfig
+	okCtx.Cfg.AuthInfos[userID].Exec = getExecConfigForContextAndNamespace(okCtx.Name, okCtx.Namespace)
+}
+
+// getExecConfigForContextAndNamespace returns ExecConfig with kubetoken command including namespace and context flags
+func getExecConfigForContextAndNamespace(context, namespace string) *clientcmdapi.ExecConfig {
+	return &clientcmdapi.ExecConfig{
+		APIVersion:         "client.authentication.k8s.io/v1",
+		Command:            "okteto",
+		Args:               []string{"kubetoken", "--context", context, "--namespace", namespace},
+		InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
+		InteractiveMode:    "Never",
+		ProvideClusterInfo: true,
+	}
 }

--- a/cmd/context/update-kubeconfig_test.go
+++ b/cmd/context/update-kubeconfig_test.go
@@ -113,7 +113,7 @@ func Test_ExecuteUpdateKubeconfig(t *testing.T) {
 			okContext := okteto.Context()
 			kubeconfigPaths := []string{file}
 
-			err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths)
+			err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, false)
 			assert.NoError(t, err, "error writing kubeconfig")
 
 			cfg := kubeconfig.Get(kubeconfigPaths)

--- a/cmd/context/update-kubeconfig_test.go
+++ b/cmd/context/update-kubeconfig_test.go
@@ -18,18 +18,21 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/internal/test"
+	"github.com/okteto/okteto/internal/test/client"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-func Test_ExecuteUpdateKubeconfig(t *testing.T) {
+func Test_ExecuteUpdateKubeconfig_DisabledKubetoken(t *testing.T) {
 
 	var tests = []struct {
-		name          string
-		kubeconfigCtx test.KubeconfigFields
-		context       *okteto.OktetoContextStore
+		name             string
+		kubeconfigCtx    test.KubeconfigFields
+		context          *okteto.OktetoContextStore
+		okClientProvider types.OktetoClientProvider
 	}{
 		{
 			name: "change current ctx",
@@ -54,6 +57,15 @@ func Test_ExecuteUpdateKubeconfig(t *testing.T) {
 					},
 				},
 			},
+			okClientProvider: client.NewFakeOktetoClientProvider(
+				&client.FakeOktetoClient{
+					KubetokenClient: client.NewFakeKubetokenClient(
+						client.FakeKubetokenResponse{
+							Err: assert.AnError,
+						},
+					),
+				},
+			),
 		},
 		{
 			name: "change current namespace",
@@ -78,6 +90,15 @@ func Test_ExecuteUpdateKubeconfig(t *testing.T) {
 					},
 				},
 			},
+			okClientProvider: client.NewFakeOktetoClientProvider(
+				&client.FakeOktetoClient{
+					KubetokenClient: client.NewFakeKubetokenClient(
+						client.FakeKubetokenResponse{
+							Err: assert.AnError,
+						},
+					),
+				},
+			),
 		},
 		{
 			name:          "create if it doesn't exist",
@@ -98,6 +119,15 @@ func Test_ExecuteUpdateKubeconfig(t *testing.T) {
 					},
 				},
 			},
+			okClientProvider: client.NewFakeOktetoClientProvider(
+				&client.FakeOktetoClient{
+					KubetokenClient: client.NewFakeKubetokenClient(
+						client.FakeKubetokenResponse{
+							Err: assert.AnError,
+						},
+					),
+				},
+			),
 		},
 	}
 
@@ -113,7 +143,7 @@ func Test_ExecuteUpdateKubeconfig(t *testing.T) {
 			okContext := okteto.Context()
 			kubeconfigPaths := []string{file}
 
-			err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, false)
+			err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, tt.okClientProvider)
 			assert.NoError(t, err, "error writing kubeconfig")
 
 			cfg := kubeconfig.Get(kubeconfigPaths)
@@ -121,6 +151,132 @@ func Test_ExecuteUpdateKubeconfig(t *testing.T) {
 			assert.Equal(t, tt.context.CurrentContext, cfg.CurrentContext, "current context has changed")
 			assert.Equal(t, tt.context.Contexts[tt.context.CurrentContext].Namespace, cfg.Contexts[tt.context.CurrentContext].Namespace, "namespace has changed")
 
+		})
+	}
+}
+
+func Test_ExecuteUpdateKubeconfig_EnabledKubetoken(t *testing.T) {
+
+	var tests = []struct {
+		name             string
+		kubeconfigCtx    test.KubeconfigFields
+		context          *okteto.OktetoContextStore
+		okClientProvider types.OktetoClientProvider
+	}{
+		{
+			name: "change current ctx",
+			kubeconfigCtx: test.KubeconfigFields{
+				Name:           []string{"test", "to-change"},
+				Namespace:      []string{"test", "test"},
+				CurrentContext: "test",
+			},
+			context: &okteto.OktetoContextStore{
+				CurrentContext: "to-change",
+				Contexts: map[string]*okteto.OktetoContext{
+					"to-change": {
+						Namespace: "test",
+						Cfg: &api.Config{
+							CurrentContext: "to-change",
+							Contexts: map[string]*api.Context{
+								"to-change": {
+									Namespace: "test",
+								},
+							},
+						},
+					},
+				},
+			},
+			okClientProvider: client.NewFakeOktetoClientProvider(
+				&client.FakeOktetoClient{
+					KubetokenClient: client.NewFakeKubetokenClient(
+						client.FakeKubetokenResponse{},
+					),
+				},
+			),
+		},
+		{
+			name: "change current namespace",
+			kubeconfigCtx: test.KubeconfigFields{
+				Name:           []string{"to-change"},
+				Namespace:      []string{"test"},
+				CurrentContext: "to-change",
+			},
+			context: &okteto.OktetoContextStore{
+				CurrentContext: "to-change",
+				Contexts: map[string]*okteto.OktetoContext{
+					"to-change": {
+						Namespace: "to-change",
+						Cfg: &api.Config{
+							CurrentContext: "to-change",
+							Contexts: map[string]*api.Context{
+								"to-change": {
+									Namespace: "to-change",
+								},
+							},
+						},
+					},
+				},
+			},
+			okClientProvider: client.NewFakeOktetoClientProvider(
+				&client.FakeOktetoClient{
+					KubetokenClient: client.NewFakeKubetokenClient(
+						client.FakeKubetokenResponse{},
+					),
+				},
+			),
+		},
+		{
+			name:          "create if it doesn't exist",
+			kubeconfigCtx: test.KubeconfigFields{},
+			context: &okteto.OktetoContextStore{
+				CurrentContext: "to-change",
+				Contexts: map[string]*okteto.OktetoContext{
+					"to-change": {
+						Namespace: "to-change",
+						Cfg: &api.Config{
+							CurrentContext: "to-change",
+							Contexts: map[string]*api.Context{
+								"to-change": {
+									Namespace: "to-change",
+								},
+							},
+						},
+					},
+				},
+			},
+			okClientProvider: client.NewFakeOktetoClientProvider(
+				&client.FakeOktetoClient{
+					KubetokenClient: client.NewFakeKubetokenClient(
+						client.FakeKubetokenResponse{},
+					),
+				},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			okteto.CurrentStore = tt.context
+			file, err := test.CreateKubeconfig(tt.kubeconfigCtx)
+			if err != nil {
+				assert.NoError(t, err, "error creating temporal kubeconfig")
+			}
+			defer os.Remove(file)
+
+			okContext := okteto.Context()
+			kubeconfigPaths := []string{file}
+
+			err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, tt.okClientProvider)
+			assert.NoError(t, err, "error writing kubeconfig")
+
+			cfg := kubeconfig.Get(kubeconfigPaths)
+			assert.NotNil(t, cfg, "kubeconfig is nil")
+			assert.Equal(t, tt.context.CurrentContext, cfg.CurrentContext, "current context has changed")
+			assert.Equal(t, tt.context.Contexts[tt.context.CurrentContext].Namespace, cfg.Contexts[tt.context.CurrentContext].Namespace, "namespace has changed")
+			assert.NotNil(t, cfg.AuthInfos)
+			assert.Len(t, cfg.AuthInfos, 1)
+			assert.NotNil(t, cfg.AuthInfos[""].Exec)
+			assert.Empty(t, cfg.AuthInfos[""].Token)
 		})
 	}
 }

--- a/cmd/context/update-kubeconfig_test.go
+++ b/cmd/context/update-kubeconfig_test.go
@@ -119,7 +119,7 @@ func Test_ExecuteUpdateKubeconfig(t *testing.T) {
 			cfg := kubeconfig.Get(kubeconfigPaths)
 			assert.NotNil(t, cfg, "kubeconfig is nil")
 			assert.Equal(t, tt.context.CurrentContext, cfg.CurrentContext, "current context has changed")
-			assert.Equal(t, tt.context.Contexts[tt.context.CurrentContext].Namespace, cfg.Contexts[tt.context.CurrentContext].Namespace, "namesapce has changed")
+			assert.Equal(t, tt.context.Contexts[tt.context.CurrentContext].Namespace, cfg.Contexts[tt.context.CurrentContext].Namespace, "namespace has changed")
 
 		})
 	}

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -26,12 +26,7 @@ func Kubeconfig() *cobra.Command {
 		Short: "Download credentials for the Kubernetes cluster selected via 'okteto context'",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			err := contextCMD.UpdateKubeconfigCMD().RunE(cmd, args)
-			if err != nil {
-				return err
-			}
-			return err
+			return contextCMD.UpdateKubeconfigCMD().RunE(cmd, args)
 		},
 	}
 	return cmd

--- a/integration/actions/apply_test.go
+++ b/integration/actions/apply_test.go
@@ -79,11 +79,11 @@ func TestApplyPipeline(t *testing.T) {
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, ""))
-	assert.NoError(t, executeApply(namespace, oktetoPath))
+	assert.NoError(t, executeApply(namespace))
 	assert.NoError(t, executeDeleteNamespaceAction(namespace))
 }
 
-func executeApply(namespace, oktetoPath string) error {
+func executeApply(namespace string) error {
 	dir, err := os.MkdirTemp("", namespace)
 	if err != nil {
 		return err
@@ -117,8 +117,8 @@ func executeApply(namespace, oktetoPath string) error {
 	if _, err := os.Stat(kubepath); err != nil {
 		log.Printf("could not get kubepath: %s", err)
 	}
+	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kubepath))
-	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s:%s", os.Getenv("PATH"), oktetoPath))
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s %s: %s", command, strings.Join(args, " "), string(o))

--- a/integration/actions/apply_test.go
+++ b/integration/actions/apply_test.go
@@ -79,12 +79,11 @@ func TestApplyPipeline(t *testing.T) {
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, ""))
-	assert.NoError(t, executeApply(namespace))
+	assert.NoError(t, executeApply(namespace, oktetoPath))
 	assert.NoError(t, executeDeleteNamespaceAction(namespace))
 }
 
-func executeApply(namespace string) error {
-
+func executeApply(namespace, oktetoPath string) error {
 	dir, err := os.MkdirTemp("", namespace)
 	if err != nil {
 		return err
@@ -119,6 +118,7 @@ func executeApply(namespace string) error {
 		log.Printf("could not get kubepath: %s", err)
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", kubepath))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s:%s", os.Getenv("PATH"), oktetoPath))
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s %s: %s", command, strings.Join(args, " "), string(o))

--- a/integration/actions/push_test.go
+++ b/integration/actions/push_test.go
@@ -47,7 +47,7 @@ func TestPushAction(t *testing.T) {
 
 	require.NoError(t, executeCreateNamespaceAction(namespace))
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, ""))
-	require.NoError(t, executeApply(namespace, oktetoPath))
+	require.NoError(t, executeApply(namespace))
 	require.NoError(t, executePushAction(t, namespace))
 	require.NoError(t, executeDeleteNamespaceAction(namespace))
 }

--- a/integration/actions/push_test.go
+++ b/integration/actions/push_test.go
@@ -47,7 +47,7 @@ func TestPushAction(t *testing.T) {
 
 	require.NoError(t, executeCreateNamespaceAction(namespace))
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, ""))
-	require.NoError(t, executeApply(namespace))
+	require.NoError(t, executeApply(namespace, oktetoPath))
 	require.NoError(t, executePushAction(t, namespace))
 	require.NoError(t, executeDeleteNamespaceAction(namespace))
 }

--- a/integration/kubeconfig/kubeconfig_test.go
+++ b/integration/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,33 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/okteto/okteto/integration"
+	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_KubeconfigHasExec kubeconfig command should use exec instead of token for the user auth
+func Test_KubeconfigHasExec(t *testing.T) {
+	t.Parallel()
+
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	home := t.TempDir()
+
+	err = commands.RunOktetoKubeconfig(oktetoPath, home)
+	require.NoError(t, err)
+
+	cfg := kubeconfig.Get([]string{filepath.Join(home, ".kube", "config")})
+	require.Len(t, cfg.AuthInfos, 1)
+
+	for _, v := range cfg.AuthInfos {
+		require.NotNil(t, v)
+		require.Empty(t, v.Token)
+		require.NotNil(t, v.Exec)
+	}
+}

--- a/integration/kubeconfig/kubeconfig_test.go
+++ b/integration/kubeconfig/kubeconfig_test.go
@@ -1,3 +1,18 @@
+//go:build integration
+// +build integration
+
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package kubeconfig
 
 import (

--- a/internal/test/client/kubetoken.go
+++ b/internal/test/client/kubetoken.go
@@ -13,6 +13,8 @@
 
 package client
 
+import "github.com/okteto/okteto/pkg/types"
+
 // FakeKubetokenClient mocks the kubetoken client interface
 type FakeKubetokenClient struct {
 	response FakeKubetokenResponse
@@ -20,7 +22,7 @@ type FakeKubetokenClient struct {
 
 // FakeKubetokenResponse mocks the kubetoken response
 type FakeKubetokenResponse struct {
-	Token string
+	Token types.KubeTokenResponse
 	Err   error
 }
 
@@ -32,6 +34,6 @@ func NewFakeKubetokenClient(response FakeKubetokenResponse) *FakeKubetokenClient
 }
 
 // GetKubeToken returns a temp token
-func (c *FakeKubetokenClient) GetKubeToken(_, _ string) (string, error) {
+func (c *FakeKubetokenClient) GetKubeToken(_, _ string) (types.KubeTokenResponse, error) {
 	return c.response.Token, c.response.Err
 }

--- a/internal/test/client/kubetoken.go
+++ b/internal/test/client/kubetoken.go
@@ -37,3 +37,8 @@ func NewFakeKubetokenClient(response FakeKubetokenResponse) *FakeKubetokenClient
 func (c *FakeKubetokenClient) GetKubeToken(_, _ string) (types.KubeTokenResponse, error) {
 	return c.response.Token, c.response.Err
 }
+
+// CheckService returns a temp token
+func (c *FakeKubetokenClient) CheckService(_, _ string) error {
+	return c.response.Err
+}


### PR DESCRIPTION
# Proposed changes

Resolves https://github.com/okteto/app/issues/6907

Changes to include the kubetoken auth plugin instead of token.

- Refactor at `kubeconfig` cmd
- Refactor `ExecuteUpdateKubeconfig` at `update-kubeconfig` injecting the context and the kubeconfig paths from `RunE` function
- Request to kubetoken CheckService in order to use Token or Exec. If service is available, Exec is used.


## Testing
- included integration test to check running `okteto kubeconfig` sets the correct auth info into the kubeconfig file
- manual testing, removing both okteto and kube context files, running `okteto kubeconfig` initialized the okteto context and includes the auth exec command into the kubeconfig file
- used helm and kubectl with the okteto context normally
