### PR TITLE
Wrap kubetoken client into OktetoClient

### DIFF
--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -27,12 +27,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type KubeTokenSerializer struct {
+type Serializer struct {
 	KubeToken types.KubeTokenResponse
 }
 
-func (k *KubeTokenSerializer) ToJson() (string, error) {
-	bytes, err := json.MarshalIndent(k.KubeToken, "", "  ")
+func (k *Serializer) ToJson() (string, error) {
+	bytes, err := json.MarshalIndent(k, "", "  ")
 	if err != nil {
 		return "", err
 	}
@@ -77,8 +77,8 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return fmt.Errorf("failed to get the kubetoken: %w", err)
 		}
 
-		serializer := &KubeTokenSerializer{
-			KubeToken: *out,
+		serializer := &Serializer{
+			KubeToken: out,
 		}
 
 		jsonStr, err := serializer.ToJson()

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -53,12 +53,12 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return errors.ErrContextIsNotOktetoCluster
 		}
 
-		c, err := okteto.NewKubeTokenClient(octx.Name, octx.Token, octx.Namespace)
+		c, err := okteto.NewOktetoClient()
 		if err != nil {
 			return fmt.Errorf("failed to initialize the kubetoken client: %w", err)
 		}
 
-		out, err := c.GetKubeToken()
+		out, err := c.Kubetoken().GetKubeToken(octx.Name, octx.Namespace)
 		if err != nil {
 			return fmt.Errorf("failed to get the kubetoken: %w", err)
 		}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -15,7 +15,9 @@ package kubetoken
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/okteto/okteto/pkg/types"
 	"os"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
@@ -24,6 +26,18 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
+
+type KubeTokenSerializer struct {
+	KubeToken types.KubeTokenResponse
+}
+
+func (k *KubeTokenSerializer) ToJson() (string, error) {
+	bytes, err := json.MarshalIndent(k.KubeToken, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
 
 func KubeToken() *cobra.Command {
 	cmd := &cobra.Command{
@@ -63,12 +77,16 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return fmt.Errorf("failed to get the kubetoken: %w", err)
 		}
 
-		json, err := out.ToJson()
+		serializer := &KubeTokenSerializer{
+			KubeToken: *out,
+		}
+
+		jsonStr, err := serializer.ToJson()
 		if err != nil {
 			return fmt.Errorf("failed to marshal KubeTokenResponse: %w", err)
 		}
 
-		cmd.Print(json)
+		cmd.Print(jsonStr)
 		return nil
 	}
 

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -63,7 +63,12 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return fmt.Errorf("failed to get the kubetoken: %w", err)
 		}
 
-		cmd.Print(out)
+		json, err := out.ToJson()
+		if err != nil {
+			return fmt.Errorf("failed to marshal KubeTokenResponse: %w", err)
+		}
+
+		cmd.Print(json)
 		return nil
 	}
 

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -32,7 +32,7 @@ type Serializer struct {
 }
 
 func (k *Serializer) ToJson() (string, error) {
-	bytes, err := json.MarshalIndent(k, "", "  ")
+	bytes, err := json.MarshalIndent(k.KubeToken, "", "  ")
 	if err != nil {
 		return "", err
 	}

--- a/internal/test/client/kubetoken.go
+++ b/internal/test/client/kubetoken.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// FakeKubetokenClient mocks the kubetoken client interface
+type FakeKubetokenClient struct {
+	response *FakeKubetokenResponse
+}
+
+// FakeKubetokenResponse mocks the kubetoken response
+type FakeKubetokenResponse struct {
+	Token string
+	Err   error
+}
+
+// NewFakeKubetokenClient returns a new fake kubetoken client
+func NewFakeKubetokenClient(response *FakeKubetokenResponse) *FakeKubetokenClient {
+	return &FakeKubetokenClient{
+		response: response,
+	}
+}
+
+// GetKubeToken returns a temp token
+func (c *FakeKubetokenClient) GetKubeToken(_, _ string) (string, error) {
+	return c.response.Token, c.response.Err
+}

--- a/internal/test/client/kubetoken.go
+++ b/internal/test/client/kubetoken.go
@@ -15,7 +15,7 @@ package client
 
 // FakeKubetokenClient mocks the kubetoken client interface
 type FakeKubetokenClient struct {
-	response *FakeKubetokenResponse
+	response FakeKubetokenResponse
 }
 
 // FakeKubetokenResponse mocks the kubetoken response
@@ -25,7 +25,7 @@ type FakeKubetokenResponse struct {
 }
 
 // NewFakeKubetokenClient returns a new fake kubetoken client
-func NewFakeKubetokenClient(response *FakeKubetokenResponse) *FakeKubetokenClient {
+func NewFakeKubetokenClient(response FakeKubetokenResponse) *FakeKubetokenClient {
 	return &FakeKubetokenClient{
 		response: response,
 	}

--- a/internal/test/client/okteto_client.go
+++ b/internal/test/client/okteto_client.go
@@ -33,11 +33,12 @@ func (p *FakeOktetoClientProvider) Provide() (types.OktetoInterface, error) {
 }
 
 type FakeOktetoClient struct {
-	Namespace      types.NamespaceInterface
-	Users          types.UserInterface
-	Preview        types.PreviewInterface
-	PipelineClient types.PipelineInterface
-	StreamClient   types.StreamInterface
+	Namespace       types.NamespaceInterface
+	Users           types.UserInterface
+	Preview         types.PreviewInterface
+	PipelineClient  types.PipelineInterface
+	StreamClient    types.StreamInterface
+	KubetokenClient types.KubetokenInterface
 }
 
 func NewFakeOktetoClient() *FakeOktetoClient {
@@ -67,4 +68,9 @@ func (c *FakeOktetoClient) Pipeline() types.PipelineInterface {
 // Stream retrieves the SSE client
 func (c *FakeOktetoClient) Stream() types.StreamInterface {
 	return c.StreamClient
+}
+
+// Kubetoken retrieves the Kubetoken client
+func (c *FakeOktetoClient) Kubetoken() types.KubetokenInterface {
+	return c.KubetokenClient
 }

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -43,6 +43,7 @@ type OktetoClient struct {
 	preview   types.PreviewInterface
 	pipeline  types.PipelineInterface
 	stream    types.StreamInterface
+	kubetoken types.KubetokenInterface
 }
 
 type OktetoClientProvider struct{}
@@ -200,6 +201,7 @@ func newOktetoClientFromGraphqlClient(url string, httpClient *http.Client) (*Okt
 	c.user = newUserClient(c.client)
 	c.pipeline = newPipelineClient(c.client, url)
 	c.stream = newStreamClient(httpClient)
+	c.kubetoken = newKubeTokenClient(httpClient)
 	return c, nil
 }
 
@@ -336,6 +338,11 @@ func (c *OktetoClient) User() types.UserInterface {
 // Stream retrieves the Stream client
 func (c *OktetoClient) Stream() types.StreamInterface {
 	return c.stream
+}
+
+// Kubetoken retrieves the Kubetoken client
+func (c *OktetoClient) Kubetoken() types.KubetokenInterface {
+	return c.kubetoken
 }
 
 func SetInsecureSkipTLSVerifyPolicy(isInsecure bool) {

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -14,50 +14,55 @@
 package okteto
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
-
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"net/url"
 )
 
-const kubetokenPath = "auth/kubetoken"
+const (
+	// kubetokenPathTemplate (baseURL, namespace)
+	kubetokenPathTemplate = "%s/auth/kubetoken/%s"
+)
 
-type KubeTokenClient struct {
-	httpClient  *http.Client
-	url         string
-	contextName string
+var (
+	errRequest      = errors.New("failed request")
+	errStatus       = errors.New("status error")
+	errUnauthorized = errors.New("unauthorized")
+)
+
+type kubeTokenClient struct {
+	httpClient *http.Client
 }
 
-func NewKubeTokenClient(contextName, token, namespace string) (*KubeTokenClient, error) {
-	if contextName == "" {
-		return nil, oktetoErrors.ErrCtxNotSet
+func newKubeTokenClient(httpClient *http.Client) *kubeTokenClient {
+	return &kubeTokenClient{
+		httpClient: httpClient,
 	}
-
-	httpClient, url, err := newOktetoHttpClient(contextName, token, fmt.Sprintf("%s/%s", kubetokenPath, namespace))
-	if err != nil {
-		return nil, err
-	}
-
-	return &KubeTokenClient{
-		httpClient:  httpClient,
-		url:         url,
-		contextName: contextName,
-	}, nil
 }
 
-func (c *KubeTokenClient) GetKubeToken() (string, error) {
-	resp, err := c.httpClient.Get(c.url)
+func getKubetokenURL(baseURL, namespace string) (*url.URL, error) {
+	return url.Parse(fmt.Sprintf(kubetokenPathTemplate, baseURL, namespace))
+}
+
+func (c *kubeTokenClient) GetKubeToken(baseURL, namespace string) (string, error) {
+	url, err := getKubetokenURL(baseURL, namespace)
 	if err != nil {
-		return "", fmt.Errorf("failed GET request: %w", err)
+		return "", err
+	}
+
+	resp, err := c.httpClient.Get(url.String())
+	if err != nil {
+		return "", fmt.Errorf("GetKubeToken %w: %w", errRequest, err)
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return "", fmt.Errorf(oktetoErrors.ErrNotLogged, c.contextName)
+		return "", fmt.Errorf("GetKubeToken %w", errUnauthorized)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("GET request returned status %s", resp.Status)
+		return "", fmt.Errorf("GetKubeToken %w: %s", errStatus, resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/pkg/okteto/kubetoken_client.go
+++ b/pkg/okteto/kubetoken_client.go
@@ -49,37 +49,37 @@ func getKubetokenURL(baseURL, namespace string) (*url.URL, error) {
 	return url.Parse(fmt.Sprintf(kubetokenPathTemplate, baseURL, namespace))
 }
 
-func (c *kubeTokenClient) GetKubeToken(baseURL, namespace string) (*types.KubeTokenResponse, error) {
+func (c *kubeTokenClient) GetKubeToken(baseURL, namespace string) (types.KubeTokenResponse, error) {
 	url, err := getKubetokenURL(baseURL, namespace)
 	if err != nil {
-		return nil, err
+		return types.KubeTokenResponse{}, err
 	}
 
 	resp, err := c.httpClient.Get(url.String())
 	if err != nil {
-		return nil, fmt.Errorf("GetKubeToken %w: %w", errRequest, err)
+		return types.KubeTokenResponse{}, fmt.Errorf("GetKubeToken %w: %w", errRequest, err)
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, fmt.Errorf("GetKubeToken %w", errUnauthorized)
+		return types.KubeTokenResponse{}, fmt.Errorf("GetKubeToken %w", errUnauthorized)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GetKubeToken %w: %s", errStatus, resp.Status)
+		return types.KubeTokenResponse{}, fmt.Errorf("GetKubeToken %w: %s", errStatus, resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read kubetoken response: %w", err)
+		return types.KubeTokenResponse{}, fmt.Errorf("failed to read kubetoken response: %w", err)
 	}
 
 	var kubeTokenResponse types.KubeTokenResponse
 	err = json.Unmarshal(body, &kubeTokenResponse)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal kubetoken response: %w", err)
+		return types.KubeTokenResponse{}, fmt.Errorf("failed to unmarshal kubetoken response: %w", err)
 	}
 
-	return &kubeTokenResponse, nil
+	return kubeTokenResponse, nil
 }
 
 func (c *kubeTokenClient) CheckService(baseURL, namespace string) error {

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -1,6 +1,7 @@
 package okteto
 
 import (
+	"encoding/json"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -42,8 +43,8 @@ func Test_GetKubeToken(t *testing.T) {
 						},
 					},
 				}
-				json, _ := mockResponse.ToJson()
-				w.Write([]byte(json))
+				jsonBytes, _ := json.Marshal(mockResponse)
+				w.Write(jsonBytes)
 			}),
 			expectedToken: "token",
 		},

--- a/pkg/okteto/kubetoken_client_test.go
+++ b/pkg/okteto/kubetoken_client_test.go
@@ -36,7 +36,7 @@ func Test_GetKubeToken(t *testing.T) {
 			name: "success response",
 			httpFakeHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				mockResponse := &types.KubeTokenResponse{
+				mockResponse := types.KubeTokenResponse{
 					TokenRequest: authenticationv1.TokenRequest{
 						Status: authenticationv1.TokenRequestStatus{
 							Token: "token",

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -83,4 +83,5 @@ type StreamInterface interface {
 // KubetokenInterface represents the kubetoken client
 type KubetokenInterface interface {
 	GetKubeToken(baseURL, namespace string) (*KubeTokenResponse, error)
+	CheckService(baseURL, namespace string) error
 }

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -82,6 +82,6 @@ type StreamInterface interface {
 
 // KubetokenInterface represents the kubetoken client
 type KubetokenInterface interface {
-	GetKubeToken(baseURL, namespace string) (*KubeTokenResponse, error)
+	GetKubeToken(baseURL, namespace string) (KubeTokenResponse, error)
 	CheckService(baseURL, namespace string) error
 }

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -27,6 +27,7 @@ type OktetoInterface interface {
 	Previews() PreviewInterface
 	Pipeline() PipelineInterface
 	Stream() StreamInterface
+	Kubetoken() KubetokenInterface
 }
 
 // UserInterface represents the client that connects to the user functions
@@ -77,4 +78,9 @@ type OktetoClientProvider interface {
 type StreamInterface interface {
 	PipelineLogs(ctx context.Context, name, namespace, actionName string) error
 	DestroyAllLogs(ctx context.Context, namespace string) error
+}
+
+// KubetokenInterface represents the kubetoken client
+type KubetokenInterface interface {
+	GetKubeToken(baseURL, namespace string) (string, error)
 }

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -82,5 +82,5 @@ type StreamInterface interface {
 
 // KubetokenInterface represents the kubetoken client
 type KubetokenInterface interface {
-	GetKubeToken(baseURL, namespace string) (string, error)
+	GetKubeToken(baseURL, namespace string) (*KubeTokenResponse, error)
 }

--- a/pkg/types/kubetoken.go
+++ b/pkg/types/kubetoken.go
@@ -1,18 +1,9 @@
 package types
 
 import (
-	"encoding/json"
 	authenticationv1 "k8s.io/api/authentication/v1"
 )
 
 type KubeTokenResponse struct {
 	authenticationv1.TokenRequest
-}
-
-func (k *KubeTokenResponse) ToJson() (string, error) {
-	bytes, err := json.MarshalIndent(k, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(bytes), nil
 }

--- a/pkg/types/kubetoken.go
+++ b/pkg/types/kubetoken.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"encoding/json"
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+type KubeTokenResponse struct {
+	authenticationv1.TokenRequest
+}
+
+func (k *KubeTokenResponse) ToJson() (string, error) {
+	bytes, err := json.MarshalIndent(k, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}


### PR DESCRIPTION
# Proposed changes

this PR wraps the existent kubetoken client code into the OktetoClient interface in order to be able to create testeable flows with this client.

Also, added new function CheckService to request a HEAD call to check if the service is available at the cluster
