### PR TITLE
fix: compose not getting image expansion from build

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -278,7 +278,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 	oktetoLog.SetStage("Load manifest")
 	manifest, err := dc.GetManifest(deployOptions.ManifestPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load manifest: %w", err)
 	}
 	deployOptions.Manifest = manifest
 	oktetoLog.Debug("found okteto manifest")

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -14,7 +14,6 @@
 package commands
 
 import (
-	"bufio"
 	"fmt"
 	"log"
 	"os"
@@ -56,20 +55,6 @@ type DestroyOptions struct {
 func GetOktetoDeployCmdOutput(oktetoPath string, deployOptions *DeployOptions) ([]byte, error) {
 	cmd := getDeployCmd(oktetoPath, deployOptions)
 	log.Printf("Running '%s'", cmd.String())
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		log.Printf("error getting stdout pipe: %s", err)
-		return nil, err
-	}
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			log.Println(scanner.Text())
-		}
-	}()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, err

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -52,8 +52,8 @@ type DestroyOptions struct {
 	IsRemote     bool
 }
 
-// RunOktetoDeploy runs an okteto deploy command
-func RunOktetoDeployWithOutput(oktetoPath string, deployOptions *DeployOptions) ([]byte, error) {
+// GetOktetoDeployCmdOutput runs an okteto deploy command
+func GetOktetoDeployCmdOutput(oktetoPath string, deployOptions *DeployOptions) ([]byte, error) {
 	cmd := getDeployCmd(oktetoPath, deployOptions)
 	log.Printf("Running '%s'", cmd.String())
 	stdout, err := cmd.StdoutPipe()
@@ -80,7 +80,7 @@ func RunOktetoDeployWithOutput(oktetoPath string, deployOptions *DeployOptions) 
 
 // RunOktetoDeploy runs an okteto deploy command
 func RunOktetoDeploy(oktetoPath string, deployOptions *DeployOptions) error {
-	_, err := RunOktetoDeployWithOutput(oktetoPath, deployOptions)
+	_, err := GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
 	return err
 }
 

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -57,7 +57,7 @@ func GetOktetoDeployCmdOutput(oktetoPath string, deployOptions *DeployOptions) (
 	log.Printf("Running '%s'", cmd.String())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return output, err
 	}
 	log.Printf("okteto deploy success")
 	return output, nil

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -533,7 +533,7 @@ services:
 		OktetoHome: dir,
 		Token:      token,
 	}
-	output, err := commands.RunOktetoDeployWithOutput(oktetoPath, deployOptions)
+	output, err := commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
 	require.Error(t, err)
 	require.Contains(t, string(output), "Invalid depends_on: Service 'app' depends on service 'nginx' which is undefined.")
 
@@ -544,7 +544,7 @@ services:
 		Token:        token,
 		ManifestPath: "docker-compose.yml",
 	}
-	output, err = commands.RunOktetoDeployWithOutput(oktetoPath, deployOptionsWithFile)
+	output, err = commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptionsWithFile)
 	require.Error(t, err)
 	require.Contains(t, string(output), "Invalid depends_on: Service 'app' depends on service 'nginx' which is undefined.")
 }

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/okteto/okteto/integration"
@@ -535,7 +536,7 @@ services:
 	}
 	output, err := commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
 	require.Error(t, err)
-	require.Contains(t, string(output), "Invalid depends_on: Service 'app' depends on service 'nginx' which is undefined.")
+	require.Contains(t, strings.ToLower(string(output)), "invalid depends_on: service 'app' depends on service 'nginx' which is undefined.")
 
 	deployOptionsWithFile := &commands.DeployOptions{
 		Workdir:      dir,
@@ -546,7 +547,7 @@ services:
 	}
 	output, err = commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptionsWithFile)
 	require.Error(t, err)
-	require.Contains(t, string(output), "Invalid depends_on: Service 'app' depends on service 'nginx' which is undefined.")
+	require.Contains(t, strings.ToLower(string(output)), "invalid depends_on: service 'app' depends on service 'nginx' which is undefined.")
 }
 
 func createComposeScenarioByManifest(dir string) error {

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -863,6 +863,9 @@ func ValidateDefinedServices(s *model.Stack, servicesToDeploy []string) error {
 			return fmt.Errorf("service '%s' is not defined. Defined services are: [%s]", svcToDeploy, strings.Join(definedSvcs, ", "))
 		}
 	}
+	if err := s.Services.ValidateDependsOn(servicesToDeploy); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -411,6 +411,7 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 		for _, composeInfo := range stackManifest.Deploy.ComposeSection.ComposesInfo {
 			composeFiles = append(composeFiles, composeInfo.File)
 		}
+		// We need to ensure that LoadStack has false because we don't want to expand env vars
 		s, stackErr := LoadStack("", composeFiles, false)
 		if stackErr != nil {
 			// if err is from validation, then return the stackErr
@@ -445,6 +446,7 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 				stackFiles = append(stackFiles, composeInfo.File)
 			}
 			// LoadStack should perform validation of the stack read from the file on compose section
+			// We need to ensure that LoadStack has false because we don't want to expand env vars
 			s, err := LoadStack("", stackFiles, false)
 			if err != nil {
 				return nil, err

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -411,7 +411,7 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 		for _, composeInfo := range stackManifest.Deploy.ComposeSection.ComposesInfo {
 			composeFiles = append(composeFiles, composeInfo.File)
 		}
-		s, stackErr := LoadStack("", composeFiles, true)
+		s, stackErr := LoadStack("", composeFiles, false)
 		if stackErr != nil {
 			// if err is from validation, then return the stackErr
 			if errors.Is(stackErr, errDependsOn) {
@@ -445,7 +445,7 @@ func getManifestFromFile(cwd, manifestPath string) (*Manifest, error) {
 				stackFiles = append(stackFiles, composeInfo.File)
 			}
 			// LoadStack should perform validation of the stack read from the file on compose section
-			s, err := LoadStack("", stackFiles, true)
+			s, err := LoadStack("", stackFiles, false)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -883,16 +883,6 @@ sync:
 			composeBytes:  nil,
 			expectedErr:   discovery.ErrOktetoManifestNotFound,
 		},
-		{
-			name:          "manifestPath to a invalid compose file - depends_on error",
-			manifestBytes: nil,
-			composeBytes: []byte(`services:
-  api:
-    image: test
-    depends_on:
-      - frontend`),
-			expectedErr: errDependsOn,
-		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -39,7 +39,7 @@ import (
 var (
 	errBadStackName     = "must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
 	deprecatedManifests = []string{"stack.yml", "stack.yaml"}
-	errDependsOn        = errors.New("Invalid depends_on")
+	errDependsOn        = errors.New("invalid depends_on")
 )
 
 // Stack represents an okteto stack
@@ -58,6 +58,14 @@ type Stack struct {
 
 // ComposeServices represents the services declared in the compose
 type ComposeServices map[string]*Service
+
+func (cs ComposeServices) getNames() []string {
+	names := []string{}
+	for k := range cs {
+		names = append(names, k)
+	}
+	return names
+}
 
 // Service represents an okteto stack service
 type Service struct {
@@ -481,7 +489,7 @@ func (s *Stack) Validate() error {
 		}
 		svc.ignoreSyncVolumes()
 	}
-	return validateDependsOn(s)
+	return s.Services.ValidateDependsOn(s.Services.getNames())
 }
 
 // validateStackName checks if the name is compliant
@@ -499,22 +507,51 @@ func validateStackName(name string) error {
 	return nil
 }
 
-func validateDependsOn(s *Stack) error {
-	for svcName, svc := range s.Services {
+type errDependsOnItself struct {
+	service string
+}
+
+func (e *errDependsOnItself) Error() string {
+	return fmt.Sprintf("%s: Service '%s' depends can not depend of itself.", errDependsOn.Error(), e.service)
+}
+
+func (e *errDependsOnItself) Unwrap() error {
+	return errDependsOn
+}
+
+type errDependsOnUndefined struct {
+	svc          string
+	dependentSvc string
+}
+
+func (e *errDependsOnUndefined) Error() string {
+	return fmt.Sprintf("%s: Service '%s' depends on service '%s' which is undefined.", errDependsOn.Error(), e.svc, e.dependentSvc)
+}
+
+func (e *errDependsOnUndefined) Unwrap() error {
+	return errDependsOn
+}
+
+func (cs ComposeServices) ValidateDependsOn(svcs []string) error {
+	for _, svcName := range svcs {
+		svc, ok := cs[svcName]
+		if !ok {
+			return fmt.Errorf("service '%s' is not defined in the stack", svcName)
+		}
 		for dependentSvc, condition := range svc.DependsOn {
 			if svcName == dependentSvc {
-				return fmt.Errorf("%w: Service '%s' depends can not depend of itself.", errDependsOn, svcName)
+				return &errDependsOnItself{service: svcName}
 			}
-			if _, ok := s.Services[dependentSvc]; !ok {
+			if _, ok := cs[dependentSvc]; !ok {
 				return fmt.Errorf("%w: Service '%s' depends on service '%s' which is undefined.", errDependsOn, svcName, dependentSvc)
 			}
-			if condition.Condition == DependsOnServiceCompleted && !s.Services[dependentSvc].IsJob() {
+			if condition.Condition == DependsOnServiceCompleted && !cs[dependentSvc].IsJob() {
 				return fmt.Errorf("%w: Service '%s' is not a job. Please make sure the 'restart_policy' is not set to 'always' in service '%s' ", errDependsOn, dependentSvc, dependentSvc)
 			}
 		}
 	}
 
-	dependencyCycle := getDependentCyclic(s.Services.toGraph())
+	dependencyCycle := getDependentCyclic(cs.toGraph())
 	if len(dependencyCycle) > 0 {
 		svcsDependents := fmt.Sprintf("%s and %s", strings.Join(dependencyCycle[:len(dependencyCycle)-1], ", "), dependencyCycle[len(dependencyCycle)-1])
 		return fmt.Errorf("%w: There was a cyclic dependendecy between %s.", errDependsOn, svcsDependents)

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -512,7 +512,7 @@ type errDependsOnItself struct {
 }
 
 func (e *errDependsOnItself) Error() string {
-	return fmt.Sprintf("%s: Service '%s' depends can not depend of itself.", errDependsOn.Error(), e.service)
+	return fmt.Sprintf("%s: Service '%s' depends cannot depend of itself.", errDependsOn.Error(), e.service)
 }
 
 func (e *errDependsOnItself) Unwrap() error {


### PR DESCRIPTION
## Bug Introduction and Root Cause

The bug was causing that compose files were not getting variable expansions when the image was set in the docker compose.

### Bug Description

We couldn't deploy applications that have a compose using the build env vars because whenever we deploy a compose using them we got the following error:
```
 x  Invalid service 'service': image cannot be empty.
 ```

## Bug Fix Explanation

The bug was a regression introduced in CLI 2.17.0 by the PR #3703. We fixed a panic when we deploy a compose with a service that had a `depends_on` field pointing to a non existing service. Adding the check we were also expanding all the env vars in the compose and because of that, the issue that is being solved arised

### Fix Description

In order to fix both bugs I tried the following approach:
1. Revert the changes done in the previous PR without doing a revert per se because the previous fix added several unit tests and explanatory comments that are worth maintaining them
2. Check that the issue #3878 is fixed with those changes
3. Try to reproduce the panic that was fixed by #3703
4. Try to fix it in a different way of the approach followed. The approach followed was to validate the services when we were about to deploy and not during the unmarshal of the compose
5. Modify an e2e test in order to not break it again the scenario
6. Add e2e testing that the compose file does't get a panic while running a depends on pointing to a non existen service

### Testing and Validation

There are two scenarios that needs to be addressed:

**Build env vars expansion**
1. Create the following okteto manifest:
```yaml
build:
  service:
    context: .
    dockerfile: ./Dockerfile
deploy:
  compose:
    - file: ./docker-compose.yml
```
2. Create the following docker compose:
```yaml
services:
  service:
    image: ${OKTETO_BUILD_SERVICE_IMAGE}
    command: sleep 100
```
3. Create the following Dockerfile:
```Dockerfile
FROM alpine

RUN echo hello
```
4. Run `okteto deploy` and check that it gets deployed:

**Panic on compose pointing to a non existent service**

1. Clone movies-with-compose:
```bash
git clone https://github.com/okteto/movies-with-compose.git
```
2. Remove the frontend service from the compose file
3. Run `okteto deploy -f docker-compose.yml`. It should return a proper error and not panic
4. Run `okteto deploy`. It should return a proper error and not panic

### Impact and Considerations

This bug was causing a breaking change in 2.17 and we should patch 2.18 and 2.17 in order to not have a breaking scenario in our maintained versions

## Checklist

- [ ] Bug fix code has been reviewed by at least one team member.
- [ ] Automated tests have been added or updated to cover the bug fix.
- [ ] Manual testing has been performed to verify the bug fix.

## Related Issues

Fixes #3878
Follow up of  #3703
