### PR TITLE
fix: if repo is not clean always return err

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -25,6 +25,10 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
+var (
+	errNotCleanRepo = errors.New("repository is not clean")
+)
+
 type gitRepoController struct {
 	path       string
 	repoGetter repositoryGetterInterface
@@ -100,18 +104,18 @@ func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
 func (r gitRepoController) getSHA() (string, error) {
 	isClean, err := r.isClean(context.TODO())
 	if err != nil {
-		return "", fmt.Errorf("failed to check if repo is clean: %w", err)
+		return "", fmt.Errorf("%w: failed to check if repo is clean: %w", errNotCleanRepo, err)
 	}
 	if !isClean {
-		return "", nil
+		return "", errNotCleanRepo
 	}
 	repo, err := r.repoGetter.get(r.path)
 	if err != nil {
-		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+		return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
 	}
 	head, err := repo.Head()
 	if err != nil {
-		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+		return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
 	}
 	return head.Hash().String(), nil
 }

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -14,8 +14,9 @@
 package repository
 
 import (
-	"github.com/go-git/go-git/v5/plumbing"
 	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/stretchr/testify/assert"
@@ -235,7 +236,7 @@ func TestGetSHA(t *testing.T) {
 			},
 			expected: expected{
 				sha: "",
-				err: nil,
+				err: errNotCleanRepo,
 			},
 		},
 		{


### PR DESCRIPTION
## Bug Fix Pull Request

### Description

This PR fixes a bug on the pull first approach feature. It as only affecting to all `okteto up` commands/remote deploy that has an image already pushed to the global registry using an empty commit sha. This was generating a hash with the following information: `commit:;target:;build_args:;secrets:;context:.;dockerfile:.Dockerfile;image:;`. If okteto up was executed on a dirty repo (a repo with changes that are not committed) could be affected

### Changes Made

- If running `git status` returns `false`, we return an error for it. Otherwise we should be checking if the repo is clean and if it has no error. 
- Modify tests to test that we are returning an error

### How It Works

If the user is on a dirty repo, with the fix we don't calculate any global tag. This will always use the dev registry if the git status is not clean. 

### Testing Scenarios

Using [movies-with-helm](https://github.com/okteto/movies-with-helm/) on a cluster that allows dev to push to the global registry

#### Scenario 1: Test that we don't break any previous scenarios

- **Steps to Reproduce:** 
1. Run `okteto build`
2. Check that the image is pushed into the global registry
3. Run `okteto up`
4. Run `kubectl get pods -oyaml | grep image` 
- **Expected Behavior:** the image built previously is the same
- **Observed Behavior (before fix):** the image built previously is the same
- **Observed Behavior (after fix):** the image built previously is the same

#### Scenario 2: Test that the new scenario is fixed

For this change we need to create a custom CLI in order to push the image that was causing the error


- **Steps to Reproduce:** 
1. Modify [if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() ](https://github.com/okteto/okteto/blob/f3d8dab026afe08ed7819f59f252af47d6b9f186/cmd/build/v2/tagger.go#L60) to `if i.cfg.HasGlobalAccess()` and comment this block [this block](https://github.com/okteto/okteto/blob/f3d8dab026afe08ed7819f59f252af47d6b9f186/pkg/repository/git.go#L102-L104) to generate the image with the empty hash.
2. Run `make build`
3. Run `okteto build` on the repo.
4. Check that the image is pushed into the global registry
5. Make the repo "dirty" by running `echo 123 > 123.txt`
6. Build again the PR branch to get the fix
7. Run `okteto up`
8. Run `kubectl get pods -oyaml | grep image` 
- **Expected Behavior:** the image is the one pointing to the dev registry
- **Observed Behavior (before fix):** the image used was the one pointing to the global registry
- **Observed Behavior (after fix):** the image is the one pointing to the dev registry

### Checklist

- [ ] Bug fix is tested and verified
- [ ] Code is reviewed for style and quality
- [ ] Unit tests are added or updated where applicable
