### PR TITLE
Adding syncthing api unittests.

### DIFF
--- a/pkg/syncthing/api.go
+++ b/pkg/syncthing/api.go
@@ -30,8 +30,15 @@ type addAPIKeyTransport struct {
 	T http.RoundTripper
 }
 
+const (
+	APIKeyHeader      = "X-Api-Key"
+	APIKeyHeaderValue = "cnd"
+)
+
+// RoundTrip implements the http.RoundTripper interface and is used to add the
+// desired request headers to http requests.
 func (akt *addAPIKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add("X-API-Key", "cnd")
+	req.Header.Add(APIKeyHeader, APIKeyHeaderValue)
 	return akt.T.RoundTrip(req)
 }
 

--- a/pkg/syncthing/api_test.go
+++ b/pkg/syncthing/api_test.go
@@ -1,0 +1,56 @@
+package syncthing
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testKeyTransport struct {
+	RT http.RoundTripper
+	t  *testing.T
+}
+
+func (t *testKeyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Check that a previous RoundTripper added the required headers.
+	val, ok := req.Header[APIKeyHeader]
+	if !ok {
+		t.t.Errorf("Header %s should be set in request", APIKeyHeader)
+		return t.RT.RoundTrip(req)
+	}
+
+	if val[0] != APIKeyHeaderValue {
+		t.t.Errorf("Header %s should be set to %s", APIKeyHeader, APIKeyHeaderValue)
+	}
+
+	return t.RT.RoundTrip(req)
+}
+
+// Ensure that the round tripper is adding the correct headers.
+func Test_RoundTrip(t *testing.T) {
+	apiKeyTransport := addAPIKeyTransport{
+		&testKeyTransport{
+			RT: http.DefaultTransport,
+			t:  t,
+		},
+	}
+
+	testRequest := httptest.NewRequest(http.MethodGet, "https://foo.com", nil)
+	apiKeyTransport.RoundTrip(testRequest)
+}
+
+func Test_APIClient(t *testing.T) {
+	client := NewAPIClient()
+
+	expectation := 60 * time.Second
+	assert.Equal(
+		t,
+		expectation,
+		client.Timeout,
+		"timeout should be set to %s seconds",
+		expectation,
+	)
+}


### PR DESCRIPTION
Added a test for the proper insertion of headers by the syncthing client roundtripper and the proper initialization of the request timeout for the http client.

