### PR TITLE
fix: wait until build stops logs to return

### DIFF
--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -289,12 +289,12 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 				oktetoLog.Debugf("could not create console from file: %s ", err)
 			}
 			go func() {
-				if err := progressui.DisplaySolveStatus(context.TODO(), "", c, oktetoLog.GetOutputWriter(), ttyChannel); err != nil {
+				if err := progressui.DisplaySolveStatus(context.TODO(), "", nil, w, plainChannel); err != nil {
 					oktetoLog.Infof("could not display solve status: %s", err)
 				}
 			}()
 			// not using shared context to not disrupt display but let it finish reporting errors
-			return progressui.DisplaySolveStatus(context.TODO(), "", nil, w, plainChannel)
+			return progressui.DisplaySolveStatus(context.TODO(), "", c, oktetoLog.GetOutputWriter(), ttyChannel)
 		case "deploy":
 			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: "deploy"})
 			commandFailChannel <- err

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -289,11 +289,13 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 				oktetoLog.Debugf("could not create console from file: %s ", err)
 			}
 			go func() {
+				// We use the plain channel to store the logs into a buffer and then show them in the UI
 				if err := progressui.DisplaySolveStatus(context.TODO(), "", nil, w, plainChannel); err != nil {
 					oktetoLog.Infof("could not display solve status: %s", err)
 				}
 			}()
 			// not using shared context to not disrupt display but let it finish reporting errors
+			// We need to wait until the tty channel is closed to avoid writing to stdout while the tty is being used
 			return progressui.DisplaySolveStatus(context.TODO(), "", c, oktetoLog.GetOutputWriter(), ttyChannel)
 		case "deploy":
 			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: "deploy"})


### PR DESCRIPTION
## Bug Fix: Race Condition in Buildkit Logs

### Description
This PR fixes a bug while showing the buildkit logs, On previous versions we were waiting until all the logs where on the UI with the stage but we didn't check if the CLI finished them.

### Root Cause
It could happen that the next CLI logs where shown before the CLI ended showing buildkit logs

### Steps to Reproduce (if applicable)
Run several `okteto build`. You'll end up with some build  

### Solution
Wait for the CLI logs instead of the ones that we store with the stage to show them in the UI

### Changes Made
<!-- Provide a high-level overview of the changes you made to fix the bug. -->

### Testing

| Before | After |
|--------|-------|
|  <img width="1250" alt="Captura de pantalla 2023-08-13 a las 19 01 43" src="https://github.com/okteto/okteto/assets/3510171/b96110a7-e406-478e-8d84-85f88dd3ecd9">
 |  <img width="676" alt="Captura de pantalla 2023-08-14 a las 17 19 31" src="https://github.com/okteto/okteto/assets/25170843/0eb9d8a3-ee82-486d-9a15-b6a5b2c1d1dc"> |

### Related Issues
Fixes: #3906 

