### PR TITLE
Add cache to registry credentials

### DIFF
--- a/pkg/okteto/registry_credentials_test.go
+++ b/pkg/okteto/registry_credentials_test.go
@@ -23,7 +23,6 @@ func TestExternalRegistryCredentialsOK(t *testing.T) {
 				Password: "pass",
 			}, nil
 		}
-
 	}
 
 	tt := []struct {
@@ -140,4 +139,58 @@ func TestExternalRegistryCredentialsOK(t *testing.T) {
 
 	}
 
+}
+
+func TestExternalRegistryCredentialsOKWithCache(t *testing.T) {
+	var calls int
+
+	r := externalRegistryCredentialsReader{
+		isOkteto: true,
+		cache:    &registryCache{},
+		getter: func(ctx context.Context, host string) (dockertypes.AuthConfig, error) {
+			calls++
+			require.Equal(t, "host.com", host)
+			return dockertypes.AuthConfig{
+				Username: "user",
+				Password: "pass",
+			}, nil
+		},
+	}
+
+	for i := 0; i < 20; i++ {
+		user, pass, err := r.read(context.Background(), "host.com")
+		require.NoError(t, err)
+		require.Equal(t, "user", user)
+		require.Equal(t, "pass", pass)
+	}
+
+	// We made 20 calls to r.read and getter should've only been executed once
+	require.Equal(t, 1, calls)
+}
+
+func TestRegistryCache(t *testing.T) {
+	rc := registryCache{}
+	user, pass, ok := rc.Get("host.com")
+	require.Equal(t, "", user)
+	require.Equal(t, "", pass)
+	require.False(t, ok)
+
+	rc.Set("thebiglebowski.com", "thedude", "elduderino")
+
+	user, pass, ok = rc.Get("thebiglebowski.com")
+	require.Equal(t, "thedude", user)
+	require.Equal(t, "elduderino", pass)
+	require.True(t, ok)
+
+	rc.Delete("thebiglebowski.com")
+
+	user, pass, ok = rc.Get("thebiglebowski.com")
+	require.Equal(t, "", user)
+	require.Equal(t, "", pass)
+	require.False(t, ok)
+
+	require.NotPanics(t, func() {
+		rc := registryCache{}
+		rc.Delete("inexistent") // delete nil cache
+	})
 }

--- a/pkg/okteto/registry_credentials_test.go
+++ b/pkg/okteto/registry_credentials_test.go
@@ -181,16 +181,4 @@ func TestRegistryCache(t *testing.T) {
 	require.Equal(t, "thedude", user)
 	require.Equal(t, "elduderino", pass)
 	require.True(t, ok)
-
-	rc.Delete("thebiglebowski.com")
-
-	user, pass, ok = rc.Get("thebiglebowski.com")
-	require.Equal(t, "", user)
-	require.Equal(t, "", pass)
-	require.False(t, ok)
-
-	require.NotPanics(t, func() {
-		rc := registryCache{}
-		rc.Delete("inexistent") // delete nil cache
-	})
 }


### PR DESCRIPTION
Adds a global cache to registry credentials. Prior to this change, we were making unnecessary roundtrips to the okteto backend to retrieve temporary credentials. We now cache these credentials during the lifecycle of the build/deploy and they are reused.

This was part of the original implementation of buildkit's [default auth provider](https://github.com/moby/buildkit/blob/master/session/auth/authprovider/authprovider.go#L230) but was not included as part of the okteto implementation.

We could not add the cache to the authprovider as in the implementation above because we use these credentials also for the registry api and the docker credentials helper. 

The trade-off for this is adding global state to the execution but there aren't too many options given the state of things.

