### PR TITLE
Extend help from kubeconfig command to mention that the generated kub…econfig requires to have Okteto CLI in the path

### DIFF
--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
@@ -119,7 +120,7 @@ func updateCfgAuthInfoWithExec(okCtx *okteto.OktetoContext) {
 		APIVersion:         "client.authentication.k8s.io/v1",
 		Command:            "okteto",
 		Args:               []string{"kubetoken", "--context", okCtx.Name, "--namespace", okCtx.Namespace},
-		InstallHint:        "Okteto needs to be installed and in your PATH to use this context. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
+		InstallHint:        "Okteto needs to be installed in your PATH and it has to be connected to your instance through 'okteto context use https://okteto.example.com'. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
 		InteractiveMode:    "Never",
 		ProvideClusterInfo: true,
 	}

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -120,7 +120,7 @@ func updateCfgAuthInfoWithExec(okCtx *okteto.OktetoContext) {
 		APIVersion:         "client.authentication.k8s.io/v1",
 		Command:            "okteto",
 		Args:               []string{"kubetoken", "--context", okCtx.Name, "--namespace", okCtx.Namespace},
-		InstallHint:        "Okteto needs to be installed in your PATH and it has to be connected to your instance through 'okteto context use https://okteto.example.com'. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
+		InstallHint:        "Okteto needs to be installed in your PATH and it has to be connected to your instance using the command 'okteto context use https://okteto.example.com'. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
 		InteractiveMode:    "Never",
 		ProvideClusterInfo: true,
 	}

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -24,7 +24,11 @@ func Kubeconfig() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig",
 		Short: "Download credentials for the Kubernetes cluster selected via 'okteto context'",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
+		Long: `Download credentials for the Kubernetes cluster selected via 'okteto context'.
+
+Generated kubeconfig file uses a credential plugin to get the cluster credentials via Okteto backend that requires the okteto CLI to be is in the PATH. Learn more about how to use the Kuberentes credentials at https://www.okteto.com/docs/cloud/credentials/#using-your-kubernetes-credentials.
+`,
+		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return contextCMD.UpdateKubeconfigCMD().RunE(cmd, args)
 		},

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -26,7 +26,7 @@ func Kubeconfig() *cobra.Command {
 		Short: "Download credentials for the Kubernetes cluster selected via 'okteto context'",
 		Long: `Download credentials for the Kubernetes cluster selected via 'okteto context'.
 
-Generated kubeconfig file uses a credential plugin to get the cluster credentials via Okteto backend that requires the okteto CLI to be in the PATH. Learn more about how to use the Kuberentes credentials at https://www.okteto.com/docs/cloud/credentials/#using-your-kubernetes-credentials.
+Generated kubeconfig file uses a credential plugin to get the cluster credentials via Okteto backend that requires the Okteto CLI to be in the PATH. Learn more about how to use the Kuberentes credentials at https://www.okteto.com/docs/cloud/credentials/#using-your-kubernetes-credentials.
 `,
 		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -26,7 +26,7 @@ func Kubeconfig() *cobra.Command {
 		Short: "Download credentials for the Kubernetes cluster selected via 'okteto context'",
 		Long: `Download credentials for the Kubernetes cluster selected via 'okteto context'.
 
-Generated kubeconfig file uses a credential plugin to get the cluster credentials via Okteto backend that requires the okteto CLI to be is in the PATH. Learn more about how to use the Kuberentes credentials at https://www.okteto.com/docs/cloud/credentials/#using-your-kubernetes-credentials.
+Generated kubeconfig file uses a credential plugin to get the cluster credentials via Okteto backend that requires the okteto CLI to be in the PATH. Learn more about how to use the Kuberentes credentials at https://www.okteto.com/docs/cloud/credentials/#using-your-kubernetes-credentials.
 `,
 		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# Proposed changes

Added a long description in the `kubeconfig`  command to indicate that Okteto CLI is required in the PATH in order to work with the generated kubeconfig.

Added also some extra information in the kubeconfig genreated to indicate that they CLI has to be already connected with the context
