### PR TITLE
refactor: restore previewLabels at default view of preview list

### DIFF
--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -17,6 +17,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -24,8 +28,6 @@ import (
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
-	"os"
-	"text/tabwriter"
 )
 
 // ListFlags are the flags available for list commands
@@ -114,6 +116,9 @@ func executeListPreviews(ctx context.Context, opts ListFlags) error {
 		fmt.Fprintf(w, "Name\tScope\tSleeping\tLabels\n")
 		for _, preview := range previewList {
 			previewLabels := "-"
+			if len(preview.PreviewLabels) > 0 {
+				previewLabels = strings.Join(preview.PreviewLabels, ", ")
+			}
 			fmt.Fprintf(w, "%s\t%s\t%v\t%s\n", preview.ID, preview.Scope, preview.Sleeping, previewLabels)
 		}
 		w.Flush()


### PR DESCRIPTION
# Proposed changes


When running `okteto preview list` and the preview had labels, no labels where shown at the default view

```
❯ okteto preview list
 i  Using - @ - as context
Name                   Scope     Sleeping  Labels
upbeat-feynman-teresa  personal  false     -
```

```
❯ ok preview list -o json
[
 {
  "name": "upbeat-feynman-teresa",
  "scope": "personal",
  "sleeping": false,
  "labels": [
   "other",
   "testing"
  ]
 }
]
```

```
❯ ok preview list -o yaml
- name: upbeat-feynman-teresa
  scope: personal
  sleeping: false
  labels:
  - testing
  - other
```

This was not happening when using `yaml` or `json` output

This bug was [introduced](https://github.com/okteto/okteto/pull/3804/files#diff-1de660ef246a78c71aa7be984185a6ab279c12c708e9d6e27799b2a4e0278ddaL79) when adding the output flag to the command, this PR reverts the logic that added the preview labels to the default view.

## Test

- run `okteto preview list` and see the labels are shown

