### PR TITLE
fix `okteto kubeconfig` for non okteto contexts

### DIFF
--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
@@ -65,21 +66,21 @@ func ExecuteUpdateKubeconfig(okCtx *okteto.OktetoContext, kubeconfigPaths []stri
 		if err := updateCfgClusterCertificate(contextName, okCtx); err != nil {
 			return err
 		}
-	}
 
-	okClient, err := okClientProvider.Provide()
-	if err != nil {
-		return err
-	}
+		okClient, err := okClientProvider.Provide()
+		if err != nil {
+			return err
+		}
 
-	if utils.LoadBoolean(oktetoUseStaticKubetokenEnvVar) {
-		removeExecFromCfg(okCtx)
-		oktetoLog.Warning(usingStaticKubetokenWarningMessage)
-	} else {
-		if err := okClient.Kubetoken().CheckService(okCtx.Name, okCtx.Namespace); err == nil {
-			updateCfgAuthInfoWithExec(okCtx)
+		if utils.LoadBoolean(oktetoUseStaticKubetokenEnvVar) {
+			removeExecFromCfg(okCtx)
+			oktetoLog.Warning(usingStaticKubetokenWarningMessage)
 		} else {
-			oktetoLog.Debug("Error checking kubetoken service: %w", err)
+			if err := okClient.Kubetoken().CheckService(okCtx.Name, okCtx.Namespace); err == nil {
+				updateCfgAuthInfoWithExec(okCtx)
+			} else {
+				oktetoLog.Debug("Error checking kubetoken service: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
# Summary

regression introduced in https://github.com/okteto/okteto/pull/3887

# Proposed changes

- instantiate okteto client only for okteto contexts
- fix tests to use `IsOkteto` propertie set to true.
- add test for non okteto contexts

Fixes #3918 
