### PR TITLE
Fix kubetoken remote deploy

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -264,7 +264,7 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	}
 
 	// once we have namespace and user identify we are able to retrieve the dynamic token for the namespace
-	getAndUseDynamicKubetoken(c.OktetoClientProvider, userContext)
+	replaceCredentialsTokenWithDynamicKubetoken(c.OktetoClientProvider, userContext)
 
 	okteto.AddOktetoContext(ctxOptions.Context, &userContext.User, ctxOptions.Namespace, userContext.User.Namespace)
 	cfg := kubeconfig.Get(config.GetKubeconfigPath())
@@ -283,10 +283,10 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	return nil
 }
 
-// getAndUseDynamicKubetoken retrieves a dynamic token for the given userContext and updates Credentials.Token
+// replaceCredentialsTokenWithDynamicKubetoken retrieves a dynamic token for the given userContext and updates Credentials.Token
 // if error while retrieving the dynamic token or flag OKTETO_USE_STATIC_KUBETOKEN is enabled, value is not updated
 // static token is fallback
-func getAndUseDynamicKubetoken(okClientProvider types.OktetoClientProvider, userContext *types.UserContext) {
+func replaceCredentialsTokenWithDynamicKubetoken(okClientProvider types.OktetoClientProvider, userContext *types.UserContext) {
 	if utils.LoadBoolean(oktetoUseStaticKubetokenEnvVar) {
 		oktetoLog.Warning(usingStaticKubetokenWarningMessage)
 		return
@@ -299,7 +299,7 @@ func getAndUseDynamicKubetoken(okClientProvider types.OktetoClientProvider, user
 
 	c, err := okClientProvider.Provide()
 	if err != nil {
-		oktetoLog.Debugf("error providing the okteto client at getAndUseDynamicKubetoken: %w", err)
+		oktetoLog.Debugf("error providing the okteto client at replaceCredentialsTokenWithDynamicKubetoken: %w", err)
 		return
 	}
 

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -264,7 +264,7 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	}
 
 	// once we have namespace and user identify we are able to retrieve the dynamic token for the namespace
-	updateDynamicTokenForNamespace(c.OktetoClientProvider, userContext)
+	getAndUseDynamicKubetoken(c.OktetoClientProvider, userContext)
 
 	okteto.AddOktetoContext(ctxOptions.Context, &userContext.User, ctxOptions.Namespace, userContext.User.Namespace)
 	cfg := kubeconfig.Get(config.GetKubeconfigPath())
@@ -283,10 +283,10 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	return nil
 }
 
-// updateDynamicTokenForNamespace retrieves a dinamic token for the given userContext and updates Credentials.Token
-// if error while retrieving the dynamic token or flag OKTETO_USE_STATIC_KUBETOKEN is true, value is not updated
+// getAndUseDynamicKubetoken retrieves a dynamic token for the given userContext and updates Credentials.Token
+// if error while retrieving the dynamic token or flag OKTETO_USE_STATIC_KUBETOKEN is enabled, value is not updated
 // static token is fallback
-func updateDynamicTokenForNamespace(okClientProvider types.OktetoClientProvider, userContext *types.UserContext) {
+func getAndUseDynamicKubetoken(okClientProvider types.OktetoClientProvider, userContext *types.UserContext) {
 	if utils.LoadBoolean(oktetoUseStaticKubetokenEnvVar) {
 		oktetoLog.Warning(usingStaticKubetokenWarningMessage)
 		return
@@ -299,7 +299,7 @@ func updateDynamicTokenForNamespace(okClientProvider types.OktetoClientProvider,
 
 	c, err := okClientProvider.Provide()
 	if err != nil {
-		oktetoLog.Debugf("error providing the okteto client at updateDynamicTokenForNamespace: %w", err)
+		oktetoLog.Debugf("error providing the okteto client at getAndUseDynamicKubetoken: %w", err)
 		return
 	}
 

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -292,6 +292,11 @@ func updateDynamicTokenForNamespace(okClientProvider types.OktetoClientProvider,
 		return
 	}
 
+	if userContext.User.Namespace == "" {
+		oktetoLog.Debug("user context namespace is empty, fallback to static token")
+		return
+	}
+
 	c, err := okClientProvider.Provide()
 	if err != nil {
 		oktetoLog.Debugf("error providing the okteto client at updateDynamicTokenForNamespace: %w", err)

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -636,7 +636,7 @@ func TestGetUserContext(t *testing.T) {
 	}
 }
 
-func Test_updateDynamicTokenForNamespace(t *testing.T) {
+func Test_getAndUseDynamicKubetoken(t *testing.T) {
 
 	tests := []struct {
 		name                  string
@@ -728,7 +728,7 @@ func Test_updateDynamicTokenForNamespace(t *testing.T) {
 				KubetokenClient: client.NewFakeKubetokenClient(tt.kubetokenMockResponse),
 			})
 
-			updateDynamicTokenForNamespace(fakeOktetoClientProvider, tt.userContext)
+			getAndUseDynamicKubetoken(fakeOktetoClientProvider, tt.userContext)
 			assert.Equal(t, tt.expectedToken, tt.userContext.Credentials.Token)
 		})
 	}

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -17,11 +17,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	authenticationv1 "k8s.io/api/authentication/v1"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
 
 	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/internal/test/client"
@@ -648,7 +649,8 @@ func Test_updateDynamicTokenForNamespace(t *testing.T) {
 			name: "dynamic kubetoken not available, falling back to static token",
 			userContext: &types.UserContext{
 				User: types.User{
-					Token: "test",
+					Token:     "test",
+					Namespace: "okteto",
 				},
 				Credentials: types.Credential{
 					Token: "static",
@@ -670,7 +672,8 @@ func Test_updateDynamicTokenForNamespace(t *testing.T) {
 			name: "dynamic kubetoken returned successfully and takes priority over static token",
 			userContext: &types.UserContext{
 				User: types.User{
-					Token: "test",
+					Token:     "test",
+					Namespace: "okteto",
 				},
 				Credentials: types.Credential{
 					Token: "static",
@@ -690,6 +693,20 @@ func Test_updateDynamicTokenForNamespace(t *testing.T) {
 		},
 		{
 			name: "using feature flag does not update the token",
+			userContext: &types.UserContext{
+				User: types.User{
+					Token:     "test",
+					Namespace: "okteto",
+				},
+				Credentials: types.Credential{
+					Token: "static",
+				},
+			},
+			useStaticTokenEnv: true,
+			expectedToken:     "static",
+		},
+		{
+			name: "empty namespace does not update token",
 			userContext: &types.UserContext{
 				User: types.User{
 					Token: "test",

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -636,7 +636,7 @@ func TestGetUserContext(t *testing.T) {
 	}
 }
 
-func Test_getAndUseDynamicKubetoken(t *testing.T) {
+func Test_replaceCredentialsTokenWithDynamicKubetoken(t *testing.T) {
 
 	tests := []struct {
 		name                  string
@@ -728,7 +728,7 @@ func Test_getAndUseDynamicKubetoken(t *testing.T) {
 				KubetokenClient: client.NewFakeKubetokenClient(tt.kubetokenMockResponse),
 			})
 
-			getAndUseDynamicKubetoken(fakeOktetoClientProvider, tt.userContext)
+			replaceCredentialsTokenWithDynamicKubetoken(fakeOktetoClientProvider, tt.userContext)
 			assert.Equal(t, tt.expectedToken, tt.userContext.Credentials.Token)
 		})
 	}


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/7039

- Updating the token to a dynamic one was done at `getUserContext` where namespace could be empty.
- in order to retrieve the kubetoken we need the namespace, if not the url will return 404 and fallback would be static token.
- new function `updateDynamicTokenForNamespace` wrapping the code that was already in place for updating `userContext.Credentials.Token`
- use `updateDynamicTokenForNamespace` at `initOktetoContext` so the token is updated when namespace has been cleared
- return `getUserContext` to its original behavour
