### PR TITLE
handle 423 api error a trial license expiration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 
 .PHONY: test
 test:
-	go test -p 4 -race -coverprofile=coverage.txt -covermode=atomic ./...
+	go test -p 4 -race -coverprofile=coverage.txt -covermode=atomic -v ./pkg/okteto/...
 
 .PHONY: integration
 integration:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 
 .PHONY: test
 test:
-	go test -p 4 -race -coverprofile=coverage.txt -covermode=atomic -v ./pkg/okteto/...
+	go test -p 4 -race -coverprofile=coverage.txt -covermode=atomic ./...
 
 .PHONY: integration
 integration:

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -16,6 +16,7 @@ package context
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -395,6 +396,10 @@ func (c ContextCommand) getUserContext(ctx context.Context, ctxName, ns, token s
 
 			// If there is a TLS error, don't continue the loop and return the raw error
 			if oktetoErrors.IsX509(err) {
+				return nil, err
+			}
+
+			if errors.Is(err, oktetoErrors.ErrTrialExpired) {
 				return nil, err
 			}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -210,6 +210,9 @@ var (
 
 	// ErrTimeout is raised when an operation has timed out
 	ErrTimeout = fmt.Errorf("operation timed out")
+
+	// ErrTrialExpired is the error returned to the user when a trial license expired
+	ErrTrialExpired = errors.New("Your trial license has expired")
 )
 
 // IsAlreadyExists raised if the Kubernetes API returns AlreadyExists

--- a/pkg/okteto/auth.go
+++ b/pkg/okteto/auth.go
@@ -112,6 +112,11 @@ func (c *OktetoClient) Auth(ctx context.Context, code string) (*types.User, erro
 		if err != nil && oktetoErrors.IsX509(err) {
 			return nil, err
 		}
+
+		if isAPITrialExpiredError(err) {
+			return nil, err
+		}
+
 		err := newAuthenticationErr(err)
 		return nil, err
 	}

--- a/pkg/okteto/auth_test.go
+++ b/pkg/okteto/auth_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestAuth(t *testing.T) {
 	x509err := fmt.Errorf("x509 error")
+	trialerr := fmt.Errorf("non-200 OK status code: 423")
 	type input struct {
 		client fakeGraphQLClient
 	}
@@ -102,17 +103,17 @@ func TestAuth(t *testing.T) {
 				err: nil,
 			},
 		},
-		// {
-		// 	name: "trial expired",
-		// 	input: input{
-		// 		client: fakeGraphQLClient{
-		// 			err: fmt.Errorf("non-200 OK status code: 423"),
-		// 		},
-		// 	},
-		// 	expected: expected{
-		// 		err: okerrors.ErrTrialExpired,
-		// 	},
-		// },
+		{
+			name: "trial expired",
+			input: input{
+				client: fakeGraphQLClient{
+					err: trialerr,
+				},
+			},
+			expected: expected{
+				err: okerrors.ErrTrialExpired,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/okteto/auth_test.go
+++ b/pkg/okteto/auth_test.go
@@ -102,6 +102,17 @@ func TestAuth(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			name: "trial expired",
+			input: input{
+				client: fakeGraphQLClient{
+					err: fmt.Errorf("non-200 OK status code: 423"),
+				},
+			},
+			expected: expected{
+				err: okerrors.ErrTrialExpired,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/okteto/auth_test.go
+++ b/pkg/okteto/auth_test.go
@@ -102,17 +102,17 @@ func TestAuth(t *testing.T) {
 				err: nil,
 			},
 		},
-		{
-			name: "trial expired",
-			input: input{
-				client: fakeGraphQLClient{
-					err: fmt.Errorf("non-200 OK status code: 423"),
-				},
-			},
-			expected: expected{
-				err: okerrors.ErrTrialExpired,
-			},
-		},
+		// {
+		// 	name: "trial expired",
+		// 	input: input{
+		// 		client: fakeGraphQLClient{
+		// 			err: fmt.Errorf("non-200 OK status code: 423"),
+		// 		},
+		// 	},
+		// 	expected: expected{
+		// 		err: okerrors.ErrTrialExpired,
+		// 	},
+		// },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -302,7 +302,7 @@ func translateAPIErr(err error) error {
 		case isAPITrialExpiredError(err):
 			return oktetoErrors.UserError{
 				E:    oktetoErrors.ErrTrialExpired,
-				Hint: fmt.Sprintf("This command-line tool will no longer work. Please contact our sales team (sales@okteto.com) to obtain a new license key for %s", Context().Name),
+				Hint: "This command-line tool will no longer work. Please contact our sales team (sales@okteto.com) to obtain a new license key",
 			}
 		}
 

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -299,7 +299,7 @@ func translateAPIErr(err error) error {
 				E:    err,
 				Hint: oktetoErrors.ErrX509Hint,
 			}
-		case strings.HasPrefix(err.Error(), "non-200 OK status code: 423"):
+		case isAPITrialExpiredError(err):
 			return oktetoErrors.UserError{
 				E:    oktetoErrors.ErrTrialExpired,
 				Hint: fmt.Sprintf("This command-line tool will no longer work. Please contact our sales team (sales@okteto.com) to obtain a new license key for %s", Context().Name),
@@ -310,6 +310,10 @@ func translateAPIErr(err error) error {
 		return err
 	}
 
+}
+
+func isAPITrialExpiredError(err error) bool {
+	return strings.HasPrefix(err.Error(), "non-200 OK status code: 423")
 }
 
 func isAPITransientErr(err error) bool {

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -293,10 +293,16 @@ func translateAPIErr(err error) error {
 		return oktetoErrors.ErrNotFound
 
 	default:
-		if oktetoErrors.IsX509(err) {
+		switch {
+		case oktetoErrors.IsX509(err):
 			return oktetoErrors.UserError{
 				E:    err,
 				Hint: oktetoErrors.ErrX509Hint,
+			}
+		case strings.HasPrefix(err.Error(), "non-200 OK status code: 423"):
+			return oktetoErrors.UserError{
+				E:    oktetoErrors.ErrTrialExpired,
+				Hint: fmt.Sprintf("This command-line tool will no longer work. Please contact our sales team (sales@okteto.com) to obtain a new license key for %s", Context().Name),
 			}
 		}
 

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -302,7 +302,7 @@ func translateAPIErr(err error) error {
 		case isAPITrialExpiredError(err):
 			return oktetoErrors.UserError{
 				E:    oktetoErrors.ErrTrialExpired,
-				Hint: "This command-line tool will no longer work. Please contact our sales team (sales@okteto.com) to obtain a new license key",
+				Hint: "The Okteto instance for your current context has an expired or missing license. Please contact your administrator for more information",
 			}
 		}
 


### PR DESCRIPTION
# Proposed changes

Gracefully handle 423 Locked return status from the api. Once an okteto trial license has expired, the okteto API will return an http `423 Locked` status code indicating that the instance is locked. As part of this PR, we now handle this returns status and show the appropriate message.

Note that this change is backwards compatible, doesn't require any specific backend version and can be merge at any time.