### PR TITLE
fix: show error for `okteto deploy` when no manifest file exists using `-f` flag 

### DIFF
--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -16,6 +16,8 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1262,6 +1264,48 @@ func TestShouldRunInRemoteDeploy(t *testing.T) {
 			t.Setenv(constants.OktetoForceRemote, string(tt.remoteForce))
 			result := shouldRunInRemote(tt.opts)
 			assert.Equal(t, result, tt.expected)
+		})
+	}
+}
+
+func TestOktetoManifestPathFlag(t *testing.T) {
+	opts := &Options{}
+	var tests = []struct {
+		name        string
+		manifest    string
+		expectedErr error
+	}{
+		{
+			name:        "manifest file path exists",
+			manifest:    "okteto.yml",
+			expectedErr: nil,
+		},
+		{
+			name:        "manifest file path doesn't exist",
+			manifest:    "nonexistent.yml",
+			expectedErr: fmt.Errorf("nonexistent.yml file doesn't exist"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewOsFs()
+			dir, err := os.Getwd()
+			assert.NoError(t, err)
+			fullpath := filepath.Join(dir, tt.manifest)
+			opts.ManifestPath = fullpath
+			if tt.manifest != "nonexistent.yml" {
+				// create the manifest file only if it's not the nonexistent scenario
+				f, err := fs.Create(fullpath)
+				assert.NoError(t, err)
+				defer func() {
+					if err := f.Close(); err != nil {
+						t.Fatalf("Error closing file %s: %s", fullpath, err)
+					}
+				}()
+			}
+			err = checkOktetoManifestPathFlag(opts, fs)
+			assert.Equal(t, tt.expectedErr, err)
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3869

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

![Screenshot from 2023-08-21 23-54-47](https://github.com/okteto/okteto/assets/86051118/8f19f3f7-1c7e-4b68-97e4-724b2be2d81d)
