### PR TITLE
fix(hybrid): read secrets from kubernetes

### DIFF
--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -245,7 +245,9 @@ func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	envs = append(envs, devContainerEnvs..., eg.getDefaultLocalEnvs()...)
+	envs = append(envs, devContainerEnvs...)
+
+	envs = append(envs, eg.getDefaultLocalEnvs()...)
 
 	for _, env := range eg.dev.Environment {
 		envs = append(envs, fmt.Sprintf("%s=%s", env.Name, env.Value))

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -282,7 +282,7 @@ func (d *devContainerEnvGetter) getEnvsFromDevContainer(ctx context.Context, spe
 		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
 			secret, err := secrets.Get(ctx, env.ValueFrom.SecretKeyRef.Name, namespace, client)
 			if err != nil {
-				return nil, err
+				return envs, fmt.Errorf("%w: the development container didn't start successfully because the kubernetes secret '%s' was not found", err, env.ValueFrom.SecretKeyRef.Name)
 			}
 			val = string(secret.Data[env.ValueFrom.SecretKeyRef.Key])
 		}

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/okteto/okteto/pkg/k8s/secrets"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,6 +41,7 @@ import (
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/ssh"
 	"github.com/okteto/okteto/pkg/types"
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -141,6 +143,10 @@ func newSyncExecutor(up *upContext) *syncExecutor {
 	}
 }
 
+type devContainerEnvGetterInterface interface {
+	getEnvsFromDevContainer(ctx context.Context, spec *apiv1.PodSpec, name, namespace string, client kubernetes.Interface) ([]string, error)
+}
+
 type configMapEnvsGetterInterface interface {
 	getEnvsFromConfigMap(ctx context.Context, name string, namespace string, client kubernetes.Interface) ([]string, error)
 }
@@ -161,8 +167,8 @@ type secretsGetterInterface interface {
 	GetUserSecrets(context.Context) ([]types.Secret, error)
 }
 
-type configMapGetter struct {
-}
+type devContainerEnvGetter struct{}
+type configMapGetter struct{}
 type secretsEnvsGetter struct {
 	secretsGetter secretsGetterInterface
 }
@@ -171,13 +177,14 @@ type imageEnvsGetter struct {
 }
 
 type envsGetter struct {
-	dev                 *model.Dev
-	name, namespace     string
-	client              kubernetes.Interface
-	configMapEnvsGetter configMapEnvsGetterInterface
-	secretsEnvsGetter   secretsEnvsGetterInterface
-	imageEnvsGetter     imageEnvsGetterInterface
-	getDefaultLocalEnvs func() []string
+	dev                   *model.Dev
+	name, namespace       string
+	client                kubernetes.Interface
+	devContainerEnvGetter devContainerEnvGetterInterface
+	configMapEnvsGetter   configMapEnvsGetterInterface
+	secretsEnvsGetter     secretsEnvsGetterInterface
+	imageEnvsGetter       imageEnvsGetterInterface
+	getDefaultLocalEnvs   func() []string
 }
 
 func newEnvsGetter(hybridCtx *HybridExecCtx) (*envsGetter, error) {
@@ -192,11 +199,12 @@ func newEnvsGetter(hybridCtx *HybridExecCtx) (*envsGetter, error) {
 	}
 
 	return &envsGetter{
-		dev:                 hybridCtx.Dev,
-		name:                hybridCtx.Name,
-		namespace:           hybridCtx.Namespace,
-		client:              hybridCtx.Client,
-		configMapEnvsGetter: &configMapGetter{},
+		dev:                   hybridCtx.Dev,
+		name:                  hybridCtx.Name,
+		namespace:             hybridCtx.Namespace,
+		client:                hybridCtx.Client,
+		devContainerEnvGetter: &devContainerEnvGetter{},
+		configMapEnvsGetter:   &configMapGetter{},
 		secretsEnvsGetter: &secretsEnvsGetter{
 			secretsGetter: secretsGetter,
 		},
@@ -233,9 +241,11 @@ func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 	}
 	envs = append(envs, configMapEnvs...)
 
-	for _, env := range apps.GetDevContainer(app.PodSpec(), "").Env {
-		envs = append(envs, fmt.Sprintf("%s=%s", env.Name, env.Value))
+	devContainerEnvs, err := eg.devContainerEnvGetter.getEnvsFromDevContainer(ctx, app.PodSpec(), "", eg.namespace, eg.client)
+	if err != nil {
+		return nil, err
 	}
+	envs = append(envs, devContainerEnvs...)
 
 	envs = append(envs, eg.getDefaultLocalEnvs()...)
 
@@ -260,6 +270,26 @@ func getDefaultLocalEnvs() []string {
 	}
 
 	return envs
+}
+
+func (d *devContainerEnvGetter) getEnvsFromDevContainer(ctx context.Context, spec *apiv1.PodSpec, name, namespace string, client kubernetes.Interface) ([]string, error) {
+	var envs []string
+
+	devContainer := apps.GetDevContainer(spec, name)
+
+	for _, env := range devContainer.Env {
+		val := env.Value
+		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+			secret, err := secrets.Get(ctx, env.ValueFrom.SecretKeyRef.Name, namespace, client)
+			if err != nil {
+				return nil, err
+			}
+			val = string(secret.Data[env.ValueFrom.SecretKeyRef.Key])
+		}
+		envs = append(envs, fmt.Sprintf("%s=%s", env.Name, val))
+	}
+
+	return envs, nil
 }
 
 func (cmg *configMapGetter) getEnvsFromConfigMap(ctx context.Context, name string, namespace string, client kubernetes.Interface) ([]string, error) {

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -245,9 +245,7 @@ func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	envs = append(envs, devContainerEnvs...)
-
-	envs = append(envs, eg.getDefaultLocalEnvs()...)
+	envs = append(envs, devContainerEnvs..., eg.getDefaultLocalEnvs()...)
 
 	for _, env := range eg.dev.Environment {
 		envs = append(envs, fmt.Sprintf("%s=%s", env.Name, env.Value))

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -45,10 +45,10 @@ func NewSecrets(k8sClient kubernetes.Interface) *Secrets {
 }
 
 // Get returns the value of a secret
-func Get(ctx context.Context, name, namespace string, c *kubernetes.Clientset) (*v1.Secret, error) {
+func Get(ctx context.Context, name, namespace string, c kubernetes.Interface) (*v1.Secret, error) {
 	secret, err := c.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return secret, fmt.Errorf("Error getting kubernetes secret: %s", err)
+		return secret, fmt.Errorf("error getting kubernetes secret: %s", err)
 	}
 	return secret, nil
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3923

## Description

This PR fixes the hybrid mode when an env var is expected to come from a kubernetes secret.

## How to test

1. Run `git clone https://github.com/okteto/movies-with-helm`
2. Checkout the hybrid branch: `git checkout origin/hybrid`
3. Delete the line `MONGODB_PASSWORD` from `okteto.yml`
4. Run `okteto deploy --build`
5. Run `okteto up api`
6. When the interactive shell is open write `printenv | grep MONGODB_PASSWORD`
7. Check that the value of `MONGODB_PASSWORD` is populated.

To verify that this change is fixing the bug, use Okteto CLI `2.19.0`and using the steps above, check that `MONGODB_PASSWORD` is empty instead.
