### PR TITLE
Tag with global and dev when pushing to global registry

### DIFF
--- a/cmd/build/v1/build.go
+++ b/cmd/build/v1/build.go
@@ -16,8 +16,9 @@ package v1
 import (
 	"context"
 	"fmt"
-	"github.com/okteto/okteto/pkg/model"
 	"path/filepath"
+
+	"github.com/okteto/okteto/pkg/model"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -110,7 +111,11 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 		oktetoLog.Success("Build succeeded")
 		oktetoLog.Information("Your image won't be pushed. To push your image specify the flag '-t'.")
 	} else {
-		oktetoLog.Success(fmt.Sprintf("Image '%s' successfully pushed", options.Tag))
+		displayTag := options.Tag
+		if options.DevTag != "" {
+			displayTag = options.DevTag
+		}
+		oktetoLog.Success(fmt.Sprintf("Image '%s' successfully pushed", displayTag))
 	}
 
 	analytics.TrackBuild(okteto.Context().Builder, true)

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -249,9 +249,14 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 	if err := bc.V1Builder.Build(ctx, buildOptions); err != nil {
 		return "", err
 	}
-	imageTagWithDigest, err := bc.Registry.GetImageTagWithDigest(buildOptions.Tag)
+	// check if the image is pushed to the dev registry if DevTag is set
+	reference := buildOptions.Tag
+	if buildOptions.DevTag != "" {
+		reference = buildOptions.DevTag
+	}
+	imageTagWithDigest, err := bc.Registry.GetImageTagWithDigest(reference)
 	if err != nil {
-		return "", fmt.Errorf("error accessing image at registry %s: %v", options.Tag, err)
+		return "", fmt.Errorf("error accessing image at registry %s: %v", reference, err)
 	}
 	return imageTagWithDigest, nil
 }

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -109,6 +109,7 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 
 	imageCtrl := registry.NewImageCtrl(okteto.Config{})
 	if okteto.IsOkteto() {
+		buildOptions.DevTag = imageCtrl.ExpandOktetoDevRegistry(registry.GetDevTagFromGlobal(buildOptions.Tag))
 		buildOptions.Tag = imageCtrl.ExpandOktetoDevRegistry(buildOptions.Tag)
 		buildOptions.Tag = imageCtrl.ExpandOktetoGlobalRegistry(buildOptions.Tag)
 		for i := range buildOptions.CacheFrom {

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -125,15 +125,29 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 	}
 
 	if buildOptions.Tag != "" {
-		opt.Exports = []client.ExportEntry{
-			{
-				Type: "image",
-				Attrs: map[string]string{
-					"name": buildOptions.Tag,
-					"push": "true",
+		// add additional tag if DevTag is defined
+		if buildOptions.DevTag != "" {
+			opt.Exports = []client.ExportEntry{
+				{
+					Type: "image",
+					Attrs: map[string]string{
+						"name": fmt.Sprintf("%s,%s", buildOptions.Tag, buildOptions.DevTag),
+						"push": "true",
+					},
 				},
-			},
+			}
+		} else {
+			opt.Exports = []client.ExportEntry{
+				{
+					Type: "image",
+					Attrs: map[string]string{
+						"name": buildOptions.Tag,
+						"push": "true",
+					},
+				},
+			}
 		}
+
 	}
 	for _, cacheFromImage := range buildOptions.CacheFrom {
 		opt.CacheImports = append(

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -131,7 +131,7 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 				{
 					Type: "image",
 					Attrs: map[string]string{
-						"name": fmt.Sprintf("%s,%s", buildOptions.Tag, buildOptions.DevTag),
+						"name": strings.Join([]string{buildOptions.Tag, buildOptions.DevTag}, ","),
 						"push": "true",
 					},
 				},

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -21,6 +21,7 @@ import (
 	containerv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 	apiv1 "k8s.io/api/core/v1"
 )
 
@@ -151,14 +152,17 @@ func GetDevTagFromGlobal(image string) string {
 	}
 
 	// separate image reference and tag eg: okteto.dev/image:tag
-	reference, _, found := strings.Cut(image, ":")
+	reference, _, found := strings.Cut(image, "@sha256")
 	if !found {
-		return ""
+		reference, _, found = strings.Cut(image, ":")
+		if !found {
+			return ""
+		}
 	}
 
 	devReference := strings.Replace(reference, constants.GlobalRegistry, constants.DevRegistry, 1)
 	if devReference == reference {
 		return ""
 	}
-	return fmt.Sprintf("%s:okteto", devReference)
+	return fmt.Sprintf("%s:%s", devReference, model.OktetoDefaultImageTag)
 }

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -144,3 +144,21 @@ func (ImageCtrl) getExposedPortsFromCfg(cfg *containerv1.ConfigFile) []Port {
 	}
 	return result
 }
+
+func GetDevTagFromGlobal(image string) string {
+	if !strings.HasPrefix(image, constants.GlobalRegistry) {
+		return ""
+	}
+
+	// separate image reference and tag eg: okteto.dev/image:tag
+	reference, _, found := strings.Cut(image, ":")
+	if !found {
+		return ""
+	}
+
+	devReference := strings.Replace(reference, constants.GlobalRegistry, constants.DevRegistry, 1)
+	if devReference == reference {
+		return ""
+	}
+	return fmt.Sprintf("%s:okteto", devReference)
+}

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -351,6 +351,11 @@ func Test_GetExpandedDevTagFromGlobal(t *testing.T) {
 			input:    "okteto.global/my-image:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
 			expected: "okteto.dev/my-image:okteto",
 		},
+		{
+			name:     "is global image with sha",
+			input:    "okteto.global/my-image@sha256:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
+			expected: "okteto.dev/my-image:okteto",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -324,3 +324,39 @@ func TestGetExposedPortsFromCfg(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetExpandedDevTagFromGlobal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "is dev image",
+			input:    "okteto.dev/my-image:okteto",
+			expected: "",
+		},
+		{
+			name:     "is dev image with sha",
+			input:    "okteto.dev/my-image@sha256:e78ad0d316485b7dbffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
+			expected: "",
+		},
+		{
+			name:     "is not okteto image",
+			input:    "mongo:okteto",
+			expected: "",
+		},
+		{
+			name:     "is global image",
+			input:    "okteto.global/my-image:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
+			expected: "okteto.dev/my-image:okteto",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetDevTagFromGlobal(tt.input)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -50,4 +50,5 @@ type BuildOptions struct {
 	SshSessions []BuildSshSession
 
 	Manifest *model.Manifest
+	DevTag   string
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3922 

- As Tag option just enables for one tag, added new `DevTag` in order to let know buildkit that the same image has 2 tags.
- translate from global to dev when applies and expand the tag to save it at DevTag
- modify opt.Exports at buildkit so it pushes two tags for the image
- when pushing to global, success message is using the dev tag instead of global
- when pushing to global, envs set for the build are using the DevTag reference

## Tested

Followed steps at issue

Now when pushing to global, we display the following success message 