### PR TITLE
Account for existing docker config in remote

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ COPY docker-credential-okteto /okteto/bin/docker-credential-okteto
 
 FROM alpine:3
 
-RUN apk add --no-cache bash ca-certificates
+RUN apk add --no-cache bash ca-certificates jq
 
 COPY --from=kubectl-builder /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=helm-builder /usr/local/bin/helm /usr/local/bin/helm
@@ -54,6 +54,7 @@ COPY --from=kustomize-builder /usr/local/bin/kustomize /usr/local/bin/kustomize
 COPY --from=builder /okteto/bin/okteto /usr/local/bin/okteto
 COPY --from=builder /okteto/bin/docker-credential-okteto /usr/local/bin/docker-credential-okteto
 
+RUN mv $(which jq) /usr/local/bin/jq
 
 ENV OKTETO_DISABLE_SPINNER=true
 

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -76,9 +76,10 @@ ENV {{$key}} {{$val}}
 ARG {{ .GitCommitArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
-RUN \
-  mkdir -p $HOME/.docker && \
-  echo '{"credsStore":"okteto"}' > $HOME/.docker/config.json
+RUN mkdir -p $HOME/.docker && \
+  touch $HOME/.docker/config.json && \
+  [ ! -s $HOME/.docker/config.json ] && (echo "{}" > $HOME/.docker/config.json);\
+  echo $(cat $HOME/.docker/config.json | jq '. + {"credsStore": "okteto"}') > $HOME/.docker/config.json
 
 RUN --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -410,9 +410,10 @@ ENV OKTETO_BUIL_SVC_IMAGE ONE_VALUE
 ARG OKTETO_GIT_COMMIT
 ARG OKTETO_INVALIDATE_CACHE
 
-RUN \
-  mkdir -p $HOME/.docker && \
-  echo '{"credsStore":"okteto"}' > $HOME/.docker/config.json
+RUN mkdir -p $HOME/.docker && \
+  touch $HOME/.docker/config.json && \
+  [ ! -s $HOME/.docker/config.json ] && (echo "{}" > $HOME/.docker/config.json);\
+  echo $(cat $HOME/.docker/config.json | jq '. + {"credsStore": "okteto"}') > $HOME/.docker/config.json
 
 RUN --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -72,9 +72,10 @@ WORKDIR /okteto/src
 ARG {{ .GitCommitArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
-RUN \
-  mkdir -p $HOME/.docker && \
-  echo '{"credsStore":"okteto"}' > $HOME/.docker/config.json
+RUN mkdir -p $HOME/.docker && \
+  touch $HOME/.docker/config.json && \
+  [ ! -s $HOME/.docker/config.json ] && (echo "{}" > $HOME/.docker/config.json);\
+  echo $(cat $HOME/.docker/config.json | jq '. + {"credsStore": "okteto"}') > $HOME/.docker/config.json
 
 RUN --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \


### PR DESCRIPTION
# Proposed changes

Came up during daily that it may exist the possibility that a user has a docker config defined in their base image and that we are overriding it in remote deploy/destroy. I don't know why would someone do that (hardcode credentials in a base image) but this would break that scenario.

## Technical Details

Instead of writing directly to `$HOME/.docker/config.json` check first that the file exists and if it does, merge it with our default `credsStore`.

@jpf-okteto the one line we debugged doesn't work well because of redirection and jq doesn't allow in place editing so I ended up doing it a little more verbose while also accounting for empty contents.

So:

```
1. mkdir -p $HOME/.docker ---------------------------------> if folder doesn't exist create it
2. touch $HOME/.docker/config.json ------------------------> if file doesn't exist create it
3. [ ! -s $HOME/.docker/config.json ] && ...; -------------> if file is empty because it was create by 2. create an empty json
4. ... | jq '. + {"credsStore": "okteto"}') > ... ---------> append our default creds helper to the docker config file
```

Note that we are also adding `jq` to the cli image. By default the [pipeline runner has jq installed](https://github.com/okteto/pipeline-runner/blob/main/Dockerfile#L20) and that binary will be used. However,  if the base image is updated and for some reason not extended from that runner base image, we default to the binary in the okteto image that will always be there.

