### PR TITLE
fix: registrytoken cmd notfound error

### DIFF
--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -95,6 +95,11 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 	if req.Host == "registry-1.docker.io" {
 		req.Host = "https://index.docker.io/v1/"
 	}
+
+	if ap.config.CredentialsStore == "okteto" {
+		ap.config.CredentialsStore = ""
+	}
+
 	ac, err := ap.config.GetAuthConfig(req.Host)
 	if err != nil {
 		if isErrCredentialsHelperNotAccessible(err) {

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -289,6 +289,8 @@ func translateAPIErr(err error) error {
 		return fmt.Errorf("server temporarily unavailable, please try again")
 	case "non-200 OK status code: 401 Unauthorized body: \"\"":
 		return fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")
+	case "not-found":
+		return oktetoErrors.ErrNotFound
 
 	default:
 		if oktetoErrors.IsX509(err) {

--- a/pkg/okteto/registry_credentials.go
+++ b/pkg/okteto/registry_credentials.go
@@ -109,6 +109,7 @@ func GetExternalRegistryCredentialsWithContext(ctx context.Context, registryOrIm
 		getter:   c.User().GetRegistryCredentials,
 		cache:    &globalRegistryCredentialsCache,
 	}
+	oktetoLog.Infof("Obtaining credentials for %q ...", registryOrImage)
 	return r.read(ctx, registryOrImage)
 }
 

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	dockertypes "github.com/docker/cli/cli/config/types"
+	dockercredentials "github.com/docker/docker-credential-helpers/credentials"
 )
 
 type userClient struct {
@@ -334,10 +335,10 @@ func (c *userClient) GetRegistryCredentials(ctx context.Context, host string) (d
 
 	if err != nil {
 		if strings.Contains(err.Error(), "Cannot query field \"registryCredentials\" on type \"Query\"") {
-			return dockertypes.AuthConfig{}, nil
+			return dockertypes.AuthConfig{}, dockercredentials.NewErrCredentialsNotFound()
 		}
 		if errors.IsNotFound(err) {
-			return dockertypes.AuthConfig{}, nil
+			return dockertypes.AuthConfig{}, dockercredentials.NewErrCredentialsNotFound()
 		}
 		return dockertypes.AuthConfig{}, err
 	}


### PR DESCRIPTION
The following PR fixes how registrytoken command should behave on notfound errors.

Docker credential helpers must return a specific error on this scenario.

The PR also adds logs for what is being requested to the credential helper.

An optimization is made to ensure the credential helper is not called by okteto if set in the dockerconfig.

Finally, not-found api error is added to the translateApiErr function to avoid the logline "Unrecognized API error".