### PR TITLE
feat: clone from global to dev reg already built images

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -55,6 +55,7 @@ type registryInterface interface {
 
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
+	CloneGlobalImageToDev(imageWithDigest, tag string) (string, error)
 }
 
 // NewBuildCommand creates a struct to run all build methods

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -88,6 +88,9 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
+func (fr fakeRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+	return "", nil
+}
 
 var fakeManifestV2 *model.Manifest = &model.Manifest{
 	Build: model.ManifestBuild{

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -50,6 +50,7 @@ type oktetoRegistryInterface interface {
 
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
+	CloneGlobalImageToDev(imageWithDigest, tag string) (string, error)
 }
 
 // oktetoBuilderConfigInterface returns the configuration that the builder has for the registry and project
@@ -169,9 +170,21 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 			// We only check that the image is built in the global registry if the noCache option is not set
 			if !options.NoCache && bc.Config.IsCleanProject() {
 				imageChecker := getImageChecker(buildSvcInfo, bc.Config, bc.Registry)
-				if imageTag, isBuilt := imageChecker.checkIfCommitHashIsBuilt(options.Manifest.Name, svcToBuild, buildSvcInfo); isBuilt {
-					oktetoLog.Warning("Skipping build of '%s' image because it's already built for commit %s", svcToBuild, bc.Config.GetGitCommit())
-					bc.SetServiceEnvVars(svcToBuild, imageTag)
+				if imageWithDigest, isBuilt := imageChecker.checkIfCommitHashIsBuilt(options.Manifest.Name, svcToBuild, buildSvcInfo); isBuilt {
+					oktetoLog.Information("Skipping build of '%s' image because it's already built for commit %s", svcToBuild, bc.Config.GetGitCommit())
+					// if the built image belongs to global registry we clone it to the dev registry
+					// so that in can be used in dev containers (i.e. okteto up)
+					if bc.Registry.IsGlobalRegistry(imageWithDigest) {
+						oktetoLog.Debugf("Copying image '%s' from global to personal registry", svcToBuild)
+						tag := bc.Config.GetBuildHash(buildSvcInfo)
+						newImage, err := bc.Registry.CloneGlobalImageToDev(imageWithDigest, tag)
+						if err != nil {
+							return err
+						}
+						imageWithDigest = newImage
+					}
+
+					bc.SetServiceEnvVars(svcToBuild, imageWithDigest)
 					bc.builtImages[svcToBuild] = true
 					continue
 				}

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -177,11 +177,11 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 					if bc.Registry.IsGlobalRegistry(imageWithDigest) {
 						oktetoLog.Debugf("Copying image '%s' from global to personal registry", svcToBuild)
 						tag := bc.Config.GetBuildHash(buildSvcInfo)
-						newImage, err := bc.Registry.CloneGlobalImageToDev(imageWithDigest, tag)
+						devImage, err := bc.Registry.CloneGlobalImageToDev(imageWithDigest, tag)
 						if err != nil {
 							return err
 						}
-						imageWithDigest = newImage
+						imageWithDigest = devImage
 					}
 
 					bc.SetServiceEnvVars(svcToBuild, imageWithDigest)

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -132,6 +132,9 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
+func (fr fakeRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+	return "", nil
+}
 
 func NewFakeBuilder(builder OktetoBuilderInterface, registry oktetoRegistryInterface, cfg oktetoBuilderConfigInterface) *OktetoBuilder {
 	return &OktetoBuilder{

--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -76,6 +76,7 @@ func (oc oktetoBuilderConfig) IsCleanProject() bool {
 	return oc.isCleanProject
 }
 
+// GetGitCommit returns the commit sha of the repository
 func (oc oktetoBuilderConfig) GetGitCommit() string {
 	commitSHA, err := oc.repository.GetSHA()
 	if err != nil {
@@ -84,7 +85,7 @@ func (oc oktetoBuilderConfig) GetGitCommit() string {
 	return commitSHA
 }
 
-// GetBuildTag returns a sha hash of the build info and the commit sha
+// GetBuildHash returns a sha hash of the build info and the commit sha
 func (oc oktetoBuilderConfig) GetBuildHash(buildInfo *model.BuildInfo) string {
 	commitSHA, err := oc.repository.GetSHA()
 	if err != nil {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -117,6 +117,9 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
+func (fr fakeRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+	return "", nil
+}
 
 var fakeManifest *model.Manifest = &model.Manifest{
 	Deploy: &model.DeployInfo{

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -84,6 +84,7 @@ func newOktetoRegistryClient(config ClientConfigInterface) client {
 	}
 }
 
+// GetDescriptor returns the descriptor of an image
 func (c client) GetDescriptor(image string) (*remote.Descriptor, error) {
 	ref, err := name.ParseReference(image)
 	if err != nil {
@@ -102,6 +103,7 @@ func (c client) GetDescriptor(image string) (*remote.Descriptor, error) {
 	return descriptor, nil
 }
 
+// Write writes an image metadata to the registry
 func (c client) Write(ref name.Reference, image v1.Image) error {
 	options := c.getOptions(ref)
 	return c.write(ref, image, options...)

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -33,6 +33,8 @@ type clientInterface interface {
 	GetDigest(image string) (string, error)
 	GetImageConfig(image string) (*v1.ConfigFile, error)
 	HasPushAccess(image string) (bool, error)
+	GetDescriptor(image string) (*remote.Descriptor, error)
+	Write(ref name.Reference, image v1.Image) error
 }
 
 type ClientConfigInterface interface {
@@ -69,6 +71,7 @@ func (oh oktetoHelper) Get(_ string) (string, string, error) {
 type client struct {
 	config  ClientConfigInterface
 	get     func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error)
+	write   func(ref name.Reference, image v1.Image, options ...remote.Option) error
 	tlsDial oktetoHttp.TLSDialFunc
 }
 
@@ -76,11 +79,12 @@ func newOktetoRegistryClient(config ClientConfigInterface) client {
 	return client{
 		config:  config,
 		get:     remote.Get,
+		write:   remote.Write,
 		tlsDial: oktetoHttp.DefaultTLSDial,
 	}
 }
 
-func (c client) getDescriptor(image string) (*remote.Descriptor, error) {
+func (c client) GetDescriptor(image string) (*remote.Descriptor, error) {
 	ref, err := name.ParseReference(image)
 	if err != nil {
 		return nil, err
@@ -98,9 +102,14 @@ func (c client) getDescriptor(image string) (*remote.Descriptor, error) {
 	return descriptor, nil
 }
 
+func (c client) Write(ref name.Reference, image v1.Image) error {
+	options := c.getOptions(ref)
+	return c.write(ref, image, options...)
+}
+
 // GetDigest returns the digest of an image
 func (c client) GetDigest(image string) (string, error) {
-	descriptor, err := c.getDescriptor(image)
+	descriptor, err := c.GetDescriptor(image)
 	if err != nil {
 		return "", fmt.Errorf("error getting image digest: %w", err)
 	}
@@ -109,7 +118,7 @@ func (c client) GetDigest(image string) (string, error) {
 
 // GetImageConfig returns the config of an image
 func (c client) GetImageConfig(image string) (*v1.ConfigFile, error) {
-	descriptor, err := c.getDescriptor(image)
+	descriptor, err := c.GetDescriptor(image)
 	if err != nil {
 		return nil, fmt.Errorf("error getting image configuration: %w", err)
 	}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -18,6 +18,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
 	"net"
 	"net/http"
 	"sync"
@@ -84,9 +86,11 @@ func (t *fakeTLSDial) tlsDial(network string, addr string, config *tls.Config) (
 
 // FakeClient has everything needed to set up a test faking API calls
 type fakeClient struct {
-	GetImageDigest getDigest
-	GetConfig      getConfig
-	HasPushAcces   hasPushAccess
+	GetImageDigest    getDigest
+	GetConfig         getConfig
+	MockGetDescriptor getDescriptor
+	MockWrite         write
+	HasPushAcces      hasPushAccess
 }
 
 // GetDigest has everything needed to mock a getDigest API call
@@ -99,6 +103,15 @@ type getDigest struct {
 type getConfig struct {
 	Result *containerv1.ConfigFile
 	Err    error
+}
+
+type getDescriptor struct {
+	Result *remote.Descriptor
+	Err    error
+}
+
+type write struct {
+	Err error
 }
 
 type hasPushAccess struct {
@@ -116,6 +129,13 @@ func (fc fakeClient) GetImageConfig(_ string) (*containerv1.ConfigFile, error) {
 
 func (fc fakeClient) HasPushAccess(_ string) (bool, error) {
 	return fc.HasPushAcces.Result, fc.HasPushAcces.Err
+}
+
+func (fc fakeClient) GetDescriptor(_ string) (*remote.Descriptor, error) {
+	return fc.MockGetDescriptor.Result, fc.MockGetDescriptor.Err
+}
+func (fc fakeClient) Write(_ name.Reference, _ v1.Image) error {
+	return fc.MockWrite.Err
 }
 
 type fakeClientConfig struct {

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"net"
 	"net/http"
 	"sync"
@@ -134,7 +133,7 @@ func (fc fakeClient) GetDescriptor(_ string) (*remote.Descriptor, error) {
 	return fc.MockGetDescriptor.Result, fc.MockGetDescriptor.Err
 }
 
-func (fc fakeClient) Write(_ name.Reference, _ v1.Image) error {
+func (fc fakeClient) Write(_ name.Reference, _ containerv1.Image) error {
 	return fc.MockWrite.Err
 }
 
@@ -535,7 +534,7 @@ func Test_GetDescriptor(t *testing.T) {
 func Test_Write(t *testing.T) {
 	type input struct {
 		ref   name.Reference
-		image v1.Image
+		image containerv1.Image
 	}
 	type writeConfig struct {
 		err error
@@ -554,7 +553,7 @@ func Test_Write(t *testing.T) {
 			name: "failed to write",
 			input: input{
 				ref:   name.Reference(nil),
-				image: v1.Image(nil),
+				image: containerv1.Image(nil),
 			},
 			expected: expected{
 				err: assert.AnError,
@@ -567,7 +566,7 @@ func Test_Write(t *testing.T) {
 			name: "success",
 			input: input{
 				ref:   name.Reference(nil),
-				image: v1.Image(nil),
+				image: containerv1.Image(nil),
 			},
 			expected: expected{
 				err: nil,
@@ -581,7 +580,7 @@ func Test_Write(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := client{
-				write: func(_ name.Reference, _ v1.Image, _ ...remote.Option) error {
+				write: func(_ name.Reference, _ containerv1.Image, _ ...remote.Option) error {
 					return tt.writeConfig.err
 				},
 			}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -146,10 +146,54 @@ func (or OktetoRegistry) HasGlobalPushAccess() (bool, error) {
 	return or.client.HasPushAccess(image)
 }
 
+// GetRegistryAndRepo returns image and registry of a given image
 func (or OktetoRegistry) GetRegistryAndRepo(image string) (string, string) {
 	return or.imageCtrl.GetRegistryAndRepo(image)
 }
 
+// GetRepoNameAndTag returns the repo name and tag of a given image
 func (or OktetoRegistry) GetRepoNameAndTag(repo string) (string, string) {
 	return or.imageCtrl.GetRepoNameAndTag(repo)
 }
+
+// CloneGlobalImageToDev clones an image from the global registry to the dev registry
+func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+	descriptor, err := or.client.GetDescriptor(imageWithDigest)
+	if err != nil {
+		return "", err
+	}
+
+	// parsing the image URI to extract registry and repository name
+	reg, repositoryWithTag := or.imageCtrl.GetRegistryAndRepo(imageWithDigest)
+	repo, _ := or.imageCtrl.GetRepoNameAndTag(repositoryWithTag)
+
+	if !strings.HasPrefix(repo, fmt.Sprintf("%s/", or.imageCtrl.config.GetGlobalNamespace())) {
+		return "", fmt.Errorf("image %s is not in the global registry", repo)
+	}
+
+	// forging a new image URI in the dev registry, using the same repo name and tag as the global image
+	globalNamespacePrefix := fmt.Sprintf("%s/", or.imageCtrl.config.GetGlobalNamespace())
+	personalNamespacePrefix := fmt.Sprintf("%s/", or.config.GetNamespace())
+	devRepo := strings.Replace(repo, globalNamespacePrefix, personalNamespacePrefix, 1)
+	devImage := fmt.Sprintf("%s/%s:%s", reg, devRepo, tag)
+
+	newRef, err := name.ParseReference(devImage)
+	if err != nil {
+		return "", err
+	}
+
+	i, err := descriptor.Image()
+	if err != nil {
+		return "", err
+	}
+
+	// writing the new image to the registry
+	err = or.client.Write(newRef, i)
+	if err != nil {
+		return "", err
+	}
+
+	return devImage, nil
+}
+
+//

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -15,6 +15,8 @@ package registry
 
 import (
 	"crypto/x509"
+	"fmt"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -48,8 +50,21 @@ func (fc FakeConfig) GetContextCertificate() (*x509.Certificate, error) {
 }
 func (fc FakeConfig) GetServerNameOverride() string { return fc.ServerName }
 func (fc FakeConfig) GetContextName() string        { return fc.ContextName }
-func (f FakeConfig) GetExternalRegistryCredentials(_ string) (string, string, error) {
-	return f.externalRegistryCredentials[0], f.externalRegistryCredentials[1], nil
+func (fc FakeConfig) GetExternalRegistryCredentials(_ string) (string, string, error) {
+	return fc.externalRegistryCredentials[0], fc.externalRegistryCredentials[1], nil
+}
+
+type fakeDescriptor struct {
+	MockImage mockImageFunc
+}
+
+func (f *fakeDescriptor) Image() (v1.Image, error) {
+	return f.MockImage.Result, f.MockImage.Err
+}
+
+type mockImageFunc struct {
+	Result v1.Image
+	Err    error
 }
 
 func TestGetImageTagWithDigest(t *testing.T) {
@@ -328,6 +343,108 @@ func TestGetImageMetadata(t *testing.T) {
 			result, err := or.GetImageMetadata(tt.input.input)
 			assert.Equal(t, tt.expected.metadata, result)
 			assert.ErrorIs(t, err, tt.expected.err)
+		})
+	}
+}
+
+func Test_OktetoRegistry_CloneGlobalImageToDev(t *testing.T) {
+	type expected struct {
+		image string
+		err   error
+	}
+	type config struct {
+		image  string
+		tag    string
+		config configInterface
+	}
+	var tests = []struct {
+		name     string
+		input    config
+		expected expected
+		client   fakeClient
+	}{
+		{
+			name: "not a global image repository returns error",
+			input: config{
+				image: "this.is.my.okteto.registry/test-ns/test-repo@sha-256:123456789",
+				tag:   "test-tag",
+				config: FakeConfig{
+					RegistryURL:        "this.is.my.okteto.registry",
+					GlobalNamespace:    "test-global",
+					IsOktetoClusterCfg: true,
+					Namespace:          "test-ns",
+				},
+			},
+			expected: expected{
+				image: "",
+				err:   fmt.Errorf("image repository 'test-ns/test-repo' is not in the global registry"),
+			},
+		},
+		{
+			name: "fail to get global image descriptor",
+			input: config{
+				image: "this.is.my.okteto.registry/test-global/test-repo@sha256:123",
+				tag:   "test-tag",
+				config: FakeConfig{
+					RegistryURL:        "this.is.my.okteto.registry",
+					GlobalNamespace:    "test-global",
+					IsOktetoClusterCfg: true,
+					Namespace:          "test-ns",
+				},
+			},
+			client: fakeClient{
+				MockGetDescriptor: mockGetDescriptor{
+					Result: nil,
+					Err:    assert.AnError,
+				},
+			},
+			expected: expected{
+				image: "",
+				err:   assert.AnError,
+			},
+		},
+		{
+			name: "success",
+			input: config{
+				image: "this.is.my.okteto.registry/test-global/test-repo@sha256:123",
+				tag:   "test-tag",
+				config: FakeConfig{
+					RegistryURL:        "this.is.my.okteto.registry",
+					GlobalNamespace:    "test-global",
+					IsOktetoClusterCfg: true,
+					Namespace:          "test-ns",
+				},
+			},
+			client: fakeClient{
+				MockGetDescriptor: mockGetDescriptor{
+					Result: &remote.Descriptor{
+						Descriptor: v1.Descriptor{},
+						Manifest:   nil,
+					},
+				},
+				MockWrite: mockWrite{
+					Err: nil,
+				},
+			},
+			expected: expected{
+				image: "this.is.my.okteto.registry/test-ns/test-repo:test-tag",
+				err:   nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			or := OktetoRegistry{
+				imageCtrl: NewImageCtrl(tt.input.config),
+				config:    tt.input.config,
+				client:    tt.client,
+			}
+
+			result, err := or.CloneGlobalImageToDev(tt.input.image, tt.input.tag)
+			assert.Equal(t, tt.expected.image, result)
+			if tt.expected.err != nil && err != nil {
+				assert.Equal(t, err.Error(), tt.expected.err.Error())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/okteto/okteto/issues/3921

## Description
This PR introduces a change that makes the Okteto CLI to clone an image that is already built in the global registry, to the dev registry.

## How to test 
Follow the steps in the issue.

Depending on your registry, it may be needed to clean up the test repo in your namespace.

## Demo
Internal demo: https://www.loom.com/share/ebdaff7cd2db4055941301e5298fb041

This is how the new log looks like: `DEBU[0001] Copying image 'frontend' from global to personal registry`

![Screenshot 2023-08-28 at 21 56 10](https://github.com/okteto/okteto/assets/2318450/366b3b2d-092e-45c7-85b7-97d2f5c89266)

