### PR TITLE
expand branch value if comes from variable

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -552,7 +552,7 @@ func (dc *DeployCommand) deployDependencies(ctx context.Context, deployOptions *
 			namespace = dep.Namespace
 		}
 
-		err := dep.ExpandVarsInSection(deployOptions.Variables)
+		err := dep.ExpandVars(deployOptions.Variables)
 		if err != nil {
 			return fmt.Errorf("could not expand variables in dependencies: %w", err)
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
@@ -550,6 +551,23 @@ func (dc *DeployCommand) deployDependencies(ctx context.Context, deployOptions *
 		namespace := okteto.Context().Namespace
 		if dep.Namespace != "" {
 			namespace = dep.Namespace
+		}
+
+		branchExpMapping := func(branchValue string) string {
+			for _, v := range deployOptions.Variables {
+				kv := strings.SplitN(v, "=", 2)
+				if len(kv) != 2 {
+					continue
+				}
+				if branchValue == kv[0] {
+					return kv[1]
+				}
+			}
+			return ""
+		}
+		expandedBranch := os.Expand(dep.Branch, branchExpMapping)
+		if expandedBranch != "" {
+			dep.Branch = expandedBranch
 		}
 		pipOpts := &pipelineCMD.DeployOptions{
 			Name:         depName,

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1030,22 +1030,16 @@ func TestDeployDependencies(t *testing.T) {
 			"a": &model.Dependency{
 				Namespace: "b",
 			},
-			"b": &model.Dependency{
-				Branch: "branchValueWithoutExpanding",
-			},
-			"c": &model.Dependency{
-				Branch: "${TEST_BRANCH_NAME}",
-			},
+			"b": &model.Dependency{},
 		},
 	}
 	type config struct {
 		pipelineErr error
 	}
 	tt := []struct {
-		name      string
-		config    config
-		expected  error
-		variables []string
+		name     string
+		config   config
+		expected error
 	}{
 		{
 			name:     "error deploying dependency",
@@ -1055,14 +1049,6 @@ func TestDeployDependencies(t *testing.T) {
 		{
 			name: "successful",
 		},
-		{
-			name:      "deploy dependency expanding branch name",
-			variables: []string{"BAD_VARIABLE_FORMAT"},
-		},
-		{
-			name:      "deploy dependency expanding branch name",
-			variables: []string{"TEST_BRANCH_NAME=myBranch"},
-		},
 	}
 
 	for _, tc := range tt {
@@ -1070,7 +1056,7 @@ func TestDeployDependencies(t *testing.T) {
 			dc := &DeployCommand{
 				PipelineCMD: fakePipelineDeployer{tc.config.pipelineErr},
 			}
-			assert.ErrorIs(t, tc.expected, dc.deployDependencies(context.Background(), &Options{Manifest: fakeManifest, Variables: tc.variables}))
+			assert.ErrorIs(t, tc.expected, dc.deployDependencies(context.Background(), &Options{Manifest: fakeManifest}))
 		})
 	}
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1030,16 +1030,22 @@ func TestDeployDependencies(t *testing.T) {
 			"a": &model.Dependency{
 				Namespace: "b",
 			},
-			"b": &model.Dependency{},
+			"b": &model.Dependency{
+				Branch: "branchValueWithoutExpanding",
+			},
+			"c": &model.Dependency{
+				Branch: "${TEST_BRANCH_NAME}",
+			},
 		},
 	}
 	type config struct {
 		pipelineErr error
 	}
 	tt := []struct {
-		name     string
-		config   config
-		expected error
+		name      string
+		config    config
+		expected  error
+		variables []string
 	}{
 		{
 			name:     "error deploying dependency",
@@ -1049,6 +1055,14 @@ func TestDeployDependencies(t *testing.T) {
 		{
 			name: "successful",
 		},
+		{
+			name:      "deploy dependency expanding branch name",
+			variables: []string{"BAD_VARIABLE_FORMAT"},
+		},
+		{
+			name:      "deploy dependency expanding branch name",
+			variables: []string{"TEST_BRANCH_NAME=myBranch"},
+		},
 	}
 
 	for _, tc := range tt {
@@ -1056,7 +1070,7 @@ func TestDeployDependencies(t *testing.T) {
 			dc := &DeployCommand{
 				PipelineCMD: fakePipelineDeployer{tc.config.pipelineErr},
 			}
-			assert.ErrorIs(t, tc.expected, dc.deployDependencies(context.Background(), &Options{Manifest: fakeManifest}))
+			assert.ErrorIs(t, tc.expected, dc.deployDependencies(context.Background(), &Options{Manifest: fakeManifest, Variables: tc.variables}))
 		})
 	}
 }

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -19,12 +19,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/okteto/okteto/pkg/k8s/secrets"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/okteto/okteto/pkg/k8s/secrets"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1021,8 +1021,8 @@ func (d *Dependency) GetTimeout(defaultTimeout time.Duration) time.Duration {
 	return defaultTimeout
 }
 
-// ExpandVarsInSection sets dependencies values if values fits with list params
-func (d *Dependency) ExpandVarsInSection(envKeyPairs []string) error {
+// ExpandVars sets dependencies values if values fits with list params
+func (d *Dependency) ExpandVars(envKeyPairs []string) error {
 	parser := parse.New("string", envKeyPairs, &parse.Restrictions{})
 
 	expandedBranch, err := parser.Parse(d.Branch)

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1022,8 +1022,8 @@ func (d *Dependency) GetTimeout(defaultTimeout time.Duration) time.Duration {
 }
 
 // ExpandVars sets dependencies values if values fits with list params
-func (d *Dependency) ExpandVars(envKeyPairs []string) error {
-	parser := parse.New("string", envKeyPairs, &parse.Restrictions{})
+func (d *Dependency) ExpandVars(variables []string) error {
+	parser := parse.New("string", append(os.Environ(), variables...), &parse.Restrictions{})
 
 	expandedBranch, err := parser.Parse(d.Branch)
 	if err != nil {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1021,7 +1021,7 @@ func (d *Dependency) GetTimeout(defaultTimeout time.Duration) time.Duration {
 	return defaultTimeout
 }
 
-// GetTimeout returns dependency.Timeout if it's set or the one passed as arg if it's not
+// ExpandVarsInSection sets dependencies values if values fits with list params
 func (d *Dependency) ExpandVarsInSection(envKeyPairs []string) error {
 	parser := parse.New("string", envKeyPairs, &parse.Restrictions{})
 

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1027,7 +1027,7 @@ func (d *Dependency) ExpandVars(variables []string) error {
 
 	expandedBranch, err := parser.Parse(d.Branch)
 	if err != nil {
-		return err
+		return fmt.Errorf("error expanding 'branch': %w", err)
 	}
 	if expandedBranch != "" {
 		d.Branch = expandedBranch
@@ -1035,7 +1035,7 @@ func (d *Dependency) ExpandVars(variables []string) error {
 
 	expandedRepository, err := parser.Parse(d.Repository)
 	if err != nil {
-		return err
+		return fmt.Errorf("error expanding 'repository': %w", err)
 	}
 	if expandedRepository != "" {
 		d.Repository = expandedRepository
@@ -1043,7 +1043,7 @@ func (d *Dependency) ExpandVars(variables []string) error {
 
 	expandedManifestPath, err := parser.Parse(d.ManifestPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("error expanding 'manifest': %w", err)
 	}
 	if expandedManifestPath != "" {
 		d.ManifestPath = expandedManifestPath
@@ -1051,7 +1051,7 @@ func (d *Dependency) ExpandVars(variables []string) error {
 
 	expandedNamespace, err := parser.Parse(d.Namespace)
 	if err != nil {
-		return err
+		return fmt.Errorf("error expanding 'namespace': %w", err)
 	}
 	if expandedNamespace != "" {
 		d.Namespace = expandedNamespace
@@ -1061,7 +1061,7 @@ func (d *Dependency) ExpandVars(variables []string) error {
 	for _, v := range d.Variables {
 		expandedVarName, err := parser.Parse(v.Name)
 		if err != nil {
-			return err
+			return fmt.Errorf("error expanding variable name: %w", err)
 		}
 		if expandedVarName != "" {
 			v.Name = expandedVarName
@@ -1069,7 +1069,7 @@ func (d *Dependency) ExpandVars(variables []string) error {
 
 		expandedVarValue, err := parser.Parse(v.Value)
 		if err != nil {
-			return err
+			return fmt.Errorf("error expanding variable value: %w", err)
 		}
 		if expandedVarValue != "" {
 			v.Value = expandedVarValue

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1148,7 +1148,7 @@ func Test_GetTimeout(t *testing.T) {
 	}
 }
 
-func Test_ExpandVarsInSection(t *testing.T) {
+func Test_ExpandVars(t *testing.T) {
 	dependency := Dependency{
 		Repository:   "${REPO}",
 		Branch:       "${NOBRANCHSET-$BRANCH}",
@@ -1190,7 +1190,7 @@ func Test_ExpandVarsInSection(t *testing.T) {
 		"AVARVALUE=thisIsAValue",
 	}
 
-	err := dependency.ExpandVarsInSection(envVariables)
+	err := dependency.ExpandVars(envVariables)
 	require.NoError(t, err)
 	assert.Equal(t, dependency, expected)
 }

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1149,6 +1149,7 @@ func Test_GetTimeout(t *testing.T) {
 }
 
 func Test_ExpandVars(t *testing.T) {
+	t.Setenv("MY_CUSTOM_VAR_FROM_ENVIRON", "varValueFromEnv")
 	dependency := Dependency{
 		Repository:   "${REPO}",
 		Branch:       "${NOBRANCHSET-$BRANCH}",
@@ -1161,7 +1162,7 @@ func Test_ExpandVars(t *testing.T) {
 			},
 			EnvVar{
 				Name:  "$${ANAME}",
-				Value: "MyValue",
+				Value: "${MY_CUSTOM_VAR_FROM_ENVIRON}",
 			},
 		},
 	}
@@ -1177,7 +1178,7 @@ func Test_ExpandVars(t *testing.T) {
 			},
 			EnvVar{
 				Name:  "${ANAME}",
-				Value: "MyValue",
+				Value: "varValueFromEnv",
 			},
 		},
 	}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1154,7 +1154,7 @@ func Test_ExpandVars(t *testing.T) {
 		Repository:   "${REPO}",
 		Branch:       "${NOBRANCHSET-$BRANCH}",
 		ManifestPath: "${NOMPATHSET=$MPATH}",
-		Namespace:    "${FOO+$NAMESPACE}",
+		Namespace:    "${FOO+$SOME_NS_DEP_EXP}",
 		Variables: Environment{
 			EnvVar{
 				Name:  "MYVAR",
@@ -1187,13 +1187,13 @@ func Test_ExpandVars(t *testing.T) {
 		"REPO=my/repo",
 		"BRANCH=myBranch",
 		"MPATH=api/okteto.yml",
-		"NAMESPACE=oktetoNs",
+		"SOME_NS_DEP_EXP=oktetoNs",
 		"AVARVALUE=thisIsAValue",
 	}
 
 	err := dependency.ExpandVars(envVariables)
 	require.NoError(t, err)
-	assert.Equal(t, dependency, expected)
+	assert.Equal(t, expected, dependency)
 }
 
 func Test_Manifest_HasDeploySection(t *testing.T) {


### PR DESCRIPTION
# Proposed changes
- expand dependencies values if variables values fits
- add unit test

Fixes #https://github.com/okteto/app/issues/7104

# How to test changes
To test everything works as expected, I've created a repo with a custom `dependencies` section. The sections looks like:
`````yml
dependencies:
  test-depen:
    repository: ${DESIRED_REPO}
    branch: ${DESIRED_BRANCH}
    variables:
      ${CUSTOM_VARIABLE}: ${CUSTOM_VARIABLE_VALUE}
`````
The expected behavior is that every variable set in the UI need to be expanded in this section so `repository`, `branch` and values for name and value related to variable set in the section need to be expanded. 
Steps:
1. Using Okteto UI, deploy git repo `https://github.com/AdrianPedriza/movies` using the following values:
<img width="751" alt="Captura de Pantalla 2023-09-04 a las 9 45 04" src="https://github.com/okteto/okteto/assets/22500940/685748a6-1b60-44ba-be20-a946d58a6417">

2. Click "Launch" button.
3. Check variables has been propagated as expected:
- dependencies is using the desired repo and branch:
<img width="998" alt="Captura de Pantalla 2023-09-04 a las 9 47 13" src="https://github.com/okteto/okteto/assets/22500940/bce75075-09d8-4736-96f6-f52a31c082b4">

- desired variable name and value is in configmap under `variables` section. Exec the following command:
````cmd
k get cm okteto-git-test-depen -o json | jq -r '.data.variables' | base64 --decode
````
