### PR TITLE
chore: use out.String() instead of string(out.Bytes())

### DIFF
--- a/integration/commands/dev.go
+++ b/integration/commands/dev.go
@@ -101,7 +101,7 @@ func RunOktetoUpAndWaitWithOutput(oktetoPath string, upOptions *UpOptions) (byte
 	err := cmd.Wait()
 	if err != nil {
 		log.Printf("okteto up failed: %v", err)
-		log.Printf("okteto up output err: \n%s", string(out.Bytes()))
+		log.Printf("okteto up output err: \n%s", out.String())
 		return out, err
 	}
 	return out, nil


### PR DESCRIPTION
# Proposed changes

Fixes # (issue)

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
