### PR TITLE
Basic golangci lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,18 @@ jobs:
   golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.54.2
+    environment:
+      GOCACHE: /cache/go
+      GOLANGCI_LINT_CACHE: /cache/go
+      GOPATH: /go
     steps:
       - checkout
       - run: golangci-lint run -v
+      - save_cache:
+          key: cache-golangci-lint-{{ checksum "go.sum" }}
+          paths:
+            - /cache/go
+            - /go/pkg
 
   build-binaries:
     executor: golang-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,8 @@ jobs:
     docker:
       - image: golangci/golangci-lint:v1.54.2
     environment:
-      GOCACHE: /cache/go
-      GOLANGCI_LINT_CACHE: /cache/go
+      GOCACHE: ~/.cache/go
+      GOLANGCI_LINT_CACHE: ~/.cache/go
       GOPATH: /go
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,9 @@ jobs:
       - image: golangci/golangci-lint:v1.54.2
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - run: golangci-lint run -v
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ workflows:
               ignore: *release-branch-regex
             tags:
               ignore: /.*/
-          
+
       - run-unit-test:
           requires:
             - "golangci-lint"
@@ -541,7 +541,7 @@ workflows:
 
   run-windows-e2e:
     when:
-      equal: [ "run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+      equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
       - run-windows-e2e-test:
@@ -549,7 +549,7 @@ workflows:
             - build-binaries
   run-unix-e2e-tests:
     when:
-      equal: [ "run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+      equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
       - test-integration:
@@ -558,7 +558,7 @@ workflows:
 
   run-e2e-tests:
     when:
-      equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]
+      equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
       - test-integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ workflows:
             branches:
               only:
                 - master
-  test:
+  lint-build-test:
     when:
       not:
         equal: [scheduled_pipeline, << pipeline.trigger_source >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,16 @@ executors:
       - image: okteto/golang-ci:2.3.1
 
 jobs:
+  lint:
+    docker:
+      - image: golangci/golangci-lint:v1.54.2
+    steps:
+      - checkout
+      - run: golangci-lint run ./... --out-format=checkstyle --print-issued-lines=false --print-linter-name=false --issues-exit-code=0 --enable=revive > golanci-report.xml
+      - store_artifacts:
+          path: golangci-report.xml
+          destination: golangci-report.xml
+
   build-binaries:
     executor: golang-ci
     resource_class: large
@@ -94,9 +104,6 @@ jobs:
     executor: golang-ci
     steps:
       - checkout
-      - run:
-          name: Check go.mod and go.sum
-          command: go mod tidy && git diff --exit-code go.sum > /dev/null
       - run:
           name: Compile integration tests
           command: make build-integration
@@ -155,7 +162,7 @@ jobs:
             curl -L "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
             chmod +x /usr/local/bin/kubectl
             cp $(pwd)/artifacts/bin/okteto-Linux-x86_64 /usr/local/bin/okteto
-             /usr/local/bin/okteto login --token ${API_STAGING_TOKEN}
+            /usr/local/bin/okteto login --token ${API_STAGING_TOKEN}
       - integration-deploy
       - integration-up
       - integration-actions
@@ -220,7 +227,7 @@ jobs:
       - run:
           name: Prepare env
           environment:
-            - OKTETO_URL: https://staging.okteto.dev/
+            OKTETO_URL: https://staging.okteto.dev/
           command: |
             new-item $HOME\.okteto -itemtype "directory" -force
             new-item $HOME\.okteto\.noanalytics -itemtype "file" -value "noanalytics" -force
@@ -229,9 +236,9 @@ jobs:
       - run:
           name: Run deprecated integration tests
           environment:
-            - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_SKIP_CLEANUP: 'true'
-            - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
+            OKTETO_URL: https://staging.okteto.dev/
+            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
@@ -240,18 +247,18 @@ jobs:
       - run:
           name: Run build integration tests
           environment:
-            - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_SKIP_CLEANUP: 'true'
-            - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
+            OKTETO_URL: https://staging.okteto.dev/
+            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
       - run:
           name: Run deploy integration tests
           environment:
-            - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_SKIP_CLEANUP: 'true'
-            - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
+            OKTETO_URL: https://staging.okteto.dev/
+            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
@@ -259,9 +266,9 @@ jobs:
       - run:
           name: Run up integration tests
           environment:
-            - OKTETO_URL: https://staging.okteto.dev/
-            - OKTETO_SKIP_CLEANUP: 'true'
-            - OKTETO_APPS_SUBDOMAIN: staging.okteto.net
+            OKTETO_URL: https://staging.okteto.dev/
+            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_APPS_SUBDOMAIN: staging.okteto.net
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
@@ -340,8 +347,9 @@ jobs:
 
 
 workflows:
-  version: 2
-
+  ci:
+    jobs:
+      - lint
   upload-static:
     jobs:
       - upload-static:
@@ -531,7 +539,7 @@ workflows:
       - test-integration:
           requires:
             - build-binaries
-  
+
   run-e2e-tests:
     when:
       equal: [ "run-e2e", << pipeline.parameters.GHA_Meta >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
 workflows:
   ci:
     jobs:
-      - lint
+      - golangci-lint
   upload-static:
     jobs:
       - upload-static:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,9 +344,6 @@ jobs:
 
 
 workflows:
-  ci:
-    jobs:
-      - golangci-lint
   upload-static:
     jobs:
       - upload-static:
@@ -355,62 +352,70 @@ workflows:
             branches:
               only:
                 - master
-  # test:
-  #   when:
-  #     not:
-  #       equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-  #   jobs:
-  #     - build-binaries:
-  #         filters:
-  #           branches:
-  #             ignore: *release-branch-regex
-  #           tags:
-  #             ignore: /.*/
-  #     - run-unit-test:
-  #         filters:
-  #           branches:
-  #             ignore: *release-branch-regex
-  #           tags:
-  #             ignore: /.*/
-  #     - run-windows-unit-test:
-  #         filters:
-  #           branches:
-  #             ignore: *release-branch-regex
-  #           tags:
-  #             ignore: /.*/
-  #     - run-windows-e2e-test:
-  #         requires:
-  #           - build-binaries
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - /.*(windows|win)/
-  #     - test-integration:
-  #         requires:
-  #           - build-binaries
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - /.*(e2e)/
-  #     - test-release:
-  #         context: GKE
-  #         requires:
-  #           - build-binaries
-  #         filters:
-  #           tags:
-  #             ignore: /.*/
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - *release-branch-regex
-  #     - push-image-latest:
-  #         requires:
-  #           - build-binaries
-  #         filters:
-  #           branches:
-  #             only: master
+  test:
+    when:
+      not:
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+    jobs:
+      - golangci-lint
+      - build-binaries:
+          requires:
+            - "golangci-lint"
+          filters:
+            branches:
+              ignore: *release-branch-regex
+            tags:
+              ignore: /.*/
+          
+      - run-unit-test:
+          requires:
+            - "golangci-lint"
+          filters:
+            branches:
+              ignore: *release-branch-regex
+            tags:
+              ignore: /.*/
+      - run-windows-unit-test:
+          requires:
+            - "golangci-lint"
+          filters:
+            branches:
+              ignore: *release-branch-regex
+            tags:
+              ignore: /.*/
+      - run-windows-e2e-test:
+          requires:
+            - build-binaries
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
+      - test-integration:
+          requires:
+            - build-binaries
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
+      - test-release:
+          context: GKE
+          requires:
+            - build-binaries
+          filters:
+            tags:
+              ignore: /.*/
+            branches:
+              ignore:
+                - master
+                - *release-branch-regex
+      - push-image-latest:
+          requires:
+            - build-binaries
+          filters:
+            branches:
+              only: master
 
   release-branch:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,8 @@ jobs:
     docker:
       - image: golangci/golangci-lint:v1.54.2
     environment:
-      GOCACHE: ~/.cache/go
-      GOLANGCI_LINT_CACHE: ~/.cache/go
+      GOCACHE: /cache/go
+      GOLANGCI_LINT_CACHE: /cache/go
       GOPATH: /go
     steps:
       - checkout
@@ -88,7 +88,7 @@ jobs:
       - save_cache:
           key: cache-golangci-lint-{{ checksum "go.sum" }}
           paths:
-            - ~/.cache/go
+            - /cache/go
             - /go/pkg
 
   build-binaries:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
       GOPATH: /go
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
       - restore_cache:
           keys:
             - cache-golangci-lint-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,15 +72,16 @@ executors:
       - image: okteto/golang-ci:2.3.1
 
 jobs:
-  lint:
+  golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.54.2
     steps:
       - checkout
-      - run: golangci-lint run ./... --out-format=checkstyle --print-issued-lines=false --print-linter-name=false --issues-exit-code=0 --enable=revive > golanci-report.xml
-      - store_artifacts:
-          path: golangci-report.xml
-          destination: golangci-report.xml
+      - run: golangci-lint run
+      - persist_to_workspace:
+          root: .
+          paths:
+            - golanci-report.xml
 
   build-binaries:
     executor: golang-ci
@@ -358,62 +359,62 @@ workflows:
             branches:
               only:
                 - master
-  test:
-    when:
-      not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-    jobs:
-      - build-binaries:
-          filters:
-            branches:
-              ignore: *release-branch-regex
-            tags:
-              ignore: /.*/
-      - run-unit-test:
-          filters:
-            branches:
-              ignore: *release-branch-regex
-            tags:
-              ignore: /.*/
-      - run-windows-unit-test:
-          filters:
-            branches:
-              ignore: *release-branch-regex
-            tags:
-              ignore: /.*/
-      - run-windows-e2e-test:
-          requires:
-            - build-binaries
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(windows|win)/
-      - test-integration:
-          requires:
-            - build-binaries
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
-      - test-release:
-          context: GKE
-          requires:
-            - build-binaries
-          filters:
-            tags:
-              ignore: /.*/
-            branches:
-              ignore:
-                - master
-                - *release-branch-regex
-      - push-image-latest:
-          requires:
-            - build-binaries
-          filters:
-            branches:
-              only: master
+  # test:
+  #   when:
+  #     not:
+  #       equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+  #   jobs:
+  #     - build-binaries:
+  #         filters:
+  #           branches:
+  #             ignore: *release-branch-regex
+  #           tags:
+  #             ignore: /.*/
+  #     - run-unit-test:
+  #         filters:
+  #           branches:
+  #             ignore: *release-branch-regex
+  #           tags:
+  #             ignore: /.*/
+  #     - run-windows-unit-test:
+  #         filters:
+  #           branches:
+  #             ignore: *release-branch-regex
+  #           tags:
+  #             ignore: /.*/
+  #     - run-windows-e2e-test:
+  #         requires:
+  #           - build-binaries
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - /.*(windows|win)/
+  #     - test-integration:
+  #         requires:
+  #           - build-binaries
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - /.*(e2e)/
+  #     - test-release:
+  #         context: GKE
+  #         requires:
+  #           - build-binaries
+  #         filters:
+  #           tags:
+  #             ignore: /.*/
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - *release-branch-regex
+  #     - push-image-latest:
+  #         requires:
+  #           - build-binaries
+  #         filters:
+  #           branches:
+  #             only: master
 
   release-branch:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,14 +77,7 @@ jobs:
       - image: golangci/golangci-lint:v1.54.2
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
       - run: golangci-lint run -v
-      - persist_to_workspace:
-          root: .
-          paths:
-            - golanci-report.xml
 
   build-binaries:
     executor: golang-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - image: golangci/golangci-lint:v1.54.2
     steps:
       - checkout
-      - run: golangci-lint run
+      - run: golangci-lint run -v
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,11 +81,14 @@ jobs:
       GOPATH: /go
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - cache-golangci-lint-{{ checksum "go.sum" }}
       - run: golangci-lint run -v
       - save_cache:
           key: cache-golangci-lint-{{ checksum "go.sum" }}
           paths:
-            - /cache/go
+            - ~/.cache/go
             - /go/pkg
 
   build-binaries:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,9 +8,9 @@ Please include a summary of the changes and the related issue. Please also inclu
 
 Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.
 
-1. 
-1. 
-1. 
+1.
+1.
+1.
 
 ## CLI Quality Reminders 🔧
 
@@ -23,7 +23,7 @@ For both authors and reviewers:
 - If too broad, consider breaking into smaller PRs
 - Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
 
-<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests 
+<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
 ----
 
 <details>

--- a/.github/workflows/run-circleci-from-label.yml
+++ b/.github/workflows/run-circleci-from-label.yml
@@ -2,7 +2,7 @@ name: Run CircleCI from label
 
 on:
   pull_request:
-    types: 
+    types:
       - opened
       - labeled
       - unlabeled
@@ -32,7 +32,7 @@ jobs:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
 
   run-e2e:
-    if: contains(github.event.pull_request.labels.*.name, 'run-e2e') 
+    if: contains(github.event.pull_request.labels.*.name, 'run-e2e')
     runs-on: ubuntu-latest
     steps:
       - name: Run e2e tests on CircleCI

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist
 
 # don't add the binary created by running go build from the root of the repo
 /okteto
+
+# lint 
+golangci-report.xml

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ dist
 # don't add the binary created by running go build from the root of the repo
 /okteto
 
-# lint 
+# lint
 golangci-report.xml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - gosimple
     - ineffassign
     - errcheck
-
 # Enabled by your configuration linters:
 # deadcode: Finds unused code [fast: false, auto-fix: false]
 # gosimple (megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,11 @@
 run:
   timeout: 5m
-  go: 1.20
+  
+output:
+  format: checkstyle:golangci-report.xml
+  print-issued-lines: false
+  # print-linter-name: false
+  sort-results: true
 # All possible options can be found here https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
 linters-settings:
   errcheck:
@@ -13,9 +18,12 @@ linters:
     # TODO: enable when fixed
     - whitespace
     - staticcheck
-  enable:
+    - govet
+    - unused
     - errcheck
     - unparam
+    - gosimple
+    - ineffassign
 # Enabled by your configuration linters:
 # deadcode: Finds unused code [fast: false, auto-fix: false]
 # gosimple (megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,5 @@
 run:
   timeout: 5m
-  issues-exit-code: 0
-  
 output:
   # format: checkstyle:golangci-report.xml
   print-issued-lines: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,6 @@
 run:
   timeout: 5m
+  issues-exit-code: 0
   
 output:
   # format: checkstyle:golangci-report.xml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 5m
   
 output:
-  format: checkstyle:golangci-report.xml
+  # format: checkstyle:golangci-report.xml
   print-issued-lines: false
   # print-linter-name: false
   sort-results: true
@@ -20,10 +20,12 @@ linters:
     - staticcheck
     - govet
     - unused
-    - errcheck
     - unparam
     - gosimple
     - ineffassign
+  enable:
+    - errcheck
+
 # Enabled by your configuration linters:
 # deadcode: Finds unused code [fast: false, auto-fix: false]
 # gosimple (megacheck): Linter for Go source code that specializes in simplifying code [fast: false, auto-fix: false]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,6 @@ linters:
     - unparam
     - gosimple
     - ineffassign
-  enable:
     - errcheck
 
 # Enabled by your configuration linters:

--- a/contributing.md
+++ b/contributing.md
@@ -152,13 +152,16 @@ Before making a PR, we recommend contributors to run a lint check on their code 
 make lint
 ```
 
-This command will run `pre-commit run --all-files` and `golangci-lint run` for the repository and raise any issue that might appear.
+This command will run `golangci-lint` for the repository and raise any issue that might appear. When the branch is pushed to remote, a workflow will run also this lint tool.
 
 > You will need to download these tools in order to run the lint locally
 >
 > - [golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
+>
+> We recommend to have an [integration](https://golangci-lint.run/usage/integrations/) with your IDE so that golangci-lint is used as default linter
+
+We also recommend to install `pre-commit` hooks before opening a PR.
+
 > - [pre-commit](https://pre-commit.com/#installation)
 
-We recommend to have an [integration](https://golangci-lint.run/usage/integrations/) with your IDE so that golangci-lint is used as default linter
-
-There is also a [lint workflow](.github/workflows/lint.yml) running `pre-commit` and static code analysis for Go is done by [DeepSource](https://deepsource.io/) pipeline.
+Once downloaded, run `pre-commit install` to install the hooks and before the commit is done, the checks will be run.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -3,8 +3,8 @@
 - [Purpose of code reviews](#purpose-of-code-reviews)
 - [Agreements](#agreements)
 - [Expectations](#expectations)
-  * [As an Author](#as-an-author)
-  * [As a Reviewer](#as-a-reviewer)
+  - [As an Author](#as-an-author)
+  - [As a Reviewer](#as-a-reviewer)
 - [What to look for in a code review?](#what-to-look-for-in-a-code-review)
   - [Code review checklist](#code-review-checklist)
   - [PR Description](#pr-description)
@@ -45,7 +45,6 @@ We believe our code review process is foundational in ensuring that:
 - **Clear Actionable Feedback**: We provide unambiguous, actionable feedback in our comments. "Nice-to-have" suggestions should lead to new issues instead of blocking PRs.
 - **Reviewers**: PRs typically require 2 approvals for merging. Use discretion: some might need more approvers, depending on the scope.
 - **PR Scope**: Keep PRs concise and focused.
-
 
 ## Expectations
 

--- a/docs/how-to-run-tests.md
+++ b/docs/how-to-run-tests.md
@@ -139,7 +139,6 @@ You'll need to set your working directory on the root of your Okteto CLI project
 pre-commit run --all-files
 ```
 
-
 ## How to run e2e tests from a PR?
 
 Use the following labels to trigger integration test on this branch:

--- a/scripts/get-okteto.sh
+++ b/scripts/get-okteto.sh
@@ -83,11 +83,11 @@
                         esac
                 fi
         fi
-        printf '> Using Release Channel: %s\n' ${OKTETO_CHANNEL}
+        printf '> Using Release Channel: %s\n' "${OKTETO_CHANNEL}"
 
         download_uri="https://downloads.okteto.com/cli"
         if [ -z "$OKTETO_VERSION" ]; then
-                OKTETO_VERSION=$(curl -fsSL $download_uri/${OKTETO_CHANNEL}/versions | tail -n1)
+                OKTETO_VERSION=$(curl -fsSL "$download_uri/${OKTETO_CHANNEL}/versions" | tail -n1)
         fi
         printf '> Using Version: %s\n' "$OKTETO_VERSION"
 


### PR DESCRIPTION
# Proposed changes

Partially resolves #3828 

As part of the CLI Quality initiative, this PR enables the job for running `golangci-lint` during our dev process. 
The pipeline is run before `build-binaries` or `unit-tests` in order to make the static check before continuing.

Also, disabled couple linterns that where failing locally but as we did not have the ci tool where not being tracked.

Following PRs will fix this and enable the linters so we can track them and inform at the PR level.

Regarding `pre-commit` i tried to add this to our circleci config as we removed form github action workflow but it was kind of tricky. I updated README so its clear to run this locally by configuring the hook in a pre-commit so it uses the configuration we have in place
