### PR TITLE
feat: add support for labels when deploying a pipeline

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -56,6 +56,7 @@ type deployFlags struct {
 	timeout      time.Duration
 	file         string
 	variables    []string
+	labels       []string
 
 	// Deprecated fields
 	filename string
@@ -72,6 +73,7 @@ type DeployOptions struct {
 	Timeout      time.Duration
 	File         string
 	Variables    []string
+	Labels       []string
 }
 
 func deploy(ctx context.Context) *cobra.Command {
@@ -124,6 +126,7 @@ func deploy(ctx context.Context) *cobra.Command {
 	if err := cmd.Flags().MarkHidden("filename"); err != nil {
 		oktetoLog.Infof("failed to mark 'filename' flag as hidden: %s", err)
 	}
+	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "set a preview environment label (can be set more than once)")
 	return cmd
 }
 
@@ -416,6 +419,7 @@ func (f deployFlags) toOptions() *DeployOptions {
 		Timeout:      f.timeout,
 		File:         file,
 		Variables:    f.variables,
+		Labels:       f.labels,
 	}
 }
 
@@ -489,5 +493,6 @@ func (o *DeployOptions) toPipelineDeployClientOptions() (types.PipelineDeployOpt
 		Filename:   o.File,
 		Variables:  varList,
 		Namespace:  o.Namespace,
+		Labels:     o.Labels,
 	}, nil
 }

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -126,7 +126,7 @@ func deploy(ctx context.Context) *cobra.Command {
 	if err := cmd.Flags().MarkHidden("filename"); err != nil {
 		oktetoLog.Infof("failed to mark 'filename' flag as hidden: %s", err)
 	}
-	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "set a preview environment label (can be set more than once)")
+	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "set an environment label (can be set more than once)")
 	return cmd
 }
 

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -419,3 +419,65 @@ func TestSetEnvsFromDependencyWithError(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset(cmap)
 	assert.Error(t, setEnvsFromDependency(ctx, "test", "test", fakeClient))
 }
+
+func TestFlagsToOptions(t *testing.T) {
+	tt := []struct {
+		name   string
+		flags  deployFlags
+		expect *DeployOptions
+	}{
+		{
+			name:   "no flags",
+			flags:  deployFlags{},
+			expect: &DeployOptions{},
+		},
+		{
+			name: "filename and file",
+			flags: deployFlags{
+				file:     "file",
+				filename: "filename",
+			},
+			expect: &DeployOptions{
+				File: "file",
+			},
+		},
+		{
+			name: "just filename",
+			flags: deployFlags{
+				filename: "filename",
+			},
+			expect: &DeployOptions{
+				File: "filename",
+			},
+		},
+		{
+			name: "all flags ",
+			flags: deployFlags{
+				branch:     "branch",
+				repository: "repository",
+				name:       "name",
+				namespace:  "namespace",
+				wait:       true,
+				timeout:    2 * time.Second,
+				labels:     []string{"label1", "label2"},
+				variables:  []string{"var1=1", "var2=2"},
+			},
+			expect: &DeployOptions{
+				Branch:     "branch",
+				Repository: "repository",
+				Name:       "name",
+				Namespace:  "namespace",
+				Wait:       true,
+				Timeout:    2 * time.Second,
+				Labels:     []string{"label1", "label2"},
+				Variables:  []string{"var1=1", "var2=2"},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tc.flags.toOptions()
+			assert.Equal(t, tc.expect, opts)
+		})
+	}
+}

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -28,11 +28,12 @@ import (
 )
 
 var (
-	ErrDeployPipelineLabelsFeatureNotSupported = errors.New(`deploying a preview environments with labels requires a more recent version of Okteto.
+	ErrDeployPipelineLabelsFeatureNotSupported = oktetoErrors.UserError{
+		E: errors.New(`deploying a preview environments with labels requires a more recent version of Okteto.
 
-    Consider removing the "--label" flag, or please upgrade to the latest version.
-
-    For more information and upgrade instructions, please visit our docs at https://www.okteto.com/docs or contact your system administrator.`)
+		Consider removing the "--label" flag, or please upgrade to the latest version`),
+		Hint: "For more information and upgrade instructions, please visit our docs at https://www.okteto.com/docs or contact your system administrator.",
+	}
 )
 
 type pipelineClient struct {

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -15,6 +15,7 @@ package okteto
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -24,6 +25,14 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/shurcooL/graphql"
+)
+
+var (
+	ErrDeployPipelineLabelsFeatureNotSupported = errors.New(`deploying a preview environments with labels requires a more recent version of Okteto.
+
+    Consider removing the "--label" flag, or please upgrade to the latest version.
+
+    For more information and upgrade instructions, please visit our docs at https://www.okteto.com/docs or contact your system administrator.`)
 )
 
 type pipelineClient struct {
@@ -44,6 +53,10 @@ func newPipelineClient(client graphqlClientInterface, url string) *pipelineClien
 
 type deployPipelineMutation struct {
 	Response deployPipelineResponse `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename)"`
+}
+
+type deployPipelineMutationWithLabels struct {
+	Response deployPipelineResponse `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename, labels: $labels)"`
 }
 
 type getPipelineByNameQuery struct {
@@ -104,91 +117,83 @@ type deprecatedDestroyPipelineResponse struct {
 // Deploy creates a pipeline
 func (c *pipelineClient) Deploy(ctx context.Context, opts types.PipelineDeployOptions) (*types.GitDeployResponse, error) {
 	oktetoLog.Infof("deploying pipeline '%s' mutation on %s", opts.Name, opts.Namespace)
-	origin := config.GetDeployOrigin()
 
-	gitDeployResponse := &types.GitDeployResponse{}
-
-	if len(opts.Variables) > 0 {
-		var mutation deployPipelineMutation
-
-		variablesArg := []InputVariable{}
-		for _, v := range opts.Variables {
-			variablesArg = append(variablesArg, InputVariable{
-				Name:  graphql.String(v.Name),
-				Value: graphql.String(v.Value),
-			})
-		}
-		// if OKTETO_ORIGIN was provided don't override it
-		injectOrigin := true
-		for _, v := range variablesArg {
-			if v.Name == "OKTETO_ORIGIN" {
-				injectOrigin = false
-			}
-		}
-		if injectOrigin {
-			variablesArg = append(variablesArg, InputVariable{
-				Name:  graphql.String("OKTETO_ORIGIN"),
-				Value: graphql.String(origin),
-			})
-		}
-		queryVariables := map[string]interface{}{
-			"name":       graphql.String(opts.Name),
-			"repository": graphql.String(opts.Repository),
-			"space":      graphql.String(opts.Namespace),
-			"branch":     graphql.String(opts.Branch),
-			"variables":  variablesArg,
-			"filename":   graphql.String(opts.Filename),
-		}
-
-		err := mutate(ctx, &mutation, queryVariables, c.client)
+	mutationVariables := c.getDeployVariables(opts)
+	var response deployPipelineResponse
+	if len(opts.Labels) == 0 {
+		mutationStruct := &deployPipelineMutation{}
+		err := mutate(ctx, mutationStruct, mutationVariables, c.client)
 		if err != nil {
 			return nil, fmt.Errorf("failed to deploy pipeline: %w", err)
 		}
-
-		gitDeployResponse.Action = &types.Action{
-			ID:     string(mutation.Response.Action.Id),
-			Name:   string(mutation.Response.Action.Name),
-			Status: string(mutation.Response.Action.Status),
-		}
-		gitDeployResponse.GitDeploy = &types.GitDeploy{
-			ID:         string(mutation.Response.GitDeploy.Id),
-			Name:       string(mutation.Response.GitDeploy.Name),
-			Repository: string(mutation.Response.GitDeploy.Repository),
-			Status:     string(mutation.Response.GitDeploy.Status),
-		}
-
+		response = mutationStruct.Response
 	} else {
-		var mutation deployPipelineMutation
-		queryVariables := map[string]interface{}{
-			"name":       graphql.String(opts.Name),
-			"repository": graphql.String(opts.Repository),
-			"space":      graphql.String(opts.Namespace),
-			"branch":     graphql.String(opts.Branch),
-			"filename":   graphql.String(opts.Filename),
-			"variables": []InputVariable{
-				{Name: graphql.String("OKTETO_ORIGIN"), Value: graphql.String(origin)},
-			},
-		}
+		mutationStruct := &deployPipelineMutationWithLabels{}
+		err := mutate(ctx, mutationStruct, mutationVariables, c.client)
 
-		err := mutate(ctx, &mutation, queryVariables, c.client)
 		if err != nil {
+			if strings.Contains(err.Error(), "Unknown argument \"labels\" on field \"deployGitRepository\" of type \"Mutation\"") {
+				return nil, oktetoErrors.UserError{E: ErrDeployPipelineLabelsFeatureNotSupported, Hint: "Please upgrade to the latest version or ask your administrator"}
+			}
 			return nil, fmt.Errorf("failed to deploy pipeline: %w", err)
 		}
+		response = mutationStruct.Response
+	}
 
-		gitDeployResponse.Action = &types.Action{
-			ID:     string(mutation.Response.Action.Id),
-			Name:   string(mutation.Response.Action.Name),
-			Status: string(mutation.Response.Action.Status),
-		}
-		gitDeployResponse.GitDeploy = &types.GitDeploy{
-			ID:         string(mutation.Response.GitDeploy.Id),
-			Name:       string(mutation.Response.GitDeploy.Name),
-			Repository: string(mutation.Response.GitDeploy.Repository),
-			Status:     string(mutation.Response.GitDeploy.Status),
-		}
-
+	gitDeployResponse := &types.GitDeployResponse{
+		Action: &types.Action{
+			ID:     string(response.Action.Id),
+			Name:   string(response.Action.Name),
+			Status: string(response.Action.Status),
+		},
+		GitDeploy: &types.GitDeploy{
+			ID:         string(response.GitDeploy.Id),
+			Name:       string(response.GitDeploy.Name),
+			Repository: string(response.GitDeploy.Repository),
+			Status:     string(response.GitDeploy.Status),
+		},
 	}
 	return gitDeployResponse, nil
+}
+
+func (c *pipelineClient) getDeployVariables(opts types.PipelineDeployOptions) map[string]interface{} {
+	variablesVariable := make([]InputVariable, 0)
+	for _, v := range opts.Variables {
+		variablesVariable = append(variablesVariable, InputVariable{
+			Name:  graphql.String(v.Name),
+			Value: graphql.String(v.Value),
+		})
+	}
+	injectOrigin := true
+	for _, v := range variablesVariable {
+		if v.Name == "OKTETO_ORIGIN" {
+			injectOrigin = false
+		}
+	}
+	if injectOrigin {
+		origin := config.GetDeployOrigin()
+		variablesVariable = append(variablesVariable, InputVariable{
+			Name:  graphql.String("OKTETO_ORIGIN"),
+			Value: graphql.String(origin),
+		})
+	}
+	vars := map[string]interface{}{
+		"name":       graphql.String(opts.Name),
+		"space":      graphql.String(opts.Namespace),
+		"repository": graphql.String(opts.Repository),
+		"branch":     graphql.String(opts.Branch),
+		"variables":  variablesVariable,
+		"filename":   graphql.String(opts.Filename),
+	}
+
+	if len(opts.Labels) > 0 {
+		labelsVariable := make(labelList, 0)
+		for _, l := range opts.Labels {
+			labelsVariable = append(labelsVariable, graphql.String(l))
+		}
+		vars["labels"] = labelsVariable
+	}
+	return vars
 }
 
 // GetByName gets a pipeline given its name

--- a/pkg/types/gitdeploy.go
+++ b/pkg/types/gitdeploy.go
@@ -21,6 +21,7 @@ type PipelineDeployOptions struct {
 	Filename   string
 	Variables  []Variable
 	Namespace  string
+	Labels     []string
 }
 
 // SpaceBody top body answer


### PR DESCRIPTION
# Proposed changes

Fixes #6996

Adds CLI support for labels flag under the pipeline command. If the okteto cluster that the user is not connected doesn't support the labels it returns a user friendly error as you can see below:
<img width="1068" alt="Captura de pantalla 2023-09-05 a las 13 53 12" src="https://github.com/okteto/okteto/assets/25170843/df065eb2-8f95-4074-bce4-23a61e81e7e3">


## How to validate

1. Use a cluster context that supports pipeline labels 
1. Run `okteto pipeline deploy --branch cli-e2e --repository https://github.com/okteto/movies --namespace your-ns --wait --label=key`
1. Check that the configmap generated has the label `key`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

