### PR TITLE
Fix preview list output

### DIFF
--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -23,7 +23,6 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
@@ -104,13 +103,13 @@ func executeListPreviews(previews []previewOutput, outputFormat string) error {
 		if err != nil {
 			return err
 		}
-		oktetoLog.Println(string(bytes))
+		fmt.Println(string(bytes))
 	case "yaml":
 		bytes, err := yaml.Marshal(previews)
 		if err != nil {
 			return err
 		}
-		oktetoLog.Println(string(bytes))
+		fmt.Println(string(bytes))
 	default:
 		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
 		fmt.Fprint(w, "Name\tScope\tSleeping\tLabels\n")

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -112,6 +112,7 @@ func executeListPreviews(ctx context.Context, opts ListFlags) error {
 	return nil
 }
 
+// getPreviewDefaultOutput returns the rows for the default list output format
 func getPreviewDefaultOutput(preview previewOutput) string {
 	previewLabels := "-"
 	if len(preview.Labels) > 0 {

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -30,8 +30,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// ListFlags are the flags available for list commands
-type ListFlags struct {
+// listFlags are the flags available for list commands
+type listFlags struct {
 	labels []string
 	output string
 }
@@ -45,7 +45,7 @@ type previewOutput struct {
 
 // List lists all the previews
 func List(ctx context.Context) *cobra.Command {
-	flags := &ListFlags{}
+	flags := &listFlags{}
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all preview environments",

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -64,7 +64,7 @@ func List(ctx context.Context) *cobra.Command {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			if err := ValidateOutput(flags.output); err != nil {
+			if err := validatePreviewListOutput(flags.output); err != nil {
 				return err
 			}
 
@@ -141,7 +141,8 @@ func getPreviewOutput(ctx context.Context, opts ListFlags, oktetoClient types.Ok
 	return previewSlice, nil
 }
 
-func ValidateOutput(output string) error {
+// validatePreviewListOutput returns error if output flag is not valid
+func validatePreviewListOutput(output string) error {
 	switch output {
 	case "", "json", "yaml":
 		return nil

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -93,12 +93,13 @@ func List(ctx context.Context) *cobra.Command {
 
 // executeListPreviews prints the list of previews
 func executeListPreviews(previews []previewOutput, outputFormat string) error {
-	if len(previews) == 0 {
-		fmt.Println("There are no previews")
-		return nil
-	}
 	switch outputFormat {
 	case "json":
+		// json marshal return null for empty objects, returning the empty list if no previews are retrieved
+		if len(previews) == 0 {
+			fmt.Println(previews)
+			return nil
+		}
 		bytes, err := json.MarshalIndent(previews, "", " ")
 		if err != nil {
 			return err
@@ -111,6 +112,10 @@ func executeListPreviews(previews []previewOutput, outputFormat string) error {
 		}
 		fmt.Println(string(bytes))
 	default:
+		if len(previews) == 0 {
+			fmt.Println("There are no previews")
+			return nil
+		}
 		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
 		fmt.Fprint(w, "Name\tScope\tSleeping\tLabels\n")
 		for _, preview := range previews {

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -107,11 +107,11 @@ func (cmd *listPreviewCommand) run(ctx context.Context) error {
 	}
 
 	previewOutput := getPreviewOutput(previewList)
-	return executeListPreviews(previewOutput, cmd.flags.output)
+	return displayListPreviews(previewOutput, cmd.flags.output)
 }
 
-// executeListPreviews prints the list of previews
-func executeListPreviews(previews []previewOutput, outputFormat string) error {
+// displayListPreviews prints the list of previews
+func displayListPreviews(previews []previewOutput, outputFormat string) error {
 	switch outputFormat {
 	case "json":
 		// json marshal return null for empty objects, returning the empty list if no previews are retrieved

--- a/cmd/preview/list_test.go
+++ b/cmd/preview/list_test.go
@@ -107,37 +107,31 @@ func Test_listPreview(t *testing.T) {
 	}
 }
 
-func Test_PreviewListOutputValidation(t *testing.T) {
+func Test_validatePreviewListOutput(t *testing.T) {
 	var tests = []struct {
 		name        string
-		output      ListFlags
+		output      string
 		expectedErr error
 	}{
 		{
-			name: "output format is yaml",
-			output: ListFlags{
-				output: "yaml",
-			},
+			name:        "output format is yaml",
+			output:      "yaml",
 			expectedErr: nil,
 		},
 		{
-			name: "output format is json",
-			output: ListFlags{
-				output: "json",
-			},
+			name:        "output format is json",
+			output:      "json",
 			expectedErr: nil,
 		},
 		{
-			name: "output format is not valid",
-			output: ListFlags{
-				output: "xml",
-			},
+			name:        "output format is not valid",
+			output:      "xml",
 			expectedErr: fmt.Errorf("output format is not accepted. Value must be one of: ['json', 'yaml']"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateOutput(tt.output.output)
+			err := validatePreviewListOutput(tt.output)
 			assert.Equal(t, tt.expectedErr, err)
 		})
 	}

--- a/cmd/preview/list_test.go
+++ b/cmd/preview/list_test.go
@@ -143,6 +143,16 @@ func Test_executeListPreviews(t *testing.T) {
 			expectedOutput: "There are no previews\n",
 		},
 		{
+			name:           "empty list ",
+			format:         "json",
+			expectedOutput: "[]\n",
+		},
+		{
+			name:           "empty list ",
+			format:         "json",
+			expectedOutput: "[]\n",
+		},
+		{
 			name:   "list - default format",
 			format: "",
 			input: []previewOutput{

--- a/cmd/preview/list_test.go
+++ b/cmd/preview/list_test.go
@@ -131,7 +131,7 @@ func Test_getPreviewDefaultOutput(t *testing.T) {
 	}
 }
 
-func Test_executeListPreviews(t *testing.T) {
+func Test_displayListPreviews(t *testing.T) {
 	tests := []struct {
 		name   string
 		format string
@@ -222,7 +222,7 @@ test2  global    true      -
 			// replace Stdout for tests
 			os.Stdout = w
 
-			err := executeListPreviews(tt.input, tt.format)
+			err := displayListPreviews(tt.input, tt.format)
 			assert.NoError(t, err)
 
 			w.Close()


### PR DESCRIPTION
# Proposed changes

Fixes #3904 

When the flag `--output` was implemented in order to get the preview list in different formats (`yaml` or `json`) the function used to show this output was our custom logger `oktetoLog.Println()`.

The logger format is set as a global flag `--log-output`, which default is TTY, but it can change to json, plain, silent, etc...

The command `okteto preview list` by default shows a table with a list of preview environments, when we where setting the `--log-output` to `json` and the `--output` to `json`, the logger has a fixed setting to mrashall the log into specific fields (stage log) so it was not marshalling the previews list, and the output was empty.

To fix this:
- Change `oktetoLog.Println()` to` fmt.Println()` for both `json` and `yaml` outputs, the output flag was linked to the log output format, this dependency has been removed. https://github.com/okteto/okteto/pull/3970/commits/0e1f3cffcfd6a9819f96ad282a0285672d43def2
- Refactor the command `okteto preview list` in order to add unit-tests to all components of the command and extract the oktetoClient which retrieves the previews list at the top of the command.

## How to validate

1. Use okteto context to log into your okteto instance
2. Run `okteto preview deploy` with or without labels (its recommended with so all the fields of the list are filled). This will create a preview environment
3. Run `okteto preview list` check that a table is the output

```
❯ okteto preview list
 i  Using teresaromero @ cloud.okteto.com as context
Name                       Scope     Sleeping  Labels
goofy-leakey-teresaromero  personal  false     testing
```

4. Run `okteto preview --log-output json` shows the default view, as there are only info and debug logs we should change the log level to see the logs in json format running `okteto preview list --log-output json --log-level debug`. This does not conflict with `--output` as the print function to show the table is not tied to `oktetoLog`

```
{"level":"debug","stage":"","message":"server name override: \"\"","timestamp":1693921450}
{"level":"info","stage":"","message":"started okteto preview list --log-output json --log-level debug","timestamp":1693921450}
{"level":"info","stage":"","message":"Using teresaromero @ cloud.okteto.com as context","timestamp":1693921451}
Name                       Scope     Sleeping  Labels
goofy-leakey-teresaromero  personal  false     testing
{"level":"info","stage":"","message":"finished okteto preview list --log-output json --log-level debug","timestamp":1693921451}
```

5. Running `okteto preview list --log-output json --log-level debug --output json` we see that the logs are shown but the preview list is not shown in any format

```
❯ okteto preview list --log-output json --log-level debug --output json
{"level":"debug","stage":"","message":"server name override: \"\"","timestamp":1693921590}
{"level":"info","stage":"","message":"started okteto preview list --log-output json --log-level debug --output json","timestamp":1693921590}
{"level":"info","stage":"","message":"finished okteto preview list --log-output json --log-level debug --output json","timestamp":1693921591}
```

When fixed:

```
❯ ok preview list --log-output json --log-level debug --output json
{"level":"debug","stage":"","message":"server name override: \"\"","timestamp":1694065981}
{"level":"info","stage":"","message":"started /Users/teresaromero/github.com/okteto/okteto/bin/okteto preview list --log-output json --log-level debug --output json","timestamp":1694065981}
[
 {
  "name": "goofy-leakey-teresaromero",
  "scope": "personal",
  "sleeping": true,
  "labels": [
   "testing"
  ]
 }
]
{"level":"info","stage":"","message":"finished /Users/teresaromero/github.com/okteto/okteto/bin/okteto preview list --log-output json --log-level debug --output json","timestamp":1694065982}
```

6. Run `okteto preview list --log-output json --log-level debug --output yaml` and check is fixed


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

