### PR TITLE
[golangci-lint] enable govet ineffassign staticcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,15 +20,15 @@ linters-settings:
 # All possible linters can be found here
 linters:
   disable:
-    - govet
-    - ineffassign
-    - staticcheck
     - unused
     - unparam
   enable:
     - errcheck
     - gosimple
     - typecheck
+    - govet
+    - ineffassign
+    - staticcheck
 
 # Enabled by your configuration linters:
 # deadcode: Finds unused code [fast: false, auto-fix: false]

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -409,6 +409,7 @@ func TestCheckAccessToNamespace(t *testing.T) {
 	fakeOktetoClient := &client.FakeOktetoClient{
 		Namespace: client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
 		Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
+		Preview:   client.NewFakePreviewClient(&client.FakePreviewResponse{}),
 	}
 
 	fakeCtxCommand := newFakeContextCommand(fakeOktetoClient, user, []runtime.Object{
@@ -419,6 +420,7 @@ func TestCheckAccessToNamespace(t *testing.T) {
 		},
 	})
 
+	// TODO: add unit-test to cover preview environments access from context
 	var tests = []struct {
 		name           string
 		ctxOptions     *ContextOptions
@@ -459,8 +461,8 @@ func TestCheckAccessToNamespace(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 
 			currentCtxCommand := *fakeCtxCommand
 			if tt.ctxOptions.IsOkteto {

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -482,12 +482,12 @@ func (ph *proxyHandler) translateVirtualServiceSpec(body map[string]json.RawMess
 		return nil
 	}
 
-	var spec istioNetworkingV1beta1.VirtualService
+	var spec *istioNetworkingV1beta1.VirtualService
 	if err := json.Unmarshal(body["spec"], &spec); err != nil {
 		oktetoLog.Infof("error unmarshalling replicaset on proxy: %s", err.Error())
 		return nil
 	}
-	spec = ph.DivertDriver.UpdateVirtualService(spec)
+	ph.DivertDriver.UpdateVirtualService(spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
 		return fmt.Errorf("could not process virtual service's spec: %s", err)

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -199,7 +199,6 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	if sshSock != "" {
 		if _, err := os.Stat(sshSock); err != nil {
 			oktetoLog.Debugf("Not mounting ssh agent. Error reading socket: %s", err.Error())
-			sshSock = ""
 		} else {
 			sshSession := types.BuildSshSession{Id: "remote", Target: sshSock}
 			buildOptions.SshSessions = append(buildOptions.SshSessions, sshSession)

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -202,7 +202,6 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	if sshSock != "" {
 		if _, err := os.Stat(sshSock); err != nil {
 			oktetoLog.Debugf("Not mounting ssh agent. Error reading socket: %s", err.Error())
-			sshSock = ""
 		} else {
 			sshSession := types.BuildSshSession{Id: "remote", Target: sshSock}
 			buildOptions.SshSessions = append(buildOptions.SshSessions, sshSession)

--- a/cmd/utils/okteto.go
+++ b/cmd/utils/okteto.go
@@ -51,6 +51,8 @@ func HasAccessToOktetoClusterNamespace(ctx context.Context, namespace string, ok
 		}
 	}
 
+	// added possibility to point a context to a preview environment (namespace)
+	// https://github.com/okteto/okteto/pull/2018
 	previewList, err := oktetoClient.Previews().List(ctx, []string{})
 	if err != nil {
 		return false, err

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func init() {
 		oktetoLog.Info("cannot use cryptoRead. Fallback to timestamp seed generator")
 		seed = time.Now().UnixNano()
 	}
-	rand.Seed(seed)
+	rand.New(rand.NewSource(seed))
 
 	// override client-go error handlers to downgrade the "logging before flag.Parse" error
 	errorHandlers := []func(error){

--- a/pkg/divert/driver.go
+++ b/pkg/divert/driver.go
@@ -33,7 +33,7 @@ type Driver interface {
 	Deploy(ctx context.Context) error
 	Destroy(ctx context.Context) error
 	UpdatePod(spec apiv1.PodSpec) apiv1.PodSpec
-	UpdateVirtualService(vs istioNetworkingV1beta1.VirtualService) istioNetworkingV1beta1.VirtualService
+	UpdateVirtualService(vs *istioNetworkingV1beta1.VirtualService)
 }
 
 func New(m *model.Manifest, c kubernetes.Interface) (Driver, error) {

--- a/pkg/divert/istio/divert.go
+++ b/pkg/divert/istio/divert.go
@@ -123,8 +123,8 @@ func (d *Driver) UpdatePod(pod apiv1.PodSpec) apiv1.PodSpec {
 	return pod
 }
 
-func (d *Driver) UpdateVirtualService(vs istioNetworkingV1beta1.VirtualService) istioNetworkingV1beta1.VirtualService {
-	return d.injectDivertHeader(vs)
+func (d *Driver) UpdateVirtualService(vs *istioNetworkingV1beta1.VirtualService) {
+	d.injectDivertHeader(vs)
 }
 
 func (d *Driver) retryTranslateDivertVirtualService(ctx context.Context, divertVS model.DivertVirtualService) error {

--- a/pkg/divert/istio/virtualservices.go
+++ b/pkg/divert/istio/virtualservices.go
@@ -79,7 +79,7 @@ func (d *Driver) translateDivertHost(vs *istioV1beta1.VirtualService) *istioV1be
 		fmt.Sprintf("%s.%s.svc.cluster.local", result.Name, d.namespace),
 	}
 
-	result.Spec = d.injectDivertHeader(result.Spec)
+	d.injectDivertHeader(&result.Spec)
 
 	for i := range result.Spec.Http {
 
@@ -92,7 +92,7 @@ func (d *Driver) translateDivertHost(vs *istioV1beta1.VirtualService) *istioV1be
 	return result
 }
 
-func (d *Driver) injectDivertHeader(vsSpec istioNetworkingV1beta1.VirtualService) istioNetworkingV1beta1.VirtualService {
+func (d *Driver) injectDivertHeader(vsSpec *istioNetworkingV1beta1.VirtualService) {
 	for i := range vsSpec.Http {
 		if vsSpec.Http[i].Headers == nil {
 			vsSpec.Http[i].Headers = &istioNetworkingV1beta1.Headers{}
@@ -105,5 +105,4 @@ func (d *Driver) injectDivertHeader(vsSpec istioNetworkingV1beta1.VirtualService
 		}
 		vsSpec.Http[i].Headers.Request.Add[constants.OktetoDivertBaggageHeader] = fmt.Sprintf("%s=%s", constants.OktetoDivertHeaderName, d.namespace)
 	}
-	return vsSpec
 }

--- a/pkg/divert/weaver/divert.go
+++ b/pkg/divert/weaver/divert.go
@@ -86,6 +86,4 @@ func (d *Driver) UpdatePod(pod apiv1.PodSpec) apiv1.PodSpec {
 	return pod
 }
 
-func (d *Driver) UpdateVirtualService(vs istioNetworkingV1beta1.VirtualService) istioNetworkingV1beta1.VirtualService {
-	return vs
-}
+func (d *Driver) UpdateVirtualService(vs *istioNetworkingV1beta1.VirtualService) {}

--- a/pkg/model/volumes.go
+++ b/pkg/model/volumes.go
@@ -146,7 +146,6 @@ func (dev *Dev) getSourceSubPath(path string) string {
 			}
 			if filepath.IsAbs(path) {
 				oktetoLog.Info("could not retrieve subpath")
-				path = filepath.Base(path)
 			} else {
 				p, err := filepath.Abs(path)
 				if err != nil {


### PR DESCRIPTION
# Proposed changes

Fixes #3967 

This PR enables 3 more linters and fixes the issues that are already in place when enabling them.
Before the changes, issues where:


- Fix `loopclosure` by using local `tt` variable inside the loop and keeping `t.Paralell()` at the begining of the test and not inside the loop. 
When this was fixed, the test started to fail with a panic, as the loop was only using the last case, so when the PreviewList was introduced at HasAccessToOktetoClusterNamespace the test did not run, so the panic was not catched.

```
cmd/context/create_test.go:466:7: loopclosure: loop variable tt captured by func literal (govet)
cmd/context/create_test.go:469:9: loopclosure: loop variable tt captured by func literal (govet)
cmd/context/create_test.go:474:68: loopclosure: loop variable tt captured by func literal (govet)
cmd/context/create_test.go:478:20: loopclosure: loop variable tt captured by func literal (govet)
cmd/context/create_test.go:479:50: loopclosure: loop variable tt captured by func literal (govet)
```

- Fix `ineffassign` by removing unused `sshSock` value assignement from both deploy and destroy remote.

```
cmd/deploy/remote.go:202:4: ineffectual assignment to sshSock (ineffassign)
cmd/destroy/remote.go:205:4: ineffectual assignment to sshSock (ineffassign)
```

- Fix unused `path` value assignement from getSourceSubPath
- Fix deprecated use of `rand.Seed` at init function

```
main.go:67:2: SA1019: rand.Seed has been deprecated since Go 1.20 and an alternative has been available since Go 1.0: As of Go 1.20 there is no reason to call Seed with a random value. Programs that call Seed with a known value to get a specific sequence of results should use New(NewSource(seed)) to obtain a local random generator. (staticcheck)

pkg/model/volumes.go:149:5: SA4006: this value of `path` is never used (staticcheck)
```

- Fix `copylocks`:  `ph.DivertDriver.UpdateVirtualService` was updating the object `istio.io/api/networking/v1beta1.VirtualService` witch had a Mutex as different goroutines could access this value. To fix this instead of passing the value, i changed it to use the pointer. 


```
cmd/deploy/proxy.go:490:46: copylocks: call of ph.DivertDriver.UpdateVirtualService copies lock value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
cmd/deploy/proxy.go:491:34: copylocks: call of json.Marshal copies lock value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
pkg/divert/istio/divert.go:126:42: copylocks: UpdateVirtualService passes lock by value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
pkg/divert/istio/divert.go:127:30: copylocks: call of d.injectDivertHeader copies lock value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
pkg/divert/istio/virtualservices.go:82:37: copylocks: call of d.injectDivertHeader copies lock value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
pkg/divert/istio/virtualservices.go:95:44: copylocks: injectDivertHeader passes lock by value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
pkg/divert/istio/virtualservices.go:108:9: copylocks: return copies lock value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
pkg/divert/weaver/divert.go:89:42: copylocks: UpdateVirtualService passes lock by value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
pkg/divert/weaver/divert.go:90:9: copylocks: return copies lock value: istio.io/api/networking/v1beta1.VirtualService contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
```

## How to validate

Running tests, manually checking that functionality around Deploy, Destroy (remote) and Divert has not changed

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

