### PR TITLE
Generic invalid license error

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -399,7 +399,7 @@ func (c ContextCommand) getUserContext(ctx context.Context, ctxName, ns, token s
 				return nil, err
 			}
 
-			if errors.Is(err, oktetoErrors.ErrTrialExpired) {
+			if errors.Is(err, oktetoErrors.ErrInvalidLicense) {
 				return nil, err
 			}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -211,8 +211,9 @@ var (
 	// ErrTimeout is raised when an operation has timed out
 	ErrTimeout = fmt.Errorf("operation timed out")
 
-	// ErrTrialExpired is the error returned to the user when a trial license expired
-	ErrTrialExpired = errors.New("Your trial license has expired")
+	// ErrInvalidLicense is the error returned to the user when a trial is invalid.
+	// This can be either an expired trial license or no license at all
+	ErrInvalidLicense = errors.New("Your license is invalid")
 )
 
 // IsAlreadyExists raised if the Kubernetes API returns AlreadyExists

--- a/pkg/okteto/auth.go
+++ b/pkg/okteto/auth.go
@@ -113,7 +113,7 @@ func (c *OktetoClient) Auth(ctx context.Context, code string) (*types.User, erro
 			return nil, err
 		}
 
-		if isAPITrialExpiredError(err) {
+		if isAPILicenseError(err) {
 			return nil, err
 		}
 

--- a/pkg/okteto/auth_test.go
+++ b/pkg/okteto/auth_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestAuth(t *testing.T) {
 	x509err := fmt.Errorf("x509 error")
-	trialerr := fmt.Errorf("non-200 OK status code: 423")
+	licerr := fmt.Errorf("non-200 OK status code: 423")
 	type input struct {
 		client fakeGraphQLClient
 	}
@@ -107,11 +107,11 @@ func TestAuth(t *testing.T) {
 			name: "trial expired",
 			input: input{
 				client: fakeGraphQLClient{
-					err: trialerr,
+					err: licerr,
 				},
 			},
 			expected: expected{
-				err: okerrors.ErrTrialExpired,
+				err: okerrors.ErrInvalidLicense,
 			},
 		},
 	}

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -299,9 +299,9 @@ func translateAPIErr(err error) error {
 				E:    err,
 				Hint: oktetoErrors.ErrX509Hint,
 			}
-		case isAPITrialExpiredError(err):
+		case isAPILicenseError(err):
 			return oktetoErrors.UserError{
-				E:    oktetoErrors.ErrTrialExpired,
+				E:    oktetoErrors.ErrInvalidLicense,
 				Hint: "The Okteto instance for your current context has an expired or missing license. Please contact your administrator for more information",
 			}
 		}
@@ -312,7 +312,7 @@ func translateAPIErr(err error) error {
 
 }
 
-func isAPITrialExpiredError(err error) bool {
+func isAPILicenseError(err error) bool {
 	return strings.HasPrefix(err.Error(), "non-200 OK status code: 423")
 }
 


### PR DESCRIPTION
The license error added in: https://github.com/okteto/okteto/pull/3929 was not accounting for the invalid/no license case, only for the trial expired case.

This simply renames all variables to use the correct name and also change the display message from `Your trial license has expired` to `Your license is invalid`

