### PR TITLE
fix: kubeconfig duplicate log

### DIFF
--- a/cmd/context/cmd_test.go
+++ b/cmd/context/cmd_test.go
@@ -27,7 +27,7 @@ func Test_NoArgsAcceptedCtx(t *testing.T) {
 }
 
 func Test_NoArgsAcceptedShow(t *testing.T) {
-	cmd := Context()
+	cmd := Context(nil)
 	cmd.SetArgs([]string{"args"})
 	err := cmd.Execute()
 	if err == nil {
@@ -45,7 +45,7 @@ func Test_NoArgsAcceptedList(t *testing.T) {
 }
 
 func Test_NoArgsAcceptedUpdateKubeConfig(t *testing.T) {
-	cmd := UpdateKubeconfigCMD()
+	cmd := NewKubeconfigCMD(nil).UpdateKubeconfigCMD()
 	cmd.SetArgs([]string{"args"})
 	err := cmd.Execute()
 	if err == nil {

--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Context points okteto to a cluster.
-func Context() *cobra.Command {
+func Context(okClientProvider oktetoClientProvider) *cobra.Command {
 	ctxOptions := &ContextOptions{}
 	cmd := &cobra.Command{
 		Use:     "context",
@@ -57,7 +57,7 @@ This will prompt you to select one of your existing contexts or to create a new 
 
 	// deprecated
 	cmd.AddCommand(CreateCMD())
-	cmd.AddCommand(UpdateKubeconfigCMD())
+	cmd.AddCommand(NewKubeconfigCMD(okClientProvider).UpdateKubeconfigCMD())
 	cmd.AddCommand(UseNamespace())
 
 	cmd.PersistentFlags().BoolVarP(&ctxOptions.InsecureSkipTlsVerify, "insecure-skip-tls-verify", "", false, " If enabled, the server's certificate will not be checked for validity. This will make your connections insecure")

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -42,23 +42,41 @@ type oktetoClientProvider interface {
 	Provide(...okteto.Option) (types.OktetoInterface, error)
 }
 
+type kubeconfigTokenController interface {
+	updateOktetoContextToken(*types.UserContext) error
+}
+
 // ContextCommand has the dependencies to run a ctxCommand
 type ContextCommand struct {
 	K8sClientProvider    okteto.K8sClientProvider
 	LoginController      login.LoginInterface
 	OktetoClientProvider oktetoClientProvider
 
+	kubetokenController kubeconfigTokenController
 	OktetoContextWriter okteto.ContextConfigWriterInterface
 }
 
+type ctxCmdOption func(*ContextCommand)
+
+func withKubeTokenController(k kubeconfigTokenController) ctxCmdOption {
+	return func(c *ContextCommand) {
+		c.kubetokenController = k
+	}
+}
+
 // NewContextCommand creates a new ContextCommand
-func NewContextCommand() *ContextCommand {
-	return &ContextCommand{
+func NewContextCommand(ctxCmdOption ...ctxCmdOption) *ContextCommand {
+	cfg := &ContextCommand{
 		K8sClientProvider:    okteto.NewK8sClientProvider(),
 		LoginController:      login.NewLoginController(),
 		OktetoClientProvider: okteto.NewOktetoClientProvider(),
 		OktetoContextWriter:  okteto.NewContextConfigWriter(),
 	}
+
+	for _, o := range ctxCmdOption {
+		o(cfg)
+	}
+	return cfg
 }
 
 // CreateCMD adds a new cluster to okteto context
@@ -270,7 +288,11 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	}
 
 	// once we have namespace and user identify we are able to retrieve the dynamic token for the namespace
-	replaceCredentialsTokenWithDynamicKubetoken(c.OktetoClientProvider, userContext)
+	err = c.kubetokenController.updateOktetoContextToken(userContext)
+	if err != nil {
+		// TODO: when the static token feature gets removed, we must return an error to the user here
+		oktetoLog.Infof("error updating okteto context token: %v", err)
+	}
 
 	okteto.AddOktetoContext(ctxOptions.Context, &userContext.User, ctxOptions.Namespace, userContext.User.Namespace)
 	cfg := kubeconfig.Get(config.GetKubeconfigPath())
@@ -287,36 +309,6 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	os.Setenv(model.OktetoUserNameEnvVar, okteto.Context().Username)
 
 	return nil
-}
-
-// replaceCredentialsTokenWithDynamicKubetoken retrieves a dynamic token for the given userContext and updates Credentials.Token
-// if error while retrieving the dynamic token or flag OKTETO_USE_STATIC_KUBETOKEN is enabled, value is not updated
-// static token is fallback
-func replaceCredentialsTokenWithDynamicKubetoken(okClientProvider oktetoClientProvider, userContext *types.UserContext) {
-	if utils.LoadBoolean(OktetoUseStaticKubetokenEnvVar) {
-		oktetoLog.Warning(usingStaticKubetokenWarningMessage)
-		return
-	}
-
-	if userContext.User.Namespace == "" {
-		oktetoLog.Debug("user context namespace is empty, fallback to static token")
-		return
-	}
-
-	c, err := okClientProvider.Provide()
-	if err != nil {
-		oktetoLog.Debugf("error providing the okteto client at replaceCredentialsTokenWithDynamicKubetoken: %w", err)
-		return
-	}
-
-	kubetoken, err := c.Kubetoken().GetKubeToken(okteto.Context().Name, userContext.User.Namespace)
-	if err != nil || kubetoken.Status.Token == "" {
-		oktetoLog.Debug("Dynamic kubernetes token not available: falling back to static token")
-		// TODO: when the static token feature gets removed, we must return an error here instead
-		return
-	}
-
-	userContext.Credentials.Token = kubetoken.Status.Token
 }
 
 func getLoggedUserContext(ctx context.Context, c *ContextCommand, ctxOptions *ContextOptions) (*types.UserContext, error) {

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -42,6 +42,7 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User, fakeObj
 		LoginController:      test.NewFakeLoginController(user, nil),
 		OktetoClientProvider: client.NewFakeOktetoClientProvider(c),
 		OktetoContextWriter:  test.NewFakeOktetoContextWriter(),
+		kubetokenController:  newStaticKubetokenController(),
 	}
 }
 
@@ -639,7 +640,6 @@ func TestGetUserContext(t *testing.T) {
 }
 
 func Test_replaceCredentialsTokenWithDynamicKubetoken(t *testing.T) {
-
 	tests := []struct {
 		name                  string
 		userContext           *types.UserContext
@@ -730,7 +730,7 @@ func Test_replaceCredentialsTokenWithDynamicKubetoken(t *testing.T) {
 				KubetokenClient: client.NewFakeKubetokenClient(tt.kubetokenMockResponse),
 			})
 
-			replaceCredentialsTokenWithDynamicKubetoken(fakeOktetoClientProvider, tt.userContext)
+			newDynamicKubetokenController(fakeOktetoClientProvider).updateOktetoContextToken(tt.userContext)
 			assert.Equal(t, tt.expectedToken, tt.userContext.Credentials.Token)
 		})
 	}

--- a/cmd/context/kubetoken.go
+++ b/cmd/context/kubetoken.go
@@ -1,0 +1,146 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const (
+	// OktetoUseStaticKubetokenEnvVar is used to opt in to use static kubetoken
+	OktetoUseStaticKubetokenEnvVar = "OKTETO_USE_STATIC_KUBETOKEN"
+)
+
+var (
+	usingStaticKubetokenWarningMessage = fmt.Sprintf("Using static Kubernetes token due to env var: '%s'. This feature will be removed in the future. We recommend using a dynamic kubernetes token.", OktetoUseStaticKubetokenEnvVar)
+)
+
+// staticKubetokenWarner is used to print a warning message when the static kubetoken is enabled and the cluster has dynamic kubetoken capabilities.
+type staticKubetokenWarner struct {
+	once sync.Once
+}
+
+// warn prints a warning message when the static kubetoken is enabled and the cluster has dynamic kubetoken capabilities.
+func (wp *staticKubetokenWarner) warn() {
+	wp.once.Do(func() {
+		oktetoLog.Warning(usingStaticKubetokenWarningMessage)
+	})
+}
+
+// staticKubetokenController is used to update the kubeconfig stored in the okteto context by using a static token to connect to the cluster.
+type staticKubetokenController struct {
+	staticKubetokenWarner
+}
+
+// newStaticKubetokenController creates a new staticKubetokenController
+func newStaticKubetokenController() *staticKubetokenController {
+	return &staticKubetokenController{
+		staticKubetokenWarner: staticKubetokenWarner{},
+	}
+}
+
+// updateOktetoContext when the dynamic kubetoken is disabled removes the exec from the kubeconfig stored in the okteto context
+// so okteto can still use the old kubeconfig auth method (by static token) to connect to the cluster.
+func (kc *staticKubetokenController) updateOktetoContextExec(okCtx *okteto.OktetoContext) error {
+	kc.staticKubetokenWarner.warn()
+
+	if okCtx == nil || okCtx.UserID == "" || okCtx.Cfg == nil || okCtx.Cfg.AuthInfos == nil || okCtx.Cfg.AuthInfos[okCtx.UserID] == nil {
+		return nil
+	}
+	okCtx.Cfg.AuthInfos[okCtx.UserID].Exec = nil
+	return nil
+}
+
+func (kc *staticKubetokenController) updateOktetoContextToken(uCtx *types.UserContext) error {
+	kc.staticKubetokenWarner.warn()
+	if uCtx.Credentials.Token == "" {
+		return errors.New("static kubernetes token not available")
+	}
+	return nil
+}
+
+// dynamicKubetokenController is used to update the kubeconfig stored in the okteto context by using a dynamic token to connect to the cluster.
+type dynamicKubetokenController struct {
+	oktetoClientProvider oktetoClientProvider
+}
+
+// newDynamicKubetokenController creates a new dynamicKubetokenController
+func newDynamicKubetokenController(okClientProvider oktetoClientProvider) *dynamicKubetokenController {
+	return &dynamicKubetokenController{
+		oktetoClientProvider: okClientProvider,
+	}
+}
+
+// updateOktetoContext when the dynamic kubetoken is enabled configures the kubeconfig auth method to be executed by okteto kubetoken
+// which returns a dynamic token to connect to the cluster.
+func (dkc *dynamicKubetokenController) updateOktetoContextExec(okCtx *okteto.OktetoContext) error {
+	okClient, err := dkc.oktetoClientProvider.Provide()
+	if err != nil {
+		return err
+	}
+
+	err = okClient.Kubetoken().CheckService(okCtx.Name, okCtx.Namespace)
+	if err != nil {
+		return fmt.Errorf("error checking kubetoken service: %w", err)
+	}
+
+	k8sCfg := okCtx.Cfg
+	if k8sCfg.AuthInfos == nil {
+		k8sCfg.AuthInfos = clientcmdapi.NewConfig().AuthInfos
+		k8sCfg.AuthInfos[okCtx.UserID] = clientcmdapi.NewAuthInfo()
+	}
+
+	if token := k8sCfg.AuthInfos[okCtx.UserID].Token; token != "" {
+		k8sCfg.AuthInfos[okCtx.UserID].Token = ""
+	}
+
+	k8sCfg.AuthInfos[okCtx.UserID].Exec = &clientcmdapi.ExecConfig{
+		APIVersion:         "client.authentication.k8s.io/v1",
+		Command:            "okteto",
+		Args:               []string{"kubetoken", "--context", okCtx.Name, "--namespace", okCtx.Namespace},
+		InstallHint:        "Okteto needs to be installed in your PATH and it has to be connected to your instance using the command 'okteto context use https://okteto.example.com'. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
+		InteractiveMode:    "Never",
+		ProvideClusterInfo: true,
+	}
+	return nil
+}
+
+// updateOktetoContextToken retrieves a dynamic token for the given userContext and updates Credentials.Token
+// if error while retrieving the dynamic token or flag OKTETO_USE_STATIC_KUBETOKEN is enabled, value is not updated
+// and fallback to static token
+func (dkc *dynamicKubetokenController) updateOktetoContextToken(userContext *types.UserContext) error {
+	if userContext.User.Namespace == "" {
+		return errors.New("user context namespace is empty")
+	}
+
+	c, err := dkc.oktetoClientProvider.Provide()
+	if err != nil {
+		return fmt.Errorf("error providing the okteto client while updating okteto context token: %w", err)
+	}
+
+	kubetoken, err := c.Kubetoken().GetKubeToken(okteto.Context().Name, userContext.User.Namespace)
+	if err != nil || kubetoken.Status.Token == "" {
+		return errors.New("Dynamic kubernetes token not available: falling back to static token")
+	}
+
+	userContext.Credentials.Token = kubetoken.Status.Token
+	return nil
+}

--- a/cmd/context/kubetoken_test.go
+++ b/cmd/context/kubetoken_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package context
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func Test_RemoveExecFromCfg(t *testing.T) {
+	var tests = []struct {
+		name     string
+		input    *okteto.OktetoContext
+		expected *okteto.OktetoContext
+	}{
+		{
+			name:     "nil context",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty UserID",
+			input:    &okteto.OktetoContext{},
+			expected: &okteto.OktetoContext{},
+		},
+		{
+			name:     "nil config",
+			input:    &okteto.OktetoContext{UserID: "test-user"},
+			expected: &okteto.OktetoContext{UserID: "test-user"},
+		},
+		{
+			name:     "nil AuthInfos",
+			input:    &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{}},
+			expected: &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{}},
+		},
+		{
+			name:     "missing user in AuthInfos",
+			input:    &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{AuthInfos: make(map[string]*api.AuthInfo)}},
+			expected: &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{AuthInfos: make(map[string]*api.AuthInfo)}},
+		},
+		{
+			name: "Exec removed successfully",
+			input: &okteto.OktetoContext{
+				UserID: "test-user",
+				Cfg: &api.Config{AuthInfos: map[string]*api.AuthInfo{
+					"test-user": {Token: "test-token", Exec: &api.ExecConfig{Command: "test-cmd"}},
+				}},
+			},
+			expected: &okteto.OktetoContext{
+				UserID: "test-user",
+				Cfg: &api.Config{AuthInfos: map[string]*api.AuthInfo{
+					"test-user": {Token: "test-token", Exec: nil},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newStaticKubetokenController().updateOktetoContextExec(tt.input)
+
+			assert.Equal(t, tt.expected, tt.input)
+		})
+	}
+}

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -16,7 +16,6 @@ package context
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
@@ -24,20 +23,35 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-const (
-	// OktetoUseStaticKubetokenEnvVar is used to opt in to use static kubetoken
-	OktetoUseStaticKubetokenEnvVar = "OKTETO_USE_STATIC_KUBETOKEN"
-)
+// kubeconfigController has all the functions that the context command needs to update the kubeconfig stored in the okteto context
+// and the ones to store in the kubeconfig file
+type kubeconfigController interface {
+	kubeconfigTokenController
 
-var (
-	usingStaticKubetokenWarningMessage = fmt.Sprintf("Using static Kubernetes token due to env var: '%s'. This feature will be removed in the future. We recommend using a dynamic kubernetes token.", OktetoUseStaticKubetokenEnvVar)
-)
+	updateOktetoContextExec(*okteto.OktetoContext) error
+}
+
+type KubeconfigCMD struct {
+	kubetokenController kubeconfigController
+}
+
+// NewKubeconfigCMD creates a new command to update the kubeconfig stored in the okteto context
+func NewKubeconfigCMD(okClientProvider oktetoClientProvider) *KubeconfigCMD {
+	var kubetokenController kubeconfigController
+	if utils.LoadBoolean(OktetoUseStaticKubetokenEnvVar) {
+		kubetokenController = newStaticKubetokenController()
+	} else {
+		kubetokenController = newDynamicKubetokenController(okClientProvider)
+	}
+	return &KubeconfigCMD{
+		kubetokenController: kubetokenController,
+	}
+}
 
 // UpdateKubeconfigCMD all contexts managed by okteto
-func UpdateKubeconfigCMD() *cobra.Command {
+func (kc *KubeconfigCMD) UpdateKubeconfigCMD() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "update-kubeconfig",
@@ -47,18 +61,18 @@ func UpdateKubeconfigCMD() *cobra.Command {
 			ctx := context.Background()
 
 			// Run context command to get the Cfg into Okteto Context
-			if err := NewContextCommand().Run(ctx, &ContextOptions{}); err != nil {
+			if err := NewContextCommand(withKubeTokenController(kc.kubetokenController)).Run(ctx, &ContextOptions{}); err != nil {
 				return err
 			}
 
-			return ExecuteUpdateKubeconfig(okteto.Context(), config.GetKubeconfigPath(), okteto.NewOktetoClientProvider())
+			return kc.Execute(okteto.Context(), config.GetKubeconfigPath())
 		},
 	}
 
 	return cmd
 }
 
-func ExecuteUpdateKubeconfig(okCtx *okteto.OktetoContext, kubeconfigPaths []string, okClientProvider oktetoClientProvider) error {
+func (k *KubeconfigCMD) Execute(okCtx *okteto.OktetoContext, kubeconfigPaths []string) error {
 	contextName := okCtx.Name
 	if okCtx.IsOkteto {
 		contextName = okteto.UrlToKubernetesContext(contextName)
@@ -66,20 +80,9 @@ func ExecuteUpdateKubeconfig(okCtx *okteto.OktetoContext, kubeconfigPaths []stri
 			return err
 		}
 
-		okClient, err := okClientProvider.Provide()
+		err := k.kubetokenController.updateOktetoContextExec(okCtx)
 		if err != nil {
-			return err
-		}
-
-		if utils.LoadBoolean(OktetoUseStaticKubetokenEnvVar) {
-			removeExecFromCfg(okCtx)
-			oktetoLog.Warning(usingStaticKubetokenWarningMessage)
-		} else {
-			if err := okClient.Kubetoken().CheckService(okCtx.Name, okCtx.Namespace); err == nil {
-				updateCfgAuthInfoWithExec(okCtx)
-			} else {
-				oktetoLog.Debug("Error checking kubetoken service: %w", err)
-			}
+			oktetoLog.Infof("failed to update okteto kubeconfig: %s", err)
 		}
 	}
 
@@ -103,32 +106,4 @@ func updateCfgClusterCertificate(contextName string, okContext *okteto.OktetoCon
 	}
 	okContext.Cfg.Clusters[contextName].CertificateAuthorityData = certPEM
 	return nil
-}
-
-func updateCfgAuthInfoWithExec(okCtx *okteto.OktetoContext) {
-	if okCtx.Cfg.AuthInfos == nil {
-		okCtx.Cfg.AuthInfos = clientcmdapi.NewConfig().AuthInfos
-		okCtx.Cfg.AuthInfos[okCtx.UserID] = clientcmdapi.NewAuthInfo()
-	}
-
-	if token := okCtx.Cfg.AuthInfos[okCtx.UserID].Token; token != "" {
-		okCtx.Cfg.AuthInfos[okCtx.UserID].Token = ""
-	}
-
-	okCtx.Cfg.AuthInfos[okCtx.UserID].Exec = &clientcmdapi.ExecConfig{
-		APIVersion:         "client.authentication.k8s.io/v1",
-		Command:            "okteto",
-		Args:               []string{"kubetoken", "--context", okCtx.Name, "--namespace", okCtx.Namespace},
-		InstallHint:        "Okteto needs to be installed in your PATH and it has to be connected to your instance using the command 'okteto context use https://okteto.example.com'. Please visit https://www.okteto.com/docs/getting-started/ for more information.",
-		InteractiveMode:    "Never",
-		ProvideClusterInfo: true,
-	}
-}
-
-func removeExecFromCfg(okCtx *okteto.OktetoContext) {
-	if okCtx == nil || okCtx.UserID == "" || okCtx.Cfg == nil || okCtx.Cfg.AuthInfos == nil || okCtx.Cfg.AuthInfos[okCtx.UserID] == nil {
-		return
-	}
-
-	okCtx.Cfg.AuthInfos[okCtx.UserID].Exec = nil
 }

--- a/cmd/context/update-kubeconfig_test.go
+++ b/cmd/context/update-kubeconfig_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -142,7 +143,7 @@ func Test_ExecuteUpdateKubeconfig_DisabledKubetoken(t *testing.T) {
 			okContext := okteto.Context()
 			kubeconfigPaths := []string{file}
 
-			err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, tt.okClientProvider)
+			err = NewKubeconfigCMD(tt.okClientProvider).Execute(okContext, kubeconfigPaths)
 			assert.NoError(t, err, "error writing kubeconfig")
 
 			cfg := kubeconfig.Get(kubeconfigPaths)
@@ -255,74 +256,17 @@ func Test_ExecuteUpdateKubeconfig_EnabledKubetoken(t *testing.T) {
 			okContext := okteto.Context()
 			kubeconfigPaths := []string{file}
 
-			err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, okClientProvider)
+			err = NewKubeconfigCMD(okClientProvider).Execute(okContext, kubeconfigPaths)
 			assert.NoError(t, err, "error writing kubeconfig")
 
 			cfg := kubeconfig.Get(kubeconfigPaths)
-			assert.NotNil(t, cfg, "kubeconfig is nil")
+			require.NotNil(t, cfg, "kubeconfig is nil")
 			assert.Equal(t, tt.context.CurrentContext, cfg.CurrentContext, "current context has changed")
 			assert.Equal(t, tt.context.Contexts[tt.context.CurrentContext].Namespace, cfg.Contexts[tt.context.CurrentContext].Namespace, "namespace has changed")
-			assert.NotNil(t, cfg.AuthInfos)
+			require.NotNil(t, cfg.AuthInfos)
 			assert.Len(t, cfg.AuthInfos, 1)
 			assert.NotNil(t, cfg.AuthInfos[""].Exec)
 			assert.Empty(t, cfg.AuthInfos[""].Token)
-		})
-	}
-}
-
-func Test_RemoveExecFromCfg(t *testing.T) {
-	var tests = []struct {
-		name     string
-		input    *okteto.OktetoContext
-		expected *okteto.OktetoContext
-	}{
-		{
-			name:     "nil context",
-			input:    nil,
-			expected: nil,
-		},
-		{
-			name:     "empty UserID",
-			input:    &okteto.OktetoContext{},
-			expected: &okteto.OktetoContext{},
-		},
-		{
-			name:     "nil config",
-			input:    &okteto.OktetoContext{UserID: "test-user"},
-			expected: &okteto.OktetoContext{UserID: "test-user"},
-		},
-		{
-			name:     "nil AuthInfos",
-			input:    &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{}},
-			expected: &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{}},
-		},
-		{
-			name:     "missing user in AuthInfos",
-			input:    &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{AuthInfos: make(map[string]*api.AuthInfo)}},
-			expected: &okteto.OktetoContext{UserID: "test-user", Cfg: &api.Config{AuthInfos: make(map[string]*api.AuthInfo)}},
-		},
-		{
-			name: "Exec removed successfully",
-			input: &okteto.OktetoContext{
-				UserID: "test-user",
-				Cfg: &api.Config{AuthInfos: map[string]*api.AuthInfo{
-					"test-user": {Token: "test-token", Exec: &api.ExecConfig{Command: "test-cmd"}},
-				}},
-			},
-			expected: &okteto.OktetoContext{
-				UserID: "test-user",
-				Cfg: &api.Config{AuthInfos: map[string]*api.AuthInfo{
-					"test-user": {Token: "test-token", Exec: nil},
-				}},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			removeExecFromCfg(tt.input)
-
-			assert.Equal(t, tt.expected, tt.input)
 		})
 	}
 }
@@ -367,7 +311,7 @@ func Test_ExecuteUpdateKubeconfig_With_OktetoUseStaticKubetokenEnvVar(t *testing
 		},
 	)
 
-	err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, okClientProvider)
+	err = NewKubeconfigCMD(okClientProvider).Execute(okContext, kubeconfigPaths)
 	assert.NoError(t, err, "error writing kubeconfig")
 
 	cfg := kubeconfig.Get(kubeconfigPaths)
@@ -406,7 +350,7 @@ func Test_ExecuteUpdateKubeconfig_ForNonOktetoContext(t *testing.T) {
 	okContext := okteto.Context()
 	kubeconfigPaths := []string{file}
 
-	err = ExecuteUpdateKubeconfig(okContext, kubeconfigPaths, nil)
+	err = NewKubeconfigCMD(nil).Execute(okContext, kubeconfigPaths)
 	assert.NoError(t, err, "error writing kubeconfig")
 
 	cfg := kubeconfig.Get(kubeconfigPaths)

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -16,11 +16,18 @@ package cmd
 import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
 )
 
+// oktetoClientProvider provides an okteto client ready to use or fail
+type oktetoClientProvider interface {
+	Provide(...okteto.Option) (types.OktetoInterface, error)
+}
+
 // Kubeconfig fetch credentials for a cluster namespace
-func Kubeconfig() *cobra.Command {
+func Kubeconfig(okClientProvider oktetoClientProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig",
 		Short: "Download credentials for the Kubernetes cluster selected via 'okteto context'",
@@ -30,7 +37,7 @@ Generated kubeconfig file uses a credential plugin to get the cluster credential
 `,
 		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return contextCMD.UpdateKubeconfigCMD().RunE(cmd, args)
+			return contextCMD.NewKubeconfigCMD(okClientProvider).UpdateKubeconfigCMD().RunE(cmd, args)
 		},
 	}
 	return cmd

--- a/main.go
+++ b/main.go
@@ -129,11 +129,15 @@ func main() {
 		oktetoLog.Infof("error hiding server-name flag: %s", err)
 	}
 
+	okClientProvider := okteto.NewOktetoClientProvider()
+
 	root.AddCommand(cmd.Analytics())
 	root.AddCommand(cmd.Version())
 	root.AddCommand(cmd.Login())
-	root.AddCommand(contextCMD.Context())
-	root.AddCommand(cmd.Kubeconfig())
+
+	root.AddCommand(contextCMD.Context(okClientProvider))
+	root.AddCommand(cmd.Kubeconfig(okClientProvider))
+
 	root.AddCommand(kubetoken.NewKubetokenCmd().Cmd())
 	root.AddCommand(registrytoken.RegistryToken(ctx))
 


### PR DESCRIPTION
# Proposed changes

Fixes #3924

Fixes the bug by creating a new interface that modifies the kubeconfig depending if it's a dynamic token or a static token. In the static token controller we introduced a new warning printer that is controlled with a mutex to only run once.
In order to be able to not print the same message from `context.create` and `kubeconfig.update` we reuse the controller in both commands.


## Tests done

| Context | Before | After |
|----------|----------|----------|
| kubeconfig with env var   | <img width="706" alt="Captura de pantalla 2023-09-15 a las 13 42 38" src="https://github.com/okteto/okteto/assets/25170843/c63aa42b-2e14-4070-a2c9-cd105f1d9023">  | <img width="698" alt="Captura de pantalla 2023-09-15 a las 14 24 31" src="https://github.com/okteto/okteto/assets/25170843/a53728b2-9954-4123-b7f0-90a6833a7770">  |
| kubeconfig without env var   | <img width="708" alt="Captura de pantalla 2023-09-15 a las 14 25 21" src="https://github.com/okteto/okteto/assets/25170843/f78b8081-7de3-4bc6-9eba-b343db4ba594">   |   <img width="704" alt="Captura de pantalla 2023-09-15 a las 14 25 50" src="https://github.com/okteto/okteto/assets/25170843/ef38d521-54f2-44d7-ae8a-368522238354"> |
| ctx with env var  | <img width="693" alt="Captura de pantalla 2023-09-15 a las 13 42 00" src="https://github.com/okteto/okteto/assets/25170843/bca975d8-c74d-4e6f-8f40-491964712f12"> |  <img width="711" alt="Captura de pantalla 2023-09-15 a las 13 27 43" src="https://github.com/okteto/okteto/assets/25170843/a316f636-49d9-48b4-b446-62c96ec05d57"> |
| ctx without env var  | <img width="576" alt="Captura de pantalla 2023-09-15 a las 13 38 51" src="https://github.com/okteto/okteto/assets/25170843/4a266ba0-7e37-433d-b0d2-f3c291b35ef8"> |  <img width="568" alt="Captura de pantalla 2023-09-15 a las 13 36 51" src="https://github.com/okteto/okteto/assets/25170843/659e0c0f-10a0-4b94-b1ce-72459d042299">  |


## How to validate

1. Export or unset the environment variable `OKTETO_USE_STATIC_KUBETOKEN`
2. Use the command to test. Remember that this change affects to every command but the commands that are affected the most are `context` and `kubeconfig`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
