### PR TITLE
Panic secret not valid

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -44,6 +44,13 @@ const (
 	doubleDockerfileWarning string = "Build '%s': Two Dockerfiles discovered in both the root and context path, defaulting to '%s/%s'"
 )
 
+var (
+	errDockerDaemonConnection = oktetoErrors.UserError{
+		E:    fmt.Errorf("cannot connect to Docker Daemon"),
+		Hint: "Please start the Docker Daemon or configure a builder endpoint with 'okteto context --builder BUILDKIT_URL",
+	}
+)
+
 // OktetoBuilderInterface runs the build of an image
 type OktetoBuilderInterface interface {
 	Run(ctx context.Context, buildOptions *types.BuildOptions) error
@@ -235,10 +242,7 @@ func translateDockerErr(err error) error {
 		return nil
 	}
 	if strings.HasPrefix(err.Error(), "failed to dial gRPC: cannot connect to the Docker daemon") {
-		return oktetoErrors.UserError{
-			E:    fmt.Errorf("cannot connect to Docker Daemon"),
-			Hint: "Please start the Docker Daemon or configure a builder endpoint with 'okteto context --builder BUILDKIT_URL",
-		}
+		return errDockerDaemonConnection
 	}
 	return err
 }

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -396,17 +396,6 @@ func extractFromContextAndDockerfile(context, dockerfile, svcName string) string
 	return joinPath
 }
 
-// GetVolumesToInclude checks if the path exists, if it doesn't it skip it
-func GetVolumesToInclude(volumesToInclude []model.StackVolume) []model.StackVolume {
-	var result []model.StackVolume
-	for _, p := range volumesToInclude {
-		if _, err := os.Stat(p.LocalPath); err == nil {
-			result = append(result, p)
-		}
-	}
-	return result
-}
-
 // replaceSecretsSourceEnvWithTempFile reads the content of the src of a secret and replaces the envs to mount into dockerfile
 func replaceSecretsSourceEnvWithTempFile(fs afero.Fs, secretTempFolder string, buildOptions *types.BuildOptions) error {
 	// for each secret at buildOptions extract the src

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -133,10 +133,7 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 
 	// inject secrets to buildkit from temp folder
 	if err := replaceSecretsSourceEnvWithTempFile(afero.NewOsFs(), secretTempFolder, buildOptions); err != nil {
-		return oktetoErrors.UserError{
-			E:    err,
-			Hint: "secret should have the format 'id=mysecret,src=/local/secret' where source exists as local file",
-		}
+		return fmt.Errorf("%w: secret should have the format 'id=mysecret,src=/local/secret'", err)
 	}
 
 	opt, err := getSolveOpt(buildOptions)

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -437,12 +437,10 @@ func parseTempSecrets(secretTempFolder string, buildOptions *types.BuildOptions)
 	// create a new file under tempFolder with the expanded content
 	// replace the src of the secret with the tempSrc
 	for indx, s := range buildOptions.Secrets {
-		splitSecret := strings.SplitN(s, "src=", 2)
-		if len(splitSecret) <= 0 {
-			return fmt.Errorf("unable to get secret src")
+		secretId, srcFileName, err := parseSecretFromString(s)
+		if err != nil {
+			return err
 		}
-		srcFileName := strings.TrimSpace(splitSecret[1])
-
 		// read source file
 		srcFile, err := os.Open(srcFileName)
 		if err != nil {
@@ -482,7 +480,7 @@ func parseTempSecrets(secretTempFolder string, buildOptions *types.BuildOptions)
 		}
 
 		// replace src
-		buildOptions.Secrets[indx] = fmt.Sprintf("%ssrc=%s", splitSecret[0], tmpfile.Name())
+		buildOptions.Secrets[indx] = fmt.Sprintf("id=%s,src=%s", secretId, tmpfile.Name())
 	}
 
 	return nil

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -405,6 +405,31 @@ func GetVolumesToInclude(volumesToInclude []model.StackVolume) []model.StackVolu
 	return result
 }
 
+// parseSecretFromString returns id and src from the given secret string
+// format should be id=<name>,src=<source file>
+// if no id or src if found, error is returned
+func parseSecretFromString(s string) (string, string, error) {
+	_, afterId, found := strings.Cut(s, "id=")
+	if !found {
+		return "", "", fmt.Errorf("secret should have an id")
+	}
+	id, _, _ := strings.Cut(afterId, ",")
+	if id == "" {
+		return "", "", fmt.Errorf("secret id can not be empty")
+	}
+
+	_, afterSrc, found := strings.Cut(s, "src=")
+	if !found {
+		return "", "", fmt.Errorf("secret should have a source")
+	}
+	srcFileName, _, _ := strings.Cut(afterSrc, ",")
+	if srcFileName == "" {
+		return "", "", fmt.Errorf("secret source should not be empty")
+	}
+
+	return id, srcFileName, nil
+}
+
 // parseTempSecrets reads the content of the src of a secret and replaces the envs to mount into dockerfile
 func parseTempSecrets(secretTempFolder string, buildOptions *types.BuildOptions) error {
 	// for each secret at buildOptions extract the src

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -624,3 +624,78 @@ func Test_parseTempSecrets(t *testing.T) {
 	require.Contains(t, string(b), envValue)
 
 }
+func Test_parseSecretFromString(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expectedId  string
+		expectedSrc string
+		expectedErr bool
+	}{
+		{
+			name: "valid secret format",
+			args: args{
+				s: "id=mysecret,src=/local/path",
+			},
+			expectedId:  "mysecret",
+			expectedSrc: "/local/path",
+		},
+		{
+			name: "valid secret format 2",
+			args: args{
+				s: "src=/local/path,id=mysecret",
+			},
+			expectedId:  "mysecret",
+			expectedSrc: "/local/path",
+		},
+		{
+			name: "invalid secret format",
+			args: args{
+				s: "id=mysecret",
+			},
+			expectedId:  "",
+			expectedSrc: "",
+			expectedErr: true,
+		},
+		{
+			name: "invalid secret format 2",
+			args: args{
+				s: "src=/local/path",
+			},
+			expectedId:  "",
+			expectedSrc: "",
+			expectedErr: true,
+		},
+		{
+			name: "invalid secret format 3",
+			args: args{
+				s: "id=,src=/local/path",
+			},
+			expectedId:  "",
+			expectedSrc: "",
+			expectedErr: true,
+		},
+		{
+			name: "invalid secret format 4",
+			args: args{
+				s: "id=mysecret,src=",
+			},
+			expectedId:  "",
+			expectedSrc: "",
+			expectedErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, src, err := parseSecretFromString(tt.args.s)
+			require.Truef(t, tt.expectedErr == (err != nil), "expected error")
+
+			require.Equal(t, tt.expectedId, id)
+			require.Equal(t, tt.expectedSrc, src)
+
+		})
+	}
+}

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -762,3 +762,49 @@ func Test_translateDockerErr(t *testing.T) {
 
 	}
 }
+
+func Test_setOutputMode(t *testing.T) {
+	tests := []struct {
+		name                     string
+		input                    string
+		envBuildkitProgressValue string
+		expected                 string
+	}{
+		{
+			name:     "not empty input",
+			input:    "outputmode",
+			expected: "outputmode",
+		},
+		{
+			name:     "empty input and empty env BUILDKIT_PROGRESS  - default output",
+			input:    "",
+			expected: "tty",
+		},
+		{
+			name:                     "empty input and unknown env BUILDKIT_PROGRESS  - default output",
+			input:                    "",
+			envBuildkitProgressValue: "unknown",
+			expected:                 "tty",
+		},
+		{
+			name:                     "empty input and plain env BUILDKIT_PROGRESS  - default output",
+			input:                    "",
+			envBuildkitProgressValue: "plain",
+			expected:                 "plain",
+		},
+		{
+			name:                     "empty input and json env BUILDKIT_PROGRESS  - default output",
+			input:                    "",
+			envBuildkitProgressValue: "json",
+			expected:                 "plain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BUILDKIT_PROGRESS", tt.envBuildkitProgressValue)
+			got := setOutputMode(tt.input)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -652,6 +652,16 @@ func Test_replaceSecretsSourceEnvWithTempFile(t *testing.T) {
 			expectedErr:             true,
 			expectedReplacedSecrets: false,
 		},
+		{
+			name:             "invalid secret, no = found",
+			fs:               fakeFs,
+			secretTempFolder: t.TempDir(),
+			buildOptions: &types.BuildOptions{
+				Secrets: []string{"mysecret"},
+			},
+			expectedErr:             true,
+			expectedReplacedSecrets: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -726,5 +727,38 @@ func Test_createTempFileWithExpandedEnvsAtSource(t *testing.T) {
 
 			require.Contains(t, string(f), "value of env")
 		})
+	}
+}
+
+func Test_translateDockerErr(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       error
+		expectedErr error
+	}{
+		{
+			name:        "err is nil",
+			input:       nil,
+			expectedErr: nil,
+		},
+		{
+			name:        "err is docker error",
+			input:       fmt.Errorf("failed to dial gRPC: cannot connect to the Docker daemon"),
+			expectedErr: errDockerDaemonConnection,
+		},
+		{
+			name:        "err is not docker error",
+			input:       assert.AnError,
+			expectedErr: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			got := translateDockerErr(tt.input)
+			require.Equal(t, tt.expectedErr, got)
+		})
+
 	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes #3958 

When a secret string was not valid, we where throwing a panic. This PR refactors how we extract the information on the secret string, returning an error if this is not valid.

EDIT: Approach to validate the secret string has change into using the csv reader as build.ParseSecret function https://github.com/moby/buildkit/blob/a14b4e097ae1dc7514c5febd6d75f742a166ea75/cmd/buildctl/build/secret.go#L29C1-L29C1 



## How to validate

Following the steps at the issue, testing the input of secrets work as expected and throw an error instead of a panic when secret string is not valid


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

