### PR TITLE
fix(hybrid): terminate process correctly

### DIFF
--- a/cmd/up/process.go
+++ b/cmd/up/process.go
@@ -1,0 +1,70 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"os"
+	"syscall"
+)
+
+type oktetoProcessInterface interface {
+	Getpid() int
+	Getpgid(pid int) (int, error)
+	Find() error
+	Signal(os.Signal) error
+	Wait() (*os.ProcessState, error)
+	Kill() error
+	IsProcessSessionLeader() (bool, error)
+}
+
+type OktetoProcess struct {
+	pid     int
+	process *os.Process
+}
+
+func newOktetoProcess(pid int) oktetoProcessInterface {
+	return &OktetoProcess{
+		pid: pid,
+	}
+}
+
+func (p *OktetoProcess) Getpid() int {
+	return p.pid
+}
+
+func (p *OktetoProcess) Getpgid(pid int) (int, error) {
+	return syscall.Getpgid(pid)
+}
+
+func (p *OktetoProcess) Find() error {
+	osProcess, err := os.FindProcess(p.pid)
+	if err != nil {
+		return err
+	}
+	p.process = osProcess
+	return nil
+}
+
+func (p *OktetoProcess) Kill() error {
+	return p.process.Kill()
+}
+
+func (p *OktetoProcess) Signal(signal os.Signal) error {
+	return p.process.Signal(signal)
+}
+
+func (p *OktetoProcess) Wait() (*os.ProcessState, error) {
+	state, err := p.process.Wait()
+	return state, err
+}

--- a/cmd/up/process.go
+++ b/cmd/up/process.go
@@ -15,12 +15,10 @@ package up
 
 import (
 	"os"
-	"syscall"
 )
 
 type oktetoProcessInterface interface {
 	Getpid() int
-	Getpgid(pid int) (int, error)
 	Find() error
 	Signal(os.Signal) error
 	Wait() (*os.ProcessState, error)
@@ -41,10 +39,6 @@ func newOktetoProcess(pid int) oktetoProcessInterface {
 
 func (p *OktetoProcess) Getpid() int {
 	return p.pid
-}
-
-func (p *OktetoProcess) Getpgid(pid int) (int, error) {
-	return syscall.Getpgid(pid)
 }
 
 func (p *OktetoProcess) Find() error {

--- a/cmd/up/process_test.go
+++ b/cmd/up/process_test.go
@@ -25,7 +25,6 @@ type mockOktetoProcess struct {
 
 	signalsReceived []os.Signal
 
-	getpgidErr                error
 	findErr                   error
 	signalErr                 error
 	waitProcessState          *os.ProcessState
@@ -37,10 +36,6 @@ type mockOktetoProcess struct {
 
 func (m *mockOktetoProcess) Getpid() int {
 	return m.pid
-}
-
-func (m *mockOktetoProcess) Getpgid(pid int) (int, error) {
-	return pid, m.getpgidErr
 }
 
 func (m *mockOktetoProcess) Find() error {

--- a/cmd/up/process_test.go
+++ b/cmd/up/process_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+type mockOktetoProcess struct {
+	pid     int
+	process *os.Process
+
+	signalsReceived []os.Signal
+
+	getpgidErr                error
+	findErr                   error
+	signalErr                 error
+	waitProcessState          *os.ProcessState
+	waitErr                   error
+	killErr                   error
+	isProcessSessionLeader    bool
+	isProcessSessionLeaderErr error
+}
+
+func (m *mockOktetoProcess) Getpid() int {
+	return m.pid
+}
+
+func (m *mockOktetoProcess) Getpgid(pid int) (int, error) {
+	return pid, m.getpgidErr
+}
+
+func (m *mockOktetoProcess) Find() error {
+	if m.findErr != nil {
+		return m.findErr
+	}
+
+	m.process = &os.Process{Pid: m.pid}
+
+	return nil
+}
+
+func (m *mockOktetoProcess) Signal(s os.Signal) error {
+	m.signalsReceived = append(m.signalsReceived, s)
+	return m.signalErr
+}
+
+func (m *mockOktetoProcess) Wait() (*os.ProcessState, error) {
+	return m.waitProcessState, m.waitErr
+}
+
+func (m *mockOktetoProcess) Kill() error {
+	m.signalsReceived = append(m.signalsReceived, os.Kill)
+	return m.killErr
+}
+
+func (m *mockOktetoProcess) IsProcessSessionLeader() (bool, error) {
+	return m.isProcessSessionLeader, m.isProcessSessionLeaderErr
+}
+
+func TestOktetoProcess_Getpid(t *testing.T) {
+	pid := 1234
+	p := newOktetoProcess(pid)
+
+	assert.Equal(t, p.Getpid(), pid)
+}

--- a/cmd/up/process_unix.go
+++ b/cmd/up/process_unix.go
@@ -1,14 +1,29 @@
 //go:build !windows
 // +build !windows
 
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package up
 
-import "syscall"
+import (
+	"syscall"
+)
 
-func isProcessSessionLeader(pid int) (bool, error) {
-	pgid, err := syscall.Getpgid(pid)
+func (p *OktetoProcess) IsProcessSessionLeader() (bool, error) {
+	pgid, err := syscall.Getpgid(p.pid)
 	if err != nil {
 		return false, err
 	}
-	return pgid == pid, nil
+	return pgid == p.pid, nil
 }

--- a/cmd/up/process_unix.go
+++ b/cmd/up/process_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+// +build !windows
+
+package up
+
+import "syscall"
+
+func isProcessSessionLeader(pid int) (bool, error) {
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		return false, err
+	}
+	return pgid == pid, nil
+}

--- a/cmd/up/process_windows.go
+++ b/cmd/up/process_windows.go
@@ -3,6 +3,6 @@
 
 package up
 
-func isProcessSessionLeader(pid int) (bool, error) {
+func (p *OktetoProcess) IsProcessSessionLeader() (bool, error) {
 	return false, nil
 }

--- a/cmd/up/process_windows.go
+++ b/cmd/up/process_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+// +build windows
+
+package up
+
+func isProcessSessionLeader(pid int) (bool, error) {
+	return false, nil
+}

--- a/cmd/up/process_windows.go
+++ b/cmd/up/process_windows.go
@@ -1,6 +1,19 @@
 //go:build windows
 // +build windows
 
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package up
 
 func (p *OktetoProcess) IsProcessSessionLeader() (bool, error) {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -973,6 +973,7 @@ func terminateChildProcess(parent int, pList []ps.Process) {
 
 func terminateProcess(pid int) error {
 	oktetoLog.Debugf("terminating process: %s", pid)
+
 	p, err := os.FindProcess(pid)
 	if err != nil {
 		oktetoLog.Debugf("error getting process %s: %v", pid, err)
@@ -985,11 +986,9 @@ func terminateProcess(pid int) error {
 		return err
 	}
 
-	oktetoLog.Debugf("requesting process termination for pid: %s", pid)
-
 	if pgid == pid {
-		// If the process id (pid) is equal to its process group id (pgid), it means that the process is a session leader (ie. bash)
-		// In that case, sending a SIGTERM will not kill the process, so we need to send a SIGKILL
+		// if the pid equals its process group id (pgid), it's a session leader process such as bash
+		// SIGTERM will not terminate it, so we need to send SIGKILL instead
 		oktetoLog.Debugf("killing session leader process %s", pid)
 		if err := p.Kill(); err != nil {
 			oktetoLog.Debugf("error terminating session leader process %s: %v", p.Pid, err)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -980,15 +980,14 @@ func terminateProcess(pid int) error {
 		return err
 	}
 
-	pgid, err := syscall.Getpgid(pid)
+	isSessionLead, err := isProcessSessionLeader(pid)
 	if err != nil {
 		oktetoLog.Debugf("error getting process group id %s: %v", pid, err)
 		return err
 	}
 
-	if pgid == pid {
-		// if the pid equals its process group id (pgid), it's a session leader process such as bash
-		// SIGTERM will not terminate it, so we need to send SIGKILL instead
+	if isSessionLead {
+		// SIGTERM will not terminate session leader processes, so we need to send SIGKILL instead
 		oktetoLog.Debugf("killing session leader process %s", pid)
 		if err := p.Kill(); err != nil {
 			oktetoLog.Debugf("error terminating session leader process %s: %v", p.Pid, err)

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -113,7 +113,7 @@ func (c client) Write(ref name.Reference, image v1.Image) error {
 func (c client) GetDigest(image string) (string, error) {
 	descriptor, err := c.GetDescriptor(image)
 	if err != nil {
-		return "", fmt.Errorf("error getting image digest: %w", err)
+		return "", err
 	}
 	return descriptor.Digest.String(), nil
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -68,7 +68,7 @@ func (or OktetoRegistry) GetImageTagWithDigest(image string) (string, error) {
 
 	digest, err := or.client.GetDigest(expandedImage)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error getting image tag with digest: %w", err)
 	}
 
 	imageTag := fmt.Sprintf("%s/%s@%s", registry, repository, digest)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -68,7 +68,7 @@ func (or OktetoRegistry) GetImageTagWithDigest(image string) (string, error) {
 
 	digest, err := or.client.GetDigest(expandedImage)
 	if err != nil {
-		return "", fmt.Errorf("error getting image tag with digest: %w", err)
+		return "", err
 	}
 
 	imageTag := fmt.Sprintf("%s/%s@%s", registry, repository, digest)


### PR DESCRIPTION
# Proposed changes

Fixes https://github.com/okteto/app/issues/7117

After researching, it looks like `bash` cannot be terminated with `SIGTERM`. This is causing issues in hybrid mode because some processes remain orphans (such as `webpack` in the case of the issue reported).

To validate what I've said, try to:

1. Launch `bash` and from that session get its pid by running `echo $$`
2. Copy the PID and from another terminal run `kill -SIGTERM <PID>` notice how the bash session is not being terminated
3. Now try with `kil -SIGKILL <PID>` and notice how bash is successfully terminated.

This PR will change how shutdown procedure to treat bash and any session leader processes differently. This is a safe approach because we already safely send SIGTERM to each child process recursively, we only forcefully kill bash when all child processes have already been terminated.

## How to validate

Using the latest version of `okteto`, reproduce the bug first:

1. Start `okteto up frontend-hybrid` in `okteto/app`
2. Run `ps aux | grep frontend-hybrid` and get the PID of the CLI
3. Run `watch -n 0.1 pstree <PID>` to monitor updates of the process and its children
4. Once `okteto up` is ready, run `yarn start` inside
5. Now run `kill -SIGTERM <PID>` and observe the list of processes from the watch command, has not been fully cleaned

Now repeat the steps above using the version of the CLI from this branch, you should see the list of child processes fully cleaned.

Additionally, repeat the steps above but instead of manually killing the CLI, run an upgrade of your cluster. Observe the processes being fully cleaned up.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
