### PR TITLE
fix: high resources panic

### DIFF
--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -172,10 +172,11 @@ func isResourcesRelatedError(errorMessage string) bool {
 
 func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 	var errorToReturn string
+	var regexMaxSubstring = 2
 	if strings.Contains(errorMessage, "maximum cpu usage") {
 		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
 		maximumCpuPerPodMatchGroups := cpuMaximumRegex.FindStringSubmatch(errorMessage)
-		if len(maximumCpuPerPodMatchGroups) < 2 {
+		if len(maximumCpuPerPodMatchGroups) < regexMaxSubstring {
 			errorToReturn += "The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. "
 		} else {
 			var manifestCpu string
@@ -189,7 +190,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 	if strings.Contains(errorMessage, "maximum memory usage") {
 		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
 		maximumMemoryPerPodMatchGroups := memoryMaximumRegex.FindStringSubmatch(errorMessage)
-		if len(maximumMemoryPerPodMatchGroups) < 2 {
+		if len(maximumMemoryPerPodMatchGroups) < regexMaxSubstring {
 			errorToReturn += "The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod."
 		} else {
 			var manifestMemory string

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -176,7 +176,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
 		maximumCpuPerPodMatchGroups := cpuMaximumRegex.FindStringSubmatch(errorMessage)
 		if len(maximumCpuPerPodMatchGroups) < 2 {
-			errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. ")
+			errorToReturn += "The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. "
 		} else {
 			var manifestCpu string
 			if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
@@ -190,7 +190,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
 		maximumMemoryPerPodMatchGroups := memoryMaximumRegex.FindStringSubmatch(errorMessage)
 		if len(maximumMemoryPerPodMatchGroups) < 2 {
-			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod.")
+			errorToReturn += "The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod."
 		} else {
 			var manifestMemory string
 			if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -174,21 +174,31 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 	var errorToReturn string
 	if strings.Contains(errorMessage, "maximum cpu usage") {
 		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
-		maximumCpuPerPod := cpuMaximumRegex.FindStringSubmatch(errorMessage)[1]
-		var manifestCpu string
-		if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
-			manifestCpu = limitCpu.String()
+		maximumCpuPerPodMatchGroups := cpuMaximumRegex.FindStringSubmatch(errorMessage)
+		if len(maximumCpuPerPodMatchGroups) < 2 {
+			errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. ")
+		} else {
+			var manifestCpu string
+			if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
+				manifestCpu = limitCpu.String()
+			}
+			maximumCpuPerPod := maximumCpuPerPodMatchGroups[1]
+			errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCpu, maximumCpuPerPod)
 		}
-		errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCpu, maximumCpuPerPod)
 	}
 	if strings.Contains(errorMessage, "maximum memory usage") {
 		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
-		maximumMemoryPerPod := memoryMaximumRegex.FindStringSubmatch(errorMessage)[1]
-		var manifestMemory string
-		if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
-			manifestMemory = limitMemory.String()
+		maximumMemoryPerPodMatchGroups := memoryMaximumRegex.FindStringSubmatch(errorMessage)
+		if len(maximumMemoryPerPodMatchGroups) < 2 {
+			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod.")
+		} else {
+			var manifestMemory string
+			if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
+				manifestMemory = limitMemory.String()
+			}
+			maximumMemoryPerPod := maximumMemoryPerPodMatchGroups[1]
+			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
 		}
-		errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
 	}
 	return fmt.Errorf(strings.TrimSpace(errorToReturn))
 }

--- a/pkg/k8s/deployments/crud_test.go
+++ b/pkg/k8s/deployments/crud_test.go
@@ -474,7 +474,7 @@ func TestCheckConditionErrors(t *testing.T) {
 				t.Fatalf("wrong error. Got nil, expected %s", tt.expectedErr.Error())
 			}
 			if err != nil && tt.expectedErr == nil {
-				t.Fatalf("wrong error. Got nil, expected %s", err.Error())
+				t.Fatalf("wrong error. Expected nil, but got %s", err.Error())
 			}
 		})
 	}

--- a/pkg/k8s/deployments/crud_test.go
+++ b/pkg/k8s/deployments/crud_test.go
@@ -279,6 +279,62 @@ func TestCheckConditionErrors(t *testing.T) {
 			fmt.Errorf("The value of resources.limits.memory in your okteto manifest (5Gi) exceeds the maximum memory limit per pod (3Gi)."),
 		},
 		{
+			"Memory per pod exceeded 2",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "maximum memory usage",
+						},
+					},
+				},
+			},
+			&model.Dev{
+				Resources: model.ResourceRequirements{
+					Limits: model.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("2"),
+						apiv1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			fmt.Errorf("The value of resources.limits.memory in your okteto manifest (5Gi) exceeds the maximum memory limit per pod (3Gi)."),
+		},
+		{
+			"Cpu per pod exceeded",
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "maximum cpu usage",
+						},
+					},
+				},
+			},
+			&model.Dev{
+				Resources: model.ResourceRequirements{
+					Limits: model.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("2"),
+						apiv1.ResourceMemory: resource.MustParse("5Gi"),
+					},
+				},
+			},
+			fmt.Errorf("The value of resources.limits.cpu in your okteto manifest (2) exceeds the maximum CPU limit per pod (1)."),
+		},
+		{
 			"Cpu per pod exceeded",
 			&appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -334,19 +390,91 @@ func TestCheckConditionErrors(t *testing.T) {
 			},
 			fmt.Errorf("The value of resources.limits.cpu in your okteto manifest (2) exceeds the maximum CPU limit per pod (1). The value of resources.limits.memory in your okteto manifest (5Gi) exceeds the maximum memory limit per pod (3Gi)."),
 		},
+		{
+			name: "exceeded storage quota",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "exceeded quota: requested: requests.storage=1Gi, used: requests.storage=2Gi, limited: requests.storage=3Gi",
+						},
+					},
+				},
+			},
+			dev:         &model.Dev{},
+			expectedErr: fmt.Errorf("quota exceeded, you have reached the maximum storage per namespace"),
+		},
+		{
+			name: "exceeded number of pods quota",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "exceeded quota: requested: pods=1, used: pods=2, limited: pods=3",
+						},
+					},
+				},
+			},
+			dev:         &model.Dev{},
+			expectedErr: fmt.Errorf("quota exceeded, you have reached the maximum number of pods per namespace"),
+		},
+		{
+			name: "another error",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:    appsv1.DeploymentReplicaFailure,
+							Reason:  "FailedCreate",
+							Status:  apiv1.ConditionTrue,
+							Message: "another error",
+						},
+					},
+				},
+			},
+			dev:         &model.Dev{},
+			expectedErr: fmt.Errorf("another error"),
+		},
+		{
+			name: "No errors",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "fake",
+					Namespace: "test",
+				},
+			},
+			dev:         &model.Dev{},
+			expectedErr: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			err := CheckConditionErrors(tt.deployment, tt.dev)
 
-			if err == nil {
-				t.Fatalf("Didn't receive any error. Expected %s", tt.expectedErr)
+			if err == nil && tt.expectedErr != nil {
+				t.Fatalf("wrong error. Got nil, expected %s", tt.expectedErr.Error())
 			}
-
-			if err.Error() != tt.expectedErr.Error() {
-				t.Fatalf("wrong error. Got %s, expected %s", err, tt.expectedErr)
+			if err != nil && tt.expectedErr == nil {
+				t.Fatalf("wrong error. Got nil, expected %s", err.Error())
 			}
 		})
 	}


### PR DESCRIPTION
# Proposed changes

Fixes #3841 

Fix a panic that was happening when the message produced by k8s was missing any resource and limit. Given that I was not able to reproduce it, I added tests covering the use cases where the error could happen based on the logs provided. 

## How to validate

Check unit tests. No way to reproduce the issue on any cluster. I just could reproduce it on unit tests.
 
## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
