### PR TITLE
Handle insecure TLS verification in TestUpAutocreateV2

### DIFF
--- a/integration/commands/context.go
+++ b/integration/commands/context.go
@@ -1,0 +1,64 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/model"
+)
+
+// ContextOptions defines the options to create a context command
+type ContextOptions struct {
+	Workdir       string
+	OktetoHome    string
+	Namespace     string
+	Token         string
+	SkipTlsVerify bool
+}
+
+// RunOktetoContext creates and runs an okteto context command
+func RunOktetoContext(oktetoPath string, contextOptions *ContextOptions) error {
+	cmd := exec.Command(oktetoPath)
+	cmd.Args = append(cmd.Args, "context")
+	if contextOptions.Workdir != "" {
+		cmd.Dir = contextOptions.Workdir
+	}
+	if contextOptions.Namespace != "" {
+		cmd.Args = append(cmd.Args, "--namespace", contextOptions.Namespace)
+	}
+	if contextOptions.SkipTlsVerify {
+		cmd.Args = append(cmd.Args, "--insecure-skip-tls-verify")
+	}
+
+	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))
+	}
+
+	if contextOptions.OktetoHome != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, contextOptions.OktetoHome))
+	}
+	if contextOptions.Token != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, contextOptions.Token))
+	}
+
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("okteto context failed: \nerror: %s \noutput:\n %s", err.Error(), string(o))
+	}
+	return nil
+}

--- a/integration/commands/kubectl.go
+++ b/integration/commands/kubectl.go
@@ -26,6 +26,7 @@ type KubectlOptions struct {
 	Name       string
 	File       string
 	ConfigFile string
+	EnvVars    []string // environment variables to be added to the kubectl command. Follows the os/exec.Cmd.Env pattern
 }
 
 // RunKubectlApply runs kubectl apply command
@@ -40,6 +41,8 @@ func RunKubectlApply(kubectlBinary string, kubectlOpts *KubectlOptions) error {
 	}
 
 	cmd.Env = os.Environ()
+
+	cmd.Env = append(cmd.Env, kubectlOpts.EnvVars...)
 
 	if o, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("kubectl apply failed: %s", string(o))
@@ -59,6 +62,8 @@ func RunKubectlRolloutDeployment(kubectlBinary string, kubectlOpts *KubectlOptio
 	}
 
 	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, kubectlOpts.EnvVars...)
+
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("kubectl apply failed: %s", string(o))
@@ -70,7 +75,6 @@ func RunKubectlRolloutDeployment(kubectlBinary string, kubectlOpts *KubectlOptio
 func RunKubectlRolloutStatefulset(kubectlBinary string, kubectlOpts *KubectlOptions) (string, error) {
 	args := []string{"--namespace", kubectlOpts.Namespace, "rollout", "status", "statefulset", kubectlOpts.Name}
 	cmd := exec.Command(kubectlBinary, args...)
-	cmd.Env = os.Environ()
 
 	if kubectlOpts.ConfigFile != "" {
 		cmd.Args = append(cmd.Args, "--kubeconfig", kubectlOpts.ConfigFile)
@@ -80,6 +84,8 @@ func RunKubectlRolloutStatefulset(kubectlBinary string, kubectlOpts *KubectlOpti
 	}
 
 	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, kubectlOpts.EnvVars...)
+
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("kubectl apply failed: %s", string(o))

--- a/integration/k8s-client.go
+++ b/integration/k8s-client.go
@@ -108,6 +108,7 @@ func WaitForDeployment(kubectlBinary string, kubectlOpts *commands.KubectlOption
 		case <-ticker.C:
 			output, err := commands.RunKubectlRolloutDeployment(kubectlBinary, kubectlOpts, revision)
 			if err != nil {
+				fmt.Printf("waitForDeployment error: %s", err)
 				continue
 			}
 

--- a/integration/up/autocreate_test.go
+++ b/integration/up/autocreate_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -227,6 +228,7 @@ func TestUpAutocreateV2(t *testing.T) {
 		Namespace:  testNamespace,
 		Name:       model.DevCloneName("autocreate"),
 		ConfigFile: filepath.Join(dir, ".kube", "config"),
+		EnvVars:    []string{constants.OktetoHomeEnvVar + "=" + dir},
 	}
 	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOpts, 1, timeout))
 

--- a/integration/up/autocreate_test.go
+++ b/integration/up/autocreate_test.go
@@ -184,6 +184,16 @@ func TestUpAutocreateV2(t *testing.T) {
 	require.NoError(t, err)
 
 	testNamespace := integration.GetTestNamespace("TestUpAutocreateV2", user)
+
+	contextOpts := &commands.ContextOptions{
+		Workdir:       dir,
+		OktetoHome:    dir,
+		Token:         token,
+		Namespace:     testNamespace,
+		SkipTlsVerify: insecureSkipTlsVerify,
+	}
+	require.NoError(t, commands.RunOktetoContext(oktetoPath, contextOpts))
+
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/up_test.go
+++ b/integration/up/up_test.go
@@ -34,11 +34,12 @@ import (
 )
 
 var (
-	user            = ""
-	token           = ""
-	kubectlBinary   = "kubectl"
-	appsSubdomain   = "cloud.okteto.net"
-	ErrUpNotRunning = errors.New("Up command is no longer running")
+	user                  = ""
+	token                 = ""
+	kubectlBinary         = "kubectl"
+	appsSubdomain         = "cloud.okteto.net"
+	ErrUpNotRunning       = errors.New("Up command is no longer running")
+	insecureSkipTlsVerify = false
 )
 
 const (
@@ -68,6 +69,11 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	token = integration.GetToken()
+
+	if v := os.Getenv("OKTETO_INSECURE_SKIP_TLS_VERIFY"); v == "true" {
+		insecureSkipTlsVerify = true
+		integration.InsecureSkipTLSVerify = true
+	}
 
 	exitCode := m.Run()
 	os.Exit(exitCode)


### PR DESCRIPTION
# Proposed changes

For [TestUpAutocreateV2](https://github.com/okteto/okteto/blob/6951592d69ecc6a918595b0f2ca784052f51a641/integration/up/autocreate_test.go#L179):
- Feature to enable insecure TLS connections: can be enabled via the envvar `OKTETO_INSECURE_SKIP_TLS_VERIFY`
- Handle workspace dir in kubectl commands: set to run the `okteto kubetoken` command from the `kubeconfig auth section` with the `OKTETO_HOME` envvar

## Why

We have an e2e test in okteto/app that internally runs clones this repo and runs the `TestUpAutocreteV2` test. We need to run this tests against clusters without certificates, therefore this feature

### Considerations
- I didn't add this feature to all tests since it's not required. If you think this is a useful feature request, I can work on adding it to all tests
- I tried following the code patterns that I saw in the tests, I don't want to be too disruptive

## Testing done

I've ran the tests with the flag enabled
```
az@betsy ~/d/o/o/integration (agustin/handle-tls-envvar) [1]> OKTETO_INSECURE_SKIP_TLS_VERIFY=true OKTETO_URL=https://okteto.agustincluster.dev.okteto.net OKTETO_USER=okteto-admin OKTETO_PATH=/home/az/dev/okteto/okteto/bin/okteto OKTETO_APPS_SUBDOMAIN=agustincluster.dev.okteto.net go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m -run "TestUpAutocreateV2\$"
=== RUN   TestUpAutocreateV2
=== PAUSE TestUpAutocreateV2
=== CONT  TestUpAutocreateV2
2023/09/22 09:43:32 using /home/az/dev/okteto/okteto/bin/okteto
2023/09/22 09:43:33 okteto version 893c3ef7 

2023/09/22 09:43:37 creating namespace testupautocreatev2-linux-1695386613-okteto-admin
2023/09/22 09:43:37 Running: /home/az/dev/okteto/okteto/bin/okteto namespace create testupautocreatev2-linux-1695386613-okteto-admin -l debug
2023/09/22 09:43:40 create namespace output: 
time="2023-09-22T09:43:37-03:00" level=debug msg="server name override: \"\""
time="2023-09-22T09:43:37-03:00" level=info msg="started /home/az/dev/okteto/okteto/bin/okteto namespace create testupautocreatev2-linux-1695386613-okteto-admin -l debug"
time="2023-09-22T09:43:37-03:00" level=debug msg="certificate issuer CN=okteto-wildcard-ca"
time="2023-09-22T09:43:37-03:00" level=debug msg="context certificate not trusted by system roots: x509: certificate signed by unknown authority"
time="2023-09-22T09:43:39-03:00" level=info msg="Namespace 'testupautocreatev2-linux-1695386613-okteto-admin' created"
 ✓  Namespace 'testupautocreatev2-linux-1695386613-okteto-admin' created
time="2023-09-22T09:43:40-03:00" level=info msg="Using testupautocreatev2-linux-1695386613-okteto-admin @ okteto.agustincluster.dev.okteto.net as context"
 i  Using testupautocreatev2-linux-1695386613-okteto-admin @ okteto.agustincluster.dev.okteto.net as context
time="2023-09-22T09:43:40-03:00" level=info msg="failed to send analytics: analytics disabled by admin"
time="2023-09-22T09:43:40-03:00" level=info msg="finished /home/az/dev/okteto/okteto/bin/okteto namespace create testupautocreatev2-linux-1695386613-okteto-admin -l debug"

kubeconfig output:  ✓  Updated kubernetes context 'okteto_agustincluster_dev_okteto_net/testupautocreatev2-linux-1695386613-okteto-admin' in '[/tmp/TestUpAutocreateV23406161794/001/.kube/config]'
2023/09/22 09:43:47 original 'index.html' content: testupautocreatev2-linux-1695386613-okteto-admin
2023/09/22 09:43:47 Running up command: /home/az/dev/okteto/okteto/bin/okteto up -f /tmp/TestUpAutocreateV23406161794/001/okteto.yml -n testupautocreatev2-linux-1695386613-okteto-admin
2023/09/22 09:43:47 waiting for okteto up to be ready
2023/09/22 09:43:57 failed to read state file /tmp/TestUpAutocreateV23406161794/001/.okteto/testupautocreatev2-linux-1695386613-okteto-admin/autocreate/okteto.state: open /tmp/TestUpAutocreateV23406161794/001/.okteto/testupautocreatev2-linux-1695386613-okteto-admin/autocreate/okteto.state: no such file or directory
2023/09/22 09:44:07 okteto up is: attaching
2023/09/22 09:44:17 okteto up is: pulling
2023/09/22 09:44:26 okteto up is: ready
2023/09/22 09:44:29 waitForDeployment output: deployment "autocreate-okteto" successfully rolled out
2023/09/22 09:44:29 deployment "autocreate-okteto" successfully rolled out

2023/09/22 09:44:39 Running exec command: /home/az/dev/okteto/okteto/bin/okteto exec -n testupautocreatev2-linux-1695386613-okteto-admin -f /tmp/TestUpAutocreateV23406161794/001/okteto.yml -- cat .stignore | grep '(?d)venv'
2023/09/22 09:44:46 destroying pods with label selector: app=autocreate
2023/09/22 09:44:48 destroying pod autocreate-okteto-69959b4966-h6ps5
2023/09/22 09:44:54 endpoint http://localhost:8081/index.html didn't respond
2023/09/22 09:44:59 endpoint http://localhost:8081/index.html didn't respond
2023/09/22 09:45:09 okteto down output:
 i  Using testupautocreatev2-linux-1695386613-okteto-admin @ okteto.agustincluster.dev.okteto.net as context
 ✓  Development container 'autocreate' deactivated
 ✓  Persistent volume 'autocreate' removed
2023/09/22 09:45:09 okteto up exited: exit status 1.
Output:
 i  Using testupautocreatev2-linux-1695386613-okteto-admin @ okteto.agustincluster.dev.okteto.net as context
 i  Build section is not defined in your okteto manifest
 ✓  Client certificates generated
Installing dependencies...
syncthing-linux-amd64-v1.24.0.tar.gz  1003.81 KiB / 9.74 MiB [->______________] 10.06% ? p/ssyncthing-linux-amd64-v1.24.0.tar.gz  2.42 MiB / 9.74 MiB [---->______________] 24.82% ? p/ssyncthing-linux-amd64-v1.24.0.tar.gz  4.09 MiB / 9.74 MiB [------->___________] 41.98% ? p/ssyncthing-linux-amd64-v1.24.0.tar.gz  5.48 MiB / 9.74 MiB [------>_____] 56.25% 7.50 MiB p/ssyncthing-linux-amd64-v1.24.0.tar.gz  6.90 MiB / 9.74 MiB [-------->___] 70.85% 7.50 MiB p/ssyncthing-linux-amd64-v1.24.0.tar.gz  7.86 MiB / 9.74 MiB [--------->__] 80.63% 7.50 MiB p/ssyncthing-linux-amd64-v1.24.0.tar.gz  8.90 MiB / 9.74 MiB [---------->_] 91.37% 7.39 MiB p/ssyncthing-linux-amd64-v1.24.0.tar.gz  9.74 MiB / 9.74 MiB [-----------] 100.00% 7.23 MiB p/s ✓  Dependencies successfully installed
 ✓  Persistent volume successfully attached
 ✓  Images successfully pulled
 ✓  Files synchronized
    Context:   okteto.agustincluster.dev.okteto.net
    Namespace: testupautocreatev2-linux-1695386613-okteto-admin
    Name:      autocreate
    Forward:   8081 -> 8080

Serving HTTP on 0.0.0.0 port 8080 (http://0.0.0.0:8080/) ...
127.0.0.1 - - [22/Sep/2023 12:44:31] "GET /var.html HTTP/1.1" 200 -
127.0.0.1 - - [22/Sep/2023 12:44:33] "GET /index.html HTTP/1.1" 200 -
127.0.0.1 - - [22/Sep/2023 12:44:34] "GET /index.html HTTP/1.1" 200 -
127.0.0.1 - - [22/Sep/2023 12:44:35] "GET /index.html HTTP/1.1" 200 -
10.44.8.96 - - [22/Sep/2023 12:44:37] "GET /index.html HTTP/1.1" 200 -
127.0.0.1 - - [22/Sep/2023 12:44:39] "GET /index.html HTTP/1.1" 200 -
127.0.0.1 - - [22/Sep/2023 12:44:46] "GET /index.html HTTP/1.1" 200 -

Connection lost to your development container, reconnecting...
 ✓  Images successfully pulled
 ✓  Files synchronized
    Context:   okteto.agustincluster.dev.okteto.net
    Namespace: testupautocreatev2-linux-1695386613-okteto-admin
    Name:      autocreate
    Forward:   8081 -> 8080

Serving HTTP on 0.0.0.0 port 8080 (http://0.0.0.0:8080/) ...
127.0.0.1 - - [22/Sep/2023 12:45:04] "GET /index.html HTTP/1.1" 200 -

 x  Development container has been deactivated
    Find additional logs at: /tmp/TestUpAutocreateV23406161794/001/.okteto/testupautocreatev2-linux-1695386613-okteto-admin/autocreate/okteto.log
2023/09/22 09:45:10 okteto delete namespace testupautocreatev2-linux-1695386613-okteto-admin
--- PASS: TestUpAutocreateV2 (109.63s)
PASS
ok      github.com/okteto/okteto/integration/up 109.644s
```

## How to validate

You can run the integration tests against any cluster.

I've created a branch so that I trigger the tests with these changes. The [circleci job can be seen here](https://app.circleci.com/pipelines/github/okteto/okteto/11749/workflows/3d8e17ec-2d04-466c-8710-6108f607d4b2)

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
