### PR TITLE
fix panic deploying dependencies in vanilla

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -15,6 +15,7 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -47,6 +48,10 @@ import (
 const (
 	headerUpgrade          = "Upgrade"
 	succesfullyDeployedmsg = "Development environment '%s' successfully deployed"
+)
+
+var (
+	errDepenNotAvailableInVanilla = errors.New("dependency deployment is only supported in clusters with Okteto installed")
 )
 
 // Options represents options for deploy command
@@ -566,7 +571,7 @@ func isRemoteDeployer(runInRemoteFlag bool, deployImage string) bool {
 // deployDependencies deploy the dependencies in the manifest
 func (dc *DeployCommand) deployDependencies(ctx context.Context, deployOptions *Options) error {
 	if len(deployOptions.Manifest.Dependencies) > 0 && !okteto.Context().IsOkteto {
-		return fmt.Errorf("dependency deployment is only supported in clusters with Okteto installed")
+		return errDepenNotAvailableInVanilla
 	}
 
 	for depName, dep := range deployOptions.Manifest.Dependencies {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -565,6 +565,10 @@ func isRemoteDeployer(runInRemoteFlag bool, deployImage string) bool {
 
 // deployDependencies deploy the dependencies in the manifest
 func (dc *DeployCommand) deployDependencies(ctx context.Context, deployOptions *Options) error {
+	if len(deployOptions.Manifest.Dependencies) > 0 && !okteto.Context().IsOkteto {
+		return fmt.Errorf("dependency deployment is only supported in clusters with Okteto installed")
+	}
+
 	for depName, dep := range deployOptions.Manifest.Dependencies {
 		oktetoLog.Information("Deploying dependency '%s'", depName)
 		oktetoLog.SetStage(fmt.Sprintf("Deploying dependency %s", depName))


### PR DESCRIPTION
# Proposed changes
- check if context is related to vanilla cluster, if so, return an error when deploying dependencies
- add test covering case

Fixes #[7132](https://github.com/okteto/app/issues/7132)



## How to validate

1. Using a vanilla cluster
2. clone https://github.com/okteto/movies-frontend
3. run `okteto deploy`
4. output doesn't panic:
![Captura de Pantalla 2023-09-22 a las 18 19 16](https://github.com/okteto/okteto/assets/22500940/dc1165ef-f71b-4f1d-8625-1861a5ccd7cb)
 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
