### PR TITLE
Jlopezbarb/kubetoken update

### DIFF
--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -370,10 +370,16 @@ func (up *upContext) cleanCommand(ctx context.Context) {
 
 	cmd := "cat /var/okteto/bin/version.txt; cat /proc/sys/fs/inotify/max_user_watches; /var/okteto/bin/clean >/dev/null 2>&1"
 
-	err := k8sExec.Exec(
+	k8sClient, restConfig, err := up.K8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		oktetoLog.Infof("failed to clean session: %s", err)
+		return
+	}
+
+	err = k8sExec.Exec(
 		ctx,
-		up.Client,
-		up.RestConfig,
+		k8sClient,
+		restConfig,
 		up.Dev.Namespace,
 		up.Pod.Name,
 		up.Dev.Container,
@@ -397,13 +403,18 @@ func (up *upContext) RunCommand(ctx context.Context, cmd []string) error {
 		return err
 	}
 
+	k8sClient, restConfig, err := up.K8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		return err
+	}
+
 	if up.Dev.RemoteModeEnabled() {
 		if up.Dev.IsHybridModeEnabled() {
 			hybridCtx := &HybridExecCtx{
 				Dev:           up.Dev,
 				Name:          up.Manifest.Name,
 				Namespace:     up.Manifest.Namespace,
-				Client:        up.Client,
+				Client:        k8sClient,
 				Workdir:       up.Dev.Workdir,
 				RunOktetoExec: false,
 			}
@@ -429,8 +440,8 @@ func (up *upContext) RunCommand(ctx context.Context, cmd []string) error {
 
 	return k8sExec.Exec(
 		ctx,
-		up.Client,
-		up.RestConfig,
+		k8sClient,
+		restConfig,
 		up.Dev.Namespace,
 		up.Pod.Name,
 		up.Dev.Container,
@@ -443,21 +454,26 @@ func (up *upContext) RunCommand(ctx context.Context, cmd []string) error {
 }
 
 func (up *upContext) checkOktetoStartError(ctx context.Context, msg string) error {
-	app, err := apps.Get(ctx, up.Dev, up.Dev.Namespace, up.Client)
+	k8sClient, _, err := up.K8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		return err
+	}
+
+	app, err := apps.Get(ctx, up.Dev, up.Dev.Namespace, k8sClient)
 	if err != nil {
 		return err
 	}
 
 	devApp := app.DevClone()
-	if err := devApp.Refresh(ctx, up.Client); err != nil {
+	if err := devApp.Refresh(ctx, k8sClient); err != nil {
 		return err
 	}
-	pod, err := devApp.GetRunningPod(ctx, up.Client)
+	pod, err := devApp.GetRunningPod(ctx, k8sClient)
 	if err != nil {
 		return err
 	}
 
-	userID := pods.GetPodUserID(ctx, pod.Name, up.Dev.Container, up.Dev.Namespace, up.Client)
+	userID := pods.GetPodUserID(ctx, pod.Name, up.Dev.Container, up.Dev.Namespace, k8sClient)
 	if up.Dev.PersistentVolumeEnabled() {
 		if userID != -1 && userID != *up.Dev.SecurityContext.RunAsUser {
 			return oktetoErrors.UserError{

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -3,9 +3,12 @@ package up
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
+	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
@@ -15,6 +18,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -779,4 +783,213 @@ func TestGetEnvsFromSecretsError(t *testing.T) {
 	envs, err := secretEnvsGetter.getEnvsFromSecrets(context.Background())
 	require.Error(t, err)
 	require.Nil(t, envs)
+}
+
+func TestCheckOktetoStartError(t *testing.T) {
+	msg := "test"
+	tt := []struct {
+		name        string
+		dev         *model.Dev
+		K8sProvider *test.FakeK8sProvider
+		expected    error
+	}{
+		{
+			name: "error providing k8s client",
+			K8sProvider: &test.FakeK8sProvider{
+				ErrProvide: assert.AnError,
+			},
+			expected: assert.AnError,
+		},
+		{
+			name:        "error getting app",
+			K8sProvider: test.NewFakeK8sProvider(),
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
+			expected: apps.ErrApplicationNotFound{
+				Name: "test",
+			},
+		},
+		{
+			name: "error refreshing",
+			K8sProvider: test.NewFakeK8sProvider(
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				}),
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
+			expected: &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Status:  metav1.StatusFailure,
+					Code:    http.StatusNotFound,
+					Message: "deployments.apps \"test-okteto\" not found",
+					Reason:  metav1.StatusReasonNotFound,
+					Details: &metav1.StatusDetails{
+						Name:  "test-okteto",
+						Kind:  "deployments",
+						Group: "apps",
+					},
+				},
+			},
+		},
+		{
+			name: "error getRunningPod",
+			K8sProvider: test.NewFakeK8sProvider(
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto",
+						Namespace: "test",
+					},
+				}),
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
+			expected: fmt.Errorf("not found"),
+		},
+		{
+			name: "error pv enabled",
+			K8sProvider: test.NewFakeK8sProvider(
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto",
+						Namespace: "test",
+						UID:       "1234",
+						Annotations: map[string]string{
+							model.DeploymentRevisionAnnotation: "1",
+						},
+					},
+				},
+				&appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto-1234",
+						Namespace: "test",
+						UID:       "1234",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Deployment",
+								UID:  "1234",
+							},
+						},
+						Annotations: map[string]string{
+							model.DeploymentRevisionAnnotation: "1",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto-1234",
+						Namespace: "test",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "ReplicaSet",
+								UID:  "1234",
+							},
+						},
+					},
+				}),
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+			},
+			expected: fmt.Errorf(msg),
+		},
+		{
+			name: "error pv enabled",
+			K8sProvider: test.NewFakeK8sProvider(
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto",
+						Namespace: "test",
+						UID:       "1234",
+						Annotations: map[string]string{
+							model.DeploymentRevisionAnnotation: "1",
+						},
+					},
+				},
+				&appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto-1234",
+						Namespace: "test",
+						UID:       "1234",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "Deployment",
+								UID:  "1234",
+							},
+						},
+						Annotations: map[string]string{
+							model.DeploymentRevisionAnnotation: "1",
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto-1234",
+						Namespace: "test",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind: "ReplicaSet",
+								UID:  "1234",
+							},
+						},
+					},
+				}),
+			dev: &model.Dev{
+				Name:      "test",
+				Namespace: "test",
+				Secrets: []model.Secret{
+					{
+						LocalPath:  "test",
+						RemotePath: "test",
+					},
+				},
+			},
+			expected: fmt.Errorf(msg),
+		},
+	}
+
+	for _, tt := range tt {
+		t.Run(tt.name, func(t *testing.T) {
+			upCtx := &upContext{
+				Dev:               tt.dev,
+				K8sClientProvider: tt.K8sProvider,
+				Options: &UpOptions{
+					ManifestPathFlag: "test",
+				},
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto-1234",
+						Namespace: "test",
+					},
+				},
+			}
+			err := upCtx.checkOktetoStartError(context.Background(), msg)
+			assert.ErrorContains(t, err, tt.expected.Error())
+		})
+	}
 }

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -23,11 +23,10 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/syncthing"
 	"github.com/spf13/afero"
 	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 type registryInterface interface {
@@ -44,8 +43,6 @@ type upContext struct {
 	Dev                   *model.Dev
 	Translations          map[string]*apps.Translation
 	isRetry               bool
-	Client                *kubernetes.Clientset
-	RestConfig            *rest.Config
 	Pod                   *apiv1.Pod
 	Forwarder             forwarder
 	Disconnect            chan error
@@ -63,6 +60,8 @@ type upContext struct {
 	StartTime             time.Time
 	Options               *UpOptions
 	pidController         pidController
+	tokenUpdater          tokenUpdater
+	K8sClientProvider     okteto.K8sClientProvider
 	Fs                    afero.Fs
 	hybridCommand         *exec.Cmd
 	interruptReceived     bool

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -66,6 +66,10 @@ const (
 	composeVolumesUrl = "https://www.okteto.com/docs/reference/compose/#volumes-string-optional"
 )
 
+var (
+	errConfigNotConfigured = fmt.Errorf("kubeconfig not found")
+)
+
 // UpOptions represents the options available on up command
 type UpOptions struct {
 	// ManifestPathFlag is the option -f as introduced by the user when executing this command.
@@ -249,16 +253,18 @@ func Up() *cobra.Command {
 			}
 
 			up := &upContext{
-				Manifest:         oktetoManifest,
-				Dev:              nil,
-				Exit:             make(chan error, 1),
-				resetSyncthing:   upOptions.Reset,
-				StartTime:        time.Now(),
-				Registry:         registry.NewOktetoRegistry(okteto.Config{}),
-				Options:          upOptions,
-				Fs:               afero.NewOsFs(),
-				analyticsTracker: analyticsTracker,
-				analyticsMeta:    upMeta,
+				Manifest:          oktetoManifest,
+				Dev:               nil,
+				Exit:              make(chan error, 1),
+				resetSyncthing:    upOptions.Reset,
+				StartTime:         time.Now(),
+				Registry:          registry.NewOktetoRegistry(okteto.Config{}),
+				Options:           upOptions,
+				Fs:                afero.NewOsFs(),
+				analyticsTracker:  analyticsTracker,
+				analyticsMeta:     upMeta,
+				K8sClientProvider: okteto.NewK8sClientProvider(),
+				tokenUpdater:      newTokenUpdaterController(),
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {
@@ -270,7 +276,8 @@ func Up() *cobra.Command {
 				}
 				oktetoLog.Infof("Terminal: %v", up.stateTerm)
 			}
-			up.Client, up.RestConfig, err = okteto.GetK8sClient()
+
+			k8sClient, _, err := okteto.GetK8sClient()
 			if err != nil {
 				return fmt.Errorf("failed to load k8s client: %v", err)
 			}
@@ -281,7 +288,7 @@ func Up() *cobra.Command {
 			if upOptions.Deploy && !up.Manifest.IsV2 {
 				// the autocreate property is forced to be true
 				forceAutocreate = true
-			} else if upOptions.Deploy || (up.Manifest.IsV2 && !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, up.Client)) {
+			} else if upOptions.Deploy || (up.Manifest.IsV2 && !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, k8sClient)) {
 				err := up.deployApp(ctx)
 
 				// only allow error.ErrManifestFoundButNoDeployAndDependenciesCommands to go forward - autocreate property will deploy the app
@@ -289,7 +296,7 @@ func Up() *cobra.Command {
 					return err
 				}
 
-			} else if !upOptions.Deploy && (up.Manifest.IsV2 && pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, up.Client)) {
+			} else if !upOptions.Deploy && (up.Manifest.IsV2 && pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, k8sClient)) {
 				oktetoLog.Information("'%s' was already deployed. To redeploy run 'okteto deploy' or 'okteto up --deploy'", up.Manifest.Name)
 			}
 
@@ -324,7 +331,7 @@ func Up() *cobra.Command {
 						oktetoLog.Infof("failed to create okteto client: '%s'", err.Error())
 						return
 					}
-					if err := wakeNamespaceIfApplies(ctx, up.Dev.Namespace, up.Client, okClient); err != nil {
+					if err := wakeNamespaceIfApplies(ctx, up.Dev.Namespace, k8sClient, okClient); err != nil {
 						// If there is an error waking up namespace, we don't want to fail the up command
 						oktetoLog.Infof("failed to wake up the namespace: %s", err.Error())
 					}
@@ -727,6 +734,14 @@ func (up *upContext) activateLoop() {
 				continue
 			}
 
+			if errors.Is(err, okteto.ErrK8sUnauthorised) {
+				if err := up.tokenUpdater.UpdateKubeConfigToken(); err != nil {
+					up.Exit <- fmt.Errorf("error updating k8s token: %w", err)
+					return
+				}
+				continue
+			}
+
 			if oktetoErrors.IsTransient(err) {
 				isTransientError = true
 				continue
@@ -778,9 +793,13 @@ func (up *upContext) waitUntilExitOrInterruptOrApply(ctx context.Context) error 
 }
 
 func (up *upContext) applyToApps(ctx context.Context) chan error {
+	k8sClient, _, err := up.K8sClientProvider.Provide(okteto.Context().Cfg)
+	if err != nil {
+		return nil
+	}
 	result := make(chan error, 1)
 	for _, tr := range up.Translations {
-		go tr.App.Watch(ctx, result, up.Client)
+		go tr.App.Watch(ctx, result, k8sClient)
 	}
 	return result
 }
@@ -1068,4 +1087,49 @@ func wakeNamespaceIfApplies(ctx context.Context, ns string, k8sClient kubernetes
 
 	oktetoLog.Information("Namespace '%s' is sleeping, waking it up...", ns)
 	return okClient.Namespaces().Wake(ctx, ns)
+}
+
+// tokenUpgrader updates the token of the config when the token is outdated
+type tokenUpdater interface {
+	UpdateKubeConfigToken() error
+}
+
+// oktetoClientProvider provides an okteto client ready to use or fail
+type oktetoClientProvider interface {
+	Provide(...okteto.Option) (types.OktetoInterface, error)
+}
+
+type tokenUpdaterController struct {
+	oktetoClientProvider oktetoClientProvider
+}
+
+func newTokenUpdaterController() *tokenUpdaterController {
+	return &tokenUpdaterController{
+		oktetoClientProvider: okteto.NewOktetoClientProvider(),
+	}
+}
+
+func (tuc *tokenUpdaterController) UpdateKubeConfigToken() error {
+	oktetoLog.Info("updating kubeconfig token")
+	oktetoClient, err := tuc.oktetoClientProvider.Provide()
+	if err != nil {
+		return err
+	}
+	token, err := oktetoClient.Kubetoken().GetKubeToken(okteto.Context().Name, okteto.Context().Namespace)
+	if err != nil {
+		return err
+	}
+	// update the token in the okteto context for future client initializations
+	okCtx := okteto.Context()
+
+	ctxUserID := okCtx.UserID
+	cfg := okCtx.Cfg
+	if cfg == nil {
+		return errConfigNotConfigured
+	}
+	if _, ok := okCtx.Cfg.AuthInfos[ctxUserID]; !ok {
+		return fmt.Errorf("user %s not found in kubeconfig", ctxUserID)
+	}
+	okCtx.Cfg.AuthInfos[ctxUserID].Token = token.Status.Token
+	return nil
 }

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -19,22 +19,27 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/internal/test/client"
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 func Test_waitUntilExitOrInterrupt(t *testing.T) {
 	up := upContext{
-		Options: &UpOptions{},
+		Options:           &UpOptions{},
+		K8sClientProvider: test.NewFakeK8sProvider(),
 	}
 	up.CommandResult = make(chan error, 1)
 	up.CommandResult <- nil
@@ -474,4 +479,166 @@ func TestSetSyncDefaultsByDevModeError(t *testing.T) {
 	err := setSyncDefaultsByDevMode(dev, getSyncTempDirFake)
 	require.Error(t, err)
 	require.Equal(t, *dev, expectedDev)
+}
+
+func TestUpdateKubetoken(t *testing.T) {
+	tt := []struct {
+		name        string
+		f           *client.FakeOktetoClient
+		context     *okteto.OktetoContextStore
+		expectedCfg *api.Config
+		expected    error
+	}{
+		{
+			name: "oktetoClientError",
+			f: &client.FakeOktetoClient{
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{
+					Err: assert.AnError,
+					Token: types.KubeTokenResponse{
+						TokenRequest: authenticationv1.TokenRequest{
+							Status: authenticationv1.TokenRequestStatus{
+								Token: "token",
+							},
+						},
+					},
+				}),
+			},
+			context: &okteto.OktetoContextStore{
+				CurrentContext: "test",
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {
+						UserID: "test",
+						Cfg: &api.Config{
+							AuthInfos: map[string]*api.AuthInfo{
+								"test": {},
+							},
+						},
+					},
+				},
+			},
+			expectedCfg: &api.Config{
+				AuthInfos: map[string]*api.AuthInfo{
+					"test": {},
+				},
+			},
+			expected: assert.AnError,
+		},
+		{
+			name: "oktetoClientCorrect",
+			f: &client.FakeOktetoClient{
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{
+					Token: types.KubeTokenResponse{
+						TokenRequest: authenticationv1.TokenRequest{
+							Status: authenticationv1.TokenRequestStatus{
+								Token: "token",
+							},
+						},
+					},
+				}),
+			},
+			context: &okteto.OktetoContextStore{
+				CurrentContext: "test",
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {
+						UserID: "test",
+						Cfg: &api.Config{
+							AuthInfos: map[string]*api.AuthInfo{
+								"test": {},
+							},
+						},
+					},
+				},
+			},
+			expectedCfg: &api.Config{
+				AuthInfos: map[string]*api.AuthInfo{
+					"test": {
+						Token: "token",
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "cfg not configured",
+			f: &client.FakeOktetoClient{
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{
+					Token: types.KubeTokenResponse{
+						TokenRequest: authenticationv1.TokenRequest{
+							Status: authenticationv1.TokenRequestStatus{
+								Token: "token",
+							},
+						},
+					},
+				}),
+			},
+			context: &okteto.OktetoContextStore{
+				CurrentContext: "123",
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {
+						UserID: "test",
+						Cfg: &api.Config{
+							AuthInfos: map[string]*api.AuthInfo{
+								"test": {},
+							},
+						},
+					},
+					"123": {},
+				},
+			},
+			expectedCfg: &api.Config{
+				AuthInfos: map[string]*api.AuthInfo{
+					"test": {},
+				},
+			},
+			expected: errConfigNotConfigured,
+		},
+		{
+			name: "incorrect authInfo",
+			f: &client.FakeOktetoClient{
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{
+					Token: types.KubeTokenResponse{
+						TokenRequest: authenticationv1.TokenRequest{
+							Status: authenticationv1.TokenRequestStatus{
+								Token: "token",
+							},
+						},
+					},
+				}),
+			},
+			context: &okteto.OktetoContextStore{
+				CurrentContext: "test",
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {
+						UserID: "test",
+						Cfg: &api.Config{
+							AuthInfos: map[string]*api.AuthInfo{
+								"123": {},
+							},
+						},
+					},
+				},
+			},
+			expectedCfg: &api.Config{
+				AuthInfos: map[string]*api.AuthInfo{
+					"123": {},
+				},
+			},
+			expected: fmt.Errorf("user %s not found in kubeconfig", "test"),
+		},
+	}
+	for _, tt := range tt {
+		t.Run(tt.name, func(t *testing.T) {
+			tokenUpdater := newTokenUpdaterController()
+			tokenUpdater.oktetoClientProvider = client.NewFakeOktetoClientProvider(tt.f)
+			okteto.CurrentStore = tt.context
+
+			err := tokenUpdater.UpdateKubeConfigToken()
+			if err != nil {
+				assert.Equal(t, tt.expected, err)
+			}
+
+			resultCFG := okteto.CurrentStore.Contexts["test"].Cfg
+			assert.Equal(t, tt.expectedCfg, resultCFG)
+		})
+	}
 }

--- a/internal/test/k8s_provider.go
+++ b/internal/test/k8s_provider.go
@@ -27,7 +27,7 @@ type FakeK8sProvider struct {
 	client              *fake.Clientset
 	restConfig          *rest.Config
 	errGetIngressClient error
-	errProvide          error
+	ErrProvide          error
 }
 
 func NewFakeK8sProvider(objects ...runtime.Object) *FakeK8sProvider {
@@ -38,8 +38,8 @@ func NewFakeK8sProvider(objects ...runtime.Object) *FakeK8sProvider {
 }
 
 func (f *FakeK8sProvider) Provide(_ *clientcmdapi.Config) (kubernetes.Interface, *rest.Config, error) {
-	if f.errProvide != nil {
-		return nil, nil, f.errProvide
+	if f.ErrProvide != nil {
+		return nil, nil, f.ErrProvide
 	}
 	if f.client != nil {
 		return f.client, nil, nil

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -28,6 +28,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+type ErrApplicationNotFound struct {
+	Name string
+}
+
+func (e ErrApplicationNotFound) Error() string {
+	return fmt.Sprintf("the application '%s' referred by your okteto manifest doesn't exist", e.Name)
+}
 func Get(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Interface) (App, error) {
 	d, err := deployments.GetByDev(ctx, dev, namespace, c)
 
@@ -42,7 +49,7 @@ func Get(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Int
 	sfs, err := statefulsets.GetByDev(ctx, dev, namespace, c)
 	if err != nil {
 		if oktetoErrors.IsNotFound(err) {
-			return nil, fmt.Errorf("the application '%s' referred by your okteto manifest doesn't exist", dev.Name)
+			return nil, ErrApplicationNotFound{Name: dev.Name}
 		}
 		return nil, err
 	}

--- a/pkg/k8s/exec/exec.go
+++ b/pkg/k8s/exec/exec.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Exec executes the command in the development container
-func Exec(ctx context.Context, c *kubernetes.Clientset, config *rest.Config, podNamespace, podName, container string, tty bool, stdin io.Reader, stdout, stderr io.Writer, command []string) error {
+func Exec(ctx context.Context, c kubernetes.Interface, config *rest.Config, podNamespace, podName, container string, tty bool, stdin io.Reader, stdout, stderr io.Writer, command []string) error {
 	// dockerterm.StdStreams() configures the terminal on windows
 	dockerterm.StdStreams()
 

--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -223,7 +223,7 @@ func Destroy(ctx context.Context, podName, namespace string, c kubernetes.Interf
 }
 
 // GetPodUserID returns the user id running the dev pod
-func GetPodUserID(ctx context.Context, podName, containerName, namespace string, c *kubernetes.Clientset) int64 {
+func GetPodUserID(ctx context.Context, podName, containerName, namespace string, c kubernetes.Interface) int64 {
 	podLogs, err := ContainerLogs(ctx, containerName, podName, namespace, false, c)
 	if err != nil {
 		oktetoLog.Infof("failed to access development container logs: %s", err)

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -54,7 +54,7 @@ func Get(ctx context.Context, name, namespace string, c kubernetes.Interface) (*
 }
 
 // Create creates the syncthing config secret
-func Create(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset, s *syncthing.Syncthing) error {
+func Create(ctx context.Context, dev *model.Dev, c kubernetes.Interface, s *syncthing.Syncthing) error {
 	secretName := GetSecretName(dev)
 
 	sct, err := Get(ctx, secretName, dev.Namespace, c)

--- a/pkg/k8s/services/crud.go
+++ b/pkg/k8s/services/crud.go
@@ -27,7 +27,7 @@ import (
 )
 
 // CreateDev deploys a default k8s service for a development container
-func CreateDev(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset) error {
+func CreateDev(ctx context.Context, dev *model.Dev, c kubernetes.Interface) error {
 	s := translate(dev)
 	return Deploy(ctx, s, c)
 }

--- a/pkg/okteto/k8s.go
+++ b/pkg/okteto/k8s.go
@@ -1,6 +1,8 @@
 package okteto
 
 import (
+	"errors"
+	"net/http"
 	"os"
 	"sync"
 	"time"
@@ -15,8 +17,34 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-var timeout time.Duration
-var tOnce sync.Once
+var (
+	timeout time.Duration
+	tOnce   sync.Once
+
+	// ErrK8sUnauthorised is returned when the kubernetes API call returns a 401 error
+	ErrK8sUnauthorised = errors.New("k8s unauthorized error")
+)
+
+type OktetoKubernetesClient struct {
+	*kubernetes.Clientset
+}
+
+// NewCustomKubernetesClient initializes and returns a custom Kubernetes client.
+func NewCustomKubernetesClient() (*OktetoKubernetesClient, error) {
+	// Initialize the Kubernetes client
+	config, err := rest.InClusterConfig() // or use restconfig from kubeconfig file
+	if err != nil {
+		return nil, err
+	}
+	kubeClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OktetoKubernetesClient{
+		Clientset: kubeClient,
+	}, nil
+}
 
 const (
 	// oktetoKubernetesTimeoutEnvVar defines the timeout for kubernetes operations
@@ -25,6 +53,30 @@ const (
 
 type K8sClientProvider interface {
 	Provide(clientApiConfig *clientcmdapi.Config) (kubernetes.Interface, *rest.Config, error)
+}
+
+// tokenRotationTransport updates the token of the config when the token is outdated
+type tokenRotationTransport struct {
+	rt http.RoundTripper
+}
+
+// newTokenRotationTransport implements the RoundTripper interface
+func newTokenRotationTransport(rt http.RoundTripper) *tokenRotationTransport {
+	return &tokenRotationTransport{
+		rt: rt,
+	}
+}
+
+// RoundTrip implements the RoundTripper interface
+func (t *tokenRotationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.rt.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrK8sUnauthorised
+	}
+	return resp, err
 }
 
 type K8sClient struct{}
@@ -80,7 +132,13 @@ func getK8sClientWithApiConfig(clientApiConfig *clientcmdapi.Config) (*kubernete
 
 	config.Timeout = GetKubernetesTimeout()
 
-	client, err := kubernetes.NewForConfig(config)
+	var client *kubernetes.Clientset
+
+	config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		return newTokenRotationTransport(rt)
+	}
+
+	client, err = kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/okteto/k8s_test.go
+++ b/pkg/okteto/k8s_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -147,9 +146,8 @@ func TestKubetokenRefreshRoundTrip(t *testing.T) {
 
 func TestGetK8sClientWithApiConfig(t *testing.T) {
 	type expected struct {
-		err    error
-		cfg    *rest.Config
-		client kubernetes.Interface
+		err error
+		cfg *rest.Config
 	}
 	tt := []struct {
 		name      string

--- a/pkg/okteto/k8s_test.go
+++ b/pkg/okteto/k8s_test.go
@@ -1,7 +1,14 @@
 package okteto
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func Test_IsLocalHostname(t *testing.T) {
@@ -84,4 +91,112 @@ func Test_IsLocalHostname(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKubetokenRefreshRoundTrip(t *testing.T) {
+	tt := []struct {
+		name         string
+		handleFunc   http.HandlerFunc
+		expectedErr  error
+		expectedCode int
+	}{
+		{
+			name: "ok",
+			handleFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("Test Response"))
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "not found",
+			handleFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("Test Response"))
+			},
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name: "unauthorized",
+			handleFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte("Test Response"))
+			},
+			expectedErr: ErrK8sUnauthorised,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			testServer := httptest.NewServer(http.HandlerFunc(tc.handleFunc))
+			defer testServer.Close()
+			transport := newTokenRotationTransport(http.DefaultTransport)
+			client := &http.Client{
+				Transport: transport,
+			}
+			req, err := http.NewRequest(http.MethodGet, testServer.URL, nil)
+			require.NoError(t, err)
+
+			resp, err := client.Do(req)
+			require.ErrorIs(t, err, tc.expectedErr)
+			if resp != nil {
+				require.Equal(t, tc.expectedCode, resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestGetK8sClientWithApiConfig(t *testing.T) {
+	type expected struct {
+		err    error
+		cfg    *rest.Config
+		client kubernetes.Interface
+	}
+	tt := []struct {
+		name      string
+		apiConfig *clientcmdapi.Config
+		expected  expected
+	}{
+		{
+			name: "ok",
+			apiConfig: &clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test": {
+						Server: "https://test.com",
+					},
+				},
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"test": {
+						Token: "test",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"test": {
+						Cluster:  "test",
+						AuthInfo: "test",
+					},
+				},
+				CurrentContext: "test",
+			},
+			expected: expected{
+				cfg: &rest.Config{
+					Host: "https://test.com",
+					TLSClientConfig: rest.TLSClientConfig{
+						Insecure: true,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			client, cfg, err := getK8sClientWithApiConfig(tc.apiConfig)
+			require.ErrorIs(t, err, tc.expected.err)
+			require.NotNil(t, client)
+			require.NotNil(t, cfg)
+			require.Equal(t, tc.expected.cfg.Host, cfg.Host)
+			require.NotNil(t, cfg.WrapTransport)
+			require.Equal(t, cfg.WarningHandler, rest.NoWarnings{})
+		})
+	}
+
 }


### PR DESCRIPTION
# Proposed changes

Fixes # (issue)

Creates a new kubernetes client every time okteto up fails because of a 401.

On up package: Removes the k8s client and k8s config since its generated everytime we reconnect during okteto up

Adds tests covering the new behavior

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
