### PR TITLE
Deploy remote extra hosts

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -196,7 +196,10 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	registryUrl := okteto.Context().Registry
 	subdomain := strings.TrimPrefix(registryUrl, "registry.")
 
-	ip, _, _ := net.SplitHostPort(sc.ServerName)
+	ip, _, err := net.SplitHostPort(sc.ServerName)
+	if err != nil {
+		return fmt.Errorf("failed to parse server name network address: %w", err)
+	}
 	buildOptions.ExtraHosts = []types.HostMap{
 		{Hostname: registryUrl, IP: ip},
 		{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -193,16 +193,17 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		fmt.Sprintf("%s=%d", constants.OktetoInvalidateCacheEnvVar, int(randomNumber.Int64())),
 	)
 
-	registryUrl := okteto.Context().Registry
-	subdomain := strings.TrimPrefix(registryUrl, "registry.")
-
-	ip, _, err := net.SplitHostPort(sc.ServerName)
-	if err != nil {
-		return fmt.Errorf("failed to parse server name network address: %w", err)
-	}
-	buildOptions.ExtraHosts = []types.HostMap{
-		{Hostname: registryUrl, IP: ip},
-		{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+	if sc.ServerName != "" {
+		registryUrl := okteto.Context().Registry
+		subdomain := strings.TrimPrefix(registryUrl, "registry.")
+		ip, _, err := net.SplitHostPort(sc.ServerName)
+		if err != nil {
+			return fmt.Errorf("failed to parse server name network address: %w", err)
+		}
+		buildOptions.ExtraHosts = []types.HostMap{
+			{Hostname: registryUrl, IP: ip},
+			{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+		}
 	}
 
 	sshSock := os.Getenv(rd.sshAuthSockEnvvar)

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -200,8 +200,6 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 	buildOptions.ExtraHosts = []types.HostMap{
 		{Hostname: registryUrl, IP: ip},
 		{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
-		{Hostname: fmt.Sprintf("okteto.%s", subdomain), IP: ip},
-		{Hostname: fmt.Sprintf("buildkit.%s", subdomain), IP: ip},
 	}
 
 	sshSock := os.Getenv(rd.sshAuthSockEnvvar)

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -175,7 +175,7 @@ func TestExtraHosts(t *testing.T) {
 	rdc := remoteDeployCommand{
 		builderV1: fakeBuilder{
 			assertOptions: func(o *types.BuildOptions) {
-				require.Len(t, o.ExtraHosts, 4)
+				require.Len(t, o.ExtraHosts, 2)
 				for _, eh := range o.ExtraHosts {
 					require.Equal(t, eh.IP, "1.2.3.4")
 				}

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -161,6 +161,43 @@ func TestRemoteTest(t *testing.T) {
 	}
 }
 
+func TestExtraHosts(t *testing.T) {
+	ctx := context.Background()
+	fakeManifest := &model.Manifest{
+		Deploy: &model.DeployInfo{
+			Image: "test-image",
+		},
+	}
+	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+	fs := afero.NewMemMapFs()
+	tempCreator := filesystem.NewTemporalDirectoryCtrl(fs)
+
+	rdc := remoteDeployCommand{
+		builderV1: fakeBuilder{
+			assertOptions: func(o *types.BuildOptions) {
+				require.Len(t, o.ExtraHosts, 4)
+				for _, eh := range o.ExtraHosts {
+					require.Equal(t, eh.IP, "1.2.3.4")
+				}
+			},
+		},
+		fs:                   fs,
+		workingDirectoryCtrl: wdCtrl,
+		temporalCtrl:         tempCreator,
+		clusterMetadata: func(context.Context) (*types.ClusterMetadata, error) {
+			return &types.ClusterMetadata{
+				ServerName: "1.2.3.4:443",
+			}, nil
+		},
+		getBuildEnvVars: func() map[string]string { return nil },
+	}
+
+	err := rdc.deploy(ctx, &Options{
+		Manifest: fakeManifest,
+	})
+	require.NoError(t, err)
+}
+
 func TestRemoteDeployWithSshAgent(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	socket, err := os.CreateTemp("", "okteto-test-ssh-*")

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -199,7 +199,10 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 	registryUrl := okteto.Context().Registry
 	subdomain := strings.TrimPrefix(registryUrl, "registry.")
 
-	ip, _, _ := net.SplitHostPort(sc.ServerName)
+	ip, _, err := net.SplitHostPort(sc.ServerName)
+	if err != nil {
+		return fmt.Errorf("failed to parse server name network address: %w", err)
+	}
 	buildOptions.ExtraHosts = []types.HostMap{
 		{Hostname: registryUrl, IP: ip},
 		{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -196,16 +196,17 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 		fmt.Sprintf("%s=%d", constants.OktetoInvalidateCacheEnvVar, int(randomNumber.Int64())),
 	)
 
-	registryUrl := okteto.Context().Registry
-	subdomain := strings.TrimPrefix(registryUrl, "registry.")
-
-	ip, _, err := net.SplitHostPort(sc.ServerName)
-	if err != nil {
-		return fmt.Errorf("failed to parse server name network address: %w", err)
-	}
-	buildOptions.ExtraHosts = []types.HostMap{
-		{Hostname: registryUrl, IP: ip},
-		{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+	if sc.ServerName != "" {
+		registryUrl := okteto.Context().Registry
+		subdomain := strings.TrimPrefix(registryUrl, "registry.")
+		ip, _, err := net.SplitHostPort(sc.ServerName)
+		if err != nil {
+			return fmt.Errorf("failed to parse server name network address: %w", err)
+		}
+		buildOptions.ExtraHosts = []types.HostMap{
+			{Hostname: registryUrl, IP: ip},
+			{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+		}
 	}
 
 	sshSock := os.Getenv(rd.sshAuthSockEnvvar)

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -202,7 +202,10 @@ func TestRemoteTest(t *testing.T) {
 				destroyImage:         "",
 				registry:             newFakeRegistry(),
 				clusterMetadata: func(ctx context.Context) (*types.ClusterMetadata, error) {
-					return &types.ClusterMetadata{Certificate: []byte("cert")}, nil
+					return &types.ClusterMetadata{
+						Certificate: []byte("cert"),
+						ServerName:  "1.2.3.4:443",
+					}, nil
 				},
 			}
 			err := rdc.destroy(ctx, tt.config.options)

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	frontend = "dockerfile.v0"
+	defaultFrontend = "dockerfile.v0"
 )
 
 type buildWriter struct{}
@@ -80,6 +80,19 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 	if buildOptions.NoCache {
 		frontendAttrs["no-cache"] = ""
 	}
+
+	frontend := defaultFrontend
+
+	if len(buildOptions.ExtraHosts) > 0 {
+		hosts := ""
+		for _, eh := range buildOptions.ExtraHosts {
+			hosts += fmt.Sprintf("%s=%s,", eh.Hostname, eh.IP)
+		}
+		frontend = "gateway.v0"
+		frontendAttrs["source"] = "docker/dockerfile"
+		frontendAttrs["add-hosts"] = strings.TrimSuffix(hosts, ",")
+	}
+
 	for _, buildArg := range buildOptions.BuildArgs {
 		kv := strings.SplitN(buildArg, "=", 2)
 		if len(kv) != 2 {

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -27,6 +27,11 @@ type BuildSshSession struct {
 	Target string
 }
 
+type HostMap struct {
+	Hostname string
+	IP       string
+}
+
 // BuildOptions define the options available for build
 type BuildOptions struct {
 	BuildArgs     []string
@@ -51,4 +56,6 @@ type BuildOptions struct {
 
 	Manifest *model.Manifest
 	DevTag   string
+
+	ExtraHosts []HostMap
 }


### PR DESCRIPTION
# Proposed changes

Allows deploy remote to to talk to the internal IP of the ingress. It does so by adding and `ExtraHosts` to buildOptions to be injected into buildkit solve options. If extra hosts are defined, we use the `gateway.v0` frontend which allows this config to be injected as attributes.

Still missing test Opening early to get reviews from the team

## How to validate

1. Remove .Values.clusterEndpoint from your okteto cluster and run an upgrade
1. Clone the go-getting-started repo
1. Add `cat /etc/hosts` as a deploy step
1. The deploy succeeds 
1. See in the output that all know okteto hosts are mapped to the internal IP

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
