### PR TITLE
Skip selector in `okteto down` when only 1 dev container is active

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -87,14 +87,19 @@ func Down() *cobra.Command {
 					if !errors.Is(err, utils.ErrNoDevSelected) {
 						return err
 					}
-					selector := utils.NewOktetoSelector("Select which development container to deactivate:", "Development container")
 					options := apps.ListDevModeOn(ctx, manifest, c)
 
 					if len(options) == 0 {
 						oktetoLog.Success("All development containers are deactivated")
 						return nil
 					}
-					dev, err = utils.SelectDevFromManifest(manifest, selector, options)
+					if len(options) == 1 {
+						dev = manifest.Dev[options[0]]
+						err = nil
+					} else {
+						selector := utils.NewOktetoSelector("Select which development container to deactivate:", "Development container")
+						dev, err = utils.SelectDevFromManifest(manifest, selector, options)
+					}
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
# Proposed changes

Fixes #3801 

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Use a project with multiple services and run `okteto up` on one
1. Stop the session and run `okteto down`
1. Notice how you don't get the prompt with a single service but it automatically deactivates the dev container

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
