### PR TITLE
Remove file after test

### DIFF
--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1326,6 +1326,9 @@ func TestOktetoManifestPathFlag(t *testing.T) {
 					if err := f.Close(); err != nil {
 						t.Fatalf("Error closing file %s: %s", fullpath, err)
 					}
+					if err := fs.RemoveAll(fullpath); err != nil {
+						t.Fatalf("Error removing the file %v", err)
+					}
 				}()
 			}
 			err = checkOktetoManifestPathFlag(opts, fs)


### PR DESCRIPTION
# Proposed changes

After merging https://github.com/okteto/okteto/pull/3930 we notice the test was creating a file.
Adding the remove function to remove the file after the test.
