### PR TITLE
ci: add tenv linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,11 @@ linters-settings:
     # Such cases aren't reported by default.
     # Default: false
     check-blank: true
+  tenv:
+    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
+    # Default: false
+    all: true
 
 # All possible linters can be found https://golangci-lint.run/usage/linters/
 linters:
@@ -35,6 +40,7 @@ linters:
     - ineffassign
     - unused
     - unparam
+    - tenv
 
 issues:
   # Show only new issues created after git revision REV. Run only over the changed files

--- a/cmd/context/use_test.go
+++ b/cmd/context/use_test.go
@@ -56,8 +56,7 @@ func Test_setSecrets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				err := os.Setenv(k, v)
-				assert.NoError(t, err)
+				t.Setenv(k, v)
 			}
 			setSecrets(tt.secrets)
 			assert.Equal(t, expectedValue, os.Getenv(key))

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -215,7 +215,7 @@ func TestRemoteDeployWithSshAgent(t *testing.T) {
 
 	envvarName := fmt.Sprintf("TEST_SOCKET_%s", os.Getenv("RANDOM"))
 
-	os.Setenv(envvarName, socket.Name())
+	t.Setenv(envvarName, socket.Name())
 	defer func() {
 		t.Logf("cleaning up %s envvar", envvarName)
 		os.Unsetenv(envvarName)
@@ -253,7 +253,7 @@ func TestRemoteDeployWithBadSshAgent(t *testing.T) {
 
 	envvarName := fmt.Sprintf("TEST_SOCKET_%s", os.Getenv("RANDOM"))
 
-	os.Setenv(envvarName, "bad-socket")
+	t.Setenv(envvarName, "bad-socket")
 	defer func() {
 		t.Logf("cleaning up %s envvar", envvarName)
 		os.Unsetenv(envvarName)

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -415,7 +415,7 @@ func TestRemoteDestroyWithSshAgent(t *testing.T) {
 
 	envvarName := fmt.Sprintf("TEST_SOCKET_%s", os.Getenv("RANDOM"))
 
-	os.Setenv(envvarName, socket.Name())
+	t.Setenv(envvarName, socket.Name())
 	defer func() {
 		t.Logf("cleaning up %s envvar", envvarName)
 		os.Unsetenv(envvarName)
@@ -445,7 +445,7 @@ func TestRemoteDestroyWithBadSshAgent(t *testing.T) {
 
 	envvarName := fmt.Sprintf("TEST_SOCKET_%s", os.Getenv("RANDOM"))
 
-	os.Setenv(envvarName, "bad-socket")
+	t.Setenv(envvarName, "bad-socket")
 	defer func() {
 		t.Logf("cleaning up %s envvar", envvarName)
 		os.Unsetenv(envvarName)

--- a/cmd/stack/deploy_test.go
+++ b/cmd/stack/deploy_test.go
@@ -15,7 +15,6 @@ package stack
 
 import (
 	"fmt"
-	"os"
 	"runtime"
 	"testing"
 
@@ -93,7 +92,7 @@ func Test_loadPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv(model.ComposeFileEnvVar, tt.composeEnvVar)
+			t.Setenv(model.ComposeFileEnvVar, tt.composeEnvVar)
 			result := loadComposePaths(tt.stackPath)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -82,7 +82,7 @@ func Test_multipleStack(t *testing.T) {
 		t.Fatalf("Expected %v but got %v", svcResult.Image, svc.Image)
 	}
 
-	os.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
+	t.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
 	svcResult.Image = "test"
 
 	stack, err = model.LoadStack("", paths, true)
@@ -104,6 +104,8 @@ func Test_multipleStack(t *testing.T) {
 }
 
 func Test_overrideFileStack(t *testing.T) {
+	t.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
+
 	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
 

--- a/integration/actions/pipeline_test.go
+++ b/integration/actions/pipeline_test.go
@@ -117,9 +117,9 @@ func executeDeployWithComposePipelineAction(namespace string) error {
 	log.Printf("cloned repo %s \n", actionRepo)
 	defer integration.DeleteGitRepo(actionFolder)
 
-	os.Setenv(model.GithubRepositoryEnvVar, "okteto/movies-with-compose")
-	os.Setenv(model.GithubRefEnvVar, "main")
-	os.Setenv(model.GithubServerURLEnvVar, githubHTTPSURL)
+	t.Setenv(model.GithubRepositoryEnvVar, "okteto/movies-with-compose")
+	t.Setenv(model.GithubRefEnvVar, "main")
+	t.Setenv(model.GithubServerURLEnvVar, githubHTTPSURL)
 
 	log.Printf("deploying pipeline %s", namespace)
 	command := fmt.Sprintf("%s/entrypoint.sh", actionFolder)

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -68,7 +68,7 @@ func Test_getTrackID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			os.Setenv(constants.OktetoHomeEnvVar, dir)
+			t.Setenv(constants.OktetoHomeEnvVar, dir)
 
 			a := get()
 			a.MachineID = tt.machineID

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,7 +32,7 @@ func TestGetUserHomeDir(t *testing.T) {
 		os.Unsetenv(constants.OktetoHomeEnvVar)
 	}()
 
-	os.Setenv(constants.OktetoHomeEnvVar, dir)
+	t.Setenv(constants.OktetoHomeEnvVar, dir)
 	home = GetUserHomeDir()
 	if home != dir {
 		t.Fatalf("OKTETO_HOME override failed, got %s instead of %s", home, dir)
@@ -88,14 +88,14 @@ func Test_homedirWindows(t *testing.T) {
 			os.Unsetenv(homeDriveEnvVar)
 
 			defer func() {
-				os.Setenv(homeEnvVar, home)
-				os.Setenv(userProfileEnvVar, up)
-				os.Setenv(homePathEnvVar, hp)
-				os.Setenv(homeDriveEnvVar, hd)
+				t.Setenv(homeEnvVar, home)
+				t.Setenv(userProfileEnvVar, up)
+				t.Setenv(homePathEnvVar, hp)
+				t.Setenv(homeDriveEnvVar, hd)
 			}()
 
 			for k, v := range tt.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 
 			got, err := homedirWindows()
@@ -116,7 +116,7 @@ func TestGetOktetoHome(t *testing.T) {
 		os.Unsetenv(constants.OktetoFolderEnvVar)
 	}()
 
-	os.Setenv(constants.OktetoFolderEnvVar, dir)
+	t.Setenv(constants.OktetoFolderEnvVar, dir)
 
 	got := GetOktetoHome()
 	if got != dir {
@@ -127,7 +127,7 @@ func TestGetOktetoHome(t *testing.T) {
 func TestGetAppHome(t *testing.T) {
 	dir := t.TempDir()
 
-	os.Setenv(constants.OktetoFolderEnvVar, dir)
+	t.Setenv(constants.OktetoFolderEnvVar, dir)
 
 	got := GetAppHome("ns", "dp")
 	expected := filepath.Join(dir, "ns", "dp")

--- a/pkg/model/contextresource_test.go
+++ b/pkg/model/contextresource_test.go
@@ -55,7 +55,7 @@ func Test_GetContextResource(t *testing.T) {
 			defer os.RemoveAll(tmpFile.Name())
 
 			for k, v := range tt.env {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			result, err := GetContextResource(tmpFile.Name())
 			if err != nil {

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -328,7 +328,7 @@ services:
 				devName = "n1"
 			}
 
-			os.Setenv("value", tt.value)
+			t.Setenv("value", tt.value)
 			manifest, err := Read(manifestBytes)
 			if err != nil {
 				t.Fatal(err)
@@ -378,7 +378,7 @@ func Test_loadSelector(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dev := &Dev{Selector: tt.selector}
-			os.Setenv("value", tt.value)
+			t.Setenv("value", tt.value)
 			if err := dev.loadSelector(); err != nil {
 				t.Fatalf("couldn't load selector")
 			}
@@ -471,7 +471,7 @@ services:
 `, tt.image))
 			}
 
-			os.Setenv("tag", tt.tagValue)
+			t.Setenv("tag", tt.tagValue)
 			manifest, err := Read(manifestBytes)
 			if err != nil {
 				t.Fatal(err)
@@ -1132,12 +1132,12 @@ func TestGetTimeout(t *testing.T) {
 	}
 
 	original := os.Getenv(OktetoTimeoutEnvVar)
-	defer os.Setenv(OktetoTimeoutEnvVar, original)
+	defer t.Setenv(OktetoTimeoutEnvVar, original)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != "" {
-				os.Setenv(OktetoTimeoutEnvVar, tt.env)
+				t.Setenv(OktetoTimeoutEnvVar, tt.env)
 			}
 			got, err := GetTimeout()
 			if (err != nil) != tt.wantErr {
@@ -1191,7 +1191,7 @@ func Test_loadEnvFile(t *testing.T) {
 			}
 
 			for k, v := range tt.existing {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 
 			if err := godotenv.Load(); err != nil {
@@ -1562,7 +1562,7 @@ func Test_expandEnvFiles(t *testing.T) {
 
 			tt.dev.EnvFiles = EnvFiles{file.Name()}
 
-			os.Setenv("OKTETO_TEST", "myvalue")
+			t.Setenv("OKTETO_TEST", "myvalue")
 
 			if _, err = file.Write(tt.envs); err != nil {
 				t.Fatal("Failed to write to temporary file", err)

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -189,7 +189,7 @@ echo $TEST_VAR`,
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 
 			err := tt.manifest.ExpandEnvVars()
@@ -239,7 +239,7 @@ devs:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				os.Setenv(k, v)
+				t.Setenv(k, v)
 			}
 			m, err := Read(tt.manifest)
 			assert.NoError(t, err)
@@ -661,7 +661,7 @@ func TestInferFromStack(t *testing.T) {
 }
 
 func TestSetManifestDefaultsFromDev(t *testing.T) {
-	os.Setenv("my_key", "my_value")
+	t.Setenv("my_key", "my_value")
 	tests := []struct {
 		name              string
 		currentManifest   *Manifest

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -154,13 +154,8 @@ func TestEnvVarMarshalling(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			var result EnvVar
-			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
-				t.Fatal(err)
-			}
-
-			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("DEV_ENV", "test_environment")
+			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
 
 			if err := yaml.Unmarshal(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -400,9 +395,7 @@ func TestSecretMarshalling(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	if err := os.Setenv("TEST_HOME", file.Name()); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("TEST_HOME", file.Name())
 
 	tests := []struct {
 		name          string
@@ -729,13 +722,9 @@ func TestLabelsUnmarshalling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := make(Labels)
-			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
-				t.Fatal(err)
-			}
 
-			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("DEV_ENV", "test_environment")
+			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
 
 			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -834,13 +823,9 @@ func TestAnnotationsUnmarshalling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := make(Annotations)
-			if err := os.Setenv("DEV_ENV", "test_environment"); err != nil {
-				t.Fatal(err)
-			}
 
-			if err := os.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("DEV_ENV", "test_environment")
+			t.Setenv("OKTETO_TEST_ENV_MARSHALLING", "true")
 
 			if err := yaml.UnmarshalStrict(tt.data, &result); err != nil {
 				t.Fatal(err)
@@ -1030,7 +1015,7 @@ rescanInterval: 10`),
 }
 
 func TestSyncFoldersUnmarshalling(t *testing.T) {
-	os.Setenv("REMOTE_PATH", "/usr/src/app")
+	t.Setenv("REMOTE_PATH", "/usr/src/app")
 	tests := []struct {
 		name     string
 		data     []byte

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1719,9 +1719,7 @@ func Test_Environment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			if err := os.Setenv("OKTETO_ENVTEST", "myvalue"); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv("OKTETO_ENVTEST", "myvalue")
 
 			s, err := ReadStack(tt.manifest, false)
 			if err != nil {

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -984,7 +984,7 @@ func TestStack_ExpandEnvsAtFileLevel(t *testing.T) {
 			defer os.RemoveAll(tmpFile.Name())
 
 			for key, value := range tt.envs {
-				os.Setenv(key, value)
+				t.Setenv(key, value)
 			}
 
 			stack, err := GetStackFromPath("test", tmpFile.Name(), false)
@@ -1147,7 +1147,7 @@ func Test_getStackName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			os.Setenv(constants.OktetoNameEnvVar, tt.nameEnv)
+			t.Setenv(constants.OktetoNameEnvVar, tt.nameEnv)
 			res, err := getStackName(tt.name, tt.stackPath, tt.actualStackName)
 			resEnv := os.Getenv(constants.OktetoNameEnvVar)
 
@@ -1187,10 +1187,10 @@ func Test_translateEnvVars(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpFile2.Name())
 
-	os.Setenv("B", "2")
-	os.Setenv("ENV_PATH", tmpFile.Name())
-	os.Setenv("ENV_PATH2", tmpFile2.Name())
-	os.Setenv("OKTETO_TEST", "myvalue")
+	t.Setenv("B", "2")
+	t.Setenv("ENV_PATH", tmpFile.Name())
+	t.Setenv("ENV_PATH2", tmpFile2.Name())
+	t.Setenv("OKTETO_TEST", "myvalue")
 	stack := &Stack{
 		Name: "name",
 		Services: map[string]*Service{

--- a/pkg/model/utils_test.go
+++ b/pkg/model/utils_test.go
@@ -136,7 +136,7 @@ func Test_snapshotEnv(t *testing.T) {
 		"TEST_2": "2",
 	}
 	for k, v := range vars {
-		assert.NoError(t, os.Setenv(k, v))
+		t.Setenv(k, v)
 	}
 
 	env := snapshotEnv()
@@ -156,7 +156,7 @@ func Test_restoreEnv(t *testing.T) {
 		"TEST_2": "2",
 	}
 	for k, v := range vars {
-		assert.NoError(t, os.Setenv(k, v))
+		t.Setenv(k, v)
 	}
 
 	env := snapshotEnv()
@@ -164,7 +164,7 @@ func Test_restoreEnv(t *testing.T) {
 
 	assert.Equal(t, os.Environ(), []string{})
 
-	assert.NoError(t, os.Setenv("TEST_3", "3"))
+	t.Setenv("TEST_3", "3")
 	assert.NoError(t, restoreEnv(env))
 
 	checks := []struct {

--- a/pkg/okteto/client_test.go
+++ b/pkg/okteto/client_test.go
@@ -110,9 +110,9 @@ func (fc *fakeGraphQLMultipleCallsClient) Mutate(ctx context.Context, m interfac
 
 func TestInDevContainer(t *testing.T) {
 	v := os.Getenv(constants.OktetoNameEnvVar)
-	os.Setenv(constants.OktetoNameEnvVar, "")
+	t.Setenv(constants.OktetoNameEnvVar, "")
 	defer func() {
-		os.Setenv(constants.OktetoNameEnvVar, v)
+		t.Setenv(constants.OktetoNameEnvVar, v)
 	}()
 
 	in := InDevContainer()
@@ -120,13 +120,13 @@ func TestInDevContainer(t *testing.T) {
 		t.Errorf("in dev container when there was no marker env var")
 	}
 
-	os.Setenv(constants.OktetoNameEnvVar, "")
+	t.Setenv(constants.OktetoNameEnvVar, "")
 	in = InDevContainer()
 	if in {
 		t.Errorf("in dev container when there was an empty marker env var")
 	}
 
-	os.Setenv(constants.OktetoNameEnvVar, "1")
+	t.Setenv(constants.OktetoNameEnvVar, "1")
 	in = InDevContainer()
 	if !in {
 		t.Errorf("not in dev container when there was a marker env var")

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -218,9 +218,7 @@ func Test_removeHost(t *testing.T) {
 func TestGetPort(t *testing.T) {
 	dir := t.TempDir()
 
-	if err := os.Setenv(constants.OktetoHomeEnvVar, dir); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(constants.OktetoHomeEnvVar, dir)
 
 	defer os.Unsetenv(constants.OktetoHomeEnvVar)
 

--- a/pkg/syncthing/install_test.go
+++ b/pkg/syncthing/install_test.go
@@ -192,21 +192,15 @@ func TestGetMinimumVersion(t *testing.T) {
 	}
 
 	env := os.Getenv(model.SyncthingVersionEnvVar)
-	if err := os.Setenv(model.SyncthingVersionEnvVar, ""); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv(model.SyncthingVersionEnvVar, "")
 
 	defer func() {
-		if err := os.Setenv(model.SyncthingVersionEnvVar, env); err != nil {
-			t.Fatal(err)
-		}
+		t.Setenv(model.SyncthingVersionEnvVar, env)
 	}()
 
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			if err := os.Setenv(model.SyncthingVersionEnvVar, tt.version); err != nil {
-				t.Fatal(err)
-			}
+			t.Setenv(model.SyncthingVersionEnvVar, tt.version)
 			got := GetMinimumVersion()
 			if got.String() != tt.expected {
 				t.Errorf("got %s, expected %s", got.String(), tt.expected)

--- a/pkg/syncthing/syncthing_test.go
+++ b/pkg/syncthing/syncthing_test.go
@@ -27,7 +27,7 @@ func TestGetFiles(t *testing.T) {
 		os.Unsetenv(constants.OktetoFolderEnvVar)
 	}()
 
-	os.Setenv(constants.OktetoFolderEnvVar, dir)
+	t.Setenv(constants.OktetoFolderEnvVar, dir)
 	log := GetLogFile("test", "application")
 	expected := filepath.Join(dir, "test", "application", "syncthing.log")
 


### PR DESCRIPTION
# Proposed changes

Fixes https://app.deepsource.com/gh/okteto/okteto/run/7f2bb8cb-7d78-4480-a28b-73213044200d/go/GO-W1032?listindex=2

We don't have [tenv](https://golangci-lint.run/usage/linters/#tenv) enabled and it would be a good practice.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
