### PR TITLE
Display a friendly error when the local proxy cannot start

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -546,7 +546,7 @@ func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, b
 	// run local
 	oktetoLog.Info("Deploying locally...")
 
-	deployer, err := newLocalDeployer(ctx, opts, cmapHandler)
+	deployer, err := newLocalDeployer(ctx, opts, cmapHandler, okteto.NewK8sClientProvider(), NewKubeConfig(), model.GetAvailablePort)
 	if err != nil {
 		eWrapped := fmt.Errorf("could not initialize local deploy command: %w", err)
 		if uError, ok := err.(oktetoErrors.UserError); ok {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -548,7 +548,12 @@ func GetDeployer(ctx context.Context, manifest *model.Manifest, opts *Options, b
 
 	deployer, err := newLocalDeployer(ctx, opts, cmapHandler)
 	if err != nil {
-		return nil, fmt.Errorf("could not initialize local deploy command: %w", err)
+		eWrapped := fmt.Errorf("could not initialize local deploy command: %w", err)
+		if uError, ok := err.(oktetoErrors.UserError); ok {
+			uError.E = eWrapped
+			return nil, uError
+		}
+		return nil, eWrapped
 	}
 	return deployer, nil
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -210,9 +210,6 @@ func (f *fakeKubeConfig) Read() (*rest.Config, error) {
 func (fc *fakeKubeConfig) Modify(_ int, _, _ string) error {
 	return fc.errOnModify
 }
-func (*fakeKubeConfig) GetCMDAPIConfig() (*clientcmdapi.Config, error) {
-	return nil, nil
-}
 
 func (fk *fakeProxy) Start() {
 	fk.started = true
@@ -1372,4 +1369,8 @@ func TestOktetoManifestPathFlag(t *testing.T) {
 			assert.Equal(t, tt.expectedErr, err)
 		})
 	}
+}
+
+func Test_GetDeployer(t *testing.T) {
+
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -175,7 +175,9 @@ type fakeExecutor struct {
 }
 
 type fakeKubeConfig struct {
+	config      *rest.Config
 	errOnModify error
+	errRead     error
 }
 
 type fakeCmapHandler struct {
@@ -198,14 +200,17 @@ func (f *fakeCmapHandler) updateEnvsFromCommands(context.Context, string, string
 	return f.errUpdatingWithEnvs
 }
 
-func (*fakeKubeConfig) Read() (*rest.Config, error) {
-	return nil, nil
+func (f *fakeKubeConfig) Read() (*rest.Config, error) {
+	if f.errRead != nil {
+		return nil, f.errRead
+	}
+	return f.config, nil
 }
 
 func (fc *fakeKubeConfig) Modify(_ int, _, _ string) error {
 	return fc.errOnModify
 }
-func (*fakeKubeConfig) GetModifiedCMDAPIConfig() (*clientcmdapi.Config, error) {
+func (*fakeKubeConfig) GetCMDAPIConfig() (*clientcmdapi.Config, error) {
 	return nil, nil
 }
 

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -74,7 +74,7 @@ func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configM
 
 	kubeconfig := NewKubeConfig()
 
-	proxy, err := NewProxy(kubeconfig)
+	proxy, err := NewProxy(kubeconfig, model.GetAvailablePort)
 	if err != nil {
 		oktetoLog.Infof("could not configure local proxy: %s", err)
 		return nil, err

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -54,14 +54,14 @@ type localDeployer struct {
 }
 
 // newLocalDeployer initializes a local deployer from a name and a boolean indicating if we should run with bash or not
-func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configMapHandler) (*localDeployer, error) {
+func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configMapHandler, k8sProvider okteto.K8sClientProvider, kubeconfig kubeConfigHandler, portGetter func(string) (int, error)) (*localDeployer, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the current working directory: %w", err)
 	}
 	tempKubeconfigName := options.Name
 	if tempKubeconfigName == "" {
-		c, _, err := okteto.NewK8sClientProvider().Provide(okteto.Context().Cfg)
+		c, _, err := k8sProvider.Provide(okteto.Context().Cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -72,24 +72,21 @@ func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configM
 		}
 	}
 
-	kubeconfig := NewKubeConfig()
-
-	proxy, err := NewProxy(kubeconfig, model.GetAvailablePort)
+	proxy, err := NewProxy(kubeconfig, portGetter)
 	if err != nil {
 		oktetoLog.Infof("could not configure local proxy: %s", err)
 		return nil, err
 	}
 
-	clientProvider := okteto.NewK8sClientProvider()
 	return &localDeployer{
 		Kubeconfig:         kubeconfig,
 		Executor:           executor.NewExecutor(oktetoLog.GetOutputFormat(), options.RunWithoutBash, ""),
 		ConfigMapHandler:   cmapHandler,
 		Proxy:              proxy,
 		TempKubeconfigFile: GetTempKubeConfigFile(tempKubeconfigName),
-		K8sClientProvider:  clientProvider,
+		K8sClientProvider:  k8sProvider,
 		GetExternalControl: NewDeployExternalK8sControl,
-		deployWaiter:       NewDeployWaiter(clientProvider),
+		deployWaiter:       NewDeployWaiter(k8sProvider),
 		isRemote:           true,
 		Fs:                 afero.NewOsFs(),
 	}, nil

--- a/cmd/deploy/local_test.go
+++ b/cmd/deploy/local_test.go
@@ -15,12 +15,17 @@ package deploy
 
 import (
 	"context"
+	"net"
 	"testing"
 
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func TestDeployNotRemovingEnvFile(t *testing.T) {
@@ -42,4 +47,73 @@ func TestDeployNotRemovingEnvFile(t *testing.T) {
 	_, err = fs.Stat(".env")
 	require.NoError(t, err)
 
+}
+
+type fakeK8sProvider struct {
+	err error
+}
+
+func (f *fakeK8sProvider) Provide(_ *clientcmdapi.Config) (kubernetes.Interface, *rest.Config, error) {
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return nil, nil, nil
+}
+
+func Test_newLocalDeployer(t *testing.T) {
+	dnsError := &net.DNSError{
+		IsNotFound: true,
+	}
+	tests := []struct {
+		name             string
+		opts             *Options
+		fakePortGetter   func(string) (int, error)
+		fakeCmapHandler  configMapHandler
+		fakeK8sProvider  *fakeK8sProvider
+		expectedErr      error
+		isUserErr        bool
+		expectedDeployer *localDeployer
+	}{
+		{
+			name: "error providing k8s client when no opts.Name",
+			opts: &Options{},
+			fakeK8sProvider: &fakeK8sProvider{
+				err: assert.AnError,
+			},
+			expectedErr: assert.AnError,
+		},
+		{
+			name: "error getting new proxy: port not found",
+			opts: &Options{
+				Name: "test",
+			},
+			fakePortGetter: func(string) (int, error) {
+				return 0, dnsError
+			},
+			expectedErr: dnsError,
+			isUserErr:   true,
+		},
+		{
+			name: "error getting new proxy: any error",
+			opts: &Options{
+				Name: "test",
+			},
+			fakePortGetter: func(string) (int, error) {
+				return 0, assert.AnError
+			},
+			expectedErr: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			got, err := newLocalDeployer(ctx, tt.opts, tt.fakeCmapHandler, tt.fakeK8sProvider, &fakeKubeConfig{}, tt.fakePortGetter)
+			require.Equal(t, tt.expectedDeployer, got)
+			require.ErrorIs(t, err, tt.expectedErr)
+
+			_, ok := err.(oktetoErrors.UserError)
+			require.True(t, (tt.isUserErr == ok))
+		})
+	}
 }

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -86,8 +86,8 @@ func NewProxy(kubeconfig kubeconfigInterface, portGetter func(iface string) (int
 	if err != nil {
 		if dnsError, ok := err.(*net.DNSError); ok && dnsError.IsNotFound {
 			return nil, oktetoErrors.UserError{
-				E:    dnsError,
-				Hint: "Review your /etc/hosts configuration, make sure there is an entry for localhost",
+				E:    fmt.Errorf("could not find available ports: %w", dnsError),
+				Hint: "Review your configuration to make sure 'localhost' is resolved correctly",
 			}
 		}
 		oktetoLog.Errorf("could not find a free port to start proxy server: %s", err)

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -43,7 +43,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 type proxyInterface interface {
@@ -73,14 +72,8 @@ type proxyHandler struct {
 	DivertDriver divert.Driver
 }
 
-type kubeconfigInterface interface {
-	GetCMDAPIConfig() (*clientcmdapi.Config, error)
-	Modify(port int, sessionToken string, destKubeconfigFile string) error
-	Read() (*rest.Config, error)
-}
-
 // NewProxy creates a new proxy
-func NewProxy(kubeconfig kubeconfigInterface, portGetter func(iface string) (int, error)) (*Proxy, error) {
+func NewProxy(kubeconfig kubeConfigHandler, portGetter func(iface string) (int, error)) (*Proxy, error) {
 	// Look for a free local port to start the proxy
 	port, err := portGetter("localhost")
 	if err != nil {

--- a/cmd/deploy/proxy_test.go
+++ b/cmd/deploy/proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,7 +75,7 @@ func (pg fakePortGetter) Get(_ string) (int, error) {
 }
 
 func Test_NewProxy(t *testing.T) {
-	notFoundErr := &net.DNSError{
+	dnsErr := &net.DNSError{
 		IsNotFound: true,
 	}
 
@@ -90,12 +89,9 @@ func Test_NewProxy(t *testing.T) {
 		{
 			name: "err getting port, DNS not found error",
 			portGetter: fakePortGetter{
-				err: notFoundErr,
+				err: dnsErr,
 			},
-			expectedErr: oktetoErrors.UserError{
-				E:    notFoundErr,
-				Hint: "Review your /etc/hosts configuration, make sure there is an entry for localhost",
-			},
+			expectedErr: dnsErr,
 		},
 		{
 			name: "err getting port, any error",


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/LAKE-16

When running `okteto deploy` and the local proxy was unable to get a free port or find localhost as host, the error thrown was not being descriptive of what could be happening. 

This PR detects the error and returns a UserError with a hint that can lead the user to troubleshoot what might be happening

## How to validate

- In order to force the error, we need to manually change the host provided [here](https://github.com/okteto/okteto/blob/379524e706b70d60bc8e711aa0963413ee5d6894/cmd/deploy/proxy.go#L78), so instead of `localhost` use a random host.
- Make build
- run `ok deploy`

the repro steps provided at the issue not always reproduce the error, but also can be used to validate:

> Steps to reproduce the behavior:
> 
> Modify your /etc/hosts file and comment any rule referring to localhost
> 
> Deploy a manifest that talks to Kubernetes, for example, in the deploy section add a command to list pods kubectl get pods
> 
> You will get a no such host error


Before:

```
❯ ok deploy
 i  Using - @ - as context
 i  Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'
ERRO[0001] could not find a free port to start proxy server: lookup locaost: no such host
 x  Could not initialize local deploy command: lookup locaost: no such host
```

After:

```
❯ okteto deploy
 i  Using - @ - as context
 i  Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'
 x  Could not initialize local deploy command: could not find available ports: lookup lalhost: no such host
    Review your configuration to make sure 'localhost' is resolved correctly
```


Expect an error with a hint troubleshooting

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

