### PR TITLE
[CLI Quality][Lint] add tparallel lint and fix errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - unused
     - unparam
     - tenv
+    - tparallel
 
 issues:
   # Show only new issues created after git revision REV. Run only over the changed files

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,8 +44,6 @@ linters:
     - tparallel
 
 issues:
-  # Show only new issues created after git revision REV. Run only over the changed files
-  new-from-rev: HEAD~
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
 

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -130,6 +130,7 @@ func getFakeManifestV2(_ string) (*model.Manifest, error) {
 }
 
 func TestIsBuildV2(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		manifest       *model.Manifest
@@ -237,6 +238,7 @@ func TestBuildErrIfInvalidManifest(t *testing.T) {
 }
 
 func TestBuilderIsProperlyGenerated(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -464,7 +464,7 @@ func TestCheckAccessToNamespace(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-
+			t.Parallel()
 			currentCtxCommand := *fakeCtxCommand
 			if tt.ctxOptions.IsOkteto {
 				currentCtxCommand.K8sClientProvider = nil

--- a/cmd/deploy/proxy_test.go
+++ b/cmd/deploy/proxy_test.go
@@ -12,6 +12,7 @@ var (
 )
 
 func Test_TranslateInvalidResourceBody(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name string
 		body []byte

--- a/cmd/up/forwards_test.go
+++ b/cmd/up/forwards_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestGlobalForwarderStartsWhenRequired(t *testing.T) {
+	t.Parallel()
 	var tests = []struct {
 		name             string
 		globalFwdSection []forward.GlobalForward

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -665,7 +665,9 @@ func Test_replaceSecretsSourceEnvWithTempFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			initialSecrets := make([]string, len(tt.buildOptions.Secrets))
 			copy(initialSecrets, tt.buildOptions.Secrets)


### PR DESCRIPTION
# Proposed changes

Adding `tparallel` lintern to golangci-lint config in order to track the use of t.Parallel() correctly.
Bad use of this feature for tests can lead to flaky test.

EDIT:
offline conversation @andreafalzetti detected the option `new-from-rev` from the golangci-lint config file was not working properly.
After investigation, the only way it detects errors only on the new code added is referencing by branch name, eg: `master`.
Proposal is to remove this option from the config as the aproach we are using to add lints is to fix the issues when implementing a new one, so all the code should be clean when new code changes come up. From the docs:

https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues

> We are sure that every project can easily integrate golangci-lint, even the large one. The idea is to not fix all existing issues. Fix only newly added issue: issues in new code. To do this setup CI to run golangci-lint with option --new-from-rev=HEAD ~ 1. Also, take a look at option --new, but consider that CI scripts that generate unstaged files will make --new only point out issues in those files and not in the last commit. In that regard --new-from-rev=HEAD ~ 1 is safer. By doing this you won't create new issues in your code and can choose fix existing issues (or not).


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
