### PR TITLE
fix: e2e tests

### DIFF
--- a/integration/actions/pipeline_test.go
+++ b/integration/actions/pipeline_test.go
@@ -56,6 +56,10 @@ func TestPipelineActions(t *testing.T) {
 func TestPipelineActionsWithCompose(t *testing.T) {
 	integration.SkipIfWindows(t)
 
+	t.Setenv(model.GithubRepositoryEnvVar, "okteto/movies-with-compose")
+	t.Setenv(model.GithubRefEnvVar, "main")
+	t.Setenv(model.GithubServerURLEnvVar, githubHTTPSURL)
+
 	namespace := integration.GetTestNamespace("pipelinecomposeaction", user)
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, executeDeployWithComposePipelineAction(namespace))
@@ -116,10 +120,6 @@ func executeDeployWithComposePipelineAction(namespace string) error {
 	}
 	log.Printf("cloned repo %s \n", actionRepo)
 	defer integration.DeleteGitRepo(actionFolder)
-
-	t.Setenv(model.GithubRepositoryEnvVar, "okteto/movies-with-compose")
-	t.Setenv(model.GithubRefEnvVar, "main")
-	t.Setenv(model.GithubServerURLEnvVar, githubHTTPSURL)
 
 	log.Printf("deploying pipeline %s", namespace)
 	command := fmt.Sprintf("%s/entrypoint.sh", actionFolder)


### PR DESCRIPTION
# Proposed changes

Fixing e2e tests which were broken due to this change: https://github.com/okteto/okteto/pull/4018/files#diff-70baf2799a123b49905ea6b9b2a8dcb1d66dca0e83ea6784268aad5713d4431eR120

## How to validate

Check CI

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
