### PR TITLE
Fix panic when interrupt deploy

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -236,7 +236,7 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface) *cobra.Command {
 				oktetoLog.StartSpinner()
 				defer oktetoLog.StopSpinner()
 
-				deployer, err := c.GetDeployer(ctx, options, nil, nil, nil, nil, nil)
+				deployer, err := c.GetDeployer(ctx, options, nil, nil, nil, nil, model.GetAvailablePort)
 				if err != nil {
 					return err
 				}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -236,7 +236,7 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface) *cobra.Command {
 				oktetoLog.StartSpinner()
 				defer oktetoLog.StopSpinner()
 
-				deployer, err := c.GetDeployer(ctx, options, nil, nil, nil, nil, model.GetAvailablePort)
+				deployer, err := c.GetDeployer(ctx, options, nil, nil, k8sClientProvider, NewKubeConfig(), model.GetAvailablePort)
 				if err != nil {
 					return err
 				}
@@ -547,6 +547,8 @@ func shouldRunInRemote(opts *Options) bool {
 
 }
 
+// GetDeployer returns a remote or a local deployer
+// k8sProvider, kubeconfig and portGetter should not be nil values
 func GetDeployer(ctx context.Context,
 	opts *Options,
 	builder builderInterface,

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -310,9 +310,28 @@ func TestDeployWithErrorChangingKubeConfig(t *testing.T) {
 	assert.False(t, p.started)
 }
 
+type fakeDeployer struct {
+	proxy                   *fakeProxy
+	executor                *fakeExecutor
+	kubeconfig              *fakeKubeConfig
+	fs                      afero.Fs
+	k8sClientProvider       *test.FakeK8sProvider
+	externalControlProvider fakeExternalControlProvider
+}
+
+func (d fakeDeployer) Get(_ context.Context, _ *Options, _ builderInterface, cmapHandler configMapHandler, _ okteto.K8sClientProvider, _ kubeConfigHandler, _ portGetterFunc) (deployerInterface, error) {
+	return &localDeployer{
+		Proxy:              d.proxy,
+		Executor:           d.executor,
+		Kubeconfig:         d.kubeconfig,
+		Fs:                 d.fs,
+		K8sClientProvider:  d.k8sClientProvider,
+		GetExternalControl: d.externalControlProvider.getFakeExternalControl,
+		ConfigMapHandler:   cmapHandler,
+	}, nil
+}
+
 func TestDeployWithErrorReadingManifestFile(t *testing.T) {
-	p := &fakeProxy{}
-	e := &fakeExecutor{}
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{
 			"test": {
@@ -321,16 +340,15 @@ func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
+	fakeDeployer := &fakeDeployer{
+		proxy:      &fakeProxy{},
+		executor:   &fakeExecutor{},
+		kubeconfig: &fakeKubeConfig{},
+		fs:         afero.NewMemMapFs(),
+	}
 	c := &DeployCommand{
-		GetManifest: getManifestWithError,
-		GetDeployer: func(context.Context, *Options, builderInterface, configMapHandler, okteto.K8sClientProvider, kubeConfigHandler, func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:      p,
-				Executor:   e,
-				Kubeconfig: &fakeKubeConfig{},
-				Fs:         afero.NewMemMapFs(),
-			}, nil
-		},
+		GetManifest:       getManifestWithError,
+		GetDeployer:       fakeDeployer.Get,
 		K8sClientProvider: test.NewFakeK8sProvider(),
 	}
 	ctx := context.Background()
@@ -344,14 +362,18 @@ func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 
 	assert.Error(t, err)
 	// No command was executed
-	assert.Len(t, e.executed, 0)
+	assert.Len(t, fakeDeployer.executor.executed, 0)
 	// Proxy wasn't started
-	assert.False(t, p.started)
+	assert.False(t, fakeDeployer.proxy.started)
 }
 
 func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
-	p := &fakeProxy{}
-	e := &fakeExecutor{}
+	fakeDeployer := &fakeDeployer{
+		proxy:      &fakeProxy{},
+		executor:   &fakeExecutor{},
+		kubeconfig: &fakeKubeConfig{},
+		fs:         afero.NewMemMapFs(),
+	}
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{
 			"test": {
@@ -361,15 +383,8 @@ func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
 		CurrentContext: "test",
 	}
 	c := &DeployCommand{
-		GetManifest: getManifestWithNoDeployNorDependency,
-		GetDeployer: func(context.Context, *Options, builderInterface, configMapHandler, okteto.K8sClientProvider, kubeConfigHandler, func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:      p,
-				Executor:   e,
-				Kubeconfig: &fakeKubeConfig{},
-				Fs:         afero.NewMemMapFs(),
-			}, nil
-		},
+		GetManifest:       getManifestWithNoDeployNorDependency,
+		GetDeployer:       fakeDeployer.Get,
 		K8sClientProvider: test.NewFakeK8sProvider(),
 	}
 	ctx := context.Background()
@@ -384,9 +399,9 @@ func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
 	assert.ErrorIs(t, err, oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands)
 
 	// No command was executed
-	assert.Len(t, e.executed, 0)
+	assert.Len(t, fakeDeployer.executor.executed, 0)
 	// Proxy wasn't started
-	assert.False(t, p.started)
+	assert.False(t, fakeDeployer.proxy.started)
 }
 
 type fakeAnalyticsTracker struct{}
@@ -394,9 +409,15 @@ type fakeAnalyticsTracker struct{}
 func (fakeAnalyticsTracker) TrackImageBuild(...*analytics.ImageBuildMetadata) {}
 
 func TestCreateConfigMapWithBuildError(t *testing.T) {
-	p := &fakeProxy{}
-	e := &fakeExecutor{
-		err: assert.AnError,
+	fakeK8sClientProvider := test.NewFakeK8sProvider()
+	fakeDeployer := &fakeDeployer{
+		proxy: &fakeProxy{},
+		executor: &fakeExecutor{
+			err: assert.AnError,
+		},
+		kubeconfig:        &fakeKubeConfig{},
+		fs:                afero.NewMemMapFs(),
+		k8sClientProvider: fakeK8sClientProvider,
 	}
 	opts := &Options{
 		Name:         "testErr",
@@ -405,25 +426,15 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 		Build:        true,
 	}
 
-	clientProvider := test.NewFakeK8sProvider()
-
 	registry := newFakeRegistry()
 	builder := test.NewFakeOktetoBuilder(registry)
 	fakeTracker := fakeAnalyticsTracker{}
 	c := &DeployCommand{
-		GetManifest: getErrorManifest,
-		GetDeployer: func(context.Context, *Options, builderInterface, configMapHandler, okteto.K8sClientProvider, kubeConfigHandler, func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:             p,
-				Executor:          e,
-				Kubeconfig:        &fakeKubeConfig{},
-				K8sClientProvider: clientProvider,
-				Fs:                afero.NewMemMapFs(),
-			}, nil
-		},
+		GetManifest:       getErrorManifest,
+		GetDeployer:       fakeDeployer.Get,
 		Builder:           buildv2.NewBuilder(builder, registry, fakeTracker),
-		K8sClientProvider: clientProvider,
-		CfgMapHandler:     newDefaultConfigMapHandler(clientProvider),
+		K8sClientProvider: fakeK8sClientProvider,
+		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider),
 	}
 
 	ctx := context.Background()
@@ -473,11 +484,17 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 }
 
 func TestDeployWithErrorExecutingCommands(t *testing.T) {
-	p := &fakeProxy{}
-	e := &fakeExecutor{
-		err: assert.AnError,
+	fakeOs := afero.NewMemMapFs()
+	fakeK8sClientProvider := test.NewFakeK8sProvider()
+	fakeDeployer := &fakeDeployer{
+		proxy: &fakeProxy{},
+		executor: &fakeExecutor{
+			err: assert.AnError,
+		},
+		kubeconfig:        &fakeKubeConfig{},
+		fs:                fakeOs,
+		k8sClientProvider: fakeK8sClientProvider,
 	}
-	clientProvider := test.NewFakeK8sProvider()
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{
 			"test": {
@@ -487,19 +504,11 @@ func TestDeployWithErrorExecutingCommands(t *testing.T) {
 		CurrentContext: "test",
 	}
 	c := &DeployCommand{
-		GetManifest: getFakeManifest,
-		GetDeployer: func(context.Context, *Options, builderInterface, configMapHandler, okteto.K8sClientProvider, kubeConfigHandler, func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:             p,
-				Executor:          e,
-				Kubeconfig:        &fakeKubeConfig{},
-				K8sClientProvider: clientProvider,
-				Fs:                afero.NewMemMapFs(),
-			}, nil
-		},
-		K8sClientProvider: clientProvider,
-		CfgMapHandler:     newDefaultConfigMapHandler(clientProvider),
-		Fs:                afero.NewMemMapFs(),
+		GetManifest:       getFakeManifest,
+		GetDeployer:       fakeDeployer.Get,
+		K8sClientProvider: fakeK8sClientProvider,
+		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider),
+		Fs:                fakeOs,
 		Builder:           &fakeV2Builder{},
 	}
 	ctx := context.Background()
@@ -513,13 +522,13 @@ func TestDeployWithErrorExecutingCommands(t *testing.T) {
 
 	assert.Error(t, err)
 	// No command was executed
-	assert.Len(t, e.executed, 1)
+	assert.Len(t, fakeDeployer.executor.executed, 1)
 	// Check expected commands were executed
-	assert.Equal(t, fakeManifest.Deploy.Commands[0], e.executed[0])
+	assert.Equal(t, fakeManifest.Deploy.Commands[0], fakeDeployer.executor.executed[0])
 	// Proxy started
-	assert.True(t, p.started)
+	assert.True(t, fakeDeployer.proxy.started)
 	// Proxy shutdown
-	assert.True(t, p.shutdown)
+	assert.True(t, fakeDeployer.proxy.shutdown)
 
 	// check if configmap has been created
 	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
@@ -533,10 +542,36 @@ func TestDeployWithErrorExecutingCommands(t *testing.T) {
 }
 
 func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
-	p := &fakeProxy{
-		errOnShutdown: assert.AnError,
+	opts := &Options{
+		Name:         "movies",
+		ManifestPath: "",
+		Variables:    []string{},
 	}
-	e := &fakeExecutor{}
+	fakeK8sClientProvider := test.NewFakeK8sProvider(&apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipeline.TranslatePipelineName(opts.Name),
+			Namespace: "test",
+		},
+		Data: map[string]string{
+			"actionLock": "test",
+		},
+	}, &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				model.DeployedByLabel: "movies",
+			},
+		},
+	})
+	fakeDeployer := &fakeDeployer{
+		proxy: &fakeProxy{
+			errOnShutdown: assert.AnError,
+		},
+		executor:          &fakeExecutor{},
+		kubeconfig:        &fakeKubeConfig{},
+		fs:                afero.NewMemMapFs(),
+		k8sClientProvider: fakeK8sClientProvider,
+	}
+
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{
 			"test": {
@@ -545,41 +580,12 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	opts := &Options{
-		Name:         "movies",
-		ManifestPath: "",
-		Variables:    []string{},
-	}
-	cmap := &apiv1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pipeline.TranslatePipelineName(opts.Name),
-			Namespace: "test",
-		},
-		Data: map[string]string{
-			"actionLock": "test",
-		},
-	}
-	deployment := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				model.DeployedByLabel: "movies",
-			},
-		},
-	}
-	clientProvider := test.NewFakeK8sProvider(cmap, deployment)
+
 	c := &DeployCommand{
-		GetManifest: getFakeManifest,
-		GetDeployer: func(context.Context, *Options, builderInterface, configMapHandler, okteto.K8sClientProvider, kubeConfigHandler, func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:             p,
-				Executor:          e,
-				Kubeconfig:        &fakeKubeConfig{},
-				K8sClientProvider: clientProvider,
-				Fs:                afero.NewMemMapFs(),
-			}, nil
-		},
-		K8sClientProvider: clientProvider,
-		CfgMapHandler:     newDefaultConfigMapHandler(clientProvider),
+		GetManifest:       getFakeManifest,
+		GetDeployer:       fakeDeployer.Get,
+		K8sClientProvider: fakeK8sClientProvider,
+		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider),
 	}
 	ctx := context.Background()
 
@@ -587,9 +593,9 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 
 	assert.Error(t, err)
 	// No command was executed
-	assert.Len(t, e.executed, 0)
+	assert.Len(t, fakeDeployer.executor.executed, 0)
 	// Proxy didn't start
-	assert.False(t, p.started)
+	assert.False(t, fakeDeployer.proxy.started)
 
 	// check if configmap has been created
 	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
@@ -602,18 +608,29 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 }
 
 func TestDeployWithErrorShuttingdownProxy(t *testing.T) {
-	p := &fakeProxy{
-		errOnShutdown: assert.AnError,
-	}
-	deployment := &v1.Deployment{
+	fakeOs := afero.NewMemMapFs()
+	fakeK8sClientProvider := test.NewFakeK8sProvider(&v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				model.DeployedByLabel: "movies",
 			},
 			Namespace: "test",
 		},
+	})
+	fakeExternalControlProvider := fakeExternalControlProvider{
+		control: &fakeExternalControl{},
 	}
-	e := &fakeExecutor{}
+	fakeDeployer := &fakeDeployer{
+		proxy: &fakeProxy{
+			errOnShutdown: assert.AnError,
+		},
+		executor:                &fakeExecutor{},
+		kubeconfig:              &fakeKubeConfig{},
+		fs:                      fakeOs,
+		k8sClientProvider:       fakeK8sClientProvider,
+		externalControlProvider: fakeExternalControlProvider,
+	}
+
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{
 			"test": {
@@ -623,28 +640,14 @@ func TestDeployWithErrorShuttingdownProxy(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	cp := fakeExternalControlProvider{
-		control: &fakeExternalControl{},
-	}
-	clientProvider := test.NewFakeK8sProvider(deployment)
 	c := &DeployCommand{
-		GetManifest: getFakeManifest,
-		GetDeployer: func(context.Context, *Options, builderInterface, configMapHandler, okteto.K8sClientProvider, kubeConfigHandler, func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:              p,
-				Executor:           e,
-				Kubeconfig:         &fakeKubeConfig{},
-				ConfigMapHandler:   &fakeCmapHandler{},
-				K8sClientProvider:  clientProvider,
-				GetExternalControl: cp.getFakeExternalControl,
-				Fs:                 afero.NewMemMapFs(),
-			}, nil
-		},
-		GetExternalControl: cp.getFakeExternalControl,
-		K8sClientProvider:  clientProvider,
+		GetManifest:        getFakeManifest,
+		GetDeployer:        fakeDeployer.Get,
+		GetExternalControl: fakeExternalControlProvider.getFakeExternalControl,
+		K8sClientProvider:  fakeK8sClientProvider,
 		EndpointGetter:     getFakeEndpoint,
-		CfgMapHandler:      newDefaultConfigMapHandler(clientProvider),
-		Fs:                 afero.NewMemMapFs(),
+		CfgMapHandler:      newDefaultConfigMapHandler(fakeK8sClientProvider),
+		Fs:                 fakeOs,
 		Builder:            &fakeV2Builder{},
 	}
 	ctx := context.Background()
@@ -659,13 +662,13 @@ func TestDeployWithErrorShuttingdownProxy(t *testing.T) {
 
 	assert.NoError(t, err)
 	// No command was executed
-	assert.Len(t, e.executed, 3)
+	assert.Len(t, fakeDeployer.executor.executed, 3)
 	// Check expected commands were executed
-	assert.Equal(t, fakeManifest.Deploy.Commands, e.executed)
+	assert.Equal(t, fakeManifest.Deploy.Commands, fakeDeployer.executor.executed)
 	// Proxy started
-	assert.True(t, p.started)
+	assert.True(t, fakeDeployer.proxy.started)
 	// Proxy wasn't shutdown
-	assert.False(t, p.shutdown)
+	assert.False(t, fakeDeployer.proxy.shutdown)
 
 	// check if configmap has been created
 	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
@@ -679,8 +682,27 @@ func TestDeployWithErrorShuttingdownProxy(t *testing.T) {
 }
 
 func TestDeployWithoutErrors(t *testing.T) {
-	p := &fakeProxy{}
-	e := &fakeExecutor{}
+	fakeOs := afero.NewMemMapFs()
+	fakeK8sClientProvider := test.NewFakeK8sProvider(&v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				model.DeployedByLabel: "movies",
+			},
+			Namespace: "test",
+		},
+	})
+	fakeExternalControlProvider := fakeExternalControlProvider{
+		control: &fakeExternalControl{},
+	}
+	fakeDeployer := &fakeDeployer{
+		proxy:                   &fakeProxy{},
+		executor:                &fakeExecutor{},
+		kubeconfig:              &fakeKubeConfig{},
+		fs:                      fakeOs,
+		k8sClientProvider:       fakeK8sClientProvider,
+		externalControlProvider: fakeExternalControlProvider,
+	}
+
 	okteto.CurrentStore = &okteto.OktetoContextStore{
 		Contexts: map[string]*okteto.OktetoContext{
 			"test": {
@@ -689,38 +711,16 @@ func TestDeployWithoutErrors(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	deployment := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				model.DeployedByLabel: "movies",
-			},
-			Namespace: "test",
-		},
-	}
 
-	cp := fakeExternalControlProvider{
-		control: &fakeExternalControl{},
-	}
-	clientProvider := test.NewFakeK8sProvider(deployment)
 	c := &DeployCommand{
 		GetManifest:        getFakeManifest,
-		K8sClientProvider:  clientProvider,
+		K8sClientProvider:  fakeK8sClientProvider,
 		EndpointGetter:     getFakeEndpoint,
-		GetExternalControl: cp.getFakeExternalControl,
-		Fs:                 afero.NewMemMapFs(),
-		CfgMapHandler:      newDefaultConfigMapHandler(clientProvider),
-		GetDeployer: func(context.Context, *Options, builderInterface, configMapHandler, okteto.K8sClientProvider, kubeConfigHandler, func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:              p,
-				Executor:           e,
-				Kubeconfig:         &fakeKubeConfig{},
-				ConfigMapHandler:   &fakeCmapHandler{},
-				K8sClientProvider:  clientProvider,
-				GetExternalControl: cp.getFakeExternalControl,
-				Fs:                 afero.NewMemMapFs(),
-			}, nil
-		},
-		Builder: &fakeV2Builder{},
+		GetExternalControl: fakeExternalControlProvider.getFakeExternalControl,
+		Fs:                 fakeOs,
+		CfgMapHandler:      newDefaultConfigMapHandler(fakeK8sClientProvider),
+		GetDeployer:        fakeDeployer.Get,
+		Builder:            &fakeV2Builder{},
 	}
 	ctx := context.Background()
 	opts := &Options{
@@ -733,13 +733,13 @@ func TestDeployWithoutErrors(t *testing.T) {
 
 	assert.NoError(t, err)
 	// No command was executed
-	assert.Len(t, e.executed, 3)
+	assert.Len(t, fakeDeployer.executor.executed, 3)
 	// Check expected commands were executed
-	assert.Equal(t, fakeManifest.Deploy.Commands, e.executed)
+	assert.Equal(t, fakeManifest.Deploy.Commands, fakeDeployer.executor.executed)
 	// Proxy started
-	assert.True(t, p.started)
+	assert.True(t, fakeDeployer.proxy.started)
 	// Proxy was shutdown
-	assert.True(t, p.shutdown)
+	assert.True(t, fakeDeployer.proxy.shutdown)
 
 	// check if configmap has been created
 	fakeClient, _, err := c.K8sClientProvider.Provide(clientcmdapi.NewConfig())
@@ -1098,39 +1098,36 @@ func TestDeployDependencies(t *testing.T) {
 }
 
 func TestDeployOnlyDependencies(t *testing.T) {
-	p := &fakeProxy{}
-	e := &fakeExecutor{}
-	deployment := &v1.Deployment{
+	fakeOs := afero.NewMemMapFs()
+	fakeK8sClientProvider := test.NewFakeK8sProvider(&v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				model.DeployedByLabel: "movies",
 			},
 			Namespace: "test",
 		},
-	}
+	})
 
-	cp := fakeExternalControlProvider{
+	fakeExternalControlProvider := fakeExternalControlProvider{
 		control: &fakeExternalControl{},
 	}
-	clientProvider := test.NewFakeK8sProvider(deployment)
+	fakeDeployer := &fakeDeployer{
+		proxy:                   &fakeProxy{},
+		executor:                &fakeExecutor{},
+		kubeconfig:              &fakeKubeConfig{},
+		fs:                      fakeOs,
+		k8sClientProvider:       fakeK8sClientProvider,
+		externalControlProvider: fakeExternalControlProvider,
+	}
+
 	c := &DeployCommand{
 		PipelineCMD:        fakePipelineDeployer{nil},
 		GetManifest:        getFakeManifestWithDependency,
-		K8sClientProvider:  clientProvider,
-		GetExternalControl: cp.getFakeExternalControl,
-		Fs:                 afero.NewMemMapFs(),
-		CfgMapHandler:      newDefaultConfigMapHandler(clientProvider),
-		GetDeployer: func(_ context.Context, _ *Options, _ builderInterface, cmapHandler configMapHandler, _ okteto.K8sClientProvider, kubeconfig kubeConfigHandler, portGetter func(string) (int, error)) (deployerInterface, error) {
-			return &localDeployer{
-				Proxy:              p,
-				Executor:           e,
-				Kubeconfig:         kubeconfig,
-				ConfigMapHandler:   cmapHandler,
-				K8sClientProvider:  clientProvider,
-				GetExternalControl: cp.getFakeExternalControl,
-				Fs:                 afero.NewMemMapFs(),
-			}, nil
-		},
+		K8sClientProvider:  fakeK8sClientProvider,
+		GetExternalControl: fakeExternalControlProvider.getFakeExternalControl,
+		Fs:                 fakeOs,
+		CfgMapHandler:      newDefaultConfigMapHandler(fakeK8sClientProvider),
+		GetDeployer:        fakeDeployer.Get,
 	}
 	ctx := context.Background()
 	opts := &Options{

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -54,7 +54,7 @@ type localDeployer struct {
 }
 
 // newLocalDeployer initializes a local deployer from a name and a boolean indicating if we should run with bash or not
-func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configMapHandler, k8sProvider okteto.K8sClientProvider, kubeconfig kubeConfigHandler, portGetter func(string) (int, error)) (*localDeployer, error) {
+func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configMapHandler, k8sProvider okteto.K8sClientProvider, kubeconfig kubeConfigHandler, portGetter portGetterFunc) (*localDeployer, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get the current working directory: %w", err)

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -73,17 +72,8 @@ type proxyHandler struct {
 	DivertDriver divert.Driver
 }
 
-var (
-	errNilPortGetter = errors.New("param portGetter should be a function")
-)
-
 // NewProxy creates a new proxy
 func NewProxy(kubeconfig kubeConfigHandler, portGetter portGetterFunc) (*Proxy, error) {
-	if portGetter == nil {
-		oktetoLog.Error("port getter can't be empty")
-		return nil, errNilPortGetter
-	}
-
 	// Look for a free local port to start the proxy
 	port, err := portGetter("localhost")
 	if err != nil {

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -72,8 +73,17 @@ type proxyHandler struct {
 	DivertDriver divert.Driver
 }
 
+var (
+	errNilPortGetter = errors.New("param portGetter should be a function")
+)
+
 // NewProxy creates a new proxy
 func NewProxy(kubeconfig kubeConfigHandler, portGetter portGetterFunc) (*Proxy, error) {
+	if portGetter == nil {
+		oktetoLog.Error("port getter can't be empty")
+		return nil, errNilPortGetter
+	}
+
 	// Look for a free local port to start the proxy
 	port, err := portGetter("localhost")
 	if err != nil {

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -73,7 +73,7 @@ type proxyHandler struct {
 }
 
 // NewProxy creates a new proxy
-func NewProxy(kubeconfig kubeConfigHandler, portGetter func(iface string) (int, error)) (*Proxy, error) {
+func NewProxy(kubeconfig kubeConfigHandler, portGetter portGetterFunc) (*Proxy, error) {
 	// Look for a free local port to start the proxy
 	port, err := portGetter("localhost")
 	if err != nil {

--- a/cmd/deploy/proxy_test.go
+++ b/cmd/deploy/proxy_test.go
@@ -92,10 +92,6 @@ func Test_NewProxy(t *testing.T) {
 			},
 			expectedErr: assert.AnError,
 		},
-		{
-			name:        "err portGetter nil",
-			expectedErr: errNilPortGetter,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Proposed changes

With the latest changes injecting the port getter into GetDeployer, when the signal of stop was triggered, the sequence of shutdown was passing nil params which should not be nil.

The panic happens when k8sclientProvider, portGetter or kubeconfig are nil

Fixed by passing the correct params into the function.


## How to validate

- Compile the binary
- run okteto deploy and stop the process
- no panic should appear, instead the shutdown sequence should work properly

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
