### PR TITLE
Adds add/delete to docker credentials helper

### DIFF
--- a/pkg/auth/dockercredentials/helper_test.go
+++ b/pkg/auth/dockercredentials/helper_test.go
@@ -1,0 +1,59 @@
+package dockercredentials
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/docker/docker-credential-helpers/credentials"
+	"github.com/stretchr/testify/require"
+)
+
+var errNotFound = errors.New("fake creds not found")
+
+type fakeGetter struct {
+	creds map[string][2]string
+}
+
+func (fg fakeGetter) GetRegistryCredentials(host string) (string, string, error) {
+	if fg.creds == nil {
+		fg.creds = make(map[string][2]string)
+	}
+
+	if creds, ok := fg.creds[host]; ok {
+		return creds[0], creds[1], nil
+	}
+
+	return "", "", errNotFound
+
+}
+
+func TestAddDelete(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	h := OktetoClusterHelper{
+		dirname: dir,
+		getter:  fakeGetter{},
+	}
+	creds := &credentials.Credentials{
+		ServerURL: "registry.com",
+		Username:  "lebowski",
+		Secret:    "thedude",
+	}
+
+	err = h.Add(creds)
+	require.NoError(t, err)
+	user, pass, err := h.Get("registry.com")
+	require.NoError(t, err)
+	require.Equal(t, "lebowski", user)
+	require.Equal(t, "thedude", pass)
+
+	err = h.Delete("registry.com")
+	require.NoError(t, err)
+
+	_, _, err = h.Get("registry.com")
+	require.ErrorIs(t, err, errNotFound)
+}


### PR DESCRIPTION
# Proposed changes

In Okteto 1.14, we add a docker config file with a single `credStore` responsible for negotiating credentials with the Okteto backend. The helper doesn't implement `add` nor `delete` but catches all registries so doing something like `ko login` doesn't work.

Example repo: https://github.com/okteto/go-with-ko/blob/main/okteto.yaml. The example works because `DOCKER_CONFIG` is set to a different file.

This fix uses a separate docker config file to resolve credentials. Note that this usually run in a temporary environment (buildkit or a kuberentes job)  so managing the lifecycle of this file is not strictly necessary.

## How to validate

To reproduce:

1. Clone: https://github.com/okteto/go-with-ko
2. Check out this commit `de1f3c60037a7fcdaa1c6b3f88382f332c5ba60b`
1. Remove this line: https://github.com/okteto/go-with-ko/blob/de1f3c60037a7fcdaa1c6b3f88382f332c5ba60b/okteto.yaml#L7
1. add `set -e` at the top of the script so execution does not continue
1. Run a `okteto deploy --remote`

A `not implemented` error should be returned. This error is returned by the credentials helper

**To test the fix**: Doing the exact same as above with this patch should work. This requires making sure that `okteto deploy --remote` executes this version of the cli which is not explained in this PR for brevity.


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
