### PR TITLE
RAIN-31: Add extra hosts for internal communication to API and BUildkit when executing deploy and destroy remotely

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -199,10 +199,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		if err != nil {
 			return fmt.Errorf("failed to parse server name network address: %w", err)
 		}
-		buildOptions.ExtraHosts = []types.HostMap{
-			{Hostname: registryUrl, IP: ip},
-			{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
-		}
+		buildOptions.ExtraHosts = getExtraHosts(registryUrl, subdomain, ip, *sc)
 	}
 
 	sshSock := os.Getenv(rd.sshAuthSockEnvvar)
@@ -387,4 +384,21 @@ func fetchRemoteServerConfig(ctx context.Context) (*types.ClusterMetadata, error
 	}
 
 	return &metadata, err
+}
+
+func getExtraHosts(registryURL, subdomain, ip string, metadata types.ClusterMetadata) []types.HostMap {
+	extraHosts := []types.HostMap{
+		{Hostname: registryURL, IP: ip},
+		{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+	}
+
+	if metadata.BuildKitInternalIP != "" {
+		extraHosts = append(extraHosts, types.HostMap{Hostname: fmt.Sprintf("buildkit.%s", subdomain), IP: metadata.BuildKitInternalIP})
+	}
+
+	if metadata.PublicDomain != "" {
+		extraHosts = append(extraHosts, types.HostMap{Hostname: metadata.PublicDomain, IP: ip})
+	}
+
+	return extraHosts
 }

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -533,3 +533,54 @@ func Test_newRemoteDeployer(t *testing.T) {
 	require.IsType(t, &remoteDeployCommand{}, got)
 	require.NotNil(t, got.getBuildEnvVars)
 }
+
+func TestGetExtraHosts(t *testing.T) {
+	registryURL := "registry.test.dev.okteto.net"
+	subdomain := "test.dev.okteto.net"
+	ip := "1.2.3.4"
+
+	var tests = []struct {
+		name     string
+		metadata types.ClusterMetadata
+		expected []types.HostMap
+	}{
+		{
+			name:     "no metadata information",
+			metadata: types.ClusterMetadata{},
+			expected: []types.HostMap{
+				{Hostname: registryURL, IP: ip},
+				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+			},
+		},
+		{
+			name: "with buildkit internal ip",
+			metadata: types.ClusterMetadata{
+				BuildKitInternalIP: "4.3.2.1",
+			},
+			expected: []types.HostMap{
+				{Hostname: registryURL, IP: ip},
+				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+				{Hostname: fmt.Sprintf("buildkit.%s", subdomain), IP: "4.3.2.1"},
+			},
+		},
+		{
+			name: "with public domain",
+			metadata: types.ClusterMetadata{
+				PublicDomain: "publicdomain.dev.okteto.net",
+			},
+			expected: []types.HostMap{
+				{Hostname: registryURL, IP: ip},
+				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+				{Hostname: "publicdomain.dev.okteto.net", IP: ip},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extraHosts := getExtraHosts(registryURL, subdomain, ip, tt.metadata)
+
+			assert.EqualValues(t, tt.expected, extraHosts)
+		})
+	}
+}

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -465,3 +465,54 @@ func TestRemoteDestroyWithBadSshAgent(t *testing.T) {
 
 	assert.NoError(t, rdc.destroy(context.Background(), &Options{}))
 }
+
+func TestGetExtraHosts(t *testing.T) {
+	registryURL := "registry.test.dev.okteto.net"
+	subdomain := "test.dev.okteto.net"
+	ip := "1.2.3.4"
+
+	var tests = []struct {
+		name     string
+		metadata types.ClusterMetadata
+		expected []types.HostMap
+	}{
+		{
+			name:     "no metadata information",
+			metadata: types.ClusterMetadata{},
+			expected: []types.HostMap{
+				{Hostname: registryURL, IP: ip},
+				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+			},
+		},
+		{
+			name: "with buildkit internal ip",
+			metadata: types.ClusterMetadata{
+				BuildKitInternalIP: "4.3.2.1",
+			},
+			expected: []types.HostMap{
+				{Hostname: registryURL, IP: ip},
+				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+				{Hostname: fmt.Sprintf("buildkit.%s", subdomain), IP: "4.3.2.1"},
+			},
+		},
+		{
+			name: "with public domain",
+			metadata: types.ClusterMetadata{
+				PublicDomain: "publicdomain.dev.okteto.net",
+			},
+			expected: []types.HostMap{
+				{Hostname: registryURL, IP: ip},
+				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+				{Hostname: "publicdomain.dev.okteto.net", IP: ip},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extraHosts := getExtraHosts(registryURL, subdomain, ip, tt.metadata)
+
+			assert.EqualValues(t, tt.expected, extraHosts)
+		})
+	}
+}

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -322,6 +322,10 @@ func (c *userClient) GetClusterMetadata(ctx context.Context, ns string) (types.C
 			metadata.IsTrialLicense = string(v.Value) == "true"
 		case "companyName":
 			metadata.CompanyName = string(v.Value)
+		case "buildkitInternalIP":
+			metadata.BuildKitInternalIP = string(v.Value)
+		case "publicDomain":
+			metadata.PublicDomain = string(v.Value)
 		}
 	}
 	if metadata.PipelineRunnerImage == "" {

--- a/pkg/types/cluster_metadata.go
+++ b/pkg/types/cluster_metadata.go
@@ -20,4 +20,6 @@ type ClusterMetadata struct {
 	PipelineRunnerImage string
 	IsTrialLicense      bool
 	CompanyName         string
+	BuildKitInternalIP  string
+	PublicDomain        string
 }


### PR DESCRIPTION
# Proposed changes

Fixes RAIN-31

Add ExtraHosts for API and BuildKit when running deploy and destroy when they are run with `--remote`. In that way, any Okteto command executed as part of the command execution goes via internal IPs instead of the public ones. This is important because the CLI uses internal certificates.

As new information is needed from the metadata query, I added also those new fields.

## How to validate

1. Login against an instance returning Public domain and buildkit internal IP as part of the metadata query
2. Create a manifest with the command `cat /etc/hosts` in deploy and destroy section
3. Execute `okteto deploy --remote` and `okteto destroy --remote` to verify that the hosts are added correctly

## Testing done

I have tested it against an instance returning the information. You can see how the hosts are added there:

```
ok deploy --remote
 i  Using nacho @ okteto.xxxxxxxxx.net as context
 i  Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'
 i  Running stage 'Show /etc/hosts'
Executing command 'Show /etc/hosts'...
127.0.0.1	localhost buildkitsandbox
::1	localhost ip6-localhost ip6-loopback
10.108.0.33	registry.xxxxxxxxx.net
10.108.0.33	kubernetes.xxxxxxxxx.net
10.108.12.106	buildkit.xxxxxxxxx.net
10.108.0.33	okteto.xxxxxxxxx.net
```

I have tests it against an instance which is not returning the information (simulating a case of using a new CLI with an old cluster). Verify that it doesn't fail and only has the already existent hosts:

```
ok deploy --remote
 i  Using nacho @ okteto.xxxxxxxxx.net as context
 i  Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'
 i  Running stage 'Show /etc/hosts'
Executing command 'Show /etc/hosts'...
127.0.0.1	localhost buildkitsandbox
::1	localhost ip6-localhost ip6-loopback
10.108.0.33	registry.xxxxxxxxx.net
10.108.0.33	kubernetes.xxxxxxxxx.net
Command 'Show /etc/hosts' successfully executed
```
