### PR TITLE
add feature flag to enable disable pull first approach

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -110,7 +110,7 @@ func NewBuilderFromScratch(analyticsTracker analyticsTrackerInterface) *OktetoBu
 	config := getConfig(registry, gitRepo)
 
 	buildEnvs := map[string]string{}
-	buildEnvs[OktetoEnableSmartBuilds] = strconv.FormatBool(config.isSmartBuildsEnable)
+	buildEnvs[OktetoEnableSmartBuildEnvVar] = strconv.FormatBool(config.isSmartBuildsEnable)
 
 	return &OktetoBuilder{
 		Builder:           builder,

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -106,11 +107,16 @@ func NewBuilderFromScratch(analyticsTracker analyticsTrackerInterface) *OktetoBu
 		oktetoLog.Infof("could not get working dir: %w", err)
 	}
 	gitRepo := repository.NewRepository(wd)
+	config := getConfig(registry, gitRepo)
+
+	buildEnvs := map[string]string{}
+	buildEnvs[OktetoEnableSmartBuilds] = strconv.FormatBool(config.isSmartBuildsEnable)
+
 	return &OktetoBuilder{
 		Builder:           builder,
 		Registry:          registry,
 		V1Builder:         buildv1.NewBuilder(builder, registry),
-		buildEnvironments: map[string]string{},
+		buildEnvironments: buildEnvs,
 		Config:            getConfig(registry, gitRepo),
 		analyticsTracker:  analyticsTracker,
 	}

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -65,6 +65,7 @@ type oktetoBuilderConfigInterface interface {
 	IsOkteto() bool
 	GetAnonymizedRepo() string
 	GetBuildContextHash(*model.BuildInfo) string
+	IsSmartBuildsEnable() bool
 }
 
 type analyticsTrackerInterface interface {
@@ -207,7 +208,7 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 			meta.BuildContextHashDuration = time.Since(buildContextHashDurationStart)
 
 			// We only check that the image is built in the global registry if the noCache option is not set
-			if !options.NoCache && bc.Config.IsCleanProject() {
+			if !options.NoCache && bc.Config.IsCleanProject() && bc.Config.IsSmartBuildsEnable() {
 
 				imageChecker := getImageChecker(buildSvcInfo, bc.Config, bc.Registry)
 				cacheHitDurationStart := time.Now()

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -117,7 +117,7 @@ func NewBuilderFromScratch(analyticsTracker analyticsTrackerInterface) *OktetoBu
 		Registry:          registry,
 		V1Builder:         buildv1.NewBuilder(builder, registry),
 		buildEnvironments: buildEnvs,
-		Config:            getConfig(registry, gitRepo),
+		Config:            config,
 		analyticsTracker:  analyticsTracker,
 	}
 }

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -66,7 +66,7 @@ type oktetoBuilderConfigInterface interface {
 	IsOkteto() bool
 	GetAnonymizedRepo() string
 	GetBuildContextHash(*model.BuildInfo) string
-	IsSmartBuildsEnable() bool
+	IsSmartBuildsEnabled() bool
 }
 
 type analyticsTrackerInterface interface {
@@ -214,7 +214,7 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 			meta.BuildContextHashDuration = time.Since(buildContextHashDurationStart)
 
 			// We only check that the image is built in the global registry if the noCache option is not set
-			if !options.NoCache && bc.Config.IsCleanProject() && bc.Config.IsSmartBuildsEnable() {
+			if !options.NoCache && bc.Config.IsCleanProject() && bc.Config.IsSmartBuildsEnabled() {
 
 				imageChecker := getImageChecker(buildSvcInfo, bc.Config, bc.Registry)
 				cacheHitDurationStart := time.Now()

--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -64,7 +64,7 @@ func getConfig(registry configRegistryInterface, gitRepo configRepositoryInterfa
 	if enableSmartBuildsStr != "" {
 		smartBuildEnabledBool, err := strconv.ParseBool(enableSmartBuildsStr)
 		if err != nil {
-			oktetoLog.Infof("error trying to get feature flag %s: %w", OktetoEnableSmartBuilds, err)
+			oktetoLog.Warning("feature flag %s received an invalid value; expected boolean. Smart builds will remain enabled by default", OktetoEnableSmartBuilds)
 		} else {
 			enableSmartBuilds = smartBuildEnabledBool
 		}

--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	// OktetoEnableSmartBuilds key representing whether the feature flag to enable smart builds is enabled or not
-	OktetoEnableSmartBuilds = "OKTETO_SMART_BUILDS_ENABLED"
+	// OktetoEnableSmartBuildEnvVar represents whether the feature flag to enable smart builds is enabled or not
+	OktetoEnableSmartBuildEnvVar = "OKTETO_SMART_BUILDS_ENABLED"
 )
 
 type configRepositoryInterface interface {
@@ -71,11 +71,11 @@ func getConfig(registry configRegistryInterface, gitRepo configRepositoryInterfa
 
 func getIsSmartBuildEnabled() bool {
 	enableSmartBuilds := true
-	enableSmartBuildsStr := os.Getenv(OktetoEnableSmartBuilds)
+	enableSmartBuildsStr := os.Getenv(OktetoEnableSmartBuildEnvVar)
 	if enableSmartBuildsStr != "" {
 		smartBuildEnabledBool, err := strconv.ParseBool(enableSmartBuildsStr)
 		if err != nil {
-			oktetoLog.Warning("feature flag %s received an invalid value; expected boolean. Smart builds will remain enabled by default", OktetoEnableSmartBuilds)
+			oktetoLog.Warning("feature flag %s received an invalid value; expected boolean. Smart builds will remain enabled by default", OktetoEnableSmartBuildEnvVar)
 		} else {
 			enableSmartBuilds = smartBuildEnabledBool
 		}

--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -120,6 +120,6 @@ func (oc oktetoBuilderConfig) GetBuildContextHash(buildInfo *model.BuildInfo) st
 	return getBuildHashFromGitHash(buildInfo, treeHash, "tree_hash")
 }
 
-func (oc oktetoBuilderConfig) IsSmartBuildsEnable() bool {
+func (oc oktetoBuilderConfig) IsSmartBuildsEnabled() bool {
 	return oc.isSmartBuildsEnable
 }

--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -59,6 +59,17 @@ func getConfig(registry configRegistryInterface, gitRepo configRepositoryInterfa
 		oktetoLog.Infof("error trying to get directory: %w", err)
 	}
 
+	return oktetoBuilderConfig{
+		repository:          gitRepo,
+		hasGlobalAccess:     hasAccess,
+		isCleanProject:      isClean,
+		fs:                  afero.NewOsFs(),
+		isOkteto:            okteto.Context().IsOkteto,
+		isSmartBuildsEnable: getIsSmartBuildEnabled(),
+	}
+}
+
+func getIsSmartBuildEnabled() bool {
 	enableSmartBuilds := true
 	enableSmartBuildsStr := os.Getenv(OktetoEnableSmartBuilds)
 	if enableSmartBuildsStr != "" {
@@ -71,14 +82,7 @@ func getConfig(registry configRegistryInterface, gitRepo configRepositoryInterfa
 
 	}
 
-	return oktetoBuilderConfig{
-		repository:          gitRepo,
-		hasGlobalAccess:     hasAccess,
-		isCleanProject:      isClean,
-		fs:                  afero.NewOsFs(),
-		isOkteto:            okteto.Context().IsOkteto,
-		isSmartBuildsEnable: enableSmartBuilds,
-	}
+	return enableSmartBuilds
 }
 
 // IsOkteto checks if the context is an okteto managed context

--- a/cmd/build/v2/config_test.go
+++ b/cmd/build/v2/config_test.go
@@ -168,7 +168,7 @@ func TestGetIsSmartBuildEnabled(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(OktetoEnableSmartBuilds, tc.input)
+			t.Setenv(OktetoEnableSmartBuildEnvVar, tc.input)
 			cfg := getIsSmartBuildEnabled()
 			assert.Equal(t, tc.expected, cfg)
 		})

--- a/cmd/build/v2/config_test.go
+++ b/cmd/build/v2/config_test.go
@@ -31,8 +31,9 @@ func (fcr fakeConfigRepo) GetTreeHash(string) (string, error) { return fcr.treeH
 
 func TestGetConfig(t *testing.T) {
 	type input struct {
-		reg  fakeConfigRegistry
-		repo fakeConfigRepo
+		reg                         fakeConfigRegistry
+		repo                        fakeConfigRepo
+		smartBuildFeatureFlagEnable string
 	}
 	tt := []struct {
 		name     string
@@ -58,8 +59,9 @@ func TestGetConfig(t *testing.T) {
 					isClean: true,
 					err:     nil,
 				},
-				fs:       afero.NewOsFs(),
-				isOkteto: true,
+				fs:                  afero.NewOsFs(),
+				isOkteto:            true,
+				isSmartBuildsEnable: true,
 			},
 		},
 		{
@@ -81,8 +83,9 @@ func TestGetConfig(t *testing.T) {
 					isClean: true,
 					err:     nil,
 				},
-				fs:       afero.NewOsFs(),
-				isOkteto: true,
+				fs:                  afero.NewOsFs(),
+				isOkteto:            true,
+				isSmartBuildsEnable: true,
 			},
 		},
 		{
@@ -104,8 +107,9 @@ func TestGetConfig(t *testing.T) {
 					isClean: true,
 					err:     nil,
 				},
-				fs:       afero.NewOsFs(),
-				isOkteto: true,
+				fs:                  afero.NewOsFs(),
+				isOkteto:            true,
+				isSmartBuildsEnable: true,
 			},
 		},
 		{
@@ -127,13 +131,59 @@ func TestGetConfig(t *testing.T) {
 					isClean: false,
 					err:     assert.AnError,
 				},
-				fs:       afero.NewOsFs(),
-				isOkteto: true,
+				fs:                  afero.NewOsFs(),
+				isOkteto:            true,
+				isSmartBuildsEnable: true,
+			},
+		},
+		{
+			name: "no error and feature flag disable",
+			input: input{
+				reg: fakeConfigRegistry{
+					access: true,
+				},
+				repo: fakeConfigRepo{
+					isClean: true,
+				},
+				smartBuildFeatureFlagEnable: "false",
+			},
+			expected: oktetoBuilderConfig{
+				hasGlobalAccess: true,
+				isCleanProject:  true,
+				repository: fakeConfigRepo{
+					isClean: true,
+				},
+				fs:                  afero.NewOsFs(),
+				isOkteto:            true,
+				isSmartBuildsEnable: false,
+			},
+		},
+		{
+			name: "error converting feature flag, defaults true",
+			input: input{
+				reg: fakeConfigRegistry{
+					access: true,
+				},
+				repo: fakeConfigRepo{
+					isClean: true,
+				},
+				smartBuildFeatureFlagEnable: "falses",
+			},
+			expected: oktetoBuilderConfig{
+				hasGlobalAccess: true,
+				isCleanProject:  true,
+				repository: fakeConfigRepo{
+					isClean: true,
+				},
+				fs:                  afero.NewOsFs(),
+				isOkteto:            true,
+				isSmartBuildsEnable: true,
 			},
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(OktetoEnableSmartBuilds, tc.input.smartBuildFeatureFlagEnable)
 			cfg := getConfig(tc.input.reg, tc.input.repo)
 			assert.Equal(t, tc.expected, cfg)
 		})

--- a/cmd/build/v2/config_test.go
+++ b/cmd/build/v2/config_test.go
@@ -31,9 +31,8 @@ func (fcr fakeConfigRepo) GetTreeHash(string) (string, error) { return fcr.treeH
 
 func TestGetConfig(t *testing.T) {
 	type input struct {
-		reg                         fakeConfigRegistry
-		repo                        fakeConfigRepo
-		smartBuildFeatureFlagEnable string
+		reg  fakeConfigRegistry
+		repo fakeConfigRepo
 	}
 	tt := []struct {
 		name     string
@@ -136,55 +135,41 @@ func TestGetConfig(t *testing.T) {
 				isSmartBuildsEnable: true,
 			},
 		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := getConfig(tc.input.reg, tc.input.repo)
+			assert.Equal(t, tc.expected, cfg)
+		})
+	}
+}
+
+func TestGetIsSmartBuildEnabled(t *testing.T) {
+	tt := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
 		{
-			name: "no error and feature flag disable",
-			input: input{
-				reg: fakeConfigRegistry{
-					access: true,
-				},
-				repo: fakeConfigRepo{
-					isClean: true,
-				},
-				smartBuildFeatureFlagEnable: "false",
-			},
-			expected: oktetoBuilderConfig{
-				hasGlobalAccess: true,
-				isCleanProject:  true,
-				repository: fakeConfigRepo{
-					isClean: true,
-				},
-				fs:                  afero.NewOsFs(),
-				isOkteto:            true,
-				isSmartBuildsEnable: false,
-			},
+			name:     "enabled feature flag",
+			input:    "true",
+			expected: true,
 		},
 		{
-			name: "error converting feature flag, defaults true",
-			input: input{
-				reg: fakeConfigRegistry{
-					access: true,
-				},
-				repo: fakeConfigRepo{
-					isClean: true,
-				},
-				smartBuildFeatureFlagEnable: "falses",
-			},
-			expected: oktetoBuilderConfig{
-				hasGlobalAccess: true,
-				isCleanProject:  true,
-				repository: fakeConfigRepo{
-					isClean: true,
-				},
-				fs:                  afero.NewOsFs(),
-				isOkteto:            true,
-				isSmartBuildsEnable: true,
-			},
+			name:     "disabled feature flag",
+			input:    "false",
+			expected: false,
+		},
+		{
+			name:     "wrong feature flag value default true",
+			input:    "falsess",
+			expected: true,
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv(OktetoEnableSmartBuilds, tc.input.smartBuildFeatureFlagEnable)
-			cfg := getConfig(tc.input.reg, tc.input.repo)
+			t.Setenv(OktetoEnableSmartBuilds, tc.input)
+			cfg := getIsSmartBuildEnabled()
 			assert.Equal(t, tc.expected, cfg)
 		})
 	}

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -229,4 +229,4 @@ func (fc fakeConfig) GetGitCommit() string                        { return fc.sh
 func (fc fakeConfig) IsOkteto() bool                              { return fc.isOkteto }
 func (fc fakeConfig) GetAnonymizedRepo() string                   { return fc.repoURL }
 func (fc fakeConfig) GetBuildContextHash(*model.BuildInfo) string { return "" }
-func (fc fakeConfig) IsSmartBuildsEnable() bool                   { return fc.isSmartBuildsEnable }
+func (fc fakeConfig) IsSmartBuildsEnabled() bool                  { return fc.isSmartBuildsEnable }

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -215,11 +215,12 @@ func TestNoServiceBuiltWithSubset(t *testing.T) {
 }
 
 type fakeConfig struct {
-	isClean   bool
-	hasAccess bool
-	sha       string
-	isOkteto  bool
-	repoURL   string
+	isClean             bool
+	hasAccess           bool
+	sha                 string
+	isOkteto            bool
+	repoURL             string
+	isSmartBuildsEnable bool
 }
 
 func (fc fakeConfig) HasGlobalAccess() bool                       { return fc.hasAccess }
@@ -228,3 +229,4 @@ func (fc fakeConfig) GetGitCommit() string                        { return fc.sh
 func (fc fakeConfig) IsOkteto() bool                              { return fc.isOkteto }
 func (fc fakeConfig) GetAnonymizedRepo() string                   { return fc.repoURL }
 func (fc fakeConfig) GetBuildContextHash(*model.BuildInfo) string { return "" }
+func (fc fakeConfig) IsSmartBuildsEnable() bool                   { return fc.isSmartBuildsEnable }

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -69,7 +69,7 @@ func (i imageTagger) getServiceImageReference(manifestName, svcName string, b *m
 	// build the image reference based on context and buildInfo
 	targetRegistry := constants.DevRegistry
 	tag := ""
-	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() {
+	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() && i.cfg.IsSmartBuildsEnable() {
 		targetRegistry = constants.GlobalRegistry
 		tag = buildHash
 	}
@@ -121,7 +121,7 @@ func (i imagerTaggerWithVolumes) getServiceImageReference(manifestName, svcName 
 
 	targetRegistry := constants.DevRegistry
 	tag := ""
-	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() {
+	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() && i.cfg.IsSmartBuildsEnable() {
 		targetRegistry = constants.GlobalRegistry
 		tag = buildHash
 	}

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -69,7 +69,7 @@ func (i imageTagger) getServiceImageReference(manifestName, svcName string, b *m
 	// build the image reference based on context and buildInfo
 	targetRegistry := constants.DevRegistry
 	tag := ""
-	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() && i.cfg.IsSmartBuildsEnable() {
+	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() && i.cfg.IsSmartBuildsEnabled() {
 		targetRegistry = constants.GlobalRegistry
 		tag = buildHash
 	}
@@ -100,7 +100,7 @@ func (imageTagger) getImageReferencesForTag(manifestName, svcToBuildName, tag st
 func (i imageTagger) getImageReferencesForTagWithDefaults(manifestName, svcToBuildName, tag string) []string {
 
 	var imageReferences []string
-	if i.cfg.IsSmartBuildsEnable() {
+	if i.cfg.IsSmartBuildsEnabled() {
 		imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, tag)...)
 	}
 
@@ -126,7 +126,7 @@ func (i imagerTaggerWithVolumes) getServiceImageReference(manifestName, svcName 
 
 	targetRegistry := constants.DevRegistry
 	tag := ""
-	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() && i.cfg.IsSmartBuildsEnable() {
+	if i.cfg.HasGlobalAccess() && i.cfg.IsCleanProject() && i.cfg.IsSmartBuildsEnabled() {
 		targetRegistry = constants.GlobalRegistry
 		tag = buildHash
 	}

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -98,10 +98,15 @@ func (imageTagger) getImageReferencesForTag(manifestName, svcToBuildName, tag st
 
 // getImageReferencesForTagWithDefaults returns all the possible image references for a given service, options include the given tag and the default okteto tag
 func (i imageTagger) getImageReferencesForTagWithDefaults(manifestName, svcToBuildName, tag string) []string {
-	imageReferencesWithTag := i.getImageReferencesForTag(manifestName, svcToBuildName, tag)
-	imageReferencesWithDefault := i.getImageReferencesForTag(manifestName, svcToBuildName, model.OktetoDefaultImageTag)
 
-	return append(imageReferencesWithTag, imageReferencesWithDefault...)
+	var imageReferences []string
+	if i.cfg.IsSmartBuildsEnable() {
+		imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, tag)...)
+	}
+
+	imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, model.OktetoDefaultImageTag)...)
+
+	return imageReferences
 }
 
 // imageTaggerWithVolumes represent an imageTaggerInterface with an reference tag with volume mounts

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -291,9 +291,10 @@ func TestImageTaggerWithVolumesGetPossibleHashImages(t *testing.T) {
 
 func TestImageTaggerGetPossibleTags(t *testing.T) {
 	tt := []struct {
-		name           string
-		sha            string
-		expectedImages []string
+		name                 string
+		sha                  string
+		expectedImages       []string
+		isSmartBuildsEnabled bool
 	}{
 		{
 			name: "no sha",
@@ -302,6 +303,7 @@ func TestImageTaggerGetPossibleTags(t *testing.T) {
 				"okteto.dev/test-test:okteto",
 				"okteto.global/test-test:okteto",
 			},
+			isSmartBuildsEnabled: true,
 		},
 		{
 			name: "sha",
@@ -312,11 +314,21 @@ func TestImageTaggerGetPossibleTags(t *testing.T) {
 				"okteto.dev/test-test:okteto",
 				"okteto.global/test-test:okteto",
 			},
+			isSmartBuildsEnabled: true,
+		},
+		{
+			name: "sha but smart builds not enabled",
+			sha:  "sha",
+			expectedImages: []string{
+				"okteto.dev/test-test:okteto",
+				"okteto.global/test-test:okteto",
+			},
+			isSmartBuildsEnabled: false,
 		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			tagger := newImageTagger(fakeConfig{})
+			tagger := newImageTagger(fakeConfig{isSmartBuildsEnable: tc.isSmartBuildsEnabled})
 			assert.Equal(t, tc.expectedImages, tagger.getImageReferencesForTagWithDefaults("test", "test", tc.sha))
 		})
 	}

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -126,11 +126,26 @@ func Test_ImageTaggerWithoutVolumes_GetServiceImageReference(t *testing.T) {
 			expectedImage: "okteto.dev/test-test:okteto",
 		},
 		{
-			name: "image inferred with clean project and has access to global registry",
+			name: "image inferred with clean project, has access to global registry but no feature flag enabled",
 			cfg: fakeConfig{
-				isClean:   true,
-				hasAccess: true,
-				sha:       "sha",
+				isClean:             true,
+				hasAccess:           true,
+				sha:                 "sha",
+				isSmartBuildsEnable: false,
+			},
+			b: &model.BuildInfo{
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+			},
+			expectedImage: "okteto.dev/test-test:okteto",
+		},
+		{
+			name: "image inferred with clean project, has access to global registry and feature flag enabled",
+			cfg: fakeConfig{
+				isClean:             true,
+				hasAccess:           true,
+				sha:                 "sha",
+				isSmartBuildsEnable: true,
 			},
 			b: &model.BuildInfo{
 				Dockerfile: "Dockerfile",
@@ -182,11 +197,25 @@ func TestImageTaggerWithVolumesTag(t *testing.T) {
 			expectedImage: "okteto.dev/test-test:okteto-with-volume-mounts",
 		},
 		{
-			name: "image inferred with clean project and has access to global registry",
+			name: "image inferred with clean project, has access to global registry but no feature flag enabled",
 			cfg: fakeConfig{
 				isClean:   true,
 				hasAccess: true,
 				sha:       "sha",
+			},
+			b: &model.BuildInfo{
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+			},
+			expectedImage: "okteto.dev/test-test:okteto-with-volume-mounts",
+		},
+		{
+			name: "image inferred with clean project, has access to global registry and feature flag enabled",
+			cfg: fakeConfig{
+				isClean:             true,
+				hasAccess:           true,
+				sha:                 "sha",
+				isSmartBuildsEnable: true,
 			},
 			b: &model.BuildInfo{
 				Dockerfile: "Dockerfile",

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -236,7 +236,7 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface) *cobra.Command {
 				oktetoLog.StartSpinner()
 				defer oktetoLog.StopSpinner()
 
-				deployer, err := c.GetDeployer(ctx, options, nil, nil, k8sClientProvider, NewKubeConfig(), model.GetAvailablePort)
+				deployer, err := c.GetDeployer(ctx, options, c.Builder, c.CfgMapHandler, k8sClientProvider, NewKubeConfig(), model.GetAvailablePort)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
# Proposed changes
- create feature flag to enable smart build usage
- do not use global registry if feature flag is disabled

## How to validate

if feature flag enabled:
- `okteto build` should skip build image if it is already built for that commit

if feature flag is disabled:
- every `okteto build` command should build the image even if the version has already been built

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
