### PR TITLE
RAIN-51 and RAIN-52: Set right certificate in kubernetes client and kubeconfig generated when working with `--insecure-skip-tls-verify`

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -318,7 +318,10 @@ func (c *ContextCommand) initOktetoContext(ctx context.Context, ctxOptions *Cont
 	if cfg == nil {
 		cfg = kubeconfig.Create()
 	}
-	okteto.AddOktetoCredentialsToCfg(cfg, &userContext.Credentials, ctxOptions.Namespace, userContext.User.ID, okteto.Context().Name)
+	if err := okteto.AddOktetoCredentialsToCfg(cfg, &userContext.Credentials, ctxOptions.Namespace, userContext.User.ID, *okteto.Context()); err != nil {
+		return err
+	}
+
 	okteto.Context().Cfg = cfg
 	okteto.Context().IsOkteto = true
 	okteto.Context().IsInsecure = okteto.IsInsecureSkipTLSVerifyPolicy()

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -16,6 +16,8 @@ package context
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
+	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/config"
@@ -97,6 +99,11 @@ func (k *KubeconfigCMD) execute(okCtx *okteto.OktetoContext, kubeconfigPaths []s
 
 func updateCfgClusterCertificate(contextName string, okContext *okteto.OktetoContext) error {
 	if !okContext.IsStoredAsInsecure {
+		return nil
+	}
+
+	subdomain := strings.TrimPrefix(okContext.Registry, "registry.")
+	if okContext.Cfg.Clusters[contextName].Server != fmt.Sprintf("kubernetes.%s", subdomain) {
 		return nil
 	}
 

--- a/cmd/context/update-kubeconfig_test.go
+++ b/cmd/context/update-kubeconfig_test.go
@@ -14,6 +14,7 @@
 package context
 
 import (
+	"encoding/base64"
 	"os"
 	"testing"
 
@@ -355,4 +356,176 @@ func Test_ExecuteUpdateKubeconfig_ForNonOktetoContext(t *testing.T) {
 
 	cfg := kubeconfig.Get(kubeconfigPaths)
 	assert.NotNil(t, cfg.AuthInfos["test-user"].Exec)
+}
+
+func Test_ExecuteUpdateKubeconfig_WithRightCertificate(t *testing.T) {
+	oktetoCert := "okteto-cert"
+	oktetoCertBase64 := base64.StdEncoding.EncodeToString([]byte(oktetoCert))
+	clusterCert := "k8s-cluster-cert"
+	ctxName := "https://test.okteto.dev"
+	k8sContextName := "test_okteto_dev"
+	var tests = []struct {
+		name         string
+		context      *okteto.OktetoContextStore
+		expectedCert string
+	}{
+		{
+			name: "use cluster certificate when insecure and kubernetes api is not exposed behind our ingress controller",
+			context: &okteto.OktetoContextStore{
+				CurrentContext: ctxName,
+				Contexts: map[string]*okteto.OktetoContext{
+					ctxName: {
+						Name:      ctxName,
+						Registry:  "registry.okteto.dev",
+						Namespace: ctxName,
+						Cfg: &api.Config{
+							CurrentContext: k8sContextName,
+							Contexts: map[string]*api.Context{
+								k8sContextName: {
+									Namespace: ctxName,
+								},
+							},
+							Clusters: map[string]*api.Cluster{
+								k8sContextName: {
+									CertificateAuthorityData: []byte(clusterCert),
+									Server:                   "1.2.3.4",
+								},
+							},
+						},
+						Certificate:        oktetoCertBase64,
+						IsStoredAsInsecure: true,
+						IsOkteto:           true,
+					},
+				},
+			},
+			expectedCert: clusterCert,
+		},
+		{
+			name: "use cluster certificate when not insecure and kubernetes api is not exposed behind our ingress controller",
+			context: &okteto.OktetoContextStore{
+				CurrentContext: ctxName,
+				Contexts: map[string]*okteto.OktetoContext{
+					ctxName: {
+						Name:      ctxName,
+						Registry:  "registry.okteto.dev",
+						Namespace: ctxName,
+						Cfg: &api.Config{
+							CurrentContext: k8sContextName,
+							Contexts: map[string]*api.Context{
+								k8sContextName: {
+									Namespace: ctxName,
+								},
+							},
+							Clusters: map[string]*api.Cluster{
+								k8sContextName: {
+									CertificateAuthorityData: []byte(clusterCert),
+									Server:                   "1.2.3.4",
+								},
+							},
+						},
+						Certificate:        oktetoCertBase64,
+						IsStoredAsInsecure: false,
+						IsOkteto:           true,
+					},
+				},
+			},
+			expectedCert: clusterCert,
+		},
+		{
+			name: "use cluster certificate when not insecure and kubernetes api is exposed behind our ingress controller",
+			context: &okteto.OktetoContextStore{
+				CurrentContext: ctxName,
+				Contexts: map[string]*okteto.OktetoContext{
+					ctxName: {
+						Name:      ctxName,
+						Registry:  "registry.okteto.dev",
+						Namespace: ctxName,
+						Cfg: &api.Config{
+							CurrentContext: k8sContextName,
+							Contexts: map[string]*api.Context{
+								k8sContextName: {
+									Namespace: ctxName,
+								},
+							},
+							Clusters: map[string]*api.Cluster{
+								k8sContextName: {
+									CertificateAuthorityData: []byte(clusterCert),
+									Server:                   "kubernetes.okteto.dev",
+								},
+							},
+						},
+						Certificate:        oktetoCertBase64,
+						IsStoredAsInsecure: false,
+						IsOkteto:           true,
+					},
+				},
+			},
+			expectedCert: clusterCert,
+		},
+		{
+			name: "use okteto certificate when insecure and kubernetes api exposed behind our ingress controller",
+			context: &okteto.OktetoContextStore{
+				CurrentContext: ctxName,
+				Contexts: map[string]*okteto.OktetoContext{
+					ctxName: {
+						Name:      ctxName,
+						Registry:  "registry.okteto.dev",
+						Namespace: ctxName,
+						Cfg: &api.Config{
+							CurrentContext: k8sContextName,
+							Contexts: map[string]*api.Context{
+								k8sContextName: {
+									Namespace: ctxName,
+								},
+							},
+							Clusters: map[string]*api.Cluster{
+								k8sContextName: {
+									CertificateAuthorityData: []byte(clusterCert),
+									Server:                   "kubernetes.okteto.dev",
+								},
+							},
+						},
+						Certificate:        oktetoCertBase64,
+						IsStoredAsInsecure: true,
+						IsOkteto:           true,
+					},
+				},
+			},
+			expectedCert: oktetoCert,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			okClientProvider := client.NewFakeOktetoClientProvider(
+				&client.FakeOktetoClient{
+					KubetokenClient: client.NewFakeKubetokenClient(
+						client.FakeKubetokenResponse{},
+					),
+				},
+			)
+
+			okteto.CurrentStore = tt.context
+			kubeconfigFields := test.KubeconfigFields{
+				ClusterCert: clusterCert,
+			}
+			file, err := test.CreateKubeconfig(kubeconfigFields)
+			if err != nil {
+				assert.NoError(t, err, "error creating temporary kubeconfig")
+			}
+			defer os.Remove(file)
+
+			okContext := okteto.Context()
+			kubeconfigPaths := []string{file}
+
+			err = newKubeconfigController(okClientProvider).execute(okContext, kubeconfigPaths)
+			assert.NoError(t, err, "error writing kubeconfig")
+
+			cfg := kubeconfig.Get(kubeconfigPaths)
+			require.NotNil(t, cfg, "kubeconfig is nil")
+			require.Equal(t, tt.expectedCert, string(cfg.Clusters[k8sContextName].CertificateAuthorityData), "certificate in kubeconfig is not correct")
+
+		})
+	}
 }

--- a/internal/test/utils.go
+++ b/internal/test/utils.go
@@ -25,6 +25,7 @@ type KubeconfigFields struct {
 	Name           []string
 	Namespace      []string
 	CurrentContext string
+	ClusterCert    string
 }
 
 func CreateKubeconfig(kubeconfigFields KubeconfigFields) (string, error) {
@@ -42,6 +43,11 @@ func CreateKubeconfig(kubeconfigFields KubeconfigFields) (string, error) {
 	cfg := &clientcmdapi.Config{
 		Contexts:       contexts,
 		CurrentContext: kubeconfigFields.CurrentContext,
+		Clusters: map[string]*clientcmdapi.Cluster{
+			kubeconfigFields.CurrentContext: {
+				CertificateAuthorityData: []byte(kubeconfigFields.ClusterCert),
+			},
+		},
 	}
 	if err := kubeconfig.Write(cfg, dir.Name()); err != nil {
 		return "", err

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -350,21 +350,35 @@ func (*ContextConfigWriter) Write() error {
 }
 
 // AddOktetoCredentialsToCfg populates the provided kubernetes config using the provided credentials obtained from the Okteto API
-func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential, namespace, userName, oktetoURL string) {
+func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential, namespace, userName string, oktetoContext OktetoContext) error {
 	// If the context is being initialized within the execution of `okteto deploy` deploy command it should not
 	// write the Okteto credentials into the kubeconfig. It would overwrite the proxy settings
 	if os.Getenv(constants.OktetoSkipConfigCredentialsUpdate) == "true" {
-		return
+		return nil
 	}
 
-	clusterName := UrlToKubernetesContext(oktetoURL)
+	clusterName := UrlToKubernetesContext(oktetoContext.Name)
 	// create cluster
 	cluster, ok := cfg.Clusters[clusterName]
 	if !ok {
 		cluster = clientcmdapi.NewCluster()
 	}
 
-	cluster.CertificateAuthorityData = []byte(cred.Certificate)
+	// If the certificat included in the credentials is empty, it means that the server is kubernetes.subdomain.
+	// In that case, if the okteto context is insecure, we need to specify the certificate we have in our context.
+	// If it is not insecure it means that is a public CA or a private one already installed in the machine
+	cert := cred.Certificate
+	if cred.Certificate == "" && oktetoContext.IsStoredAsInsecure {
+		certPEM, err := base64.StdEncoding.DecodeString(oktetoContext.Certificate)
+		if err != nil {
+			oktetoLog.Debugf("couldn't decode context certificate from base64: %s", err)
+			return fmt.Errorf("failed to decode context certificate: %w", err)
+		}
+
+		cert = string(certPEM)
+	}
+
+	cluster.CertificateAuthorityData = []byte(cert)
 	cluster.Server = cred.Server
 	cfg.Clusters[clusterName] = cluster
 
@@ -391,6 +405,8 @@ func AddOktetoCredentialsToCfg(cfg *clientcmdapi.Config, cred *types.Credential,
 	cfg.Contexts[clusterName] = context
 
 	cfg.CurrentContext = clusterName
+
+	return nil
 }
 
 func GetK8sClient() (*kubernetes.Clientset, *rest.Config, error) {


### PR DESCRIPTION
# Proposed changes

Fixes RAIN-51 and RAIN-52

This PR fixes 2 different bugs related with the same. The certificate to be used in kubernetes client when the Okteto context is being configured with `--insecure-skip-tls-verify` flag.

Issue RAIN-51: When the context was using `--insecure-skip-tls-verify` and the Okteto instance has defined `cluster.endpoint` property (kubernetes is **not** exposed behind our ingress controller), we were using the wrong certificate in the generated Kubeconfig. We were always using the one stored in the context, but we should use it the context is insecure AND the kubernetes API is exposed behind Okteto's ingress controller

Issue RAIN-52: When the context was using `--insecure-skip-tls-verify` AND the Kubernetes API is exposed behind our ingress controller (helm chart property `cluster.endpoint` is not defined) we were not using the right certificate in the internal Kubernetes client. In this case, we should be using the one in the Okteto context instead of using the one retrieved from the server.

## How to validate

Issue RAIN-51. Steps to reproduce the error:

1. Have an Okteto instance using self-signed certificate and defining `cluster.endpoint` pointing to the Kubernetes API
2. Execute `okteto ctx use <instance-url> --insecure-skip-tls-verify`
3. Execute `okteto kubeconfig`
4. Try to execute `kubectl get pods`. You should get a certificate error

With my current changes, you won't get any error and you should be able to execute any kubernetes command

Issue RAIN-52. Steps to reproduce the error:

1. Have an Okteto installation using self-signed certificates and leave empty the helm setting `cluster.endpoint`
2. Execute `okteto ctx use <instance-url> --insecure-skip-tls-verify`
3. Execute some command like `okteto up` or `okteto deploy`. You should get an error

With my current changes, you won't get any error and the commands should be executed successfully

Apart from that, we should verify the rest of cases keep working fine

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
