### PR TITLE
add quotes for variables added in remote

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -274,6 +274,11 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 			Funcs(template.FuncMap{"join": strings.Join}).
 			Parse(dockerfileTemplate))
 
+	deployFlags, err := getDeployFlags(opts)
+	if err != nil {
+		return "", err
+	}
+
 	dockerfileSyntax := dockerfileTemplateProperties{
 		OktetoCLIImage:         getOktetoCLIVersion(config.VersionString),
 		UserDeployImage:        opts.Manifest.Deploy.Image,
@@ -288,7 +293,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		GitCommitArgName:       constants.OktetoGitCommitEnvVar,
 		GitBranchArgName:       constants.OktetoGitBranchEnvVar,
 		InvalidateCacheArgName: constants.OktetoInvalidateCacheEnvVar,
-		DeployFlags:            strings.Join(getDeployFlags(opts), " "),
+		DeployFlags:            strings.Join(deployFlags, " "),
 	}
 
 	dockerfile, err := rd.fs.Create(filepath.Join(tmpDir, dockerfileTemporalName))
@@ -311,7 +316,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 	return dockerfile.Name(), nil
 }
 
-func getDeployFlags(opts *Options) []string {
+func getDeployFlags(opts *Options) ([]string, error) {
 	var deployFlags []string
 
 	if opts.Name != "" {
@@ -328,8 +333,12 @@ func getDeployFlags(opts *Options) []string {
 
 	if len(opts.Variables) > 0 {
 		var varsToAddForDeploy []string
-		for _, v := range opts.Variables {
-			varsToAddForDeploy = append(varsToAddForDeploy, fmt.Sprintf("--var %s", v))
+		variables, err := parse(opts.Variables)
+		if err != nil {
+			return nil, err
+		}
+		for _, v := range variables {
+			varsToAddForDeploy = append(varsToAddForDeploy, fmt.Sprintf("--var %s=\"%s\"", v.key, v.value))
 		}
 		deployFlags = append(deployFlags, strings.Join(varsToAddForDeploy, " "))
 	}
@@ -340,7 +349,7 @@ func getDeployFlags(opts *Options) []string {
 
 	deployFlags = append(deployFlags, fmt.Sprintf("--timeout %s", opts.Timeout))
 
-	return deployFlags
+	return deployFlags, nil
 }
 
 // getOriginalCWD returns the original cwd


### PR DESCRIPTION
# Proposed changes
- add quotes for variables added in remote
- add tests

## How to validate

1. clone okteto/movies
2. consume variable TEST in deploy seccion
3. run `okteto deploy --remote --var TEST="a multi worked value"`
4. check variable in consumed

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
