### PR TITLE
 [Backport release-2.22] Extract dev `secrets` and `envFiles`  validation from serializer (#4043)

### DIFF
--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -214,6 +214,7 @@ dependencies:
 				assert.NotNil(t, err)
 			} else {
 				m.Manifest = nil
+				tt.expectedManifest.ManifestPath = filename
 				assert.EqualValues(t, tt.expectedManifest, m)
 			}
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -315,6 +315,10 @@ func Up(at analyticsTrackerInterface) *cobra.Command {
 				dev.Command.Values = upOptions.commandToExecute
 			}
 
+			if err := dev.PreparePathsAndExpandEnvFiles(oktetoManifest.ManifestPath); err != nil {
+				return fmt.Errorf("error in 'dev' section of your manifest: %w", err)
+			}
+
 			up.Dev = dev
 			if forceAutocreate {
 				// update autocreate property if needed to be forced

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -357,6 +357,9 @@ func (s *FakeOktetoSelector) AskForOptionsOkteto(_ []SelectorItem, _ int) (strin
 }
 
 func Test_SelectDevFromManifest(t *testing.T) {
+	localAbsPath, err := filepath.Abs("/")
+	assert.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		manifest *model.Manifest
@@ -384,6 +387,7 @@ func Test_SelectDevFromManifest(t *testing.T) {
 					},
 					"test-2": &model.Dev{},
 				},
+				ManifestPath: filepath.Join(localAbsPath, "okteto.yml"),
 			},
 			selector: &FakeOktetoSelector{
 				dev: "test",
@@ -434,7 +438,6 @@ func Test_SelectDevFromManifest(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_AskYesNo(t *testing.T) {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -370,15 +370,9 @@ func Get(devPath string) (*Manifest, error) {
 			return nil, err
 		}
 
-		if err := dev.loadAbsPaths(devPath); err != nil {
+		if err := dev.PreparePathsAndExpandEnvFiles(devPath); err != nil {
 			return nil, err
 		}
-
-		if err := dev.expandEnvFiles(); err != nil {
-			return nil, err
-		}
-
-		dev.computeParentSyncFolder()
 	}
 
 	return manifest, nil
@@ -406,19 +400,25 @@ func NewDev() *Dev {
 	}
 }
 
+// loadAbsPaths makes every path used in the dev struct an absolute paths
 func (dev *Dev) loadAbsPaths(devPath string) error {
 	devDir, err := filepath.Abs(filepath.Dir(devPath))
 	if err != nil {
 		return err
 	}
 
-	if uri, err := url.ParseRequestURI(dev.Image.Context); err != nil || (uri != nil && (uri.Scheme == "" || uri.Host == "")) {
-		dev.Image.Context = loadAbsPath(devDir, dev.Image.Context)
-		dev.Image.Dockerfile = loadAbsPath(devDir, dev.Image.Dockerfile)
+	if dev.Image != nil {
+		if uri, err := url.ParseRequestURI(dev.Image.Context); err != nil || (uri != nil && (uri.Scheme == "" || uri.Host == "")) {
+			dev.Image.Context = loadAbsPath(devDir, dev.Image.Context)
+			dev.Image.Dockerfile = loadAbsPath(devDir, dev.Image.Dockerfile)
+		}
 	}
-	if uri, err := url.ParseRequestURI(dev.Push.Context); err != nil || (uri != nil && (uri.Scheme == "" || uri.Host == "")) {
-		dev.Push.Context = loadAbsPath(devDir, dev.Push.Context)
-		dev.Push.Dockerfile = loadAbsPath(devDir, dev.Push.Dockerfile)
+
+	if dev.Push != nil {
+		if uri, err := url.ParseRequestURI(dev.Push.Context); err != nil || (uri != nil && (uri.Scheme == "" || uri.Host == "")) {
+			dev.Push.Context = loadAbsPath(devDir, dev.Push.Context)
+			dev.Push.Dockerfile = loadAbsPath(devDir, dev.Push.Dockerfile)
+		}
 	}
 
 	dev.loadVolumeAbsPaths(devDir)
@@ -699,6 +699,7 @@ func (dev *Dev) setTimeout() error {
 	return nil
 }
 
+// expandEnvFiles reads each env file and append all the variables to the environment
 func (dev *Dev) expandEnvFiles() error {
 	for _, envFile := range dev.EnvFiles {
 		filename, err := ExpandEnv(envFile, true)
@@ -809,6 +810,21 @@ func (dev *Dev) Validate() error {
 	return nil
 }
 
+// PreparePathsAndExpandEnvFiles calls other methods required to have the dev ready to use
+func (dev *Dev) PreparePathsAndExpandEnvFiles(manifestPath string) error {
+	if err := dev.loadAbsPaths(manifestPath); err != nil {
+		return err
+	}
+
+	if err := dev.expandEnvFiles(); err != nil {
+		return err
+	}
+
+	dev.computeParentSyncFolder()
+
+	return nil
+}
+
 func (dev *Dev) validateSync() error {
 	for _, folder := range dev.Sync.Folders {
 		validPath, err := os.Stat(folder.LocalPath)
@@ -852,6 +868,10 @@ func validatePullPolicy(pullPolicy apiv1.PullPolicy) error {
 func validateSecrets(secrets []Secret) error {
 	seen := map[string]bool{}
 	for _, s := range secrets {
+		if err := s.validate(); err != nil {
+			return err
+		}
+
 		if _, ok := seen[s.GetFileName()]; ok {
 			return fmt.Errorf("Secrets with the same basename '%s' are not supported", s.GetFileName())
 		}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1487,7 +1487,6 @@ func createEnvFile(content map[string]string) (string, error) {
 }
 
 func Test_expandEnvFiles(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		dev      *Dev
@@ -1817,6 +1816,48 @@ func TestExpandBuildArgs(t *testing.T) {
 			assert.NoError(t, tt.buildInfo.AddBuildArgs(tt.previousImageBuilt))
 
 			assert.Equal(t, tt.expected, tt.buildInfo)
+		})
+	}
+}
+
+func TestPrepare(t *testing.T) {
+	type input struct {
+		manifestPath string
+	}
+	tests := []struct {
+		name          string
+		dev           *Dev
+		input         input
+		expectedError bool
+	}{
+		{
+			name: "success",
+			dev:  &Dev{},
+			input: input{
+				manifestPath: "okteto.yml",
+			},
+			expectedError: false,
+		},
+		{
+			name: "with missing envFiles",
+			dev: &Dev{
+				EnvFiles: EnvFiles{".notfound"},
+			},
+			input: input{
+				manifestPath: "okteto.yml",
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dev.PreparePathsAndExpandEnvFiles(tt.input.manifestPath)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -97,6 +97,7 @@ type Manifest struct {
 	Namespace     string                                   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Context       string                                   `json:"context,omitempty" yaml:"context,omitempty"`
 	Icon          string                                   `json:"icon,omitempty" yaml:"icon,omitempty"`
+	ManifestPath  string                                   `json:"-" yaml:"-"`
 	Deploy        *DeployInfo                              `json:"deploy,omitempty" yaml:"deploy,omitempty"`
 	Dev           ManifestDevs                             `json:"dev,omitempty" yaml:"dev,omitempty"`
 	Destroy       *DestroyInfo                             `json:"destroy,omitempty" yaml:"destroy,omitempty"`
@@ -645,18 +646,7 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 		}
 	}
 
-	for _, dev := range manifest.Dev {
-
-		if err := dev.loadAbsPaths(devPath); err != nil {
-			return nil, err
-		}
-
-		if err := dev.expandEnvFiles(); err != nil {
-			return nil, err
-		}
-
-		dev.computeParentSyncFolder()
-	}
+	manifest.ManifestPath = devPath
 
 	return manifest, nil
 }
@@ -719,6 +709,33 @@ func (b *ManifestBuild) validate() error {
 		return fmt.Errorf("manifest validation failed: cyclic dependendecy found between %s", svcsDependents)
 	}
 	return nil
+}
+
+func (s *Secret) validate() error {
+	if s.LocalPath == "" || s.RemotePath == "" {
+		return fmt.Errorf("secrets must follow the syntax 'LOCAL_PATH:REMOTE_PATH:MODE'")
+	}
+
+	if err := checkFileAndNotDirectory(s.LocalPath, afero.NewOsFs()); err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(s.RemotePath, "/") {
+		return fmt.Errorf("secret remote path '%s' must be an absolute path", s.RemotePath)
+	}
+
+	return nil
+}
+
+func checkFileAndNotDirectory(path string, fs afero.Fs) error {
+	fileInfo, err := fs.Stat(path)
+	if err != nil {
+		return fmt.Errorf("file '%s' not found. Please make sure the file exists", path)
+	}
+	if fileInfo.Mode().IsRegular() {
+		return nil
+	}
+	return fmt.Errorf("secret '%s' is not a regular file", path)
 }
 
 // GetSvcsToBuildFromList returns the builds from a list and all its

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/spf13/afero"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1455,4 +1456,75 @@ func Test_getInferredManifestWhenNoManifestExist(t *testing.T) {
 	result, err := GetInferredManifest(wd)
 	assert.Empty(t, result)
 	assert.ErrorIs(t, err, oktetoErrors.ErrCouldNotInferAnyManifest)
+}
+
+func TestSecretValidate(t *testing.T) {
+	file, err := os.CreateTemp("", "okteto-secret-test-validate")
+	assert.NoError(t, err)
+	defer os.Remove(file.Name())
+
+	tmpDir := t.TempDir()
+	defer os.Remove(tmpDir)
+
+	var tests = []struct {
+		s           *Secret
+		expectedErr error
+		name        string
+	}{
+		{
+			name:        "missing local path",
+			s:           &Secret{LocalPath: "", RemotePath: "test"},
+			expectedErr: fmt.Errorf("secrets must follow the syntax 'LOCAL_PATH:REMOTE_PATH:MODE'"),
+		},
+		{
+			name:        "missing remote path",
+			s:           &Secret{LocalPath: "test", RemotePath: ""},
+			expectedErr: fmt.Errorf("secrets must follow the syntax 'LOCAL_PATH:REMOTE_PATH:MODE'"),
+		},
+		{
+			name:        "missing both",
+			s:           &Secret{LocalPath: "", RemotePath: ""},
+			expectedErr: fmt.Errorf("secrets must follow the syntax 'LOCAL_PATH:REMOTE_PATH:MODE'"),
+		},
+		{
+			name:        "local path must be file not directory",
+			s:           &Secret{LocalPath: tmpDir, RemotePath: "./remote"},
+			expectedErr: fmt.Errorf("secret '%s' is not a regular file", tmpDir),
+		},
+		{
+			name:        "remote path must use absolute paths",
+			s:           &Secret{LocalPath: file.Name(), RemotePath: "./remote"},
+			expectedErr: fmt.Errorf("secret remote path './remote' must be an absolute path"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.s.validate()
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestCheckFileAndNotDirectory(t *testing.T) {
+	mockFs := afero.NewMemMapFs()
+
+	t.Run("file does not exist", func(t *testing.T) {
+		err := checkFileAndNotDirectory("/tmp/not-exist", mockFs)
+		assert.Equal(t, fmt.Errorf("file '/tmp/not-exist' not found. Please make sure the file exists"), err)
+	})
+
+	t.Run("path is directory", func(t *testing.T) {
+		err := mockFs.Mkdir("/some/dir", 0755)
+		assert.NoError(t, err)
+		err = checkFileAndNotDirectory("/some/dir", mockFs)
+		assert.Equal(t, fmt.Errorf("secret '/some/dir' is not a regular file"), err)
+	})
+
+	t.Run("file exists", func(t *testing.T) {
+		err := afero.WriteFile(mockFs, "/tmp/exists", []byte(""), 0644)
+		assert.NoError(t, err)
+		err = checkFileAndNotDirectory("/tmp/exists", mockFs)
+		assert.NoError(t, err)
+	})
 }

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -457,17 +457,15 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
+	// if the secret is not formatted correctly we return an empty secret (i.e. empty LocalPath and RemotePath)
+	// and we rely on the secret validation to return the appropriate error to the user
 	if len(parts) < 2 || len(parts) > 3 {
-		return fmt.Errorf("secrets must follow the syntax 'LOCAL_PATH:REMOTE_PATH:MODE'")
+		return nil
 	}
+
 	s.LocalPath = parts[0]
-	if err := checkFileAndNotDirectory(s.LocalPath); err != nil {
-		return err
-	}
 	s.RemotePath = parts[1]
-	if !strings.HasPrefix(s.RemotePath, "/") {
-		return fmt.Errorf("Secret remote path '%s' must be an absolute path", s.RemotePath)
-	}
+
 	if len(parts) == 3 {
 		mode, err := strconv.ParseInt(parts[2], 8, 32)
 		if err != nil {
@@ -477,6 +475,7 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	} else {
 		s.Mode = 420
 	}
+
 	return nil
 }
 
@@ -718,17 +717,6 @@ func (l Lifecycle) MarshalYAML() (interface{}, error) {
 		return true, nil
 	}
 	return lifecycleRaw(l), nil
-}
-
-func checkFileAndNotDirectory(path string) error {
-	fileInfo, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("File '%s' not found. Please make sure the file exists", path)
-	}
-	if fileInfo.Mode().IsRegular() {
-		return nil
-	}
-	return fmt.Errorf("Secret '%s' is not a regular file", path)
 }
 
 type hybridModeInfo struct {

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -395,58 +395,58 @@ func TestSecretMarshalling(t *testing.T) {
 	t.Setenv("TEST_HOME", file.Name())
 
 	tests := []struct {
+		expected      *Secret
 		name          string
 		data          string
-		expected      *Secret
 		expectedError bool
 	}{
 		{
-			"local:remote",
-			fmt.Sprintf("%s:/remote", file.Name()),
-			&Secret{LocalPath: file.Name(), RemotePath: "/remote", Mode: 420},
-			false,
+			name:          "local:remote",
+			data:          fmt.Sprintf("%s:/remote", file.Name()),
+			expected:      &Secret{LocalPath: file.Name(), RemotePath: "/remote", Mode: 420},
+			expectedError: false,
 		},
 		{
-			"local:remote:mode",
-			fmt.Sprintf("%s:/remote:400", file.Name()),
-			&Secret{LocalPath: file.Name(), RemotePath: "/remote", Mode: 256},
-			false,
+			name:          "local:remote:mode",
+			data:          fmt.Sprintf("%s:/remote:400", file.Name()),
+			expected:      &Secret{LocalPath: file.Name(), RemotePath: "/remote", Mode: 256},
+			expectedError: false,
 		},
 		{
-			"variables",
-			"$TEST_HOME:/remote",
-			&Secret{LocalPath: file.Name(), RemotePath: "/remote", Mode: 420},
-			false,
+			name:          "variables",
+			data:          "$TEST_HOME:/remote",
+			expected:      &Secret{LocalPath: file.Name(), RemotePath: "/remote", Mode: 420},
+			expectedError: false,
 		},
 		{
-			"too-short",
-			"local",
-			nil,
-			true,
+			name:          "too-short",
+			data:          "local",
+			expected:      &Secret{LocalPath: "", RemotePath: "", Mode: 0},
+			expectedError: false,
 		},
 		{
-			"too-long",
-			"local:remote:mode:other",
-			nil,
-			true,
+			name:          "too-long",
+			data:          "local:remote:mode:other",
+			expected:      &Secret{LocalPath: "", RemotePath: "", Mode: 0},
+			expectedError: false,
 		},
 		{
-			"wrong-local",
-			"/local:/remote:400",
-			nil,
-			true,
+			name:          "wrong-local",
+			data:          "/local:/remote:400",
+			expected:      &Secret{LocalPath: "/local", RemotePath: "/remote", Mode: 256},
+			expectedError: false,
 		},
 		{
-			"wrong-remote",
-			fmt.Sprintf("%s:remote", file.Name()),
-			nil,
-			true,
+			name:          "wrong-remote",
+			data:          fmt.Sprintf("%s:remote", file.Name()),
+			expected:      &Secret{LocalPath: file.Name(), RemotePath: "remote", Mode: 420},
+			expectedError: false,
 		},
 		{
-			"wrong-mode",
-			fmt.Sprintf("%s:/remote:aaa", file.Name()),
-			nil,
-			true,
+			name:          "wrong-mode",
+			data:          fmt.Sprintf("%s:/remote:aaa", file.Name()),
+			expected:      nil,
+			expectedError: true,
 		},
 	}
 

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -15,7 +15,6 @@ package model
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -390,9 +389,7 @@ func TestLifecycleMarshalling(t *testing.T) {
 
 func TestSecretMarshalling(t *testing.T) {
 	file, err := os.CreateTemp("", "okteto-secret-test")
-	if err != nil {
-		log.Fatal(err)
-	}
+	assert.NoError(t, err)
 	defer os.Remove(file.Name())
 
 	t.Setenv("TEST_HOME", file.Name())

--- a/pkg/model/volumes.go
+++ b/pkg/model/volumes.go
@@ -97,6 +97,7 @@ func (dev *Dev) IsSubPathFolder(path string) (bool, error) {
 	return false, oktetoErrors.ErrNotFound
 }
 
+// computeParentSyncFolder calculates the parent sync folder
 func (dev *Dev) computeParentSyncFolder() {
 	pathSplits := map[int]string{}
 	maxIndex := -1


### PR DESCRIPTION
Backport 3c59ad31774db7ccc3b15947c9886178da5858fc from #4043