### PR TITLE
fix: use okteto api to retrieve dev env endpoints

### DIFF
--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -923,10 +923,19 @@ func (f *fakeExternalControlProvider) getFakeExternalControl(_ *rest.Config) Ext
 	return f.control
 }
 
+type fakeEndpointControl struct {
+	endpoints []string
+	err       error
+}
+
+func (f *fakeEndpointControl) List(_ context.Context, _ string, _ string) ([]string, error) {
+	return f.endpoints, f.err
+}
+
 func getFakeEndpoint() (EndpointGetter, error) {
 	return EndpointGetter{
 		K8sClientProvider: test.NewFakeK8sProvider(),
-		endpointControl:   &fakeExternalControl{},
+		endpointControl:   &fakeEndpointControl{},
 	}, nil
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -928,15 +928,13 @@ type fakeEndpointControl struct {
 	err       error
 }
 
-func (f *fakeEndpointControl) List(_ context.Context, _ string, _ string) ([]string, error) {
+func (f *fakeEndpointControl) List(_ context.Context, _ *EndpointsOptions, _ string) ([]string, error) {
 	return f.endpoints, f.err
 }
 
 func getFakeEndpoint() (EndpointGetter, error) {
 	return EndpointGetter{
-		K8sClientProvider:            test.NewFakeK8sProvider(),
-		endpointControl:              &fakeEndpointControl{},
-		getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
+		endpointControl: &fakeEndpointControl{},
 	}, nil
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -934,8 +934,9 @@ func (f *fakeEndpointControl) List(_ context.Context, _ string, _ string) ([]str
 
 func getFakeEndpoint() (EndpointGetter, error) {
 	return EndpointGetter{
-		K8sClientProvider: test.NewFakeK8sProvider(),
-		endpointControl:   &fakeEndpointControl{},
+		K8sClientProvider:            test.NewFakeK8sProvider(),
+		endpointControl:              &fakeEndpointControl{},
+		getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
 	}, nil
 }
 

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -67,10 +67,7 @@ func NewEndpointGetter() (EndpointGetter, error) {
 		if err != nil {
 			return EndpointGetter{}, err
 		}
-		endpointControl, err = NewEndpointGetterWithOktetoAPI(c)
-		if err != nil {
-			return EndpointGetter{}, err
-		}
+		endpointControl = NewEndpointGetterWithOktetoAPI(c)
 	} else {
 		endpointControl = NewEndpointGetterInStandaloneMode()
 	}
@@ -206,12 +203,10 @@ type endpointGetterWithOktetoAPI struct {
 	endpointControl endpointGetterInterface
 }
 
-func NewEndpointGetterWithOktetoAPI(c *okteto.OktetoClient) (*endpointGetterWithOktetoAPI, error) {
-	ec := endpoints.NewEndpointControl(c)
-
+func NewEndpointGetterWithOktetoAPI(c *okteto.OktetoClient) *endpointGetterWithOktetoAPI {
 	return &endpointGetterWithOktetoAPI{
-		endpointControl: ec,
-	}, nil
+		endpointControl: endpoints.NewEndpointControl(c),
+	}
 }
 
 func (eg *endpointGetterWithOktetoAPI) List(ctx context.Context, opts *EndpointsOptions, devName string) ([]string, error) {

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -62,9 +62,12 @@ type EndpointGetter struct {
 
 func NewEndpointGetter() (EndpointGetter, error) {
 	var endpointControl endpointControlInterface
-	var err error
 	if okteto.Context().IsOkteto {
-		endpointControl, err = NewEndpointGetterWithOktetoAPI()
+		c, err := okteto.NewOktetoClient()
+		if err != nil {
+			return EndpointGetter{}, err
+		}
+		endpointControl, err = NewEndpointGetterWithOktetoAPI(c)
 		if err != nil {
 			return EndpointGetter{}, err
 		}
@@ -203,8 +206,8 @@ type endpointGetterWithOktetoAPI struct {
 	endpointControl endpointGetterInterface
 }
 
-func NewEndpointGetterWithOktetoAPI() (*endpointGetterWithOktetoAPI, error) {
-	ec, err := endpoints.NewEndpointControl()
+func NewEndpointGetterWithOktetoAPI(c *okteto.OktetoClient) (*endpointGetterWithOktetoAPI, error) {
+	ec, err := endpoints.NewEndpointControl(c)
 	if err != nil {
 		return nil, fmt.Errorf("error getting okteto client: %w", err)
 	}

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -207,10 +207,7 @@ type endpointGetterWithOktetoAPI struct {
 }
 
 func NewEndpointGetterWithOktetoAPI(c *okteto.OktetoClient) (*endpointGetterWithOktetoAPI, error) {
-	ec, err := endpoints.NewEndpointControl(c)
-	if err != nil {
-		return nil, fmt.Errorf("error getting okteto client: %w", err)
-	}
+	ec := endpoints.NewEndpointControl(c)
 
 	return &endpointGetterWithOktetoAPI{
 		endpointControl: ec,

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -199,12 +199,8 @@ func (eg *EndpointGetter) getEndpoints(ctx context.Context, opts *EndpointsOptio
 	var eps []string
 	var err error
 	if okteto.Context().IsOkteto {
-		eps, err = eg.endpointControl.List(ctx, opts.Namespace, labelSelector)
+		eps, err = eg.endpointControl.List(ctx, opts.Namespace, sanitizedName)
 		if err != nil {
-			if !strings.Contains(err.Error(), "Cannot query field \"endpoints\"") {
-				return nil, err
-			}
-
 			eps, err = eg.getEndpointsInStandaloneMode(ctx, opts, labelSelector, eg.K8sClientProvider)
 			if err != nil {
 				return nil, err

--- a/cmd/deploy/endpoints_test.go
+++ b/cmd/deploy/endpoints_test.go
@@ -2,8 +2,10 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/k8s/ingresses"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +13,10 @@ import (
 )
 
 func (*fakeK8sProvider) GetIngressClient() (*ingresses.Client, error) {
+	return nil, nil
+}
+
+func getFakeEndpointsInStandaloneMode(ctx context.Context, opts *EndpointsOptions, labelSelector string, k8sProvider k8sIngressClientProvider) ([]string, error) {
 	return nil, nil
 }
 
@@ -47,6 +53,48 @@ func TestGetEndpoints(t *testing.T) {
 			},
 			isOkteto:    true,
 			expectedErr: true,
+		},
+		{
+			name: "Error when retrieving ordered endpoints using okteto API. API endpoint not found",
+			endpointGetter: &EndpointGetter{
+				endpointControl: &fakeEndpointControl{
+					err: errors.New("Cannot query field \"endpoints\""),
+				},
+				externalResourceControl: &fakeExternalControl{
+					externals: []externalresource.ExternalResource{
+						{
+							Endpoints: []*externalresource.ExternalEndpoint{
+								{
+									Name: "test1",
+									Url:  "https://this.is.a.test.okteto",
+								},
+								{
+									Name: "test",
+									Url:  "https://this.is.a.test.ok",
+								},
+							},
+						},
+					},
+				},
+				getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
+				K8sClientProvider:            &fakeK8sProvider{},
+			},
+			isOkteto: true,
+			expected: []string{
+				"https://this.is.a.test.ok (external)",
+				"https://this.is.a.test.okteto (external)",
+			},
+		},
+		{
+			name: "Retrieving ordered endpoints without okteto API",
+			endpointGetter: &EndpointGetter{
+				endpointControl: &fakeEndpointControl{
+					err: errors.New("Cannot query field \"endpoints\""),
+				},
+				getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
+				K8sClientProvider:            &fakeK8sProvider{},
+			},
+			isOkteto: false,
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/deploy/endpoints_test.go
+++ b/cmd/deploy/endpoints_test.go
@@ -1,0 +1,72 @@
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/k8s/ingresses"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func (*fakeK8sProvider) GetIngressClient() (*ingresses.Client, error) {
+	return nil, nil
+}
+
+func TestGetEndpoints(t *testing.T) {
+	testCases := []struct {
+		name           string
+		isOkteto       bool
+		expectedErr    bool
+		endpointGetter *EndpointGetter
+		expected       []string
+	}{
+		{
+			name: "Get endpoints sorted using okteto API",
+			endpointGetter: &EndpointGetter{
+				endpointControl: &fakeEndpointControl{
+					endpoints: []string{
+						"https://this.is.a.test.okteto",
+						"https://this.is.a.test.ok",
+					},
+				},
+			},
+			isOkteto: true,
+			expected: []string{
+				"https://this.is.a.test.ok",
+				"https://this.is.a.test.okteto",
+			},
+		},
+		{
+			name: "Error when retrieving ordered endpoints using okteto API",
+			endpointGetter: &EndpointGetter{
+				endpointControl: &fakeEndpointControl{
+					err: assert.AnError,
+				},
+			},
+			isOkteto:    true,
+			expectedErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			okteto.CurrentStore = &okteto.OktetoContextStore{
+				Contexts: map[string]*okteto.OktetoContext{
+					"test": {
+						Namespace: "test",
+						IsOkteto:  tc.isOkteto,
+					},
+				},
+				CurrentContext: "test",
+			}
+
+			endpoints, err := tc.endpointGetter.getEndpoints(context.Background(), &EndpointsOptions{})
+			require.Equal(t, tc.expected, endpoints)
+			if tc.expectedErr {
+				require.Error(t, err)
+			}
+		})
+	}
+
+}

--- a/cmd/deploy/endpoints_test.go
+++ b/cmd/deploy/endpoints_test.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/externalresource"
@@ -45,51 +44,35 @@ func TestGetEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "Error when retrieving ordered endpoints using okteto API",
+			name: "Error when retrieving ordered endpoints using okteto API fallback to standalone mode",
 			endpointGetter: &EndpointGetter{
 				endpointControl: &fakeEndpointControl{
 					err: assert.AnError,
 				},
-			},
-			isOkteto:    true,
-			expectedErr: true,
-		},
-		{
-			name: "Error when retrieving ordered endpoints using okteto API. API endpoint not found",
-			endpointGetter: &EndpointGetter{
-				endpointControl: &fakeEndpointControl{
-					err: errors.New("Cannot query field \"endpoints\""),
-				},
+				getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
+				K8sClientProvider:            &fakeK8sProvider{},
 				externalResourceControl: &fakeExternalControl{
 					externals: []externalresource.ExternalResource{
 						{
 							Endpoints: []*externalresource.ExternalEndpoint{
 								{
-									Name: "test1",
-									Url:  "https://this.is.a.test.okteto",
-								},
-								{
-									Name: "test",
-									Url:  "https://this.is.a.test.ok",
+									Url: "https://this.is.a.test.ok",
 								},
 							},
 						},
 					},
 				},
-				getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
-				K8sClientProvider:            &fakeK8sProvider{},
 			},
 			isOkteto: true,
 			expected: []string{
 				"https://this.is.a.test.ok (external)",
-				"https://this.is.a.test.okteto (external)",
 			},
 		},
 		{
 			name: "Retrieving ordered endpoints without okteto API",
 			endpointGetter: &EndpointGetter{
 				endpointControl: &fakeEndpointControl{
-					err: errors.New("Cannot query field \"endpoints\""),
+					err: assert.AnError,
 				},
 				getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
 				K8sClientProvider:            &fakeK8sProvider{},

--- a/cmd/deploy/endpoints_test.go
+++ b/cmd/deploy/endpoints_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/k8s/ingresses"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/assert"
@@ -49,24 +48,8 @@ func TestGetEndpoints(t *testing.T) {
 				endpointControl: &fakeEndpointControl{
 					err: assert.AnError,
 				},
-				getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
-				K8sClientProvider:            &fakeK8sProvider{},
-				externalResourceControl: &fakeExternalControl{
-					externals: []externalresource.ExternalResource{
-						{
-							Endpoints: []*externalresource.ExternalEndpoint{
-								{
-									Url: "https://this.is.a.test.ok",
-								},
-							},
-						},
-					},
-				},
 			},
 			isOkteto: true,
-			expected: []string{
-				"https://this.is.a.test.ok (external)",
-			},
 		},
 		{
 			name: "Retrieving ordered endpoints without okteto API",

--- a/cmd/deploy/endpoints_test.go
+++ b/cmd/deploy/endpoints_test.go
@@ -4,30 +4,19 @@ import (
 	"context"
 	"testing"
 
-	"github.com/okteto/okteto/pkg/k8s/ingresses"
-	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func (*fakeK8sProvider) GetIngressClient() (*ingresses.Client, error) {
-	return nil, nil
-}
-
-func getFakeEndpointsInStandaloneMode(ctx context.Context, opts *EndpointsOptions, labelSelector string, k8sProvider k8sIngressClientProvider) ([]string, error) {
-	return nil, nil
-}
-
 func TestGetEndpoints(t *testing.T) {
 	testCases := []struct {
 		name           string
-		isOkteto       bool
 		expectedErr    bool
 		endpointGetter *EndpointGetter
 		expected       []string
 	}{
 		{
-			name: "Get endpoints sorted using okteto API",
+			name: "Get endpoints sorted",
 			endpointGetter: &EndpointGetter{
 				endpointControl: &fakeEndpointControl{
 					endpoints: []string{
@@ -36,45 +25,22 @@ func TestGetEndpoints(t *testing.T) {
 					},
 				},
 			},
-			isOkteto: true,
 			expected: []string{
 				"https://this.is.a.test.ok",
 				"https://this.is.a.test.okteto",
 			},
 		},
 		{
-			name: "Error when retrieving ordered endpoints using okteto API fallback to standalone mode",
+			name: "Error when retrieving endpoints",
 			endpointGetter: &EndpointGetter{
 				endpointControl: &fakeEndpointControl{
 					err: assert.AnError,
 				},
 			},
-			isOkteto: true,
-		},
-		{
-			name: "Retrieving ordered endpoints without okteto API",
-			endpointGetter: &EndpointGetter{
-				endpointControl: &fakeEndpointControl{
-					err: assert.AnError,
-				},
-				getEndpointsInStandaloneMode: getFakeEndpointsInStandaloneMode,
-				K8sClientProvider:            &fakeK8sProvider{},
-			},
-			isOkteto: false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			okteto.CurrentStore = &okteto.OktetoContextStore{
-				Contexts: map[string]*okteto.OktetoContext{
-					"test": {
-						Namespace: "test",
-						IsOkteto:  tc.isOkteto,
-					},
-				},
-				CurrentContext: "test",
-			}
-
 			endpoints, err := tc.endpointGetter.getEndpoints(context.Background(), &EndpointsOptions{})
 			require.Equal(t, tc.expected, endpoints)
 			if tc.expectedErr {

--- a/pkg/endpoints/control.go
+++ b/pkg/endpoints/control.go
@@ -10,11 +10,7 @@ type APIControl struct {
 	OktetoClient *okteto.OktetoClient
 }
 
-func NewEndpointControl() (*APIControl, error) {
-	c, err := okteto.NewOktetoClient()
-	if err != nil {
-		return nil, err
-	}
+func NewEndpointControl(c *okteto.OktetoClient) (*APIControl, error) {
 	return &APIControl{
 		OktetoClient: c,
 	}, nil

--- a/pkg/endpoints/control.go
+++ b/pkg/endpoints/control.go
@@ -1,0 +1,25 @@
+package endpoints
+
+import (
+	"context"
+
+	"github.com/okteto/okteto/pkg/okteto"
+)
+
+type APIControl struct {
+	OktetoClient *okteto.OktetoClient
+}
+
+func NewEndpointControl() (*APIControl, error) {
+	c, err := okteto.NewOktetoClient()
+	if err != nil {
+		return nil, err
+	}
+	return &APIControl{
+		OktetoClient: c,
+	}, nil
+}
+
+func (c *APIControl) List(ctx context.Context, ns string, labelSelector string) ([]string, error) {
+	return c.OktetoClient.Endpoint().List(ctx, ns, labelSelector)
+}

--- a/pkg/endpoints/control.go
+++ b/pkg/endpoints/control.go
@@ -10,10 +10,10 @@ type APIControl struct {
 	OktetoClient *okteto.OktetoClient
 }
 
-func NewEndpointControl(c *okteto.OktetoClient) (*APIControl, error) {
+func NewEndpointControl(c *okteto.OktetoClient) *APIControl {
 	return &APIControl{
 		OktetoClient: c,
-	}, nil
+	}
 }
 
 func (c *APIControl) List(ctx context.Context, ns string, labelSelector string) ([]string, error) {

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -44,6 +44,7 @@ type OktetoClient struct {
 	pipeline  types.PipelineInterface
 	stream    types.StreamInterface
 	kubetoken types.KubetokenInterface
+	endpoint  types.EndpointInterface
 }
 
 type OktetoClientProvider struct{}
@@ -248,6 +249,7 @@ func newOktetoClientFromGraphqlClient(url string, httpClient *http.Client) (*Okt
 	c.pipeline = newPipelineClient(c.client, url)
 	c.stream = newStreamClient(httpClient)
 	c.kubetoken = newKubeTokenClient(httpClient)
+	c.endpoint = newEndpointClient(c.client)
 	return c, nil
 }
 
@@ -401,6 +403,11 @@ func (c *OktetoClient) Stream() types.StreamInterface {
 // Kubetoken retrieves the Kubetoken client
 func (c *OktetoClient) Kubetoken() types.KubetokenInterface {
 	return c.kubetoken
+}
+
+// Endpoint retrieves the Endpoint client
+func (c *OktetoClient) Endpoint() types.EndpointInterface {
+	return c.endpoint
 }
 
 func SetInsecureSkipTLSVerifyPolicy(isInsecure bool) {

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -44,7 +44,7 @@ type OktetoClient struct {
 	pipeline  types.PipelineInterface
 	stream    types.StreamInterface
 	kubetoken types.KubetokenInterface
-	endpoint  types.EndpointInterface
+	endpoint  types.EndpointClientInterface
 }
 
 type OktetoClientProvider struct{}
@@ -406,7 +406,7 @@ func (c *OktetoClient) Kubetoken() types.KubetokenInterface {
 }
 
 // Endpoint retrieves the Endpoint client
-func (c *OktetoClient) Endpoint() types.EndpointInterface {
+func (c *OktetoClient) Endpoint() types.EndpointClientInterface {
 	return c.endpoint
 }
 

--- a/pkg/okteto/endpoint.go
+++ b/pkg/okteto/endpoint.go
@@ -2,6 +2,7 @@ package okteto
 
 import (
 	"context"
+	"fmt"
 
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/shurcooL/graphql"
@@ -17,17 +18,31 @@ func newEndpointClient(client graphqlClientInterface) *endpointClient {
 	}
 }
 
-type listEndpointsQuery struct {
-	Response []string `graphql:"endpoints(space: $space, label: $label)"`
+type EndpointInfo struct {
+	Url graphql.String
 }
 
-func (c *endpointClient) List(ctx context.Context, ns, label string) ([]string, error) {
-	oktetoLog.Infof("listing endpoints in '%s' namespace with label %s", ns, label)
-	var queryStruct listEndpointsQuery
+type Component struct {
+	Endpoints  []EndpointInfo
+	DeployedBy graphql.String
+}
 
+type Space struct {
+	Deployments  []Component
+	Statefulsets []Component
+	Functions    []Component
+	Externals    []Component
+}
+
+type SpaceQuery struct {
+	Response Space `graphql:"space(id: $id)"`
+}
+
+func (c *endpointClient) List(ctx context.Context, ns, deployedBy string) ([]string, error) {
+	oktetoLog.Infof("listing endpoints in '%s' namespace deployed by %s", ns, deployedBy)
+	var queryStruct SpaceQuery
 	variables := map[string]interface{}{
-		"space": graphql.String(ns),
-		"label": graphql.String(label),
+		"id": graphql.String(ns),
 	}
 
 	err := query(ctx, &queryStruct, variables, c.client)
@@ -35,5 +50,38 @@ func (c *endpointClient) List(ctx context.Context, ns, label string) ([]string, 
 		return nil, err
 	}
 
-	return queryStruct.Response, nil
+	endpoints := make([]string, 0)
+	for _, deployment := range queryStruct.Response.Deployments {
+		if deployment.DeployedBy == graphql.String(deployedBy) {
+			for _, endpoint := range deployment.Endpoints {
+				endpoints = append(endpoints, string(endpoint.Url))
+			}
+		}
+	}
+
+	for _, sfs := range queryStruct.Response.Statefulsets {
+		if sfs.DeployedBy == graphql.String(deployedBy) {
+			for _, endpoint := range sfs.Endpoints {
+				endpoints = append(endpoints, string(endpoint.Url))
+			}
+		}
+	}
+
+	for _, external := range queryStruct.Response.Externals {
+		if external.DeployedBy == graphql.String(deployedBy) {
+			for _, endpoint := range external.Endpoints {
+				endpoints = append(endpoints, fmt.Sprintf("%s (external)", endpoint.Url))
+			}
+		}
+	}
+
+	for _, function := range queryStruct.Response.Functions {
+		if function.DeployedBy == graphql.String(deployedBy) {
+			for _, endpoint := range function.Endpoints {
+				endpoints = append(endpoints, string(endpoint.Url))
+			}
+		}
+	}
+
+	return endpoints, nil
 }

--- a/pkg/okteto/endpoint.go
+++ b/pkg/okteto/endpoint.go
@@ -1,0 +1,39 @@
+package okteto
+
+import (
+	"context"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/shurcooL/graphql"
+)
+
+type endpointClient struct {
+	client graphqlClientInterface
+}
+
+func newEndpointClient(client graphqlClientInterface) *endpointClient {
+	return &endpointClient{
+		client: client,
+	}
+}
+
+type listEndpointsQuery struct {
+	Response []string `graphql:"endpoints(space: $space, label: $label)"`
+}
+
+func (c *endpointClient) List(ctx context.Context, ns, label string) ([]string, error) {
+	oktetoLog.Infof("listing endpoints in '%s' namespace with label %s", ns, label)
+	var queryStruct listEndpointsQuery
+
+	variables := map[string]interface{}{
+		"space": graphql.String(ns),
+		"label": graphql.String(label),
+	}
+
+	err := query(ctx, &queryStruct, variables, c.client)
+	if err != nil {
+		return nil, err
+	}
+
+	return queryStruct.Response, nil
+}

--- a/pkg/okteto/endpoint.go
+++ b/pkg/okteto/endpoint.go
@@ -2,6 +2,7 @@ package okteto
 
 import (
 	"context"
+	"fmt"
 
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/shurcooL/graphql"
@@ -52,7 +53,9 @@ func (c *endpointClient) List(ctx context.Context, ns, deployedBy string) ([]str
 	endpoints := make([]string, 0)
 	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Deployments, deployedBy)...)
 	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Statefulsets, deployedBy)...)
-	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Externals, deployedBy)...)
+	for _, endpoint := range filterEndpointsFromComponent(queryStruct.Response.Externals, deployedBy) {
+		endpoints = append(endpoints, fmt.Sprintf("%s (external)", endpoint))
+	}
 	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Functions, deployedBy)...)
 
 	return endpoints, nil

--- a/pkg/okteto/endpoint.go
+++ b/pkg/okteto/endpoint.go
@@ -2,7 +2,6 @@ package okteto
 
 import (
 	"context"
-	"fmt"
 
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/shurcooL/graphql"
@@ -51,37 +50,23 @@ func (c *endpointClient) List(ctx context.Context, ns, deployedBy string) ([]str
 	}
 
 	endpoints := make([]string, 0)
-	for _, deployment := range queryStruct.Response.Deployments {
-		if deployment.DeployedBy == graphql.String(deployedBy) {
-			for _, endpoint := range deployment.Endpoints {
-				endpoints = append(endpoints, string(endpoint.Url))
-			}
-		}
-	}
-
-	for _, sfs := range queryStruct.Response.Statefulsets {
-		if sfs.DeployedBy == graphql.String(deployedBy) {
-			for _, endpoint := range sfs.Endpoints {
-				endpoints = append(endpoints, string(endpoint.Url))
-			}
-		}
-	}
-
-	for _, external := range queryStruct.Response.Externals {
-		if external.DeployedBy == graphql.String(deployedBy) {
-			for _, endpoint := range external.Endpoints {
-				endpoints = append(endpoints, fmt.Sprintf("%s (external)", endpoint.Url))
-			}
-		}
-	}
-
-	for _, function := range queryStruct.Response.Functions {
-		if function.DeployedBy == graphql.String(deployedBy) {
-			for _, endpoint := range function.Endpoints {
-				endpoints = append(endpoints, string(endpoint.Url))
-			}
-		}
-	}
+	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Deployments, deployedBy)...)
+	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Statefulsets, deployedBy)...)
+	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Externals, deployedBy)...)
+	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Functions, deployedBy)...)
 
 	return endpoints, nil
+}
+
+func filterEndpointsFromComponent(components []Component, deployedBy string) []string {
+	var endpoints []string
+	for _, component := range components {
+		if component.DeployedBy == graphql.String(deployedBy) {
+			for _, endpoint := range component.Endpoints {
+				endpoints = append(endpoints, string(endpoint.Url))
+			}
+		}
+	}
+
+	return endpoints
 }

--- a/pkg/okteto/endpoint_test.go
+++ b/pkg/okteto/endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListEndpoints(t *testing.T) {
@@ -33,12 +34,59 @@ func TestListEndpoints(t *testing.T) {
 			},
 		},
 		{
-			name: "graphql response",
+			name: "graphql response retrieve only info related to dev env",
 			cfg: input{
 				client: &fakeGraphQLClient{
-					queryResult: &listEndpointsQuery{
-						Response: []string{
-							"https://this.is.a.test.ok",
+					queryResult: &SpaceQuery{
+						Response: Space{
+							Deployments: []Component{
+								{
+									Endpoints: []EndpointInfo{
+										{
+											Url: "https://this.is.a.test.okk",
+										},
+									},
+									DeployedBy: "test",
+								},
+								{
+									Endpoints: []EndpointInfo{
+										{
+											Url: "https://this.is.a.test.to.not.include",
+										},
+									},
+									DeployedBy: "no-test",
+								},
+							},
+							Statefulsets: []Component{
+								{
+									Endpoints: []EndpointInfo{
+										{
+											Url: "https://this.is.a.test.okkkk",
+										},
+									},
+									DeployedBy: "test",
+								},
+							},
+							Externals: []Component{
+								{
+									Endpoints: []EndpointInfo{
+										{
+											Url: "https://this.is.a.test.okkk",
+										},
+									},
+									DeployedBy: "test",
+								},
+							},
+							Functions: []Component{
+								{
+									Endpoints: []EndpointInfo{
+										{
+											Url: "https://this.is.a.test.ok",
+										},
+									},
+									DeployedBy: "test",
+								},
+							},
 						},
 					},
 				},
@@ -46,6 +94,9 @@ func TestListEndpoints(t *testing.T) {
 			expected: expected{
 				result: []string{
 					"https://this.is.a.test.ok",
+					"https://this.is.a.test.okk",
+					"https://this.is.a.test.okkk (external)",
+					"https://this.is.a.test.okkkk",
 				},
 				err: nil,
 			},
@@ -54,9 +105,9 @@ func TestListEndpoints(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ec := endpointClient{client: tc.cfg.client}
-			eps, err := ec.List(context.Background(), "ns", "label")
+			eps, err := ec.List(context.Background(), "ns", "test")
 			assert.ErrorIs(t, err, tc.expected.err)
-			assert.Equal(t, tc.expected.result, eps)
+			require.ElementsMatch(t, eps, tc.expected.result)
 		})
 	}
 }

--- a/pkg/okteto/endpoint_test.go
+++ b/pkg/okteto/endpoint_test.go
@@ -1,0 +1,62 @@
+package okteto
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListEndpoints(t *testing.T) {
+	type input struct {
+		client *fakeGraphQLClient
+	}
+	type expected struct {
+		result []string
+		err    error
+	}
+	testCases := []struct {
+		name     string
+		cfg      input
+		expected expected
+	}{
+		{
+			name: "error in graphql",
+			cfg: input{
+				client: &fakeGraphQLClient{
+					err: assert.AnError,
+				},
+			},
+			expected: expected{
+				result: nil,
+				err:    assert.AnError,
+			},
+		},
+		{
+			name: "graphql response",
+			cfg: input{
+				client: &fakeGraphQLClient{
+					queryResult: &listEndpointsQuery{
+						Response: []string{
+							"https://this.is.a.test.ok",
+						},
+					},
+				},
+			},
+			expected: expected{
+				result: []string{
+					"https://this.is.a.test.ok",
+				},
+				err: nil,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ec := endpointClient{client: tc.cfg.client}
+			eps, err := ec.List(context.Background(), "ns", "label")
+			assert.ErrorIs(t, err, tc.expected.err)
+			assert.Equal(t, tc.expected.result, eps)
+		})
+	}
+}

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -478,7 +478,7 @@ func TestDeprecatedListPreview(t *testing.T) {
 	}
 }
 
-func TestListEndpoints(t *testing.T) {
+func TestListPreviewEndpoints(t *testing.T) {
 	type input struct {
 		client *fakeGraphQLClient
 		name   string

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -86,7 +86,7 @@ type KubetokenInterface interface {
 	CheckService(baseURL, namespace string) error
 }
 
-// EndpointInterface represents the endpoint client
-type EndpointInterface interface {
+// EndpointClientInterface represents the endpoint client
+type EndpointClientInterface interface {
 	List(ctx context.Context, ns, label string) ([]string, error)
 }

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -85,3 +85,8 @@ type KubetokenInterface interface {
 	GetKubeToken(baseURL, namespace string) (KubeTokenResponse, error)
 	CheckService(baseURL, namespace string) error
 }
+
+// EndpointInterface represents the endpoint client
+type EndpointInterface interface {
+	List(ctx context.Context, ns, label string) ([]string, error)
+}


### PR DESCRIPTION
## Changes
- use okteto api to retrieve endpoints using `space` query
- use old logic for vanilla or fallbacks if endpoint is not available
- remove external endpoints retrieval when backend is used to retrieve endpoints

## How to test it
- clone okteto/movies
- cd to the repo
- deploy okteto/movies with an external resource (`okteto deploy`)
- check all endpoints are correct comparing them with endpoint in okteto UI when exec `okteto endpoints`
---
### With/without changes
- clone https://github.com/okteto/divert-with-istio-sample
- cd divert-with-istio-sample
- using my own cluster `okteto ctx use <my-context>`. You need to enable istio and an okteto feature flag in order to use virtual services so is easy to use my cluster already prepared.
- run `okteto deploy -f okteto-staging.yml`
- check endpoint in UI (broken because we need an ingress but enough to test the needed logic)
- run `okteto endpoints -f okteto-staging.yml` will show same endpoints than UI using this PR and no endpoints with previous implementation

