### PR TITLE
CLI Quality - Lint - unconvert

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
     - unparam
     - tenv
     - tparallel
+    - unconvert
 
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.

--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -199,7 +199,7 @@ dependencies:
 			if err != nil {
 				t.Fatalf("failed to create dynamic manifest file: %s", err.Error())
 			}
-			if err := os.WriteFile(tmpFile.Name(), []byte(tt.manifestYAML), 0600); err != nil {
+			if err := os.WriteFile(tmpFile.Name(), tt.manifestYAML, 0600); err != nil {
 				t.Fatalf("failed to write manifest file: %s", err.Error())
 			}
 			defer os.RemoveAll(tmpFile.Name())
@@ -259,7 +259,7 @@ context: manifest-context
 				if err != nil {
 					t.Fatalf("failed to create dynamic manifest file: %s", err.Error())
 				}
-				if err := os.WriteFile(tmpFile.Name(), []byte(tt.manifestYAML), 0600); err != nil {
+				if err := os.WriteFile(tmpFile.Name(), tt.manifestYAML, 0600); err != nil {
 					t.Fatalf("failed to write manifest file: %s", err.Error())
 				}
 				defer os.RemoveAll(tmpFile.Name())

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1316,8 +1316,8 @@ func TestShouldRunInRemoteDeploy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Setenv(constants.OktetoDeployRemote, string(tt.remoteDeploy))
-			t.Setenv(constants.OktetoForceRemote, string(tt.remoteForce))
+			t.Setenv(constants.OktetoDeployRemote, tt.remoteDeploy)
+			t.Setenv(constants.OktetoForceRemote, tt.remoteForce)
 			result := shouldRunInRemote(tt.opts)
 			assert.Equal(t, result, tt.expected)
 		})

--- a/cmd/destroy/destroy_test.go
+++ b/cmd/destroy/destroy_test.go
@@ -1076,8 +1076,8 @@ func TestShouldRunInRemoteDestroy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			t.Setenv(constants.OktetoDeployRemote, string(tt.remoteDestroy))
-			t.Setenv(constants.OktetoForceRemote, string(tt.remoteForce))
+			t.Setenv(constants.OktetoDeployRemote, tt.remoteDestroy)
+			t.Setenv(constants.OktetoForceRemote, tt.remoteForce)
 			result := shouldRunInRemote(tt.opts)
 			assert.Equal(t, result, tt.expected)
 		})

--- a/cmd/manifest/init-v1_test.go
+++ b/cmd/manifest/init-v1_test.go
@@ -109,7 +109,7 @@ func TestRunJustCreateNecessaryFields(t *testing.T) {
 	file, err := os.ReadFile(p)
 	assert.NoError(t, err)
 	var result map[string]interface{}
-	require.NoError(t, yaml.Unmarshal([]byte(file), &result))
+	require.NoError(t, yaml.Unmarshal(file, &result))
 
 	optionalFields := [...]string{"annotations", "autocreate", "container", "context", "environment",
 		"externalVolumes", "healthchecks", "interface", "imagePullPolicy", "labels", "namespace",

--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -117,7 +117,7 @@ func addSyncFieldHash(dev *model.Dev) error {
 	if err != nil {
 		return err
 	}
-	dev.Metadata.Annotations[model.OktetoSyncAnnotation] = fmt.Sprintf("%x", sha512.Sum512([]byte(output)))
+	dev.Metadata.Annotations[model.OktetoSyncAnnotation] = fmt.Sprintf("%x", sha512.Sum512(output))
 	return nil
 }
 

--- a/cmd/up/watches.go
+++ b/cmd/up/watches.go
@@ -53,7 +53,7 @@ func checkLocalWatchesConfiguration() {
 }
 
 func isWatchesConfigurationTooLow(value string) bool {
-	value = strings.TrimSuffix(string(value), "\n")
+	value = strings.TrimSuffix(value, "\n")
 	if value == "" {
 		oktetoLog.Infof("max_user_watches is empty '%s'", value)
 		return false

--- a/cmd/utils/displayer/collapse_tty.go
+++ b/cmd/utils/displayer/collapse_tty.go
@@ -234,7 +234,7 @@ func (d *TTYCollapseDisplayer) CleanUp(err error) {
 		}
 		lines := renderLines(d.linesToDisplay, width)
 		for _, line := range lines {
-			if _, err := d.screenbuf.Write([]byte(line)); err != nil {
+			if _, err := d.screenbuf.Write(line); err != nil {
 				oktetoLog.Infof("Error writing line: %s", err)
 			}
 		}

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -50,7 +50,7 @@ func GetOktetoPath() (string, error) {
 	}
 	output, err := RunOktetoVersion(oktetoPath)
 	if err != nil {
-		return "", fmt.Errorf("okteto version failed: %s - %s", string(output), err)
+		return "", fmt.Errorf("okteto version failed: %s - %s", output, err)
 	}
 	log.Println(output)
 	return oktetoPath, nil

--- a/pkg/cache/cache_from_test.go
+++ b/pkg/cache/cache_from_test.go
@@ -59,7 +59,7 @@ func Test_UnmarshalYAML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var cf CacheFrom
-			err := yaml.Unmarshal([]byte(tt.data), &cf)
+			err := yaml.Unmarshal(tt.data, &cf)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, cf)
 		})

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -257,7 +257,7 @@ func translateConfigMapSandBox(data *CfgData) *apiv1.ConfigMap {
 
 	output := oktetoLog.GetOutputBuffer()
 	outputData := translateOutput(output)
-	cmap.Data[outputField] = base64.StdEncoding.EncodeToString([]byte(outputData))
+	cmap.Data[outputField] = base64.StdEncoding.EncodeToString(outputData)
 	return cmap
 }
 
@@ -307,7 +307,7 @@ func updateCmap(cmap *apiv1.ConfigMap, data *CfgData) error {
 
 	output := oktetoLog.GetOutputBuffer()
 	outputData := translateOutput(output)
-	cmap.Data[outputField] = base64.StdEncoding.EncodeToString([]byte(outputData))
+	cmap.Data[outputField] = base64.StdEncoding.EncodeToString(outputData)
 	return nil
 }
 

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -618,7 +618,7 @@ func translateServicePorts(svc model.Service) []apiv1.ServicePort {
 				result,
 				apiv1.ServicePort{
 					Name:       fmt.Sprintf("p-%d-%d-%s", p.ContainerPort, p.ContainerPort, strings.ToLower(fmt.Sprintf("%v", p.Protocol))),
-					Port:       int32(p.ContainerPort),
+					Port:       p.ContainerPort,
 					TargetPort: intstr.IntOrString{IntVal: p.ContainerPort},
 					Protocol:   p.Protocol,
 				},
@@ -629,7 +629,7 @@ func translateServicePorts(svc model.Service) []apiv1.ServicePort {
 				result,
 				apiv1.ServicePort{
 					Name:       fmt.Sprintf("p-%d-%d-%s", p.HostPort, p.ContainerPort, strings.ToLower(fmt.Sprintf("%v", p.Protocol))),
-					Port:       int32(p.HostPort),
+					Port:       p.HostPort,
 					TargetPort: intstr.IntOrString{IntVal: p.ContainerPort},
 					Protocol:   p.Protocol,
 				},

--- a/pkg/externalresource/serializer_test.go
+++ b/pkg/externalresource/serializer_test.go
@@ -111,9 +111,9 @@ endpoints:
 		t.Run(tt.name, func(t *testing.T) {
 			var result ExternalResource
 			if tt.expectedErr {
-				assert.Error(t, yaml.Unmarshal([]byte(tt.data), &result))
+				assert.Error(t, yaml.Unmarshal(tt.data, &result))
 			} else {
-				assert.NoError(t, yaml.Unmarshal([]byte(tt.data), &result))
+				assert.NoError(t, yaml.Unmarshal(tt.data, &result))
 				if !reflect.DeepEqual(result, tt.expected) {
 					t.Errorf("didn't unmarshal correctly. Actual '%+v', Expected '%+v'", result, tt.expected)
 				}

--- a/pkg/log/json_test.go
+++ b/pkg/log/json_test.go
@@ -62,7 +62,7 @@ func Test_ConvertToJson(t *testing.T) {
 				Level:     defaultLevel,
 				Stage:     defaultStage,
 				Message:   "foobar",
-				Timestamp: int64(mockedTimestamp),
+				Timestamp: mockedTimestamp,
 			},
 		}, {
 			name:    "leaving leading whitespace since it represents indentation",
@@ -73,7 +73,7 @@ func Test_ConvertToJson(t *testing.T) {
 				Level:     defaultLevel,
 				Stage:     defaultStage,
 				Message:   " \t\nsome indented line",
-				Timestamp: int64(mockedTimestamp),
+				Timestamp: mockedTimestamp,
 			},
 		}, {
 			name:    "removes trailing whitespace since each line should represent an individual line",
@@ -84,7 +84,7 @@ func Test_ConvertToJson(t *testing.T) {
 				Level:     defaultLevel,
 				Stage:     defaultStage,
 				Message:   "  some indented line",
-				Timestamp: int64(mockedTimestamp),
+				Timestamp: mockedTimestamp,
 			},
 		},
 	}

--- a/pkg/model/contextresource_test.go
+++ b/pkg/model/contextresource_test.go
@@ -49,7 +49,7 @@ func Test_GetContextResource(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create dynamic manifest file: %s", err.Error())
 			}
-			if err := os.WriteFile(tmpFile.Name(), []byte(tt.manifest), 0600); err != nil {
+			if err := os.WriteFile(tmpFile.Name(), tt.manifest, 0600); err != nil {
 				t.Fatalf("failed to write manifest file: %s", err.Error())
 			}
 			defer os.RemoveAll(tmpFile.Name())

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1967,7 +1967,7 @@ func Test_UnmarshalStackUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var result *StackSecurityContext
-			if err := yaml.Unmarshal([]byte(tt.manifest), &result); err != nil {
+			if err := yaml.Unmarshal(tt.manifest, &result); err != nil {
 				if !tt.errorExpected {
 					t.Fatalf("unexpected error unmarshaling %s: %s", tt.name, err.Error())
 				}

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -978,7 +978,7 @@ func TestStack_ExpandEnvsAtFileLevel(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create dynamic manifest file: %s", err.Error())
 			}
-			if err := os.WriteFile(tmpFile.Name(), []byte(tt.manifest), 0600); err != nil {
+			if err := os.WriteFile(tmpFile.Name(), tt.manifest, 0600); err != nil {
 				t.Fatalf("failed to write manifest file: %s", err.Error())
 			}
 			defer os.RemoveAll(tmpFile.Name())

--- a/pkg/okteto/k8s_test.go
+++ b/pkg/okteto/k8s_test.go
@@ -126,7 +126,7 @@ func TestKubetokenRefreshRoundTrip(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			testServer := httptest.NewServer(http.HandlerFunc(tc.handleFunc))
+			testServer := httptest.NewServer(tc.handleFunc)
 			defer testServer.Close()
 			transport := newTokenRotationTransport(http.DefaultTransport)
 			client := &http.Client{

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -117,7 +117,7 @@ func TestNewRepo(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(constants.OktetoGitCommitEnvVar, tc.GitCommit)
-			t.Setenv(constants.OktetoDeployRemote, string(tc.remoteDeploy))
+			t.Setenv(constants.OktetoDeployRemote, tc.remoteDeploy)
 			r := NewRepository("https://my-repo/okteto/okteto")
 			assert.Equal(t, "/okteto/okteto", r.url.Path)
 			assert.IsType(t, tc.expectedControl, r.control)

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -235,7 +235,7 @@ func New(dev *model.Dev) (*Syncthing, error) {
 		Folders:          []*Folder{},
 		RescanInterval:   strconv.Itoa(dev.Sync.RescanInterval),
 		Compression:      compression,
-		timeout:          time.Duration(dev.Timeout.Default),
+		timeout:          dev.Timeout.Default,
 	}
 	index := 1
 	for _, sync := range dev.Sync.Folders {


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/LAKE-70

This PR enables `unconvert` as linter and fixes the errors raised by it.

## How to validate

Whenever the code makes a redundant type conversion and running `make lint` should spot an error. For example a variable that is already a string and we convert it to string

```
a := "a value"
b := string(a) 
```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

