### PR TITLE
Add `make lint-fix-fieldalignment` 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,21 @@ lint:
 	pre-commit run --all-files
 	golangci-lint run
 
-.PHONY: lint-fix-fieldalignment
-lint-fix-fieldalignment:
+.PHONY: install-fieldalignment
+install-fieldalignment:
 	@which fieldalignment > /dev/null || (echo "Installing fieldalignment..." && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest)
+
+.PHONY: lint-fix-fieldalignment
+lint-fix-fieldalignment: install-fieldalignment
+lint-fix-fieldalignment:
 	fieldalignment -fix ./...
+	@echo "⚠️  Please review the changes before committing. This step might remove code comments while reordering the struct fields."
+
+.PHONY: lint-fieldalignment
+lint-fieldalignment: install-fieldalignment
+lint-fieldalignment:
+	@which fieldalignment > /dev/null || (echo "Installing fieldalignment..." && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest)
+	fieldalignment -json ./...
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,19 @@ lint:
 
 .PHONY: install-fieldalignment
 install-fieldalignment:
-	@which fieldalignment > /dev/null || (echo "Installing fieldalignment..." && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest)
-	$(eval FIELDALIGNMENT_BIN=$(shell which fieldalignment))
+	$(eval GOBIN=$(shell go env GOPATH)/bin)
+	$(eval FIELDALIGNMENT_BIN=$(GOBIN)/fieldalignment)
+	@if [ ! -x "$(FIELDALIGNMENT_BIN)" ]; then \
+    	echo "Installing fieldalignment..."; \
+    	go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest; \
+    fi
 
 .PHONY: lint-fix-fieldalignment
 lint-fix-fieldalignment: install-fieldalignment
-	@$(FIELDALIGNMENT_BIN) -fix ./...
-	@echo "⚠️  Please review the changes before committing. This step might remove code comments while reordering the struct fields."
+	@$(FIELDALIGNMENT_BIN) -fix ./...; \
+	if ! git diff --quiet -- '*.go'; then \
+		echo "⚠️  Please review the changes before committing. This step might remove code comments while reordering the struct fields."; \
+	fi
 
 .PHONY: lint-fieldalignment
 lint-fieldalignment: install-fieldalignment

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ lint:
 
 .PHONY: lint-fix-fieldalignment
 lint-fix-fieldalignment:
+	@which fieldalignment > /dev/null || (echo "Installing fieldalignment..." && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest)
 	fieldalignment -fix ./...
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ lint:
 	pre-commit run --all-files
 	golangci-lint run
 
+.PHONY: lint-fix-fieldalignment
+lint-fix-fieldalignment:
+	fieldalignment -fix ./...
+
 .PHONY: test
 test:
 	go test -p 4 -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/Makefile
+++ b/Makefile
@@ -38,18 +38,16 @@ lint:
 .PHONY: install-fieldalignment
 install-fieldalignment:
 	@which fieldalignment > /dev/null || (echo "Installing fieldalignment..." && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest)
+	$(eval FIELDALIGNMENT_BIN=$(shell which fieldalignment))
 
 .PHONY: lint-fix-fieldalignment
 lint-fix-fieldalignment: install-fieldalignment
-lint-fix-fieldalignment:
-	fieldalignment -fix ./...
+	@$(FIELDALIGNMENT_BIN) -fix ./...
 	@echo "⚠️  Please review the changes before committing. This step might remove code comments while reordering the struct fields."
 
 .PHONY: lint-fieldalignment
 lint-fieldalignment: install-fieldalignment
-lint-fieldalignment:
-	@which fieldalignment > /dev/null || (echo "Installing fieldalignment..." && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest)
-	fieldalignment -json ./...
+	@$(FIELDALIGNMENT_BIN) -json ./...
 
 .PHONY: test
 test:


### PR DESCRIPTION
# Proposed changes

Now that we use the linter `fieldalignment` it's handy to have this make command to remember how to address fieldalignment issues.

Using `golangci-lint run --fix` does not seem to work.

## How to validate

1. If you already have `fieldalignment` installed remove it
1. Make a change in a struct causing a lint issue for `fieldalignment`
1. Run `make lint-fix-fieldalignment`
1. Notice how `fieldalignment` is installed and it fixed the issues. It will output the errors that it found.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
