### PR TITLE
CLI Quality - Lint - gomnd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ linters-settings:
   gomnd:
     checks:
       - argument
-      # - case
+      - case
       # - condition
       # - operation
       # - return

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters-settings:
       - '\.NewWriter'
       - '\.NewTabWriter'
       - '\.WriteFile'
-      - '^strings.'
       - '^time.'
       - '^os.'
       - '^bcrypt.'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,7 +41,7 @@ linters-settings:
     checks:
       - argument
       - case
-      # - condition
+      - condition
       # - operation
       # - return
       # - assign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,28 @@ linters-settings:
       const:
         YEAR: '2023'
     template-path: .copyright-header.tmpl
+  gomnd:
+    checks:
+      - argument
+      # - case
+      # - condition
+      # - operation
+      # - return
+      # - assign
+    ignored-functions:
+      - '\.NewWriter'
+      - '\.NewTabWriter'
+      - '\.WriteFile'
+      - '^strings.'
+      - '^time.'
+      - '^os.'
+      - '^bcrypt.'
+      - '^math.'
+      - '^big.'
+      - '\.SetIndent'
+      - int
+      - make
+      - '\.WithTimeout'
 
 # All possible linters can be found https://golangci-lint.run/usage/linters/
 linters:
@@ -51,7 +73,7 @@ linters:
     - tenv
     - tparallel
     - gci
-    - goheader    
+    - goheader
     - unconvert
     - predeclared
     - asciicheck
@@ -60,6 +82,7 @@ linters:
     - decorder
     - exportloopref
     - makezero
+    - gomnd
 
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -140,10 +140,11 @@ func (ld *localDeployer) deploy(ctx context.Context, deployOptions *Options) err
 
 	defer ld.cleanUp(ctx, nil)
 
+	keyValueVarParts := 2
 	for _, variable := range deployOptions.Variables {
-		value := strings.SplitN(variable, "=", 2)[1]
-		if strings.TrimSpace(value) != "" {
-			oktetoLog.AddMaskedWord(value)
+		varParts := strings.SplitN(variable, "=", keyValueVarParts)
+		if len(varParts) >= keyValueVarParts && strings.TrimSpace(varParts[1]) != "" {
+			oktetoLog.AddMaskedWord(varParts[1])
 		}
 	}
 	deployOptions.Variables = append(

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -211,7 +211,7 @@ func (ph *proxyHandler) getProxyHandler(token string, clusterConfig *rest.Config
 		expectedToken := fmt.Sprintf("Bearer %s", token)
 		// Validate token with the generated for the local kubeconfig file
 		if requestToken != expectedToken {
-			rw.WriteHeader(401)
+			rw.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 
@@ -230,7 +230,7 @@ func (ph *proxyHandler) getProxyHandler(token string, clusterConfig *rest.Config
 			t, err := newProtocolTransport(clusterConfig, true)
 			if err != nil {
 				oktetoLog.Infof("could not disabled HTTP/2: %s", err)
-				rw.WriteHeader(500)
+				rw.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 			reverseProxy = httputil.NewSingleHostReverseProxy(destinationURL)
@@ -243,7 +243,7 @@ func (ph *proxyHandler) getProxyHandler(token string, clusterConfig *rest.Config
 			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				oktetoLog.Infof("could not read the request body: %s", err)
-				rw.WriteHeader(500)
+				rw.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 			defer r.Body.Close()
@@ -255,7 +255,7 @@ func (ph *proxyHandler) getProxyHandler(token string, clusterConfig *rest.Config
 			b, err = ph.translateBody(b)
 			if err != nil {
 				oktetoLog.Info(err)
-				rw.WriteHeader(500)
+				rw.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -31,8 +31,9 @@ func validateAndSet(variables []string, setEnv func(key, value string) error) er
 func parse(variables []string) ([]env.Var, error) {
 	var result []env.Var
 	for _, v := range variables {
-		kv := strings.SplitN(v, "=", 2)
-		if len(kv) != 2 {
+		variableFormatParts := 2
+		kv := strings.SplitN(v, "=", variableFormatParts)
+		if len(kv) != variableFormatParts {
 			return nil, fmt.Errorf("invalid variable value '%s': must follow KEY=VALUE format", v)
 		}
 		result = append(result, env.Var{Name: kv[0], Value: kv[1]})

--- a/cmd/destroy/build_control.go
+++ b/cmd/destroy/build_control.go
@@ -48,6 +48,7 @@ func (bc buildCtrl) buildImageIfNecessary(ctx context.Context, manifest *model.M
 
 	reg := regexp.MustCompile(`OKTETO_BUILD_(\w+)_`)
 	matches := reg.FindStringSubmatch(imageToBuild)
+	foundMatches := 2
 	if len(matches) == 0 {
 		oktetoLog.Debugf("image '%s' is not an okteto build variable", imageToBuild)
 		return nil
@@ -58,7 +59,7 @@ func (bc buildCtrl) buildImageIfNecessary(ctx context.Context, manifest *model.M
 		sanitizedSvc := strings.ToUpper(strings.ReplaceAll(buildSvc, "-", "_"))
 		sanitisedToUnsanitised[sanitizedSvc] = buildSvc
 	}
-	if len(matches) == 2 {
+	if len(matches) == foundMatches {
 		sanitisedName := matches[1]
 		svc, ok := sanitisedToUnsanitised[sanitisedName]
 		if !ok {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -145,13 +145,14 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string) error {
 		}
 
 		retries := 0
+		maxRetries := 10
 		ticker := time.NewTicker(500 * time.Millisecond)
 		for {
 			if apps.IsDevModeOn(app) {
 				break
 			}
 			retries++
-			if retries >= 10 {
+			if retries >= maxRetries {
 				return oktetoErrors.UserError{
 					E:    fmt.Errorf("development mode is not enabled"),
 					Hint: "Run 'okteto up' to enable it and try again",

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -34,6 +34,11 @@ import (
 	"github.com/stern/stern/stern"
 )
 
+const (
+	defaultTailOptionValue       = 100
+	defaultSinceOptionHoursValue = 48
+)
+
 // LogsOptions options for logs command
 type LogsOptions struct {
 	ManifestPath string
@@ -124,8 +129,8 @@ func Logs(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "the namespace to use to fetch the logs (defaults to the current okteto namespace)")
 	cmd.Flags().StringVarP(&options.Context, "context", "c", "", "the context to use to fetch the logs")
 	cmd.Flags().StringVarP(&options.exclude, "exclude", "e", "", "exclude by service name (regular expression)")
-	cmd.Flags().DurationVarP(&options.Since, "since", "s", 48*time.Hour, "return logs newer than a relative duration like 5s, 2m, or 3h")
-	cmd.Flags().Int64Var(&options.Tail, "tail", 100, "the number of lines from the end of the logs to show")
+	cmd.Flags().DurationVarP(&options.Since, "since", "s", defaultSinceOptionHoursValue*time.Hour, "return logs newer than a relative duration like 5s, 2m, or 3h")
+	cmd.Flags().Int64Var(&options.Tail, "tail", defaultTailOptionValue, "the number of lines from the end of the logs to show")
 	cmd.Flags().BoolVarP(&options.Timestamps, "timestamps", "t", false, "print timestamps")
 	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
 

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -501,8 +501,9 @@ func (o *DeployOptions) setDefaults() error {
 func (o *DeployOptions) toPipelineDeployClientOptions() (types.PipelineDeployOptions, error) {
 	var varList []types.Variable
 	for _, v := range o.Variables {
-		kv := strings.SplitN(v, "=", 2)
-		if len(kv) != 2 {
+		variableFormatParts := 2
+		kv := strings.SplitN(v, "=", variableFormatParts)
+		if len(kv) != variableFormatParts {
 			return types.PipelineDeployOptions{}, fmt.Errorf("invalid variable value '%s': must follow KEY=VALUE format", v)
 		}
 		varList = append(varList, types.Variable{

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -129,8 +129,9 @@ func (pw *Command) deployPreview(ctx context.Context, opts *DeployOptions) (*typ
 
 	var varList []types.Variable
 	for _, v := range opts.variables {
-		kv := strings.SplitN(v, "=", 2)
-		if len(kv) != 2 {
+		variableFormatParts := 2
+		kv := strings.SplitN(v, "=", variableFormatParts)
+		if len(kv) != variableFormatParts {
 			return nil, fmt.Errorf("invalid variable value '%s': must follow KEY=VALUE format", v)
 		}
 		varList = append(varList, types.Variable{

--- a/cmd/registrytoken/registrytoken.go
+++ b/cmd/registrytoken/registrytoken.go
@@ -90,7 +90,8 @@ More info about docker credentials helpers here: https://github.com/docker/docke
 }
 
 func IsRegistryCredentialHelperCommand(args []string) bool {
-	if len(args) != 3 {
+	validArgsLength := 3
+	if len(args) != validArgsLength {
 		return false
 	}
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -32,6 +32,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	completedProgress = 100
+)
+
 // Status returns the status of the synchronization process
 func Status() *cobra.Command {
 	var devPath string
@@ -129,7 +133,7 @@ func runWithWatch(ctx context.Context, sy *syncthing.Syncthing) error {
 				oktetoLog.Infof("error accessing status: %s", err)
 				continue
 			}
-			if progress == 100 {
+			if progress == completedProgress {
 				message = "Files synchronized"
 			} else {
 				message = utils.RenderProgressBar(textSpinner, progress, pbScaling)
@@ -157,7 +161,7 @@ func runWithoutWatch(ctx context.Context, sy *syncthing.Syncthing) error {
 	if err != nil {
 		return err
 	}
-	if progress == 100 {
+	if progress == completedProgress {
 		oktetoLog.Success("Synchronization status: %.2f%%", progress)
 	} else {
 		oktetoLog.Yellow("Synchronization status: %.2f%%", progress)

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -188,7 +188,8 @@ func (up *upContext) activate() error {
 
 		outByCommand := strings.Split(strings.TrimSpace(output), "\n")
 		var version, watches string
-		if len(outByCommand) >= 3 {
+		minOutCmdParts := 3
+		if len(outByCommand) >= minOutCmdParts {
 			version, watches = outByCommand[0], outByCommand[1]
 
 			if isWatchesConfigurationTooLow(watches) {

--- a/cmd/up/dependencies.go
+++ b/cmd/up/dependencies.go
@@ -23,6 +23,7 @@ import (
 )
 
 func downloadSyncthing() error {
+	maxRetries := 2
 	t := time.NewTicker(1 * time.Second)
 	var err error
 	for i := 0; i < 3; i++ {
@@ -32,7 +33,7 @@ func downloadSyncthing() error {
 			return nil
 		}
 
-		if i < 2 {
+		if i < maxRetries {
 			oktetoLog.Infof("failed to download syncthing, retrying: %s", err)
 			<-t.C
 		}

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -26,6 +26,11 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	defaultProgressBarWidth = 40
+	totalProgressValue      = 100
+)
+
 func (up *upContext) initializeSyncthing() error {
 	sy, err := syncthing.New(up.Dev)
 	if err != nil {
@@ -142,7 +147,7 @@ func (up *upContext) synchronizeFiles(ctx context.Context) error {
 		defer oktetoLog.StopSpinner()
 	}
 
-	progressBar := utils.NewSyncthingProgressBar(40)
+	progressBar := utils.NewSyncthingProgressBar(defaultProgressBarWidth)
 	defer progressBar.Finish()
 
 	quit := make(chan bool)
@@ -203,7 +208,7 @@ func (up *upContext) synchronizeFiles(ctx context.Context) error {
 		}
 	}
 
-	progressBar.SetCurrent(100)
+	progressBar.SetCurrent(totalProgressValue)
 
 	return nil
 }

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -545,8 +545,9 @@ func getOverridedEnvVarsFromCmd(manifestEnvVars env.Environment, commandEnvVaria
 	}
 
 	for _, v := range commandEnvVariables {
-		kv := strings.SplitN(v, "=", 2)
-		if len(kv) != 2 {
+		varsLength := 2
+		kv := strings.SplitN(v, "=", varsLength)
+		if len(kv) != varsLength {
 			if kv[0] == "" {
 				return nil, fmt.Errorf("invalid variable value '%s': please review the accepted formats at https://www.okteto.com/docs/reference/manifest/#environment-string-optional ", v)
 			}

--- a/cmd/utils/selector.go
+++ b/cmd/utils/selector.go
@@ -507,7 +507,8 @@ func getActiveTemplate() string {
 }
 
 func getInactiveTemplate() string {
-	whitespaces := strings.Repeat(" ", 2)
+	numOfSpaces := 2
+	whitespaces := strings.Repeat(" ", numOfSpaces)
 	result := fmt.Sprintf("{{if .Enable}}%s{{ .Label }}{{else}}%s{{ .Label }}{{end}}", whitespaces, whitespaces)
 	result = changeColorForWindows(result)
 	return result

--- a/cmd/utils/syncthing.go
+++ b/cmd/utils/syncthing.go
@@ -22,6 +22,10 @@ import (
 	decor "github.com/vbauerster/mpb/v7/decor"
 )
 
+const (
+	totalProgressValue = 100
+)
+
 // SyncthingProgress tracks the progress of all the files syncthing
 type SyncthingProgress struct {
 	progressContainer *mpb.Progress
@@ -38,7 +42,7 @@ func NewSyncthingProgressBar(width int) *SyncthingProgress {
 
 func (s *SyncthingProgress) initProgressBar() {
 	s.progressBar = s.progressContainer.Add(
-		100,
+		totalProgressValue,
 		nil,
 		mpb.PrependDecorators(
 			decor.OnComplete(decor.Spinner(nil, decor.WCSyncSpace), "Files synchronized"),
@@ -69,7 +73,7 @@ func (s *SyncthingProgress) SetCurrent(v int64) {
 // Finish finishes the progress bar
 func (s *SyncthingProgress) Finish() {
 	if s.progressBar != nil {
-		s.progressBar.SetCurrent(100)
+		s.progressBar.SetCurrent(totalProgressValue)
 	}
 	s.progressContainer.Wait()
 }
@@ -80,7 +84,7 @@ func NewLineBarFiller(filler mpb.BarFiller) mpb.BarFiller {
 			oktetoLog.Infof("error writing to writer: %s", err)
 		}
 		filler.Fill(w, reqWidth, st)
-		percentage := Percentage(st.Total, st.Current, 100)
+		percentage := Percentage(st.Total, st.Current, totalProgressValue)
 		afterBarText := fmt.Sprintf(" %d%%\n", int(percentage))
 		if _, err := w.Write([]byte(afterBarText)); err != nil {
 			oktetoLog.Infof("error writing to writer: %s", err)

--- a/integration/k8s-client.go
+++ b/integration/k8s-client.go
@@ -131,7 +131,8 @@ func WaitForDeployment(kubectlBinary string, kubectlOpts *commands.KubectlOption
 			if strings.Contains(output, "is different from the running revision") {
 				r := regexp.MustCompile(`\(\d+\)`)
 				matches := r.FindAllString(output, -1)
-				if len(matches) == 2 {
+				validMatchesLength := 2
+				if len(matches) == validMatchesLength {
 					desiredVersion := strings.ReplaceAll(strings.ReplaceAll(matches[0], "(", ""), ")", "")
 					runningVersion := strings.ReplaceAll(strings.ReplaceAll(matches[0], "(", ""), ")", "")
 					if desiredVersion <= runningVersion {

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -115,7 +115,7 @@ func GetContentFromURL(url string, timeout time.Duration) string {
 			}
 
 			defer r.Body.Close()
-			if r.StatusCode != 200 {
+			if r.StatusCode != http.StatusOK {
 				if retry%10 == 0 {
 					log.Printf("called %s, got status %d, retrying", url, r.StatusCode)
 				}

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -43,8 +43,6 @@ import (
 const (
 	warningDockerfilePath   string = "Build '%s': Dockerfile '%s' is not in a relative path to context '%s'"
 	doubleDockerfileWarning string = "Build '%s': Two Dockerfiles discovered in both the root and context path, defaulting to '%s/%s'"
-	maxArgFormatParts              = 2
-	minArgFormatParts              = 1
 )
 
 var (
@@ -295,6 +293,8 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 
 	args := []model.BuildArg{}
 	optionsBuildArgs := map[string]string{}
+	minArgFormatParts := 1
+	maxArgFormatParts := 2
 	for _, arg := range o.BuildArgs {
 
 		splittedArg := strings.SplitN(arg, "=", maxArgFormatParts)

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -43,6 +43,8 @@ import (
 const (
 	warningDockerfilePath   string = "Build '%s': Dockerfile '%s' is not in a relative path to context '%s'"
 	doubleDockerfileWarning string = "Build '%s': Two Dockerfiles discovered in both the root and context path, defaulting to '%s/%s'"
+	maxArgFormatParts              = 2
+	minArgFormatParts              = 1
 )
 
 var (
@@ -294,13 +296,14 @@ func OptsFromBuildInfo(manifestName, svcName string, b *model.BuildInfo, o *type
 	args := []model.BuildArg{}
 	optionsBuildArgs := map[string]string{}
 	for _, arg := range o.BuildArgs {
-		splittedArg := strings.SplitN(arg, "=", 2)
-		if len(splittedArg) == 1 {
+
+		splittedArg := strings.SplitN(arg, "=", maxArgFormatParts)
+		if len(splittedArg) == minArgFormatParts {
 			optionsBuildArgs[splittedArg[0]] = ""
 			args = append(args, model.BuildArg{
 				Name: splittedArg[0], Value: "",
 			})
-		} else if len(splittedArg) == 2 {
+		} else if len(splittedArg) == maxArgFormatParts {
 			optionsBuildArgs[splittedArg[0]] = splittedArg[1]
 			args = append(args, model.BuildArg{
 				Name: splittedArg[0], Value: splittedArg[1],

--- a/pkg/cmd/build/build_docker.go
+++ b/pkg/cmd/build/build_docker.go
@@ -134,6 +134,7 @@ func buildWithDockerDaemonBuildkit(ctx context.Context, buildOptions *types.Buil
 
 		dockerBuildOptions.Target = buildOptions.Target
 
+		maxArgFormatParts := 2
 		for _, buildArg := range buildOptions.BuildArgs {
 			kv := strings.SplitN(buildArg, "=", maxArgFormatParts)
 			if len(kv) != maxArgFormatParts {
@@ -399,6 +400,7 @@ func getDockerOptions(buildOptions *types.BuildOptions) (dockerTypes.ImageBuildO
 		opts.Tags = append(opts.Tags, buildOptions.Tag)
 	}
 
+	maxArgFormatParts := 2
 	for _, buildArg := range buildOptions.BuildArgs {
 		kv := strings.SplitN(buildArg, "=", maxArgFormatParts)
 		if len(kv) != maxArgFormatParts {

--- a/pkg/cmd/build/build_docker.go
+++ b/pkg/cmd/build/build_docker.go
@@ -135,8 +135,8 @@ func buildWithDockerDaemonBuildkit(ctx context.Context, buildOptions *types.Buil
 		dockerBuildOptions.Target = buildOptions.Target
 
 		for _, buildArg := range buildOptions.BuildArgs {
-			kv := strings.SplitN(buildArg, "=", 2)
-			if len(kv) != 2 {
+			kv := strings.SplitN(buildArg, "=", maxArgFormatParts)
+			if len(kv) != maxArgFormatParts {
 				return fmt.Errorf("invalid build-arg value %s", buildArg)
 			}
 			dockerBuildOptions.BuildArgs[kv[0]] = &kv[1]
@@ -400,8 +400,8 @@ func getDockerOptions(buildOptions *types.BuildOptions) (dockerTypes.ImageBuildO
 	}
 
 	for _, buildArg := range buildOptions.BuildArgs {
-		kv := strings.SplitN(buildArg, "=", 2)
-		if len(kv) != 2 {
+		kv := strings.SplitN(buildArg, "=", maxArgFormatParts)
+		if len(kv) != maxArgFormatParts {
 			return opts, fmt.Errorf("invalid build-arg value %s", buildArg)
 		}
 		opts.BuildArgs[kv[0]] = &kv[1]

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -94,8 +94,8 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 	}
 
 	for _, buildArg := range buildOptions.BuildArgs {
-		kv := strings.SplitN(buildArg, "=", 2)
-		if len(kv) != 2 {
+		kv := strings.SplitN(buildArg, "=", maxArgFormatParts)
+		if len(kv) != maxArgFormatParts {
 			return nil, fmt.Errorf("invalid build-arg value %s", buildArg)
 		}
 		frontendAttrs["build-arg:"+kv[0]] = kv[1]

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -93,6 +93,7 @@ func getSolveOpt(buildOptions *types.BuildOptions) (*client.SolveOpt, error) {
 		frontendAttrs["add-hosts"] = strings.TrimSuffix(hosts, ",")
 	}
 
+	maxArgFormatParts := 2
 	for _, buildArg := range buildOptions.BuildArgs {
 		kv := strings.SplitN(buildArg, "=", maxArgFormatParts)
 		if len(kv) != maxArgFormatParts {

--- a/pkg/cmd/build/log_filter.go
+++ b/pkg/cmd/build/log_filter.go
@@ -68,7 +68,8 @@ var BuildKitMissingCacheTransformer TransformerFunc = func(vertex *client.Vertex
 	re := regexp.MustCompile(errorPattern)
 	matches := re.FindStringSubmatch(vertex.Error)
 
-	if len(matches) < 2 {
+	minMatches := 2
+	if len(matches) < minMatches {
 		return
 	}
 

--- a/pkg/cmd/down/run.go
+++ b/pkg/cmd/down/run.go
@@ -80,7 +80,8 @@ func Run(dev *model.Dev, app apps.App, trMap map[string]*apps.Translation, wait 
 		return nil
 	}
 
-	waitForDevPodsTermination(ctx, c, dev, 30)
+	t := 30
+	waitForDevPodsTermination(ctx, c, dev, t)
 	return nil
 }
 

--- a/pkg/cmd/down/run.go
+++ b/pkg/cmd/down/run.go
@@ -80,8 +80,8 @@ func Run(dev *model.Dev, app apps.App, trMap map[string]*apps.Translation, wait 
 		return nil
 	}
 
-	t := 30
-	waitForDevPodsTermination(ctx, c, dev, t)
+	devPodTerminationRetries := 30
+	waitForDevPodsTermination(ctx, c, dev, devPodTerminationRetries)
 	return nil
 }
 

--- a/pkg/cmd/init/run.go
+++ b/pkg/cmd/init/run.go
@@ -43,6 +43,7 @@ var (
 
 const (
 	defaultWorkdirPath = "/okteto"
+	maxSystemPorts     = 1024
 )
 
 // GetDevDefaultsFromImage sets dev defaults from a image
@@ -190,7 +191,7 @@ func setForwardsFromPod(ctx context.Context, dev *model.Dev, pod *apiv1.Pod, c *
 	}
 	for _, port := range ports {
 		localPort := port
-		if port <= 1024 {
+		if port <= maxSystemPorts {
 			localPort = port + 8000
 		}
 		for seenPorts[localPort] {

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -165,7 +165,8 @@ func UpdateEnvs(ctx context.Context, name, namespace string, envs []string, c ku
 		envsToSet := make(map[string]string, len(envs))
 		for _, env := range envs {
 			result := strings.Split(env, "=")
-			if len(result) != 2 {
+			envFormatParts := 2
+			if len(result) != envFormatParts {
 				return fmt.Errorf("invalid env format: '%s'", env)
 			}
 
@@ -352,8 +353,9 @@ func removeSensitiveDataFromGitURL(gitURL string) string {
 func translateVariables(variables []string) string {
 	var v []types.DeployVariable
 	for _, item := range variables {
-		splitV := strings.SplitN(item, "=", 2)
-		if len(splitV) != 2 {
+		maxVariableFormatParts := 2
+		splitV := strings.SplitN(item, "=", maxVariableFormatParts)
+		if len(splitV) != maxVariableFormatParts {
 			continue
 		}
 		v = append(v, types.DeployVariable{

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -770,7 +770,8 @@ func waitForPodsToBeRunning(ctx context.Context, s *model.Stack, c kubernetes.In
 	}
 
 	ticker := time.NewTicker(100 * time.Millisecond)
-	timeout := time.Now().Add(600 * time.Second)
+	timeoutDuration := 600 * time.Second
+	timeout := time.Now().Add(timeoutDuration)
 
 	selector := map[string]string{model.StackNameLabel: format.ResourceK8sMetaString(s.Name)}
 	for time.Now().Before(timeout) {

--- a/pkg/cmd/stack/destroy.go
+++ b/pkg/cmd/stack/destroy.go
@@ -250,7 +250,8 @@ func destroyIngresses(ctx context.Context, s *model.Stack, c kubernetes.Interfac
 
 func waitForPodsToBeDestroyed(ctx context.Context, s *model.Stack, c *kubernetes.Clientset) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
-	timeout := time.Now().Add(300 * time.Second)
+	timeoutDuration := 300 * time.Second
+	timeout := time.Now().Add(timeoutDuration)
 
 	selector := map[string]string{model.StackNameLabel: format.ResourceK8sMetaString(s.Name)}
 	for time.Now().Before(timeout) {

--- a/pkg/cmd/status/run.go
+++ b/pkg/cmd/status/run.go
@@ -27,6 +27,10 @@ import (
 	"github.com/okteto/okteto/pkg/syncthing"
 )
 
+const (
+	completedProgressValue = 100
+)
+
 // Run runs the "okteto status" sequence
 func Run(ctx context.Context, sy *syncthing.Syncthing) (float64, error) {
 	progressLocal, err := getCompletionProgress(ctx, sy, true)
@@ -53,21 +57,21 @@ func getCompletionProgress(ctx context.Context, s *syncthing.Syncthing, local bo
 		return 0, err
 	}
 	if completion.GlobalBytes == 0 {
-		return 100, nil
+		return completedProgressValue, nil
 	}
 	progress := (float64(completion.GlobalBytes-completion.NeedBytes) / float64(completion.GlobalBytes)) * 100
 	return progress, nil
 }
 
 func computeProgress(local, remote float64) float64 {
-	if local == 100 && remote == 100 {
-		return 100
+	if local == completedProgressValue && remote == completedProgressValue {
+		return completedProgressValue
 	}
 
-	if local == 100 {
+	if local == completedProgressValue {
 		return remote
 	}
-	if remote == 100 {
+	if remote == completedProgressValue {
 		return local
 	}
 	return (local + remote) / 2

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -137,7 +137,7 @@ frontend:
     # ignored comment
     branch: frontend-branch
     variables:
-      ENVIROMENT: test
+      ENVIRONMENT: test
     wait: true
     timeout: 5m`),
 			expected: ManifestSection{
@@ -147,7 +147,7 @@ frontend:
 					Branch:       "frontend-branch",
 					Variables: env.Environment{
 						env.Var{
-							Name:  "ENVIROMENT",
+							Name:  "ENVIRONMENT",
 							Value: "test",
 						},
 					},

--- a/pkg/env/var.go
+++ b/pkg/env/var.go
@@ -36,9 +36,10 @@ func (v *Var) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err != nil {
 		return err
 	}
-	parts := strings.SplitN(raw, "=", 2)
+	maxVarStringParts := 2
+	parts := strings.SplitN(raw, "=", maxVarStringParts)
 	v.Name = parts[0]
-	if len(parts) == 2 {
+	if len(parts) == maxVarStringParts {
 		v.Value, err = ExpandEnv(parts[1])
 		if err != nil {
 			return err

--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -98,7 +98,8 @@ func (p *PortForwardManager) Add(f forward.Forward) error {
 	}
 
 	if !model.IsPortAvailable(p.iface, f.Local) {
-		if f.Local <= 1024 {
+		maxSystemPorts := 1024
+		if f.Local <= maxSystemPorts {
 			os := runtime.GOOS
 			switch os {
 			case "darwin":

--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -260,11 +260,13 @@ func NewTrip(restConfig *rest.Config, opts *Options) (*Trip, error) {
 		return nil, err
 	}
 
+	defaultMaxWeight := int64(10)
+
 	var sem *semaphore.Weighted
 	if opts.Parallelism > 0 {
 		sem = semaphore.NewWeighted(opts.Parallelism)
 	} else {
-		sem = semaphore.NewWeighted(10)
+		sem = semaphore.NewWeighted(defaultMaxWeight)
 	}
 
 	return &Trip{

--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -249,8 +249,9 @@ func parseUserID(output string) int64 {
 		return -1
 	}
 
+	validUserLineParts := 2
 	parts := strings.Split(lines[0], ":")
-	if len(parts) != 2 {
+	if len(parts) != validUserLineParts {
 		oktetoLog.Infof("failed to parse USER entry: %s", lines[0])
 		return -1
 	}

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -172,6 +172,7 @@ func Destroy(ctx context.Context, name, namespace string, c *kubernetes.Clientse
 	ticker := time.NewTicker(1 * time.Second)
 	timeoutDuration := 3 * timeout
 	to := time.Now().Add(timeoutDuration) // 90 seconds
+	logDebounceInterval := 5
 
 	for i := 0; ; i++ {
 		err := vClient.Delete(ctx, name, metav1.DeleteOptions{})
@@ -192,7 +193,7 @@ func Destroy(ctx context.Context, name, namespace string, c *kubernetes.Clientse
 			return fmt.Errorf("volume claim '%s' wasn't destroyed after %s", name, timeout.String())
 		}
 
-		if i%10 == 5 {
+		if i%10 == logDebounceInterval {
 			oktetoLog.Infof("waiting for volume '%s' to be destroyed", name)
 		}
 

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -170,7 +170,8 @@ func Destroy(ctx context.Context, name, namespace string, c *kubernetes.Clientse
 	oktetoLog.Infof("destroying volume '%s'", name)
 
 	ticker := time.NewTicker(1 * time.Second)
-	to := time.Now().Add(timeout * 3) // 90 seconds
+	timeoutDuration := 3 * timeout
+	to := time.Now().Add(timeoutDuration) // 90 seconds
 
 	for i := 0; ; i++ {
 		err := vClient.Delete(ctx, name, metav1.DeleteOptions{})

--- a/pkg/log/spinner.go
+++ b/pkg/log/spinner.go
@@ -56,8 +56,8 @@ func (sl *spinnerLogger) unhold() {
 }
 
 func newSpinner() *sp.Spinner {
-	duration := 100 * time.Millisecond
-	spinner := sp.New(sp.CharSets[14], duration, sp.WithHiddenCursor(true))
+	rotationSpeed := 100 * time.Millisecond
+	spinner := sp.New(sp.CharSets[14], rotationSpeed, sp.WithHiddenCursor(true))
 	spinner.PreUpdate = func(spinner *sp.Spinner) {
 		width, _, err := term.GetSize(int(os.Stdout.Fd()))
 		if err != nil {

--- a/pkg/log/spinner.go
+++ b/pkg/log/spinner.go
@@ -56,7 +56,8 @@ func (sl *spinnerLogger) unhold() {
 }
 
 func newSpinner() *sp.Spinner {
-	spinner := sp.New(sp.CharSets[14], 100*time.Millisecond, sp.WithHiddenCursor(true))
+	duration := 100 * time.Millisecond
+	spinner := sp.New(sp.CharSets[14], duration, sp.WithHiddenCursor(true))
 	spinner.PreUpdate = func(spinner *sp.Spinner) {
 		width, _, err := term.GetSize(int(os.Stdout.Fd()))
 		if err != nil {

--- a/pkg/model/forward/forward_serializer.go
+++ b/pkg/model/forward/forward_serializer.go
@@ -39,8 +39,10 @@ func (f *Forward) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return f.UnmarshalExtendedForm(unmarshal)
 	}
 
+	maxForwardParts := 3
+	minForwardParts := 2
 	parts := strings.Split(raw, ":")
-	if len(parts) < 2 || len(parts) > 3 {
+	if len(parts) < minForwardParts || len(parts) > maxForwardParts {
 		return fmt.Errorf(MalformedPortForward, raw)
 	}
 
@@ -50,7 +52,7 @@ func (f *Forward) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	f.Local = localPort
 
-	if len(parts) == 2 {
+	if len(parts) == minForwardParts {
 		p, err := strconv.Atoi(parts[1])
 		if err != nil {
 			return fmt.Errorf(MalformedPortForward, raw)

--- a/pkg/model/forward/global_forward_serializer.go
+++ b/pkg/model/forward/global_forward_serializer.go
@@ -1,3 +1,16 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package forward
 
 import (
@@ -17,8 +30,9 @@ func (gf *GlobalForward) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		return gf.UnmarshalExtendedForm(unmarshal)
 	}
 
+	validGlobalForwardParts := 3
 	parts := strings.Split(raw, ":")
-	if len(parts) != 3 {
+	if len(parts) != validGlobalForwardParts {
 		return fmt.Errorf(malformedGlobalForward, raw)
 	}
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -38,6 +38,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	maxVolumeParamDefinition   = 3
+	volumeParamsWithSubPath    = 3
+	volumeParamsWithoutSubpath = 2
+)
+
 var (
 
 	// errDevModeNotValid is raised when development mode in manifest is not 'sync' nor 'hybrid'
@@ -606,12 +612,12 @@ func (v *ExternalVolume) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		return err
 	}
 
-	parts := strings.SplitN(raw, ":", 3)
+	parts := strings.SplitN(raw, ":", maxVolumeParamDefinition)
 	switch len(parts) {
-	case 2:
+	case volumeParamsWithoutSubpath:
 		v.Name = parts[0]
 		v.MountPath = parts[1]
-	case 3:
+	case volumeParamsWithSubPath:
 		v.Name = parts[0]
 		v.SubPath = parts[1]
 		v.MountPath = parts[2]

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -208,8 +208,9 @@ func getListDiff(l1, l2 []string) []string {
 func snapshotEnv() map[string]string {
 	env := os.Environ()
 	snapshot := make(map[string]string, len(env))
+	keyValueVarParts := 2
 	for _, e := range env {
-		pair := strings.SplitN(e, "=", 2)
+		pair := strings.SplitN(e, "=", keyValueVarParts)
 		snapshot[pair[0]] = pair[1]
 	}
 	return snapshot

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -52,6 +52,8 @@ type OktetoContextStore struct {
 const (
 	localClusterType  = "local"
 	remoteClusterType = "remote"
+	hoursInADay       = 24
+	hoursInAWeek      = 168
 )
 
 var (
@@ -579,9 +581,9 @@ func GetContextCertificate() (*x509.Certificate, error) {
 			if cert.Issuer.CommonName == config.OktetoDefaultSelfSignedIssuer {
 				hoursSinceInstall := time.Since(cert.NotBefore).Hours()
 				switch {
-				case hoursSinceInstall <= 24: // less than 1 day
+				case hoursSinceInstall <= hoursInADay: // less than 1 day
 					oktetoLog.Information("Your Okteto installation is using selfsigned certificates. Please switch to your own certificates before production use.")
-				case hoursSinceInstall <= 168: // less than 1 week
+				case hoursSinceInstall <= hoursInAWeek: // less than 1 week
 					oktetoLog.Warning("Your Okteto installation has been using selfsigned certificates for more than a day. It's important to use your own certificates before production use.")
 				default: // more than 1 week
 					oktetoLog.Fail("[PLEASE READ] Your Okteto installation has been using selfsigned certificates for more than a week. It's important to use your own certificates before production use.")

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -91,7 +91,7 @@ func (ImageCtrl) GetRegistryAndRepo(tag string) (string, string) {
 
 	if len(splittedImage) == 1 {
 		imageTag = splittedImage[0]
-	} else if len(splittedImage) == 2 {
+	} else if len(splittedImage) == 2 { //nolint:gomnd
 		if strings.Contains(splittedImage[0], ".") {
 			return splittedImage[0], splittedImage[1]
 		}

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -147,9 +147,10 @@ func (*LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
 		if line == "" {
 			continue
 		}
+		maxValidGitStatusParts := 2
 		// line example values can be: "M modified-file.go", "?? new-file.go", etc
-		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", 2)
-		if len(parts) == 2 {
+		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", maxValidGitStatusParts)
+		if len(parts) == maxValidGitStatusParts {
 			status[strings.Trim(parts[1], " ")] = &git.FileStatus{
 				Staging: git.StatusCode([]byte(parts[0])[0]),
 			}

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -123,7 +123,8 @@ func (fm *ForwardManager) Start(devPod, namespace string) error {
 	oktetoLog.Info("starting SSH forward manager")
 
 	ticker := time.NewTicker(200 * time.Millisecond)
-	to := time.Now().Add(10 * time.Second)
+	timeoutDuration := 10 * time.Second
+	to := time.Now().Add(timeoutDuration)
 	retries := 0
 
 	for {

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -28,6 +28,10 @@ import (
 	forwardModel "github.com/okteto/okteto/pkg/model/forward"
 )
 
+const (
+	maxSystemPorts = 1024
+)
+
 // ForwardManager handles the lifecycle of all the forwards
 type ForwardManager struct {
 	localInterface  string
@@ -75,7 +79,7 @@ func (fm *ForwardManager) canAdd(localPort int, checkAvailable bool) error {
 	}
 
 	if !model.IsPortAvailable(fm.localInterface, localPort) {
-		if localPort <= 1024 {
+		if localPort <= maxSystemPorts {
 			os := runtime.GOOS
 			switch os {
 			case "darwin":

--- a/pkg/syncthing/completion.go
+++ b/pkg/syncthing/completion.go
@@ -55,7 +55,7 @@ func (s *Syncthing) WaitForCompletion(ctx context.Context, reporter chan float64
 			wfc.retries++
 			if wfc.retries%40 == 0 {
 				oktetoLog.Info("checking syncthing for error....")
-				if err := s.IsHealthy(ctx, false, 3); err != nil {
+				if err := s.IsHealthy(ctx, false, maxRetries); err != nil {
 					return err
 				}
 			}

--- a/pkg/syncthing/completion.go
+++ b/pkg/syncthing/completion.go
@@ -21,6 +21,11 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
+const (
+	completedProgress     = 100
+	maxNeedDeletesRetries = 50
+)
+
 // Completion represents the completion of a syncthing folder.
 type Completion struct {
 	Completion  float64 `json:"completion"`
@@ -98,7 +103,7 @@ func (wfc *waitForCompletion) computeProgress(ctx context.Context) error {
 	wfc.localCompletion = localCompletion
 	oktetoLog.Infof("syncthing status in local: globalBytes %d, needBytes %d, globalItems %d, needItems %d, needDeletes %d", localCompletion.GlobalBytes, localCompletion.NeedBytes, localCompletion.GlobalItems, localCompletion.NeedItems, localCompletion.NeedDeletes)
 	if localCompletion.GlobalBytes == 0 {
-		wfc.progress = 100
+		wfc.progress = completedProgress
 	} else {
 		wfc.progress = (float64(localCompletion.GlobalBytes-localCompletion.NeedBytes) / float64(localCompletion.GlobalBytes)) * 100
 	}
@@ -158,7 +163,7 @@ func (wfc *waitForCompletion) isCompleted() bool {
 
 	if wfc.localCompletion.NeedDeletes > 0 {
 		wfc.needDeletesRetries++
-		if wfc.needDeletesRetries < 50 {
+		if wfc.needDeletesRetries < maxNeedDeletesRetries {
 			oktetoLog.Info("synced completed, but need deletes, retrying...")
 			return false
 		}

--- a/pkg/syncthing/install.go
+++ b/pkg/syncthing/install.go
@@ -30,7 +30,9 @@ import (
 )
 
 const (
-	syncthingVersion = "1.24.0"
+	syncthingVersion          = "1.24.0"
+	syncthingVersionStringNew = 3
+	syncthingVersionStringOld = 2
 )
 
 var (
@@ -156,9 +158,9 @@ func parseVersionFromOutput(output []byte) (*semver.Version, error) {
 
 	v := ""
 	switch len(found) {
-	case 3:
+	case syncthingVersionStringNew:
 		v = fmt.Sprintf("%s%s", found[1], found[2])
-	case 2:
+	case syncthingVersionStringOld:
 		v = fmt.Sprint(found[1])
 	default:
 		return nil, fmt.Errorf("failed to extract the version from `%s`", output)

--- a/pkg/syncthing/monitor.go
+++ b/pkg/syncthing/monitor.go
@@ -33,7 +33,7 @@ func (s *Syncthing) Monitor(ctx context.Context, disconnect chan error) {
 				continue
 			}
 			oktetoLog.Infof("syncthing ping error %d", retries)
-			if retries >= 3 {
+			if retries >= maxRetries {
 				oktetoLog.Infof("syncthing ping error, sending disconnect signal")
 				disconnect <- oktetoErrors.ErrLostSyncthing
 				return

--- a/pkg/syncthing/monitor.go
+++ b/pkg/syncthing/monitor.go
@@ -74,8 +74,8 @@ func (s *Syncthing) checkLocalAndRemotePing(ctx context.Context) bool {
 }
 
 func (s *Syncthing) checkLocalAndRemoteStatus(ctx context.Context) error {
-	if err := s.IsHealthy(ctx, true, 3); err != nil {
+	if err := s.IsHealthy(ctx, true, maxRetries); err != nil {
 		return err
 	}
-	return s.IsHealthy(ctx, false, 3)
+	return s.IsHealthy(ctx, false, maxRetries)
 }

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -458,7 +458,8 @@ func (s *Syncthing) waitForFolderScanning(ctx context.Context, folder *Folder, l
 	ticker := time.NewTicker(100 * time.Millisecond)
 	oktetoLog.Infof("waiting for initial scan to complete path=%s local=%t", folder.LocalPath, local)
 
-	to := time.Now().Add(s.timeout * 10) // 5 minutes
+	timeoutDuration := s.timeout * 10
+	to := time.Now().Add(timeoutDuration) // 5 minutes
 
 	for retries := 0; ; retries++ {
 		status, err := s.GetSyncthingStatus(ctx, folder, local)

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -66,6 +66,8 @@ const (
 
 	// GUIPort is the port used by syncthing in the cluster for the http endpoint
 	GUIPort = 8384
+
+	maxRetries = 3
 )
 
 // Syncthing represents the local syncthing process.
@@ -361,7 +363,7 @@ func (s *Syncthing) WaitForPing(ctx context.Context, local bool) error {
 
 // Ping checks if syncthing is available
 func (s *Syncthing) Ping(ctx context.Context, local bool) bool {
-	_, err := s.APICall(ctx, "rest/system/ping", "GET", 200, nil, local, nil, false, 0)
+	_, err := s.APICall(ctx, "rest/system/ping", "GET", http.StatusOK, nil, local, nil, false, 0)
 	if err == nil {
 		return true
 	}
@@ -377,7 +379,7 @@ func (s *Syncthing) Overwrite(ctx context.Context) error {
 	for _, folder := range s.Folders {
 		oktetoLog.Infof("overriding local changes to the remote syncthing path=%s", folder.LocalPath)
 		params := getFolderParameter(folder)
-		_, err := s.APICall(ctx, "rest/db/override", "POST", 200, params, true, nil, false, 3)
+		_, err := s.APICall(ctx, "rest/db/override", "POST", http.StatusOK, params, true, nil, false, maxRetries)
 		if err != nil {
 			oktetoLog.Infof("error posting 'rest/db/override' syncthing API: %s", err)
 			if strings.Contains(err.Error(), "Client.Timeout") {
@@ -407,7 +409,7 @@ func (s *Syncthing) WaitForConnected(ctx context.Context) error {
 	to := time.Now().Add(s.timeout)
 	for retries := 0; ; retries++ {
 		connections := &Connections{}
-		body, err := s.APICall(ctx, "rest/system/connections", "GET", 200, nil, true, nil, true, 3)
+		body, err := s.APICall(ctx, "rest/system/connections", "GET", http.StatusOK, nil, true, nil, true, maxRetries)
 		if err != nil {
 			oktetoLog.Infof("error getting connections: %s", err.Error())
 			if strings.Contains(err.Error(), "Client.Timeout") {
@@ -493,7 +495,7 @@ func (s *Syncthing) waitForFolderScanning(ctx context.Context, folder *Folder, l
 func (s *Syncthing) GetCompletion(ctx context.Context, local bool, device string) (*Completion, error) {
 	params := map[string]string{"device": device}
 	completion := &Completion{}
-	body, err := s.APICall(ctx, "rest/db/completion", "GET", 200, params, local, nil, true, 3)
+	body, err := s.APICall(ctx, "rest/db/completion", "GET", http.StatusOK, params, local, nil, true, maxRetries)
 	if err != nil {
 		oktetoLog.Infof("error calling 'rest/db/completion' local=%t syncthing API: %s", local, err)
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -551,7 +553,7 @@ func (s *Syncthing) GetSyncthingStatus(ctx context.Context, folder *Folder, loca
 		"events":  "StateChanged",
 	}
 	scList := []StateChangedEvent{}
-	body, err := s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true, 3)
+	body, err := s.APICall(ctx, "rest/events", "GET", http.StatusOK, params, local, nil, true, maxRetries)
 	if err != nil {
 		oktetoLog.Infof("error getting events: %s", err.Error())
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -577,7 +579,7 @@ func (s *Syncthing) GetSyncthingStatus(ctx context.Context, folder *Folder, loca
 	delete(params, "events")
 	delete(params, "limit")
 
-	body, err = s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true, 3)
+	body, err = s.APICall(ctx, "rest/events", "GET", http.StatusOK, params, local, nil, true, maxRetries)
 	if err != nil {
 		oktetoLog.Infof("error getting events: %s", err.Error())
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -613,7 +615,7 @@ func (s *Syncthing) GetPullErrors(ctx context.Context, local bool) (int64, error
 		"events":  "FolderSummary",
 	}
 	fsList := []FolderSummaryEvent{}
-	body, err := s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true, 3)
+	body, err := s.APICall(ctx, "rest/events", "GET", http.StatusOK, params, local, nil, true, maxRetries)
 	if err != nil {
 		oktetoLog.Infof("error getting events: %s", err.Error())
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -639,7 +641,7 @@ func (s *Syncthing) GetPullErrors(ctx context.Context, local bool) (int64, error
 	delete(params, "events")
 	delete(params, "limit")
 
-	body, err = s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true, 3)
+	body, err = s.APICall(ctx, "rest/events", "GET", http.StatusOK, params, local, nil, true, maxRetries)
 	if err != nil {
 		oktetoLog.Infof("error getting events: %s", err.Error())
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -674,7 +676,7 @@ func (s *Syncthing) GetFolderErrors(ctx context.Context, local bool) error {
 		"events":  "FolderErrors",
 	}
 	folderErrorsList := []FolderErrorEvent{}
-	body, err := s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true, 3)
+	body, err := s.APICall(ctx, "rest/events", "GET", http.StatusOK, params, local, nil, true, maxRetries)
 	if err != nil {
 		oktetoLog.Infof("error getting events: %s", err.Error())
 		if strings.Contains(err.Error(), "Client.Timeout") {
@@ -701,7 +703,7 @@ func (s *Syncthing) GetFolderErrors(ctx context.Context, local bool) error {
 			delete(params, "events")
 			delete(params, "limit")
 
-			body, err = s.APICall(ctx, "rest/events", "GET", 200, params, local, nil, true, 3)
+			body, err = s.APICall(ctx, "rest/events", "GET", http.StatusOK, params, local, nil, true, maxRetries)
 			if err != nil {
 				oktetoLog.Infof("error getting events: %s", err.Error())
 				if strings.Contains(err.Error(), "Client.Timeout") {
@@ -751,7 +753,7 @@ func (s *Syncthing) GetInSynchronizationFile(ctx context.Context) string {
 		"timeout": "0",
 		"events":  "DownloadProgress",
 	}
-	body, err := s.APICall(ctx, "rest/events", "GET", 200, params, false, nil, true, 0)
+	body, err := s.APICall(ctx, "rest/events", "GET", http.StatusOK, params, false, nil, true, 0)
 	if err != nil {
 		oktetoLog.Infof("error getting GetInSynchronizationItem: %s", err.Error())
 		return ""
@@ -786,7 +788,7 @@ func getInSynchronizationLargestFile(e ItemEvent) string {
 
 // Restart restarts the syncthing process
 func (s *Syncthing) Restart(ctx context.Context) error {
-	_, err := s.APICall(ctx, "rest/system/restart", "POST", 200, nil, true, nil, false, 3)
+	_, err := s.APICall(ctx, "rest/system/restart", "POST", http.StatusOK, nil, true, nil, false, maxRetries)
 	return err
 }
 


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/LAKE-75

This PR enables and fixes the problems raised by linter `gomnd`. this spots magic numbers.
Configuration has been set so we avoid magic numbers when passing arguments, and adding some ignored functions where we can use numbers as argument.

## How to validate

When passing some argument (int) into a function directly as number without previously declaring it as const

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
