### PR TITLE
CLI Quality - Lint-  musttag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.3.1
+      - image: okteto/golang-ci:2.3.3
 
 jobs:
   golangci-lint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
     - tenv
     - tparallel
     - gci
-    - goheader    
+    - goheader
     - unconvert
     - predeclared
     - asciicheck
@@ -60,6 +60,7 @@ linters:
     - decorder
     - exportloopref
     - makezero
+    - musttag
 
 issues:
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -137,7 +137,7 @@ frontend:
     # ignored comment
     branch: frontend-branch
     variables:
-      ENVIROMENT: test
+      ENVIRONMENT: test
     wait: true
     timeout: 5m`),
 			expected: ManifestSection{
@@ -147,7 +147,7 @@ frontend:
 					Branch:       "frontend-branch",
 					Variables: env.Environment{
 						env.Var{
-							Name:  "ENVIROMENT",
+							Name:  "ENVIRONMENT",
 							Value: "test",
 						},
 					},

--- a/pkg/k8s/apps/utils.go
+++ b/pkg/k8s/apps/utils.go
@@ -23,7 +23,7 @@ import (
 )
 
 type stateBeforeSleeping struct {
-	Replicas int
+	Replicas int `json:"replicas"`
 }
 
 func getPreviousAppReplicas(app App) int32 {

--- a/pkg/model/contextresource.go
+++ b/pkg/model/contextresource.go
@@ -25,8 +25,8 @@ import (
 
 // ContextResource provides the context and namespace to operate within a manifest
 type ContextResource struct {
-	Context   string
-	Namespace string
+	Context   string `yaml:"context"`
+	Namespace string `yaml:"namespace"`
 }
 
 // GetContextResource returns a ContextResource object from a given file

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -230,8 +230,8 @@ type Volume struct {
 
 // Sync represents a sync info in the development container
 type Sync struct {
-	LocalPath      string
-	RemotePath     string
+	LocalPath      string       `json:"-"`
+	RemotePath     string       `json:"-"`
 	Folders        []SyncFolder `json:"folders,omitempty" yaml:"folders,omitempty"`
 	RescanInterval int          `json:"rescanInterval,omitempty" yaml:"rescanInterval,omitempty"`
 	Compression    bool         `json:"compression" yaml:"compression"`

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -230,8 +230,8 @@ type Volume struct {
 
 // Sync represents a sync info in the development container
 type Sync struct {
-	LocalPath      string       `json:"-"`
-	RemotePath     string       `json:"-"`
+	LocalPath      string       `json:"-" yaml:"-"`
+	RemotePath     string       `json:"-" yaml:"-"`
 	Folders        []SyncFolder `json:"folders,omitempty" yaml:"folders,omitempty"`
 	RescanInterval int          `json:"rescanInterval,omitempty" yaml:"rescanInterval,omitempty"`
 	Compression    bool         `json:"compression" yaml:"compression"`


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/LAKE-77

This PR enables lint musttag to check all the structs are tagged correctly.
This lint needs the version of the runner upgraded, so updated the image to 2.3.3 at circleci config

## How to validate

Any struct without json or yaml tags wich is serialize should have this properties

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

