### PR TITLE
Fix panic on okteto up with plain output

### DIFF
--- a/cmd/utils/executor/plain.go
+++ b/cmd/utils/executor/plain.go
@@ -25,7 +25,9 @@ type plainExecutor struct {
 }
 
 func newPlainExecutor() *plainExecutor {
-	return &plainExecutor{}
+	return &plainExecutor{
+		displayer: displayer.NewDisplayer(oktetoLog.PlainFormat, nil, nil),
+	}
 }
 
 func (e *plainExecutor) startCommand(cmd *exec.Cmd) error {

--- a/cmd/utils/executor/plain_test.go
+++ b/cmd/utils/executor/plain_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInititalization(t *testing.T) {
+	e := newPlainExecutor()
+
+	assert.NotNil(t, e)
+	assert.NotEmpty(t, e.displayer)
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -163,6 +163,7 @@ func SetOutput(output io.Writer) {
 // SetOutputFormat sets the output format
 func SetOutputFormat(format string) {
 	log.writer = log.getWriter(format)
+	log.spinner.spinnerSupport = !loadBool(OktetoDisableSpinnerEnvVar) && IsInteractive()
 }
 
 // GetOutputWriter sets the output format

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -16,6 +16,7 @@ package log
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,6 +68,39 @@ func Test_GetContextResource(t *testing.T) {
 			DisableMasking()
 			result = redactMessage(tt.message)
 			assert.Equal(t, tt.message, result)
+		})
+	}
+}
+
+func TestSetOutputFormat(t *testing.T) {
+	Init(logrus.DebugLevel)
+	var tests = []struct {
+		name              string
+		expectedWriter    interface{}
+		hasSpinnerSupport bool
+	}{
+		{
+			name:              "tty",
+			expectedWriter:    &TTYWriter{},
+			hasSpinnerSupport: true,
+		},
+		{
+			name:              "plain",
+			expectedWriter:    &PlainWriter{},
+			hasSpinnerSupport: false,
+		},
+		{
+			name:              "json",
+			expectedWriter:    &JSONWriter{},
+			hasSpinnerSupport: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetOutputFormat(tt.name)
+			assert.IsType(t, tt.expectedWriter, log.writer)
+			assert.Equal(t, tt.hasSpinnerSupport, log.spinner.spinnerSupport)
 		})
 	}
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -75,8 +75,8 @@ func Test_GetContextResource(t *testing.T) {
 func TestSetOutputFormat(t *testing.T) {
 	Init(logrus.DebugLevel)
 	var tests = []struct {
-		name              string
 		expectedWriter    interface{}
+		name              string
 		hasSpinnerSupport bool
 	}{
 		{


### PR DESCRIPTION
Fixes LAKE-103

# Proposed changes

- Fix spinner to only work with TTY output mode
- Fix panic on okteto up with plain output mode

## How to validate

Repo used: [GitHub - okteto/filemanager: Filemanager stack example app](https://github.com/okteto/filemanager) 

1. Run `gh repo clone okteto/filemanager`
1. Run `okteto up -f filemanager/okteto.yml -c https://cloud.okteto.com --log-output plain filemanager`


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
