### PR TITLE
remove okteto cloud as context option

### DIFF
--- a/cmd/context/selector.go
+++ b/cmd/context/selector.go
@@ -34,7 +34,6 @@ func getContextsSelection(ctxOptions *ContextOptions) []utils.SelectorItem {
 	}
 	clusters := make([]utils.SelectorItem, 0)
 
-	clusters = append(clusters, utils.SelectorItem{Name: okteto.CloudURL, Label: cloudOption, Enable: true})
 	clusters = append(clusters, getOktetoClusters(true)...)
 	if len(k8sClusters) > 0 {
 		clusters = append(clusters, getK8sClusters(k8sClusters)...)

--- a/cmd/context/selector.go
+++ b/cmd/context/selector.go
@@ -14,7 +14,6 @@
 package context
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 
@@ -23,7 +22,6 @@ import (
 )
 
 var (
-	cloudOption = fmt.Sprintf("%s (Okteto Cloud)", okteto.CloudURL)
 	newOEOption = "Create new context"
 )
 

--- a/cmd/context/selector.go
+++ b/cmd/context/selector.go
@@ -22,10 +22,10 @@ import (
 )
 
 var (
-	newOEOption = "Create new context"
+	newOEOption = "Add new context"
 )
 
-func getContextsSelection(ctxOptions *ContextOptions) []utils.SelectorItem {
+func getAvailableContexts(ctxOptions *ContextOptions) []utils.SelectorItem {
 	k8sClusters := make([]string, 0)
 	if !ctxOptions.OnlyOkteto {
 		k8sClusters = getKubernetesContextList(true)
@@ -36,19 +36,6 @@ func getContextsSelection(ctxOptions *ContextOptions) []utils.SelectorItem {
 	if len(k8sClusters) > 0 {
 		clusters = append(clusters, getK8sClusters(k8sClusters)...)
 	}
-
-	if len(clusters) > 0 {
-		clusters = append(clusters, utils.SelectorItem{
-			Label:  "",
-			Enable: false,
-		})
-	}
-
-	clusters = append(clusters, utils.SelectorItem{
-		Name:   newOEOption,
-		Label:  newOEOption,
-		Enable: true,
-	})
 
 	return clusters
 }

--- a/cmd/context/selector.go
+++ b/cmd/context/selector.go
@@ -36,17 +36,19 @@ func getContextsSelection(ctxOptions *ContextOptions) []utils.SelectorItem {
 	if len(k8sClusters) > 0 {
 		clusters = append(clusters, getK8sClusters(k8sClusters)...)
 	}
-	clusters = append(clusters, []utils.SelectorItem{
-		{
+
+	if len(clusters) > 0 {
+		clusters = append(clusters, utils.SelectorItem{
 			Label:  "",
 			Enable: false,
-		},
-		{
-			Name:   newOEOption,
-			Label:  newOEOption,
-			Enable: true,
-		},
-	}...)
+		})
+	}
+
+	clusters = append(clusters, utils.SelectorItem{
+		Name:   newOEOption,
+		Label:  newOEOption,
+		Enable: true,
+	})
 
 	return clusters
 }

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	personalAccessTokenURL            = "https://www.okteto.com/docs/cloud/personal-access-tokens/"
-	messageHintFirstOktetoContextInit = "To install your own instance follow these steps: https://www.okteto.com/free-trial/: "
-	messageSuggestingCurrentContext   = "Enter the URL of your Okteto instance"
+	personalAccessTokenURL          = "https://www.okteto.com/docs/cloud/personal-access-tokens/"
+	suggestInstallOktetoSH          = "Don't have an Okteto instance? Start by installing Okteto on your Kubernetes cluster: https://www.okteto.com/free-trial/"
+	messageSuggestingCurrentContext = "Enter the URL of your Okteto instance: "
 )
 
 // Use context points okteto to a cluster.
@@ -176,7 +176,7 @@ func getContext(ctxOptions *ContextOptions) (string, error) {
 			if oCtx, ok := ctxStore.Contexts[ctxStore.CurrentContext]; ok && oCtx.IsOkteto {
 				clusterURL = ctxStore.CurrentContext
 			}
-			question := fmt.Sprintf("%s [%s]: ", messageSuggestingCurrentContext, clusterURL)
+			question := fmt.Sprintf("%s[%s]: ", messageSuggestingCurrentContext, clusterURL)
 			oktetoContext, err = askForOktetoURL(question)
 			if err != nil {
 				return "", err
@@ -187,8 +187,8 @@ func getContext(ctxOptions *ContextOptions) (string, error) {
 		}
 	} else {
 		var err error
-		question := fmt.Sprintf("%s. %s", messageSuggestingCurrentContext, messageHintFirstOktetoContextInit)
-		oktetoContext, err = askForOktetoURL(question)
+		oktetoLog.Information(suggestInstallOktetoSH)
+		oktetoContext, err = askForOktetoURL(messageSuggestingCurrentContext)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -31,7 +31,9 @@ import (
 )
 
 const (
-	personalAccessTokenURL = "https://www.okteto.com/docs/cloud/personal-access-tokens/"
+	personalAccessTokenURL            = "https://www.okteto.com/docs/cloud/personal-access-tokens/"
+	messageHintFirstOktetoContextInit = "To install your own instance follow these steps: https://www.okteto.com/free-trial/: "
+	messageSuggestingCurrentContext   = "Enter the URL of your Okteto instance"
 )
 
 // Use context points okteto to a cluster.
@@ -148,22 +150,49 @@ func (c *ContextCommand) Run(ctx context.Context, ctxOptions *ContextOptions) er
 }
 
 func getContext(ctxOptions *ContextOptions) (string, error) {
-	ctxs := getContextsSelection(ctxOptions)
-	initialPosition := getInitialPosition(ctxs)
-	selector := utils.NewOktetoSelector("A context defines the default cluster/namespace for any Okteto CLI command.\nSelect the context you want to use:", "Context")
-	oktetoContext, err := selector.AskForOptionsOkteto(ctxs, initialPosition)
-	if err != nil {
-		return "", err
-	}
+	ctxs := getAvailableContexts(ctxOptions)
 
-	if isCreateNewContextOption(oktetoContext) {
-		oktetoContext, err = askForOktetoURL()
+	var oktetoContext string
+	if len(ctxs) > 0 {
+		ctxs = append(ctxs, utils.SelectorItem{
+			Label:  "",
+			Enable: false,
+		})
+		ctxs = append(ctxs, utils.SelectorItem{
+			Name:   newOEOption,
+			Label:  newOEOption,
+			Enable: true,
+		})
+
+		initialPosition := getInitialPosition(ctxs)
+		selector := utils.NewOktetoSelector("A context defines the default Okteto instance or cluster for any Okteto CLI command.\nSelect the context you want to use:", "Option")
+		oktetoContext, err := selector.AskForOptionsOkteto(ctxs, initialPosition)
+		if err != nil {
+			return "", err
+		}
+		if isCreateNewContextOption(oktetoContext) {
+			ctxStore := okteto.ContextStore()
+			clusterURL := okteto.CloudURL
+			if oCtx, ok := ctxStore.Contexts[ctxStore.CurrentContext]; ok && oCtx.IsOkteto {
+				clusterURL = ctxStore.CurrentContext
+			}
+			question := fmt.Sprintf("%s [%s]: ", messageSuggestingCurrentContext, clusterURL)
+			oktetoContext, err = askForOktetoURL(question)
+			if err != nil {
+				return "", err
+			}
+			ctxOptions.IsOkteto = true
+		} else {
+			ctxOptions.IsOkteto = okteto.IsOktetoContext(oktetoContext)
+		}
+	} else {
+		var err error
+		question := fmt.Sprintf("%s. %s", messageSuggestingCurrentContext, messageHintFirstOktetoContextInit)
+		oktetoContext, err = askForOktetoURL(question)
 		if err != nil {
 			return "", err
 		}
 		ctxOptions.IsOkteto = true
-	} else {
-		ctxOptions.IsOkteto = okteto.IsOktetoContext(oktetoContext)
 	}
 
 	return oktetoContext, nil

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	personalAccessTokenURL          = "https://www.okteto.com/docs/cloud/personal-access-tokens/"
-	suggestInstallOktetoSH          = "Don't have an Okteto instance? Start by installing Okteto on your Kubernetes cluster: https://www.okteto.com/free-trial/"
+	suggestInstallOktetoSH          = "Don't have an Okteto instance?\n    Start by installing Okteto on your Kubernetes cluster: https://www.okteto.com/free-trial/"
 	messageSuggestingCurrentContext = "Enter the URL of your Okteto instance: "
 )
 

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -153,6 +153,7 @@ func getContext(ctxOptions *ContextOptions) (string, error) {
 	ctxs := getAvailableContexts(ctxOptions)
 
 	var oktetoContext string
+	var err error
 	if len(ctxs) > 0 {
 		ctxs = append(ctxs, utils.SelectorItem{
 			Label:  "",
@@ -166,7 +167,7 @@ func getContext(ctxOptions *ContextOptions) (string, error) {
 
 		initialPosition := getInitialPosition(ctxs)
 		selector := utils.NewOktetoSelector("A context defines the default Okteto instance or cluster for any Okteto CLI command.\nSelect the context you want to use:", "Option")
-		oktetoContext, err := selector.AskForOptionsOkteto(ctxs, initialPosition)
+		oktetoContext, err = selector.AskForOptionsOkteto(ctxs, initialPosition)
 		if err != nil {
 			return "", err
 		}
@@ -186,7 +187,7 @@ func getContext(ctxOptions *ContextOptions) (string, error) {
 			ctxOptions.IsOkteto = okteto.IsOktetoContext(oktetoContext)
 		}
 	} else {
-		var err error
+
 		oktetoLog.Information(suggestInstallOktetoSH)
 		oktetoContext, err = askForOktetoURL(messageSuggestingCurrentContext)
 		if err != nil {

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -82,20 +82,15 @@ func isCreateNewContextOption(option string) bool {
 	return option == newOEOption
 }
 
-func askForOktetoURL() (string, error) {
-	clusterURL := okteto.CloudURL
-	ctxStore := okteto.ContextStore()
-	if oCtx, ok := ctxStore.Contexts[ctxStore.CurrentContext]; ok && oCtx.IsOkteto {
-		clusterURL = ctxStore.CurrentContext
-	}
-
-	err := oktetoLog.Question("Enter your Okteto URL [%s]: ", clusterURL)
+func askForOktetoURL(message string) (string, error) {
+	err := oktetoLog.Question(message)
 	if err != nil {
 		return "", err
 	}
-	fmt.Scanln(&clusterURL)
+	var oktetoURL string
+	fmt.Scanln(&oktetoURL)
 
-	url, err := url.Parse(clusterURL)
+	url, err := url.Parse(oktetoURL)
 	if err != nil {
 		return "", nil
 	}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -138,6 +138,7 @@ func (fc fakeClient) Write(_ name.Reference, _ containerv1.Image) error {
 }
 
 type fakeClientConfig struct {
+	err                         error
 	cert                        *x509.Certificate
 	externalRegistryCredentials [2]string
 	registryURL                 string
@@ -152,11 +153,11 @@ func (f fakeClientConfig) GetRegistryURL() string                            { r
 func (f fakeClientConfig) GetUserID() string                                 { return f.userID }
 func (f fakeClientConfig) GetToken() string                                  { return f.token }
 func (f fakeClientConfig) IsInsecureSkipTLSVerifyPolicy() bool               { return f.isInsecure }
-func (f fakeClientConfig) GetContextCertificate() (*x509.Certificate, error) { return f.cert, nil }
+func (f fakeClientConfig) GetContextCertificate() (*x509.Certificate, error) { return f.cert, f.err }
 func (f fakeClientConfig) GetServerNameOverride() string                     { return f.serverName }
 func (f fakeClientConfig) GetContextName() string                            { return f.contextName }
 func (f fakeClientConfig) GetExternalRegistryCredentials(_ string) (string, string, error) {
-	return f.externalRegistryCredentials[0], f.externalRegistryCredentials[1], nil
+	return f.externalRegistryCredentials[0], f.externalRegistryCredentials[1], f.err
 }
 
 func TestGetDigest(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

- remove okteto cloud as context option

## How to validate

Run `okteto context` and check if okteto cloud context is displayed. It shouldn't

Context shown shouldn't display cloud context:
![Captura de pantalla 2023-11-29 a las 13 23 00](https://github.com/okteto/okteto/assets/22500940/cc4cfc99-0d6f-4a53-9cce-0fd6a6ddad60)

