### PR TITLE
Fix connection issues to dev containers using vscode remote ssh

### DIFF
--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -296,7 +296,7 @@ services:
 					{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 					{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 					{Name: "BASHOPTS", Value: "histappend"},
-					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 				},
 				SecurityContext: &apiv1.SecurityContext{
 					RunAsUser:  &runAsUser,
@@ -520,7 +520,7 @@ services:
 					{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 					{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 					{Name: "BASHOPTS", Value: "histappend"},
-					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 				},
 				SecurityContext: &apiv1.SecurityContext{
 					RunAsUser:  pointer.Int64Ptr(0),
@@ -1467,7 +1467,7 @@ environment:
 		{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 		{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 		{Name: "BASHOPTS", Value: "histappend"},
-		{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+		{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 	}
 	if !reflect.DeepEqual(envOK, tr.DevApp.PodSpec().Containers[0].Env) {
 		t.Fatalf("Wrong env generation %+v", tr.DevApp.PodSpec().Containers[0].Env)
@@ -1719,7 +1719,7 @@ services:
 					{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 					{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 					{Name: "BASHOPTS", Value: "histappend"},
-					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 				},
 				SecurityContext: &apiv1.SecurityContext{
 					RunAsUser:  &runAsUser,
@@ -1932,7 +1932,7 @@ services:
 					{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 					{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 					{Name: "BASHOPTS", Value: "histappend"},
-					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+					{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 				},
 				VolumeMounts: []apiv1.VolumeMount{
 					{

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1185,7 +1185,7 @@ func enableHistoryVolume(rule *TranslationRule, main *Dev) {
 		},
 		env.Var{
 			Name:  "PROMPT_COMMAND",
-			Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND",
+			Value: "history -a ; history -c ; history -r",
 		})
 }
 

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -97,7 +97,7 @@ services:
 			{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 			{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 			{Name: "BASHOPTS", Value: "histappend"},
-			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 		},
 		SecurityContext: &SecurityContext{
 			RunAsUser:  pointer.Int64Ptr(0),
@@ -199,7 +199,7 @@ services:
 			{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 			{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 			{Name: "BASHOPTS", Value: "histappend"},
-			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 		},
 		Volumes: []VolumeMount{
 			{
@@ -271,7 +271,7 @@ initContainer:
 			{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 			{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 			{Name: "BASHOPTS", Value: "histappend"},
-			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 		},
 		SecurityContext: &SecurityContext{
 			RunAsUser:  pointer.Int64Ptr(0),
@@ -366,7 +366,7 @@ sync:
 			{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 			{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 			{Name: "BASHOPTS", Value: "histappend"},
-			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 		},
 		SecurityContext: &SecurityContext{
 			RunAsUser:  pointer.Int64Ptr(0),
@@ -428,7 +428,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 				{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 				{Name: "BASHOPTS", Value: "histappend"},
-				{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+				{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 			},
 		},
 		{
@@ -446,7 +446,7 @@ func TestSSHServerPortTranslationRule(t *testing.T) {
 				{Name: "HISTCONTROL", Value: "ignoreboth:erasedups"},
 				{Name: "HISTFILE", Value: "/var/okteto/bashrc/.bash_history"},
 				{Name: "BASHOPTS", Value: "histappend"},
-				{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r ; $PROMPT_COMMAND"},
+				{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 			},
 		},
 	}


### PR DESCRIPTION
# Proposed changes

Fixes: https://github.com/okteto/remote-kubernetes/issues/232
Fixes: LAKE-76


## Description

When connecting via VSCode Remote SSH to an okteto dev container, the terminal crashes. This is caused by the script `shellIntegration-bash.sh` which is executed by `terminalEnvironment.ts` as follows:

```bash
bash --init-file <PATH TO shellIntegration-bash.sh>

# example

bash --init-file /root/.vscode-server/bin/1a5daa3a0231a0fbba4f14db7ec463cf99d7768e/out/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
```

This is the command that is executed when a new terminal is launched within VSCode while connected via Remote SSH.

However the command fails with:

```bash
Segmentation fault (core dumped)
```

The script fails only if the `PROMPT_COMMAND` contains an empty env var. When we create the dev container, we set `PROMPT_COMMAND` to be `history -a ; history -c ; history -r ; $PROMPT_COMMAND` but because `$PROMPT_COMMAND` is not expanded, it conflicts with the script which fails and crashes the terminal (because bash cannot start).

I think it's safe to remove `PROMPT_COMMAND` here because:

1. We are not exanding it locally, so the user cannot inject a custom cmd (and we may not want that anyway)
2. We remove the possibility of side effects from the image, in case in the future the image has defined `PROMPT_COMMAND`, it will affect the user experience

## How to validate

1. Using `okteto/movies`
1. Using okteto stable run `okteto up api`
1. Open VSCode and make sure you have the `Remote SSH` extension installed
1. Connect to the dev container (api.okteto)
1. Start a new terminal and observe how the terminal crashes
1. Now run `okteto down api`
1. Build the CLI from this branch
1. Run `okteto up api` again
1. Connect to the dev container and observe how the terminal works as expected

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
