### PR TITLE
fix external resource markdown able to generate it dinamycally using …

### DIFF
--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -27,6 +27,7 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	"github.com/okteto/okteto/pkg/divert"
+	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/format"
 	"github.com/okteto/okteto/pkg/k8s/ingresses"
 	kconfig "github.com/okteto/okteto/pkg/k8s/kubeconfig"
@@ -350,7 +351,17 @@ func (ld *localDeployer) deployExternals(ctx context.Context, opts *Options, dyn
 			return err
 		}
 
-		err := control.Deploy(ctx, externalName, opts.Manifest.Namespace, externalInfo)
+		ef := externalresource.ERFilesystemManager{
+			Fs:               ld.Fs,
+			ExternalResource: *externalInfo,
+		}
+
+		err := ef.LoadMarkdownContent(opts.Manifest.ManifestPath)
+		if err != nil {
+			oktetoLog.Infof("error loading external resource %s: %s", externalName, err.Error())
+		}
+
+		err = control.Deploy(ctx, externalName, opts.Manifest.Namespace, externalInfo)
 		if err != nil {
 			return err
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -630,17 +630,8 @@ func getOktetoManifest(devPath string) (*Manifest, error) {
 		return nil, newManifestFriendlyError(err)
 	}
 
-	ef := externalresource.ERFilesystemManager{
-		Fs: afero.NewOsFs(),
-	}
-
 	for name, external := range manifest.External {
 		external.SetDefaults(name)
-		ef.ExternalResource = *external
-		err := ef.LoadMarkdownContent(devPath)
-		if err != nil {
-			oktetoLog.Infof("error loading external resource %s: %s", name, err.Error())
-		}
 	}
 
 	manifest.ManifestPath = devPath


### PR DESCRIPTION
…deploy section

# Proposed changes
- read external markdown after run deploy section in order to benefit from any modification of the file during that step

## How to validate
- clone https://github.com/AdrianPedriza/go-getting-started
- run `okteto deploy`  generates the external resource with the content properly. Check UI:
<img width="419" alt="Captura de pantalla 2023-11-30 a las 13 09 13" src="https://github.com/okteto/okteto/assets/22500940/b2fa2d52-6618-4ddc-b0f4-915a3116855e">

- to run `okteto deploy --remote`, you will need to build this cli version and use that image name [here](https://github.com/okteto/okteto/blob/master/cmd/deploy/remote.go#L282). Result should be same as running `okteto deploy` 
## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
