### PR TITLE
makefile: add lint-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ lint:
 	pre-commit run --all-files
 	golangci-lint run
 
+.PHONY: lint-fix
+lint-fix:
+	golangci-lint run --fix
+
 .PHONY: install-fieldalignment
 install-fieldalignment:
 	$(eval GOBIN=$(shell go env GOPATH)/bin)


### PR DESCRIPTION
# Proposed changes

Adding a `make lint-fix` especially useful for linters like `gci` to automatically fix import orders.

Ideally the IDE should respect the `.golangci.yml` directives but in case the IDE is not configured properly the automated import does not follow the rules defined and therefore I think this make cmd can be handy to have.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----


<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->