### PR TITLE
Fix panic in `okteto init --deploy`

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -101,22 +101,22 @@ func NewBuilder(builder OktetoBuilderInterface, registry oktetoRegistryInterface
 // NewBuilderFromScratch creates a new okteto builder
 func NewBuilderFromScratch(analyticsTracker analyticsTrackerInterface, ioCtrl *io.IOController) *OktetoBuilder {
 	builder := &build.OktetoBuilder{}
-	registry := registry.NewOktetoRegistry(okteto.Config{})
+	reg := registry.NewOktetoRegistry(okteto.Config{})
 	wdCtrl := filesystem.NewOsWorkingDirectoryCtrl()
 	wd, err := wdCtrl.Get()
 	if err != nil {
 		ioCtrl.Logger().Infof("could not get working dir: %s", err)
 	}
 	gitRepo := repository.NewRepository(wd)
-	config := getConfig(registry, gitRepo, ioCtrl.Logger())
+	config := getConfig(reg, gitRepo, ioCtrl.Logger())
 
 	buildEnvs := map[string]string{}
 	buildEnvs[OktetoEnableSmartBuildEnvVar] = strconv.FormatBool(config.isSmartBuildsEnable)
 
 	return &OktetoBuilder{
 		Builder:           builder,
-		Registry:          registry,
-		V1Builder:         buildv1.NewBuilder(builder, registry, ioCtrl),
+		Registry:          reg,
+		V1Builder:         buildv1.NewBuilder(builder, reg, ioCtrl),
 		buildEnvironments: buildEnvs,
 		Config:            config,
 		analyticsTracker:  analyticsTracker,

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -114,7 +114,7 @@ type DeployCommand struct {
 	DivertDriver       divert.Driver
 	PipelineCMD        pipelineCMD.PipelineDeployerInterface
 	AnalyticsTracker   analyticsTrackerInterface
-	ioCtrl             *io.IOController
+	IoCtrl             *io.IOController
 
 	PipelineType       model.Archetype
 	isRemote           bool
@@ -217,7 +217,7 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.IOCont
 				PipelineCMD:        pc,
 				runningInInstaller: config.RunningInInstaller(),
 				AnalyticsTracker:   at,
-				ioCtrl:             ioCtrl,
+				IoCtrl:             ioCtrl,
 			}
 			startTime := time.Now()
 
@@ -361,7 +361,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		oktetoLog.Infof("failed to recreate failed pods: %s", err.Error())
 	}
 
-	deployer, err := dc.GetDeployer(ctx, deployOptions, dc.Builder, dc.CfgMapHandler, dc.K8sClientProvider, NewKubeConfig(), model.GetAvailablePort, dc.ioCtrl)
+	deployer, err := dc.GetDeployer(ctx, deployOptions, dc.Builder, dc.CfgMapHandler, dc.K8sClientProvider, NewKubeConfig(), model.GetAvailablePort, dc.IoCtrl)
 	if err != nil {
 		return err
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"github.com/okteto/okteto/pkg/log/io"
 	"os"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
@@ -27,7 +28,7 @@ import (
 )
 
 // Init creates okteto manifest
-func Init() *cobra.Command {
+func Init(ioCtrl *io.IOController) *cobra.Command {
 	opts := &manifest.InitOpts{}
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -61,7 +62,9 @@ func Init() *cobra.Command {
 			opts.ShowCTA = oktetoLog.IsInteractive()
 			mc := &manifest.ManifestCommand{
 				K8sClientProvider: okteto.NewK8sClientProvider(),
+				IoCtrl:            ioCtrl,
 			}
+
 			if opts.Version1 {
 				if err := mc.RunInitV1(ctx, opts); err != nil {
 					return err

--- a/cmd/manifest/init-v1.go
+++ b/cmd/manifest/init-v1.go
@@ -42,52 +42,6 @@ const (
 	defaultInitValues = "Use default values"
 )
 
-// InitV1 automatically generates the manifest
-func InitV1(opts *InitOpts, at analyticsTrackerInterface) error {
-	ctx := context.Background()
-
-	ctxResource := &model.ContextResource{}
-	if err := ctxResource.UpdateNamespace(opts.Namespace); err != nil {
-		return err
-	}
-
-	if err := ctxResource.UpdateContext(opts.Context); err != nil {
-		return err
-	}
-	ctxOptions := &contextCMD.ContextOptions{
-		Context:   ctxResource.Context,
-		Namespace: ctxResource.Namespace,
-		Show:      true,
-	}
-	if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
-		return err
-	}
-
-	opts.Language = os.Getenv(model.OktetoLanguageEnvVar)
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	opts.Workdir = cwd
-
-	mc := &ManifestCommand{
-		analyticsTracker: at,
-	}
-	if err := mc.RunInitV1(ctx, opts); err != nil {
-		return err
-	}
-
-	oktetoLog.Success(fmt.Sprintf("okteto manifest (%s) created", opts.DevPath))
-
-	if opts.DevPath == utils.DefaultManifest {
-		oktetoLog.Information("Run 'okteto up' to activate your development container")
-	} else {
-		oktetoLog.Information("Run 'okteto up -f %s' to activate your development container", opts.DevPath)
-	}
-	return nil
-}
-
 // RunInitV1 runs the sequence to generate okteto.yml
 func (*ManifestCommand) RunInitV1(ctx context.Context, opts *InitOpts) error {
 	oktetoLog.Println("This command walks you through creating an okteto manifest.")

--- a/cmd/manifest/init-v1.go
+++ b/cmd/manifest/init-v1.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	initCMD "github.com/okteto/okteto/pkg/cmd/init"

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -54,7 +54,7 @@ type ManifestCommand struct {
 	K8sClientProvider okteto.K8sClientProvider
 	analyticsTracker  analyticsTrackerInterface
 
-	ioCtrl *io.IOController
+	IoCtrl *io.IOController
 }
 
 // InitOpts defines the option for manifest init
@@ -284,16 +284,18 @@ func (mc *ManifestCommand) deploy(ctx context.Context, opts *InitOpts) error {
 		return err
 	}
 	c := &deploy.DeployCommand{
+		GetDeployer:        deploy.GetDeployer,
 		GetManifest:        mc.getManifest,
 		TempKubeconfigFile: deploy.GetTempKubeConfigFile(mc.manifest.Name),
 		K8sClientProvider:  mc.K8sClientProvider,
-		Builder:            buildv2.NewBuilderFromScratch(mc.analyticsTracker, mc.ioCtrl),
+		Builder:            buildv2.NewBuilderFromScratch(mc.analyticsTracker, mc.IoCtrl),
 		GetExternalControl: deploy.NewDeployExternalK8sControl,
 		Fs:                 afero.NewOsFs(),
 		CfgMapHandler:      deploy.NewConfigmapHandler(mc.K8sClientProvider),
 		PipelineCMD:        pc,
 		DeployWaiter:       deploy.NewDeployWaiter(mc.K8sClientProvider),
 		EndpointGetter:     deploy.NewEndpointGetter,
+		IoCtrl:             mc.IoCtrl,
 	}
 
 	err = c.RunDeploy(ctx, &deploy.Options{

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func main() {
 	root.AddCommand(build.Build(ctx, ioController, at))
 
 	root.AddCommand(namespace.Namespace(ctx))
-	root.AddCommand(cmd.Init())
+	root.AddCommand(cmd.Init(ioController))
 	root.AddCommand(up.Up(at, ioController))
 	root.AddCommand(cmd.Down())
 	root.AddCommand(cmd.Status())

--- a/pkg/log/io/io.go
+++ b/pkg/log/io/io.go
@@ -56,14 +56,14 @@ func (ioc *IOController) Logger() *oktetoLogger {
 	return ioc.oktetoLogger
 }
 
-// SetOutput format sets the output format for the CLI. We need that the logger and the output generates the same
-// type of messages so we don't end up mixing formats like json and tty.
+// SetOutputFormat sets the output format for the CLI. We need that the logger and the output generates the same
+// type of messages, so we don't end up mixing formats like json and tty.
 func (ioc *IOController) SetOutputFormat(output string) {
 	ioc.oktetoLogger.SetOutputFormat(output)
 	ioc.out.SetOutputFormat(output)
 }
 
-// Set stage sets the current stage where the CLI is performing.
+// SetStage sets the current stage where the CLI is performing.
 func (ioc *IOController) SetStage(stage string) {
 	ioc.oktetoLogger.SetStage(stage)
 	ioc.out.SetStage(stage)


### PR DESCRIPTION
# Proposed changes

Fix a panic caused by the `GetDeployer` not being passed properly to the `RunDeploy`. Additionally, the `ioCtrl` too was causing issues because it was not passed`

## How to validate

1. Using `okteto/movies`
1. Run `okteto init --deploy`
1. Make sure the command executes without any panic 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
