### PR TITLE
Fix: detect top level git rep dir to set `OKTETO_GIT_BRANCH` and `OKTETO_GIT_COMMIT` properly when service is nested

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -301,7 +301,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 
 	topLevelGitDir, err := repository.FindTopLevelGitDir(cwd, dc.Fs)
 	if err != nil {
-		oktetoLog.Warning("Repository not detected: the env vars 'OKTETO_GIT_BRANCH' and 'OKTETO_GIT_COMMIT' might not be available: %s.\n    For more information, check out: https://www.okteto.com/docs/cloud/okteto-cli/#built-in-environment-variables", err.Error())
+		oktetoLog.Warning("Repository not detected: the env vars '%s' and '%s' might not be available: %s.\n    For more information, check out: https://www.okteto.com/docs/cloud/okteto-cli/#built-in-environment-variables", constants.OktetoGitBranchEnvVar, constants.OktetoGitCommitEnvVar, err.Error())
 	}
 
 	if topLevelGitDir != "" {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -299,7 +299,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 		return fmt.Errorf("failed to get the current working directory: %w", err)
 	}
 
-	topLevelGitDir, err := repository.FindTopLevelGitDir(cwd, afero.NewOsFs())
+	topLevelGitDir, err := repository.FindTopLevelGitDir(cwd, dc.Fs)
 	if err != nil {
 		oktetoLog.Warning("Some git env vars might not be available: %s", err.Error())
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -301,7 +301,7 @@ func (dc *DeployCommand) RunDeploy(ctx context.Context, deployOptions *Options) 
 
 	topLevelGitDir, err := repository.FindTopLevelGitDir(cwd, dc.Fs)
 	if err != nil {
-		oktetoLog.Warning("Some git env vars might not be available: %s", err.Error())
+		oktetoLog.Warning("Repository not detected: the env vars 'OKTETO_GIT_BRANCH' and 'OKTETO_GIT_COMMIT' might not be available: %s.\n    For more information, check out: https://www.okteto.com/docs/cloud/okteto-cli/#built-in-environment-variables", err.Error())
 	}
 
 	if topLevelGitDir != "" {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -427,13 +427,13 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 		Build:        true,
 	}
 
-	registry := newFakeRegistry()
-	builder := test.NewFakeOktetoBuilder(registry)
+	reg := newFakeRegistry()
+	builder := test.NewFakeOktetoBuilder(reg)
 	fakeTracker := fakeAnalyticsTracker{}
 	c := &DeployCommand{
 		GetManifest:       getErrorManifest,
 		GetDeployer:       fakeDeployer.Get,
-		Builder:           buildv2.NewBuilder(builder, registry, io.NewIOController(), fakeTracker),
+		Builder:           buildv2.NewBuilder(builder, reg, io.NewIOController(), fakeTracker),
 		K8sClientProvider: fakeK8sClientProvider,
 		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider),
 	}
@@ -480,7 +480,11 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 	assert.Equal(t, expectedCfg.Name, cfg.Name)
 	assert.Equal(t, expectedCfg.Namespace, cfg.Namespace)
 	assert.Equal(t, expectedCfg.Labels, cfg.Labels)
-	assert.Equal(t, expectedCfg.Data, cfg.Data)
+
+	keysToCompare := []string{"actionName", "name", "status", "filename", "icon", "yaml"}
+	for _, key := range keysToCompare {
+		assert.Equal(t, expectedCfg.Data[key], cfg.Data[key])
+	}
 	assert.NotEmpty(t, cfg.Annotations[constants.LastUpdatedAnnotation])
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -436,6 +436,7 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 		Builder:           buildv2.NewBuilder(builder, reg, io.NewIOController(), fakeTracker),
 		K8sClientProvider: fakeK8sClientProvider,
 		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider),
+		Fs:                afero.NewMemMapFs(),
 	}
 
 	ctx := context.Background()
@@ -591,6 +592,7 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 		GetDeployer:       fakeDeployer.Get,
 		K8sClientProvider: fakeK8sClientProvider,
 		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider),
+		Fs:                afero.NewMemMapFs(),
 	}
 	ctx := context.Background()
 

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -38,9 +38,10 @@ type gitRepoController struct {
 	path       string
 }
 
-func newGitRepoController() gitRepoController {
+func newGitRepoController(path string) gitRepoController {
 	return gitRepoController{
 		repoGetter: gitRepositoryGetter{},
+		path:       path,
 	}
 }
 

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -15,7 +15,7 @@ package repository
 
 import (
 	"context"
-	errors "errors"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -266,7 +266,7 @@ func FindTopLevelGitDir(workingDir string, fs afero.Fs) (string, error) {
 	}
 
 	for {
-		if _, err := fs.Stat(filepath.Join(dir, ".git")); err == nil {
+		if filesystem.FileExistsWithFilesystem(filepath.Join(dir, ".git"), fs) {
 			return dir, nil
 		}
 

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -504,6 +504,9 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		cwd    string
 	}
 
+	rootDir, err := filepath.Abs(filepath.Clean("/tmp"))
+	assert.NoError(t, err)
+
 	tests := []struct {
 		input        input
 		expectedErr  error
@@ -513,7 +516,7 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		{
 			name: "not found",
 			input: input{
-				cwd: "/home/user/test/service",
+				cwd: filepath.Join(rootDir, "example", "services", "api"),
 				mockFs: func() afero.Fs {
 					return afero.NewMemMapFs()
 				},
@@ -535,15 +538,16 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		{
 			name: "found",
 			input: input{
-				cwd: filepath.Join("/tmp", "example", "services", "api"),
+				cwd: filepath.Join(rootDir, "example", "services", "api"),
 				mockFs: func() afero.Fs {
 					fs := afero.NewMemMapFs()
-					_, err := fs.Create(filepath.Join("/tmp", "example", ".git"))
+					gitDirPath := filepath.Join(rootDir, "example", ".git")
+					_, err := fs.Create(gitDirPath)
 					assert.NoError(t, err)
 					return fs
 				},
 			},
-			expectedPath: filepath.Join("/tmp", "example"),
+			expectedPath: filepath.Join(rootDir, "example"),
 			expectedErr:  nil,
 		},
 	}

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -14,6 +14,7 @@
 package repository
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -534,15 +535,15 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		{
 			name: "found",
 			input: input{
-				cwd: "/tmp/example/services/api",
+				cwd: filepath.Join("/tmp", "example", "services", "api"),
 				mockFs: func() afero.Fs {
 					fs := afero.NewMemMapFs()
-					_, err := fs.Create("/tmp/example/.git")
+					_, err := fs.Create(filepath.Join("/tmp", "example", ".git"))
 					assert.NoError(t, err)
 					return fs
 				},
 			},
-			expectedPath: "/tmp/example",
+			expectedPath: filepath.Join("/tmp", "example"),
 			expectedErr:  nil,
 		},
 	}

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -504,6 +504,8 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		cwd    string
 	}
 
+	rootDir := filepath.ToSlash("/tmp")
+
 	tests := []struct {
 		input        input
 		expectedErr  error
@@ -535,15 +537,15 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		{
 			name: "found",
 			input: input{
-				cwd: filepath.Join("/tmp", "example", "services", "api"),
+				cwd: filepath.Join(rootDir, "example", "services", "api"),
 				mockFs: func() afero.Fs {
 					fs := afero.NewMemMapFs()
-					_, err := fs.Create(filepath.Join("/tmp", "example", ".git"))
+					_, err := fs.Create(filepath.Join(rootDir, "example", ".git"))
 					assert.NoError(t, err)
 					return fs
 				},
 			},
-			expectedPath: filepath.Join("/tmp", "example"),
+			expectedPath: filepath.Join(rootDir, "example"),
 			expectedErr:  nil,
 		},
 	}

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -504,8 +504,6 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		cwd    string
 	}
 
-	rootDir := filepath.ToSlash("/tmp")
-
 	tests := []struct {
 		input        input
 		expectedErr  error
@@ -537,15 +535,15 @@ func TestFindTopLevelGitDir(t *testing.T) {
 		{
 			name: "found",
 			input: input{
-				cwd: filepath.Join(rootDir, "example", "services", "api"),
+				cwd: filepath.Join("/tmp", "example", "services", "api"),
 				mockFs: func() afero.Fs {
 					fs := afero.NewMemMapFs()
-					_, err := fs.Create(filepath.Join(rootDir, "example", ".git"))
+					_, err := fs.Create(filepath.Join("/tmp", "example", ".git"))
 					assert.NoError(t, err)
 					return fs
 				},
 			},
-			expectedPath: filepath.Join(rootDir, "example"),
+			expectedPath: filepath.Join("/tmp", "example"),
 			expectedErr:  nil,
 		},
 	}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -65,7 +65,7 @@ func getURLFromPath(path string) repositoryURL {
 func NewRepository(path string) Repository {
 	repoURL := getURLFromPath(path)
 
-	var controller repositoryInterface = newGitRepoController()
+	var controller repositoryInterface = newGitRepoController(path)
 	// check if we are inside a remote deploy
 	if v := os.Getenv(constants.OktetoDeployRemote); v != "" {
 		sha := os.Getenv(constants.OktetoGitCommitEnvVar)


### PR DESCRIPTION
# Proposed changes

When deploying a service in a monorepo with a manifest per service, example:

```
my-app/
└── services/
    ├── api/
    │   └── okteto.yml
    └── frontend/
        └── okteto.yml      
```

And running `okteto deploy -f services/api/okteto.yml` the env vars `OKTETO_GIT_BRANCH` and `OKTETO_GIT_COMMIT` are not properly set.

In case of `OKTETO_GIT_COMMIT` we auto-generate a commit id because we cannot find the related `.git` folder and `OKTETO_GIT_BRANCH` is empty.

This is a problem if the user depends on such variables for deployment. In this PR we change the behaviour to attempt finding the parent `.git` directory

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Test using a fork of `okteto/movies`: `git clone git@github.com:andreafalzetti/movies.git`
1. Switch branch `git checkout af/fast-12`
1. Run `okteto deploy -f services/api/okteto.yml`)
1. Make sure `OKTETO_GIT_BRANCH` and `OKTETO_GIT_COMMIT` are populed properly
1. Now repest the deploy from the `services/api` directory using `okteto deploy`
1. Check the env vars to make sure they are set correctly

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
