### PR TITLE
chore: update syncthing version to 1.27.1

### DIFF
--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	// OktetoBinImageTag image tag with okteto internal binaries
-	OktetoBinImageTag = "okteto/bin:1.4.3"
+	OktetoBinImageTag = "okteto/bin:1.4.4"
 
 	errBadName = fmt.Errorf("Invalid name: must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character")
 

--- a/pkg/syncthing/install.go
+++ b/pkg/syncthing/install.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	syncthingVersion          = "1.24.0"
+	syncthingVersion          = "1.27.1"
 	syncthingVersionStringNew = 3
 	syncthingVersionStringOld = 2
 )


### PR DESCRIPTION
# Proposed changes

Upgrades syncthing version to 1.27.1.0

## Proposed changes
- Upgrades syncthing to the latest version
- Need this PR https://github.com/okteto/bin-image/pull/10 and create new tag
- https://github.com/syncthing/syncthing/releases/tag/v1.27.1
