### PR TITLE
improve err response for expired tokens

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -411,7 +411,6 @@ func (c ContextCommand) getUserContext(ctx context.Context, ctxName, ns, token s
 		userContext, err := client.User().GetContext(ctx, ns)
 
 		if err != nil {
-
 			if errors.Is(err, oktetoErrors.ErrTokenExpired) {
 				return nil, err
 			}

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -554,6 +554,19 @@ func TestGetUserContext(t *testing.T) {
 			},
 		},
 		{
+			name: "token expired error",
+			input: input{
+				ns: "test",
+				userErr: []error{
+					oktetoErrors.ErrTokenExpired,
+				},
+			},
+			output: output{
+				uc:  nil,
+				err: oktetoErrors.ErrTokenExpired,
+			},
+		},
+		{
 			name: "not found + redirect to personal namespace",
 			input: input{
 				ns: "test",

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -36,6 +36,7 @@ type ContextOptions struct {
 	IsOkteto              bool
 	raiseNotCtxError      bool
 	InsecureSkipTlsVerify bool
+	InferredToken         bool
 }
 
 func (o *ContextOptions) InitFromContext() {
@@ -86,6 +87,7 @@ func (o *ContextOptions) InitFromEnvVars() {
 			usedEnvVars = append(usedEnvVars, model.OktetoTokenEnvVar)
 		}
 		o.Token = envToken
+		o.InferredToken = true
 	}
 
 	if o.Namespace == "" && os.Getenv(model.OktetoNamespaceEnvVar) != "" {

--- a/cmd/context/options_test.go
+++ b/cmd/context/options_test.go
@@ -173,9 +173,10 @@ func Test_initFromEnvVars(t *testing.T) {
 				"OKTETO_NAMESPACE": "",
 			},
 			want: &ContextOptions{
-				Token:    "token",
-				Context:  okteto.CloudURL,
-				IsOkteto: true,
+				Token:         "token",
+				Context:       okteto.CloudURL,
+				IsOkteto:      true,
+				InferredToken: true,
 			},
 		},
 		{
@@ -262,9 +263,10 @@ func Test_initFromEnvVars(t *testing.T) {
 				"OKTETO_NAMESPACE": "",
 			},
 			want: &ContextOptions{
-				Token:    "token-envvar",
-				Context:  "okteto-url",
-				IsOkteto: true,
+				Token:         "token-envvar",
+				Context:       "okteto-url",
+				IsOkteto:      true,
+				InferredToken: true,
 			},
 		},
 		{

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -214,6 +214,9 @@ var (
 	// ErrInvalidLicense is the error returned to the user when a trial is invalid.
 	// This can be either an expired trial license or no license at all
 	ErrInvalidLicense = errors.New("Your license is invalid")
+
+	// ErrTokenExpired is raised when token used for API auth is expired
+	ErrTokenExpired = errors.New("your token has expired")
 )
 
 // IsAlreadyExists raised if the Kubernetes API returns AlreadyExists

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -343,6 +343,8 @@ func translateAPIErr(err error) error {
 		return fmt.Errorf("server temporarily unavailable, please try again")
 	case "non-200 OK status code: 401 Unauthorized body: \"\"":
 		return fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")
+	case "non-200 OK status code: 401 Unauthorized body: \"not-authorized: token is expired\\n\"":
+		return oktetoErrors.ErrTokenExpired
 	case "not-found":
 		return oktetoErrors.ErrNotFound
 

--- a/pkg/okteto/secrets_test.go
+++ b/pkg/okteto/secrets_test.go
@@ -23,6 +23,7 @@ import (
 	dockertypes "github.com/docker/cli/cli/config/types"
 	dockercredentials "github.com/docker/docker-credential-helpers/credentials"
 	"github.com/okteto/okteto/pkg/constants"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/shurcooL/graphql"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ import (
 func TestGetContext(t *testing.T) {
 	globalNsErr := fmt.Errorf("Cannot query field \"globalNamespace\" on type \"me\"")
 	telemetryEnabledErr := fmt.Errorf("Cannot query field \"telemetryEnabled\" on type \"me\"")
+	tokenExpiredErr := fmt.Errorf("non-200 OK status code: 401 Unauthorized body: \"not-authorized: token is expired\\n\"")
 	type input struct {
 		client *fakeGraphQLClient
 	}
@@ -211,6 +213,19 @@ func TestGetContext(t *testing.T) {
 			expected: expected{
 				userContext: nil,
 				err:         telemetryEnabledErr,
+			},
+		},
+		{
+			name: "error because token is expired",
+			cfg: input{
+				client: &fakeGraphQLClient{
+					queryResult: nil,
+					err:         tokenExpiredErr,
+				},
+			},
+			expected: expected{
+				userContext: nil,
+				err:         oktetoErrors.ErrTokenExpired,
 			},
 		},
 	}


### PR DESCRIPTION
# Proposed changes
- handle responses with `non-200 OK status code: 401 Unauthorized body: \"not-authorized: token is expired\\n\"` error message, meaning token is expired
- if token is provided by user and is expired, suggest a new token generation

## How to validate

1. using a cluster that return the reason when token is expired. 
2. run `okteto ctx use <cluster-url> --token <expired-token>`
3. check output is:
<img width="897" alt="Captura de pantalla 2023-12-18 a las 11 15 42" src="https://github.com/okteto/okteto/assets/22500940/421184d7-c360-4620-a818-dba9d62199c8">


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
