### PR TITLE
refactor: set deploy image tag as buildopt in deploy pkg

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -194,6 +194,10 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		fmt.Sprintf("%s=%d", constants.OktetoInvalidateCacheEnvVar, int(randomNumber.Int64())),
 	)
 
+	if buildOptions.Manifest != nil && buildOptions.Manifest.Deploy != nil {
+		buildOptions.Tag = buildOptions.Manifest.Deploy.Image
+	}
+
 	if sc.ServerName != "" {
 		registryUrl := okteto.Context().Registry
 		subdomain := strings.TrimPrefix(registryUrl, "registry.")

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -208,14 +208,7 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 		}
 	}
 
-	var tag string
-	if buildOptions != nil {
-		tag = buildOptions.Tag
-		if buildOptions.Manifest != nil && buildOptions.Manifest.Deploy != nil {
-			tag = buildOptions.Manifest.Deploy.Image
-		}
-	}
-	err = getErrorMessage(err, tag)
+	err = getErrorMessage(err, buildOptions.Tag)
 	return err
 }
 


### PR DESCRIPTION
# Proposed changes
- set build tag in deploy remote preparation instead in build logic

## How to validate

1. check an invalid image in deploy section returns the proper error. More context here: https://github.com/okteto/okteto/pull/3462
## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
