### PR TITLE
Revert "refactor: set deploy image tag as buildopt in deploy pkg (#40…

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -194,10 +194,6 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		fmt.Sprintf("%s=%d", constants.OktetoInvalidateCacheEnvVar, int(randomNumber.Int64())),
 	)
 
-	if buildOptions.Manifest != nil && buildOptions.Manifest.Deploy != nil {
-		buildOptions.Tag = buildOptions.Manifest.Deploy.Image
-	}
-
 	if sc.ServerName != "" {
 		registryUrl := okteto.Context().Registry
 		subdomain := strings.TrimPrefix(registryUrl, "registry.")

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -208,7 +208,14 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 		}
 	}
 
-	err = getErrorMessage(err, buildOptions.Tag)
+	var tag string
+	if buildOptions != nil {
+		tag = buildOptions.Tag
+		if buildOptions.Manifest != nil && buildOptions.Manifest.Deploy != nil {
+			tag = buildOptions.Manifest.Deploy.Image
+		}
+	}
+	err = getErrorMessage(err, tag)
 	return err
 }
 


### PR DESCRIPTION
…93)"

This reverts commit d8e3a0faaa107e08d2e19657e9619a7107ed3820.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
