### PR TITLE
Add feature flag `OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED` env var to disable node affinity for volumes

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/okteto/okteto/pkg/env"
 	"os"
 	"sort"
 	"strconv"
@@ -25,6 +24,7 @@ import (
 
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/format"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/okteto/okteto/pkg/env"
 	"os"
 	"sort"
 	"strconv"
@@ -51,6 +52,9 @@ const (
 	destroyingStatus  = "destroying"
 
 	pvcName = "pvc"
+
+	// oktetoComposeVolumeAffinityEnabledEnvVar represents whether the feature flag to enable volume affinity is enabled or not
+	oktetoComposeVolumeAffinityEnabledEnvVar = "OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED"
 )
 
 // +enum
@@ -461,6 +465,10 @@ func translateVolumeLabels(volumeName string, s *model.Stack) map[string]string 
 }
 
 func translateAffinity(svc *model.Service) *apiv1.Affinity {
+	if !env.LoadBooleanOrDefault(oktetoComposeVolumeAffinityEnabledEnvVar, true) {
+		return nil
+	}
+
 	requirements := make([]apiv1.PodAffinityTerm, 0)
 	for _, volume := range svc.Volumes {
 		if volume.LocalPath == "" {

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1412,8 +1412,8 @@ func Test_translateAffinity(t *testing.T) {
 	tests := []struct {
 		svc                   *model.Service
 		affinity              *apiv1.Affinity
-		disableVolumeAffinity bool
 		name                  string
+		disableVolumeAffinity bool
 	}{
 		{
 			name: "none",

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1410,9 +1410,10 @@ func Test_translateResources(t *testing.T) {
 
 func Test_translateAffinity(t *testing.T) {
 	tests := []struct {
-		svc      *model.Service
-		affinity *apiv1.Affinity
-		name     string
+		svc                   *model.Service
+		affinity              *apiv1.Affinity
+		disableVolumeAffinity bool
+		name                  string
 	}{
 		{
 			name: "none",
@@ -1519,14 +1520,36 @@ func Test_translateAffinity(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "multiple volumes with volume affinity disabled",
+			svc: &model.Service{
+				Volumes: []model.StackVolume{
+					{
+						LocalPath:  "test-1",
+						RemotePath: "/var",
+					},
+					{
+						LocalPath:  "test-2",
+						RemotePath: "/var",
+					},
+					{
+						LocalPath:  "test-3",
+						RemotePath: "/var",
+					},
+				},
+			},
+			disableVolumeAffinity: true,
+			affinity:              nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			aff := translateAffinity(tt.svc)
-			if !reflect.DeepEqual(tt.affinity, aff) {
-				t.Fatal("Wrong translation")
+			if tt.disableVolumeAffinity {
+				t.Setenv(oktetoComposeVolumeAffinityEnabledEnvVar, "false")
 			}
+			aff := translateAffinity(tt.svc)
+			assert.Equal(t, tt.affinity, aff)
 		})
 	}
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -104,3 +104,19 @@ func LoadBoolean(k string) bool {
 
 	return h
 }
+
+// LoadBooleanOrDefault loads a boolean environment variable and returns it value
+// If the variable is not defined, it returns the default value
+func LoadBooleanOrDefault(k string, d bool) bool {
+	v := os.Getenv(k)
+	if v == "" {
+		return d
+	}
+
+	h, err := strconv.ParseBool(v)
+	if err != nil {
+		oktetoLog.Yellow("'%s' is not a valid value for environment variable %s", v, k)
+	}
+
+	return h
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -239,3 +239,52 @@ func TestLoadBoolean(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadBooleanOrDefault(t *testing.T) {
+	type tc struct {
+		Name           string
+		EnvKey         string
+		EnvValue       string
+		DefaultValue   bool
+		ExpectedResult bool
+	}
+
+	testCases := []tc{
+		{
+			Name:           "Environment variable is 'true'",
+			EnvKey:         "TEST_KEY",
+			EnvValue:       "true",
+			DefaultValue:   false,
+			ExpectedResult: true,
+		},
+		{
+			Name:           "Environment variable is 'false'",
+			EnvKey:         "TEST_KEY",
+			EnvValue:       "false",
+			DefaultValue:   true,
+			ExpectedResult: false,
+		},
+		{
+			Name:           "Environment variable is not defined",
+			EnvKey:         "TEST_KEY",
+			EnvValue:       "",
+			DefaultValue:   true,
+			ExpectedResult: true,
+		},
+		{
+			Name:           "Environment variable has an invalid value",
+			EnvKey:         "TEST_KEY",
+			EnvValue:       "invalid",
+			DefaultValue:   false,
+			ExpectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Setenv(tc.EnvKey, tc.EnvValue)
+			result := LoadBooleanOrDefault(tc.EnvKey, tc.DefaultValue)
+			assert.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes LAKE-133

This change allows users to disable the node affinity automatically set by the Okteto CLI when a service is using a volune.

## How to validate

1. Clone a test repo `git clone git@github.com:andreafalzetti/movies-with-compose.git`
1. Switch to a test branch `git checkout affinity`
1. Use latest okteto stable, run `okteto deploy`
1. Then using `kubectl` inspect the pod affinity using `kubectl get pod -n <ns> -o yaml <pod name>` (for `<pod-name` use `mongodb-0`)
1. Inspect the YAML and observe that the CLI has set the following affinity:
```yaml
spec:
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - preference:
          matchExpressions:
          - key: dev.okteto.com/overloaded
            operator: DoesNotExist
        weight: 50
      - preference:
          matchExpressions:
          - key: dev.okteto.com/many-volumes
            operator: DoesNotExist
        weight: 100
    podAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - podAffinityTerm:
          labelSelector:
            matchExpressions:
            - key: dev.okteto.com/affinity
              operator: In
              values:
              - peppino
          topologyKey: kubernetes.io/hostname
        weight: 10
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: stack.okteto.com/volume-data
            operator: Exists
        topologyKey: kubernetes.io/hostname
```
1. Now destroy the resource and deploy again using the CLI from this branch using the feature flag `OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED=false`
1. Notice how the affinity is now:
```yaml
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - preference:
          matchExpressions:
          - key: dev.okteto.com/overloaded
            operator: DoesNotExist
        weight: 50
      - preference:
          matchExpressions:
          - key: dev.okteto.com/many-volumes
            operator: DoesNotExist
        weight: 100
    podAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - podAffinityTerm:
          labelSelector:
            matchExpressions:
            - key: dev.okteto.com/affinity
              operator: In
              values:
              - peppino
          topologyKey: kubernetes.io/hostname
        weight: 10
```
1. Verify that the volume-data expression is missing
1. Validate by switching the feature flag back to `true` and deploy, you should have the affinity set this time

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
