### PR TITLE
Fix preview URL to not use hash pathname

### DIFF
--- a/cmd/preview/deploy_utils.go
+++ b/cmd/preview/deploy_utils.go
@@ -106,6 +106,6 @@ func getExpandedName(name string) string {
 
 func getPreviewURL(name string) string {
 	oktetoURL := okteto.Context().Name
-	previewURL := fmt.Sprintf("%s/#/previews/%s", oktetoURL, name)
+	previewURL := fmt.Sprintf("%s/previews/%s", oktetoURL, name)
 	return previewURL
 }

--- a/cmd/preview/deploy_utils_test.go
+++ b/cmd/preview/deploy_utils_test.go
@@ -115,3 +115,21 @@ func Test_optionsSetup(t *testing.T) {
 	}
 
 }
+
+func Test_getPreviewURL(t *testing.T) {
+	ctxName := "https://my.okteto.instance"
+	okteto.CurrentStore = &okteto.OktetoContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.OktetoContext{
+			"test": {
+				Name: ctxName,
+			},
+		},
+	}
+
+	t.Run("full-previews-url", func(t *testing.T) {
+		expected := "https://my.okteto.instance/previews/foo-bar"
+		actual := getPreviewURL("foo-bar")
+		assert.Equal(t, expected, actual)
+	})
+}


### PR DESCRIPTION
e.g.*
```shell
❯ okteto preview deploy …
  i  Using foo-bar @ my.okteto.instance as context
  i  Preview URL: https://my.okteto.instance/#/previews/foo-bar
  ✓  Preview environment 'foo-bar' scheduled for deployment
```

https://my.okteto.instance/#/previews/foo-bar URLs are supported for backward compatibility, redirecting to https://my.okteto.instance/previews/foo-bar, which was done back in ~October 2022. This particular URL instance was missed back then it appears.

Using the expected normal pathname of https://my.okteto.instance/previews/foo-bar will enable us to remove the backward compat-redirect on the frontend UI app _eventually_, once CLI version up til this change being released is officially deprecated.

## How to validate

1. Build CLI from this branch (`make build` etc.)
1. `./bin/okteto preview deploy …`, see expected URL in terminal, e.g.*

```shell
 ❯ ./bin/okteto preview deploy …
 i  Using foo-bar @ my.okteto.instance as context
 i  Preview URL: https://my.okteto.instance/previews/foo-bar
 ✓  Preview environment 'foo-bar' scheduled for deployment
```

*_redacted real CLI args, context, and preview name_

[LAKE-158]: https://okteto.atlassian.net/browse/LAKE-158