### PR TITLE
Fix Golang version in contributing guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -94,7 +94,7 @@ If a pull request does not have one of these labels checks will fail and PR merg
 
 ## Development Guide
 
-Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.20](https://go.dev/doc/go1.20). It uses go modules for dependency management.
+Okteto is developed using the [Go](https://golang.org/) programming language. The current version of Go being used is [v1.21](https://go.dev/doc/go1.21). It uses go modules for dependency management.
 
 ### Building
 


### PR DESCRIPTION
The recommended version is wrong, noticed when building locally since I got this err with v1.20:

```shell
...
../../../go/pkg/mod/github.com/samber/slog-common@v0.11.0/attributes.go:6:2: package log/slog is not in GOROOT (/opt/homebrew/Cellar/go@1.20/1.20.12/libexec/src/log/slog)
note: imported by a module that requires go 1.21
make: *** [build] Error 1
```

Fix matches version defined in https://github.com/okteto/okteto/blob/094ca6b3fca887832e321f5d86feec7d31c51c1e/go.mod#L3 and https://github.com/okteto/okteto/blob/094ca6b3fca887832e321f5d86feec7d31c51c1e/Dockerfile#L8-L35