### PR TITLE
Lax Codecov threshold on project delta

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: '0%'
+        threshold: '1%' # Not set to 0% to avoid failues due to -0.0X% deltas
 
     patch:
       default:


### PR DESCRIPTION
Should avoid Codecov from failing like in recent PRs[[1](https://github.com/okteto/okteto/pull/4103)][[2](https://github.com/okteto/okteto/pull/4102)]