### PR TITLE
fix: wrap error while creating secrets

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -114,7 +114,7 @@ func (up *upContext) activate() error {
 
 	if !up.isRetry && buildDevImage {
 		if err := up.buildDevImage(ctx, app); err != nil {
-			return fmt.Errorf("error building dev image: %s", err)
+			return fmt.Errorf("error building dev image: %w", err)
 		}
 	}
 
@@ -145,7 +145,7 @@ func (up *upContext) activate() error {
 		if _, ok := err.(oktetoErrors.UserError); ok {
 			return err
 		}
-		return fmt.Errorf("couldn't activate your development container\n    %s", err.Error())
+		return fmt.Errorf("couldn't activate your development container\n    %w", err)
 	}
 
 	if up.isRetry {
@@ -163,12 +163,12 @@ func (up *upContext) activate() error {
 			err := up.checkOktetoStartError(ctx, "Failed to connect to your development container")
 			if err == oktetoErrors.ErrLostSyncthing {
 				if err := pods.Destroy(ctx, up.Pod.Name, up.Dev.Namespace, k8sClient); err != nil {
-					return fmt.Errorf("error recreating development container: %s", err.Error())
+					return fmt.Errorf("error recreating development container: %w", err)
 				}
 			}
 			return err
 		}
-		return fmt.Errorf("couldn't connect to your development container: %s", err.Error())
+		return fmt.Errorf("couldn't connect to your development container: %w", err)
 	}
 	go up.cleanCommand(ctx)
 

--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -162,7 +162,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 		}
 		c := linguist.GetSTIgnore(l)
 		if err := os.WriteFile(stignorePath, c, 0600); err != nil {
-			return fmt.Errorf("failed to write stignore file for '%s': %s", folder, err.Error())
+			return fmt.Errorf("failed to write stignore file for '%s': %w", folder, err)
 		}
 		return nil
 	}
@@ -170,24 +170,24 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 	oktetoLog.Information("Okteto requires a '.stignore' file to ignore file patterns that help optimize the synchronization service.")
 	stignoreDefaults, err := utils.AskYesNo("Do you want to infer defaults for the '.stignore' file? (otherwise, it will be left blank)", utils.YesNoDefault_Yes)
 	if err != nil {
-		return fmt.Errorf("failed to add '.stignore' to '%s': %s", folder, err.Error())
+		return fmt.Errorf("failed to add '.stignore' to '%s': %w", folder, err)
 	}
 
 	if !stignoreDefaults {
 		stignoreContent := ""
 		if err := os.WriteFile(stignorePath, []byte(stignoreContent), 0600); err != nil {
-			return fmt.Errorf("failed to create empty '%s': %s", stignorePath, err.Error())
+			return fmt.Errorf("failed to create empty '%s': %w", stignorePath, err)
 		}
 		return nil
 	}
 
 	language, err := manifest.GetLanguage("", folder)
 	if err != nil {
-		return fmt.Errorf("failed to get language for '%s': %s", folder, err.Error())
+		return fmt.Errorf("failed to get language for '%s': %w", folder, err)
 	}
 	c := linguist.GetSTIgnore(language)
 	if err := os.WriteFile(stignorePath, c, 0600); err != nil {
-		return fmt.Errorf("failed to write stignore file for '%s': %s", folder, err.Error())
+		return fmt.Errorf("failed to write stignore file for '%s': %w", folder, err)
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 func checkIfStignoreHasGitFolder(stignorePath string) error {
 	stignoreBytes, err := os.ReadFile(stignorePath)
 	if err != nil {
-		return fmt.Errorf("failed to read '%s': %s", stignorePath, err.Error())
+		return fmt.Errorf("failed to read '%s': %w", stignorePath, err)
 	}
 	stignoreContent := string(stignoreBytes)
 	if strings.Contains(stignoreContent, ".git") {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -279,7 +279,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.IOController) *cobra.Command {
 
 			k8sClient, _, err := okteto.GetK8sClient()
 			if err != nil {
-				return fmt.Errorf("failed to load k8s client: %v", err)
+				return fmt.Errorf("failed to load k8s client: %w", err)
 			}
 
 			// if manifest v1 - either set autocreate: true or pass --deploy (okteto forces autocreate: true)

--- a/pkg/divert/weaver/ingresses.go
+++ b/pkg/divert/weaver/ingresses.go
@@ -71,7 +71,7 @@ func (d *Driver) divertIngress(ctx context.Context, name string) error {
 	for _, rule := range in.Spec.Rules {
 		for _, path := range rule.IngressRuleValue.HTTP.Paths {
 			if err := d.divertService(ctx, path.Backend.Service.Name); err != nil {
-				return fmt.Errorf("error diverting ingress '%s/%s' service '%s': %v", in.Namespace, in.Name, path.Backend.Service.Name, err)
+				return fmt.Errorf("error diverting ingress '%s/%s' service '%s': %w", in.Namespace, in.Name, path.Backend.Service.Name, err)
 			}
 		}
 	}

--- a/pkg/k8s/apps/deployments.go
+++ b/pkg/k8s/apps/deployments.go
@@ -127,7 +127,7 @@ func (i *DeploymentApp) RestoreOriginal() error {
 	oktetoLog.Info("deprecated devmodeoff behavior")
 	dOrig := &appsv1.Deployment{}
 	if err := json.Unmarshal([]byte(manifest), dOrig); err != nil {
-		return fmt.Errorf("malformed manifest: %v", err)
+		return fmt.Errorf("malformed manifest: %w", err)
 	}
 	i.d = dOrig
 	return nil

--- a/pkg/k8s/apps/statefulsets.go
+++ b/pkg/k8s/apps/statefulsets.go
@@ -116,7 +116,7 @@ func (i *StatefulSetApp) RestoreOriginal() error {
 	oktetoLog.Info("depreccated devmodeoff behavior")
 	sfsOrig := &appsv1.StatefulSet{}
 	if err := json.Unmarshal([]byte(manifest), sfsOrig); err != nil {
-		return fmt.Errorf("malformed manifest: %v", err)
+		return fmt.Errorf("malformed manifest: %w", err)
 	}
 	i.sfs = sfsOrig
 	return nil

--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -318,7 +318,7 @@ func Restart(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset, sn st
 			if strings.Contains(err.Error(), "not found") {
 				return nil
 			}
-			return fmt.Errorf("error deleting kubernetes service: %s", err)
+			return fmt.Errorf("error deleting kubernetes service: %w", err)
 		}
 	}
 
@@ -356,7 +356,7 @@ func waitUntilRunning(ctx context.Context, namespace, selector string, c *kubern
 				allRunning = false
 				notready[pods.Items[i].GetName()] = true
 			} else if phase == apiv1.PodFailed {
-				return fmt.Errorf("Pod %s failed to start", pods.Items[i].Name)
+				return fmt.Errorf("pod %s failed to start", pods.Items[i].Name)
 			} else if phase == apiv1.PodRunning {
 				if isRunning(&pods.Items[i]) {
 					if _, ok := notready[pods.Items[i].GetName()]; ok {
@@ -386,7 +386,7 @@ func waitUntilRunning(ctx context.Context, namespace, selector string, c *kubern
 		pods = append(pods, k)
 	}
 
-	return fmt.Errorf("Pod(s) %s didn't restart after 60 seconds", strings.Join(pods, ","))
+	return fmt.Errorf("pod(s) %s didn't restart after 60 seconds", strings.Join(pods, ","))
 }
 
 func isRunning(p *apiv1.Pod) bool {

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -59,12 +59,12 @@ func Create(ctx context.Context, dev *model.Dev, c kubernetes.Interface, s *sync
 
 	sct, err := Get(ctx, secretName, dev.Namespace, c)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return fmt.Errorf("error getting kubernetes secret: %s", err)
+		return fmt.Errorf("error getting kubernetes secret: %w", err)
 	}
 
 	config, err := getConfigXML(s)
 	if err != nil {
-		return fmt.Errorf("error generating syncthing configuration: %s", err)
+		return fmt.Errorf("error generating syncthing configuration: %w", err)
 	}
 	data := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -85,7 +85,7 @@ func Create(ctx context.Context, dev *model.Dev, c kubernetes.Interface, s *sync
 	for _, s := range dev.Secrets {
 		content, err := os.ReadFile(s.LocalPath)
 		if err != nil {
-			return fmt.Errorf("error reading secret '%s': %s", s.LocalPath, err)
+			return fmt.Errorf("error reading secret '%s': %w", s.LocalPath, err)
 		}
 		if strings.Contains(s.GetKeyName(), "stignore") {
 			idx++
@@ -99,14 +99,14 @@ func Create(ctx context.Context, dev *model.Dev, c kubernetes.Interface, s *sync
 	if sct.Name == "" {
 		_, err := c.CoreV1().Secrets(dev.Namespace).Create(ctx, data, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("error creating kubernetes sync secret: %s", err)
+			return fmt.Errorf("error creating kubernetes sync secret: %w", err)
 		}
 
 		oktetoLog.Infof("created okteto secret '%s'", secretName)
 	} else {
 		_, err := c.CoreV1().Secrets(dev.Namespace).Update(ctx, data, metav1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("error updating kubernetes okteto secret: %s", err)
+			return fmt.Errorf("error updating kubernetes okteto secret: %w", err)
 		}
 		oktetoLog.Infof("updated okteto secret '%s'", secretName)
 	}

--- a/pkg/k8s/statefulsets/crud.go
+++ b/pkg/k8s/statefulsets/crud.go
@@ -154,7 +154,7 @@ func Destroy(ctx context.Context, name, namespace string, c kubernetes.Interface
 		if oktetoErrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting kubernetes job: %s", err)
+		return fmt.Errorf("error deleting kubernetes job: %w", err)
 	}
 	oktetoLog.Infof("statefulset '%s' deleted", name)
 	return nil

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -50,13 +50,13 @@ func CreateForDev(ctx context.Context, dev *model.Dev, c kubernetes.Interface, d
 	pvcForDev := translate(dev)
 	k8Volume, err := vClient.Get(ctx, pvcForDev.Name, metav1.GetOptions{})
 	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return fmt.Errorf("error getting kubernetes volume claim: %s", err)
+		return fmt.Errorf("error getting kubernetes volume claim: %w", err)
 	}
 	if k8Volume.Name == "" {
 		oktetoLog.Infof("creating volume claim '%s'", pvcForDev.Name)
 		_, err = vClient.Create(ctx, pvcForDev, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("error creating kubernetes volume claim: %s", err)
+			return fmt.Errorf("error creating kubernetes volume claim: %w", err)
 		}
 	} else {
 		if err := checkPVCValues(k8Volume, dev, devPath); err != nil {
@@ -216,7 +216,7 @@ func DestroyWithoutTimeout(ctx context.Context, name, namespace string, c kubern
 	err := vClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !oktetoErrors.IsNotFound(err) {
-			return fmt.Errorf("error deleting kubernetes volume: %s", err)
+			return fmt.Errorf("error deleting kubernetes volume: %w", err)
 		}
 	}
 

--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -32,12 +32,12 @@ func getPrivateKey() (ssh.Signer, error) {
 	_, private := getKeyPaths()
 	buf, err := os.ReadFile(private)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load private key: %s", err)
+		return nil, fmt.Errorf("failed to load private key: %w", err)
 	}
 
 	key, err := ssh.ParsePrivateKey(buf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key: %s", err)
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	return key, nil

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -231,7 +231,7 @@ func (config *sshConfig) writeToFilepath(p string) error {
 	var mode os.FileMode
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to get info on %s: %s", p, err)
+			return fmt.Errorf("failed to get info on %s: %w", p, err)
 		}
 
 		// default for ssh_config
@@ -243,7 +243,7 @@ func (config *sshConfig) writeToFilepath(p string) error {
 	dir := filepath.Dir(p)
 	temp, err := os.CreateTemp(dir, "")
 	if err != nil {
-		return fmt.Errorf("failed to create temporary config file: %s", err)
+		return fmt.Errorf("failed to create temporary config file: %w", err)
 	}
 
 	defer os.Remove(temp.Name())
@@ -257,15 +257,15 @@ func (config *sshConfig) writeToFilepath(p string) error {
 	}
 
 	if err := os.Chmod(temp.Name(), mode); err != nil {
-		return fmt.Errorf("failed to set permissions to %s: %s", temp.Name(), err)
+		return fmt.Errorf("failed to set permissions to %s: %w", temp.Name(), err)
 	}
 
 	if _, err := getConfig(temp.Name()); err != nil {
-		return fmt.Errorf("new config is not valid: %s", err)
+		return fmt.Errorf("new config is not valid: %w", err)
 	}
 
 	if err := os.Rename(temp.Name(), p); err != nil {
-		return fmt.Errorf("failed to move %s to %s: %s", temp.Name(), p, err)
+		return fmt.Errorf("failed to move %s to %s: %w", temp.Name(), p, err)
 	}
 
 	return nil

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -36,7 +36,7 @@ import (
 func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Reader, outW, errW io.Writer, command []string) error {
 	sshConfig, err := getSSHClientConfig()
 	if err != nil {
-		return fmt.Errorf("failed to get SSH configuration: %s", err)
+		return fmt.Errorf("failed to get SSH configuration: %w", err)
 	}
 
 	// dockerterm.StdStreams() configures the terminal on windows
@@ -54,7 +54,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to connect to SSH server: %s", err)
+		return fmt.Errorf("failed to connect to SSH server: %w", err)
 	}
 	defer func() {
 		if err := connection.Close(); err != nil {
@@ -75,7 +75,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 
 	session, err := connection.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %s", err)
+		return fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer func() {
 		if err := session.Close(); err != nil {
@@ -121,7 +121,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 		}()
 
 		if err := session.RequestPty("xterm-256color", height, width, modes); err != nil {
-			return fmt.Errorf("request for pseudo terminal failed: %s", err)
+			return fmt.Errorf("request for pseudo terminal failed: %w", err)
 		}
 	}
 
@@ -139,13 +139,13 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 
 	stdin, err := session.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("unable to setup stdin for session: %v", err)
+		return fmt.Errorf("unable to setup stdin for session: %w", err)
 	}
 	Copy(inR, stdin)
 
 	stdout, err := session.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("unable to setup stdout for session: %v", err)
+		return fmt.Errorf("unable to setup stdout for session: %w", err)
 	}
 
 	go func() {
@@ -156,7 +156,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 
 	stderr, err := session.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("unable to setup stderr for session: %v", err)
+		return fmt.Errorf("unable to setup stderr for session: %w", err)
 	}
 
 	go func() {

--- a/pkg/ssh/key.go
+++ b/pkg/ssh/key.go
@@ -62,22 +62,22 @@ func GenerateKeys() error {
 func generate(public, private string, bitSize int) error {
 	privateKey, err := generatePrivateKey(bitSize)
 	if err != nil {
-		return fmt.Errorf("failed to generate private SSH key: %s", err)
+		return fmt.Errorf("failed to generate private SSH key: %w", err)
 	}
 
 	publicKeyBytes, err := generatePublicKey(&privateKey.PublicKey)
 	if err != nil {
-		return fmt.Errorf("failed to generate public SSH key: %s", err)
+		return fmt.Errorf("failed to generate public SSH key: %w", err)
 	}
 
 	privateKeyBytes := encodePrivateKeyToPEM(privateKey)
 
 	if err := os.WriteFile(public, publicKeyBytes, 0600); err != nil {
-		return fmt.Errorf("failed to write public SSH key: %s", err)
+		return fmt.Errorf("failed to write public SSH key: %w", err)
 	}
 
 	if err := os.WriteFile(private, privateKeyBytes, 0600); err != nil {
-		return fmt.Errorf("failed to write private SSH key: %s", err)
+		return fmt.Errorf("failed to write private SSH key: %w", err)
 	}
 
 	oktetoLog.Infof("created ssh keypair at  %s and %s", public, private)

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -144,7 +144,7 @@ func (fm *ForwardManager) Start(devPod, namespace string) error {
 
 		c, err := getSSHClientConfig()
 		if err != nil {
-			return fmt.Errorf("failed to get SSH configuration: %s", err)
+			return fmt.Errorf("failed to get SSH configuration: %w", err)
 		}
 
 		oktetoLog.Infof("starting SSH connection pool on %s", fm.sshAddr)

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -138,7 +138,7 @@ func getConfig(path string) (*sshConfig, error) {
 			}, nil
 		}
 
-		return nil, fmt.Errorf("can't open %s: %s", path, err)
+		return nil, fmt.Errorf("can't open %s: %w", path, err)
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -148,7 +148,7 @@ func getConfig(path string) (*sshConfig, error) {
 
 	cfg, err := parse(f)
 	if err != nil {
-		return nil, fmt.Errorf("fail to decode %s: %s", path, err)
+		return nil, fmt.Errorf("fail to decode %s: %w", path, err)
 	}
 
 	return cfg, nil

--- a/pkg/syncthing/install.go
+++ b/pkg/syncthing/install.go
@@ -77,19 +77,19 @@ func Install(p getter.ProgressTracker) error {
 	defer os.RemoveAll(dir)
 
 	if err := client.Get(); err != nil {
-		return fmt.Errorf("failed to download syncthing from %s: %s", client.Src, err)
+		return fmt.Errorf("failed to download syncthing from %s: %w", client.Src, err)
 	}
 
 	i := getInstallPath()
 	b := getBinaryPathInDownload(dir, downloadURL)
 
 	if _, err := os.Stat(b); err != nil {
-		return fmt.Errorf("%s didn't include the syncthing binary: %s", downloadURL, err)
+		return fmt.Errorf("%s didn't include the syncthing binary: %w", downloadURL, err)
 	}
 
 	// skipcq GSC-G302 syncthing is a binary so it needs exec permissions
 	if err := os.Chmod(b, 0700); err != nil {
-		return fmt.Errorf("failed to set permissions to %s: %s", b, err)
+		return fmt.Errorf("failed to set permissions to %s: %w", b, err)
 	}
 
 	if filesystem.FileExists(i) {
@@ -99,7 +99,7 @@ func Install(p getter.ProgressTracker) error {
 	}
 
 	if err := filesystem.CopyFile(b, i); err != nil {
-		return fmt.Errorf("failed to write %s: %s", i, err)
+		return fmt.Errorf("failed to write %s: %w", i, err)
 	}
 
 	oktetoLog.Infof("downloaded syncthing %s to %s", syncthingVersion, i)
@@ -168,7 +168,7 @@ func parseVersionFromOutput(output []byte) (*semver.Version, error) {
 
 	s, err := semver.NewVersion(v)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse the current syncthing version `%s`: %s", v, err)
+		return nil, fmt.Errorf("failed to parse the current syncthing version `%s`: %w", v, err)
 	}
 
 	return s, nil

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -262,7 +262,7 @@ func New(dev *model.Dev) (*Syncthing, error) {
 
 func (s *Syncthing) initConfig() error {
 	if err := os.MkdirAll(s.Home, 0700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", s.Home, err)
+		return fmt.Errorf("failed to create %s: %w", s.Home, err)
 	}
 
 	if err := s.UpdateConfig(); err != nil {
@@ -852,11 +852,11 @@ func (s *Syncthing) SoftTerminate() error {
 	}
 	p, err := process.NewProcess(int32(s.pid))
 	if err != nil {
-		return fmt.Errorf("error getting syncthing process %d: %s", s.pid, err.Error())
+		return fmt.Errorf("error getting syncthing process %d: %w", s.pid, err)
 	}
 	oktetoLog.Infof("terminating syncthing %d without wait", s.pid)
 	if err := terminate(p, false); err != nil {
-		return fmt.Errorf("error terminating syncthing %d without wait: %s", p.Pid, err.Error())
+		return fmt.Errorf("error terminating syncthing %d without wait: %w", p.Pid, err)
 	}
 	oktetoLog.Infof("terminated syncthing %d without wait", s.pid)
 	return nil


### PR DESCRIPTION
# Proposed changes

Fixes an issue where the kubetoken was expired and we were not using the wrapped error. This was causing that the execution failed instead of renovating the token. 

## How to validate

1. Run okteto up and wait until the token has expired
1. While it's connecting to the new pod kill the pod(kubectl delete pod pod-name)
1. See error

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
