### PR TITLE
Jlopezbarb/wrap errors

### DIFF
--- a/cmd/build/remote/build.go
+++ b/cmd/build/remote/build.go
@@ -78,7 +78,7 @@ func (bc *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 	}
 
 	if err := utils.CheckIfDirectory(path); err != nil {
-		return fmt.Errorf("invalid build context: %s", err.Error())
+		return fmt.Errorf("invalid build context: %w", err)
 	}
 	options.Path = path
 

--- a/cmd/build/v1/build.go
+++ b/cmd/build/v1/build.go
@@ -85,7 +85,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 	}
 
 	if err := utils.CheckIfDirectory(path); err != nil {
-		return fmt.Errorf("invalid build context: %s", err.Error())
+		return fmt.Errorf("invalid build context: %w", err)
 	}
 	options.Path = path
 

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -384,7 +384,7 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 	}
 	imageTagWithDigest, err := bc.Registry.GetImageTagWithDigest(reference)
 	if err != nil {
-		return "", fmt.Errorf("error accessing image at registry %s: %v", reference, err)
+		return "", fmt.Errorf("error accessing image at registry %s: %w", reference, err)
 	}
 	return imageTagWithDigest, nil
 }
@@ -423,7 +423,7 @@ func (bc *OktetoBuilder) addVolumeMounts(ctx context.Context, manifest *model.Ma
 	}
 	imageTagWithDigest, err := bc.Registry.GetImageTagWithDigest(buildOptions.Tag)
 	if err != nil {
-		return "", fmt.Errorf("error accessing image at registry %s: %v", options.Tag, err)
+		return "", fmt.Errorf("error accessing image at registry %s: %w", options.Tag, err)
 	}
 	return imageTagWithDigest, nil
 }

--- a/cmd/build/v2/imagechecker.go
+++ b/cmd/build/v2/imagechecker.go
@@ -99,7 +99,7 @@ func (ic imageChecker) getImageDigestReferenceForService(manifestName, svcToBuil
 				continue
 			}
 			// return error if the registry doesn't send a not found error
-			return "", fmt.Errorf("error checking image at registry %s: %v", ref, err)
+			return "", fmt.Errorf("error checking image at registry %s: %w", ref, err)
 		}
 		return imageWithDigest, nil
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -648,18 +648,18 @@ func (dc *DeployCommand) deployDependencies(ctx context.Context, deployOptions *
 func (dc *DeployCommand) recreateFailedPods(ctx context.Context, name string) error {
 	c, _, err := dc.K8sClientProvider.Provide(okteto.Context().Cfg)
 	if err != nil {
-		return fmt.Errorf("could not get kubernetes client: %s", err)
+		return fmt.Errorf("could not get kubernetes client: %w", err)
 	}
 
 	pods, err := c.CoreV1().Pods(okteto.Context().Namespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", model.DeployedByLabel, format.ResourceK8sMetaString(name))})
 	if err != nil {
-		return fmt.Errorf("could not list pods: %s", err)
+		return fmt.Errorf("could not list pods: %w", err)
 	}
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == "Failed" {
 			err := c.CoreV1().Pods(okteto.Context().Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			if err != nil {
-				return fmt.Errorf("could not delete pod %s: %s", pod.Name, err)
+				return fmt.Errorf("could not delete pod %s: %w", pod.Name, err)
 			}
 		}
 	}

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -314,7 +314,7 @@ func (ld *localDeployer) deployEndpoints(ctx context.Context, opts *Options) err
 
 	iClient, err := ingresses.GetClient(c)
 	if err != nil {
-		return fmt.Errorf("error getting ingress client: %s", err.Error())
+		return fmt.Errorf("error getting ingress client: %w", err)
 	}
 
 	translateOptions := &ingresses.TranslateOptions{

--- a/cmd/deploy/proxy.go
+++ b/cmd/deploy/proxy.go
@@ -358,7 +358,7 @@ func (ph *proxyHandler) translateMetadata(body map[string]json.RawMessage) error
 
 	metadataAsByte, err := json.Marshal(metadata)
 	if err != nil {
-		return fmt.Errorf("could not process resource's metadata: %s", err)
+		return fmt.Errorf("could not process resource's metadata: %w", err)
 	}
 
 	body["metadata"] = metadataAsByte
@@ -376,7 +376,7 @@ func (ph *proxyHandler) translateDeploymentSpec(body map[string]json.RawMessage)
 	spec.Template.Spec = ph.applyDivertToPod(spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process deployment's spec: %s", err)
+		return fmt.Errorf("could not process deployment's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil
@@ -392,7 +392,7 @@ func (ph *proxyHandler) translateStatefulSetSpec(body map[string]json.RawMessage
 	spec.Template.Spec = ph.applyDivertToPod(spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process statefulset's spec: %s", err)
+		return fmt.Errorf("could not process statefulset's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil
@@ -408,7 +408,7 @@ func (ph *proxyHandler) translateJobSpec(body map[string]json.RawMessage) error 
 	spec.Template.Spec = ph.applyDivertToPod(spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process job's spec: %s", err)
+		return fmt.Errorf("could not process job's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil
@@ -424,7 +424,7 @@ func (ph *proxyHandler) translateCronJobSpec(body map[string]json.RawMessage) er
 	spec.JobTemplate.Spec.Template.Spec = ph.applyDivertToPod(spec.JobTemplate.Spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process cronjob's spec: %s", err)
+		return fmt.Errorf("could not process cronjob's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil
@@ -440,7 +440,7 @@ func (ph *proxyHandler) translateDaemonSetSpec(body map[string]json.RawMessage) 
 	spec.Template.Spec = ph.applyDivertToPod(spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process daemonset's spec: %s", err)
+		return fmt.Errorf("could not process daemonset's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil
@@ -456,7 +456,7 @@ func (ph *proxyHandler) translateReplicationControllerSpec(body map[string]json.
 	spec.Template.Spec = ph.applyDivertToPod(spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process replicationcontroller's spec: %s", err)
+		return fmt.Errorf("could not process replicationcontroller's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil
@@ -472,7 +472,7 @@ func (ph *proxyHandler) translateReplicaSetSpec(body map[string]json.RawMessage)
 	spec.Template.Spec = ph.applyDivertToPod(spec.Template.Spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process replicaset's spec: %s", err)
+		return fmt.Errorf("could not process replicaset's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil
@@ -498,7 +498,7 @@ func (ph *proxyHandler) translateVirtualServiceSpec(body map[string]json.RawMess
 	ph.DivertDriver.UpdateVirtualService(spec)
 	specAsByte, err := json.Marshal(spec)
 	if err != nil {
-		return fmt.Errorf("could not process virtual service's spec: %s", err)
+		return fmt.Errorf("could not process virtual service's spec: %w", err)
 	}
 	body["spec"] = specAsByte
 	return nil

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -382,7 +382,7 @@ func fetchRemoteServerConfig(ctx context.Context) (*types.ClusterMetadata, error
 	cp := okteto.NewOktetoClientProvider()
 	c, err := cp.Provide()
 	if err != nil {
-		return nil, fmt.Errorf("failed to provide okteto client for fetching certs: %s", err)
+		return nil, fmt.Errorf("failed to provide okteto client for fetching certs: %w", err)
 	}
 	uc := c.User()
 

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -173,7 +173,7 @@ func (ld *localDestroyCommand) runDestroy(ctx context.Context, opts *Options) er
 			oktetoLog.Information("Running '%s'", command.Name)
 			oktetoLog.SetStage(command.Name)
 			if err := ld.executor.Execute(command, opts.Variables); err != nil {
-				err = fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
+				err = fmt.Errorf("error executing command '%s': %w", command.Name, err)
 				if !opts.ForceDestroy {
 					if err := ld.ConfigMapHandler.setErrorStatus(ctx, cfg, data, err); err != nil {
 						exit <- err

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -368,7 +368,7 @@ func fetchClusterMetadata(ctx context.Context) (*types.ClusterMetadata, error) {
 	cp := okteto.NewOktetoClientProvider()
 	c, err := cp.Provide()
 	if err != nil {
-		return nil, fmt.Errorf("failed to provide okteto client for fetching certs: %s", err)
+		return nil, fmt.Errorf("failed to provide okteto client for fetching certs: %w", err)
 	}
 	uc := c.User()
 

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -77,7 +77,7 @@ func (nc *NamespaceCommand) Create(ctx context.Context, opts *CreateOptions) err
 
 	if opts.Members != nil && len(*opts.Members) > 0 {
 		if err := nc.okClient.Namespaces().AddMembers(ctx, opts.Namespace, *opts.Members); err != nil {
-			return fmt.Errorf("failed to invite %s to the namespace: %s", strings.Join(*opts.Members, ", "), err)
+			return fmt.Errorf("failed to invite %s to the namespace: %w", strings.Join(*opts.Members, ", "), err)
 		}
 	}
 
@@ -98,7 +98,7 @@ func (nc *NamespaceCommand) Create(ctx context.Context, opts *CreateOptions) err
 	}
 
 	if err := nc.ctxCmd.Run(ctx, ctxOptions); err != nil {
-		return fmt.Errorf("failed to activate your new namespace %s: %s", oktetoNS, err)
+		return fmt.Errorf("failed to activate your new namespace %s: %w", oktetoNS, err)
 	}
 
 	return nil

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -72,7 +72,7 @@ func (nc *NamespaceCommand) ExecuteDeleteNamespace(ctx context.Context, namespac
 
 	// trigger namespace deletion
 	if err := nc.okClient.Namespaces().Delete(ctx, namespace); err != nil {
-		return fmt.Errorf("%w: %v", errFailedDeleteNamespace, err)
+		return fmt.Errorf("%w: %w", errFailedDeleteNamespace, err)
 	}
 
 	if err := nc.watchDelete(ctx, namespace); err != nil {

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -56,7 +56,7 @@ func List(ctx context.Context) *cobra.Command {
 func (nc *NamespaceCommand) executeListNamespaces(ctx context.Context) error {
 	spaces, err := nc.okClient.Namespaces().List(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get namespaces: %s", err)
+		return fmt.Errorf("failed to get namespaces: %w", err)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
 	fmt.Fprintf(w, "Namespace\tStatus\n")

--- a/cmd/namespace/sleep.go
+++ b/cmd/namespace/sleep.go
@@ -65,7 +65,7 @@ func (nc *NamespaceCommand) ExecuteSleepNamespace(ctx context.Context, namespace
 
 	// trigger namespace to sleep
 	if err := nc.okClient.Namespaces().Sleep(ctx, namespace); err != nil {
-		return fmt.Errorf("%w: %v", errFailedSleepNamespace, err)
+		return fmt.Errorf("%w: %w", errFailedSleepNamespace, err)
 	}
 
 	oktetoLog.Success("Namespace '%s' is sleeping", namespace)

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -128,7 +128,7 @@ func getNamespacesSelection(ctx context.Context) ([]utils.SelectorItem, error) {
 	}
 	spaces, err := oktetoClient.Namespaces().List(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get namespaces: %s", err)
+		return nil, fmt.Errorf("failed to get namespaces: %w", err)
 	}
 
 	namespaces := []utils.SelectorItem{}

--- a/cmd/namespace/wake.go
+++ b/cmd/namespace/wake.go
@@ -61,7 +61,7 @@ func (nc *NamespaceCommand) ExecuteWakeNamespace(ctx context.Context, namespace 
 
 	// trigger namespace to sleep
 	if err := nc.okClient.Namespaces().Wake(ctx, namespace); err != nil {
-		return fmt.Errorf("%w: %v", errFailedWakeNamespace, err)
+		return fmt.Errorf("%w: %w", errFailedWakeNamespace, err)
 	}
 
 	oktetoLog.Success("Namespace '%s' is awake now", namespace)

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -145,7 +145,7 @@ func (pc *Command) ExecuteDeployPipeline(ctx context.Context, opts *DeployOption
 
 	c, _, err := pc.k8sClientProvider.Provide(okteto.Context().Cfg)
 	if err != nil {
-		return fmt.Errorf("failed to load okteto context '%s': %v", okteto.Context().Name, err)
+		return fmt.Errorf("failed to load okteto context '%s': %w", okteto.Context().Name, err)
 	}
 
 	exists := false

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -16,6 +16,7 @@ package pipeline
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -117,7 +118,7 @@ func pipelineListCommandHandler(ctx context.Context, flags *listFlags, initOkCtx
 	}
 	c, _, err := pc.k8sClientProvider.Provide(okCtx.Cfg)
 	if err != nil {
-		return fmt.Errorf("failed to load okteto context '%s': %v", okCtx.Name, err)
+		return fmt.Errorf("failed to load okteto context '%s': %w", okCtx.Name, err)
 	}
 
 	return executeListPipelines(ctx, *flags, configmaps.List, getPipelineListOutput, c, os.Stdout)
@@ -183,7 +184,7 @@ func getLabelSelector(labels []string) (string, error) {
 		}
 		errs := validation.IsValidLabelValue(label)
 		if len(errs) > 0 {
-			return "", fmt.Errorf("invalid label '%s': %v", label, errs[0])
+			return "", fmt.Errorf("invalid label '%s': %w", label, errors.New(errs[0]))
 		}
 		labelSelector = append(labelSelector, fmt.Sprintf("%s/%s", constants.EnvironmentLabelKeyPrefix, label))
 	}

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -102,7 +102,7 @@ func (c destroyPreviewCommand) executeDestroyPreview(ctx context.Context, opts *
 	defer oktetoLog.StopSpinner()
 
 	if err := c.okClient.Previews().Destroy(ctx, opts.name); err != nil {
-		return fmt.Errorf("failed to destroy preview environment: %s", err)
+		return fmt.Errorf("failed to destroy preview environment: %w", err)
 	}
 
 	if !opts.wait {

--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -95,7 +95,7 @@ func executeListPreviewEndpoints(ctx context.Context, name, output string) error
 	}
 	endpointList, err := oktetoClient.Previews().ListEndpoints(ctx, name)
 	if err != nil {
-		return fmt.Errorf("failed to get preview environments: %s", err)
+		return fmt.Errorf("failed to get preview environments: %w", err)
 	}
 
 	switch output {

--- a/cmd/preview/sleep.go
+++ b/cmd/preview/sleep.go
@@ -60,7 +60,7 @@ func (pr *Command) ExecuteSleepPreview(ctx context.Context, preview string) erro
 
 	// trigger preview environment to sleep
 	if err := pr.okClient.Namespaces().Sleep(ctx, preview); err != nil {
-		return fmt.Errorf("%w: %v", errFailedSleepPreview, err)
+		return fmt.Errorf("%w: %w", errFailedSleepPreview, err)
 	}
 
 	oktetoLog.Success("Preview environment '%s' is sleeping", preview)

--- a/cmd/preview/wake.go
+++ b/cmd/preview/wake.go
@@ -60,7 +60,7 @@ func (pr *Command) ExecuteWakePreview(ctx context.Context, preview string) error
 
 	// trigger preview environment to wake
 	if err := pr.okClient.Namespaces().Wake(ctx, preview); err != nil {
-		return fmt.Errorf("%w: %v", errFailedWakePreview, err)
+		return fmt.Errorf("%w: %w", errFailedWakePreview, err)
 	}
 
 	oktetoLog.Success("Preview environment '%s' is awake now", preview)

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -77,7 +77,7 @@ func Restart() *cobra.Command {
 			}
 			err = executeRestart(ctx, dev, serviceName)
 			if err != nil {
-				return fmt.Errorf("failed to restart your deployments: %s", err)
+				return fmt.Errorf("failed to restart your deployments: %w", err)
 			}
 			analytics.TrackRestart(err == nil)
 

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -114,7 +114,7 @@ func (up *upContext) activate() error {
 
 	if !up.isRetry && buildDevImage {
 		if err := up.buildDevImage(ctx, app); err != nil {
-			return fmt.Errorf("error building dev image: %s", err)
+			return fmt.Errorf("error building dev image: %w", err)
 		}
 	}
 
@@ -145,7 +145,7 @@ func (up *upContext) activate() error {
 		if _, ok := err.(oktetoErrors.UserError); ok {
 			return err
 		}
-		return fmt.Errorf("couldn't activate your development container\n    %s", err.Error())
+		return fmt.Errorf("couldn't activate your development container\n    %w", err)
 	}
 
 	if up.isRetry {
@@ -163,12 +163,12 @@ func (up *upContext) activate() error {
 			err := up.checkOktetoStartError(ctx, "Failed to connect to your development container")
 			if err == oktetoErrors.ErrLostSyncthing {
 				if err := pods.Destroy(ctx, up.Pod.Name, up.Dev.Namespace, k8sClient); err != nil {
-					return fmt.Errorf("error recreating development container: %s", err.Error())
+					return fmt.Errorf("error recreating development container: %w", err)
 				}
 			}
 			return err
 		}
-		return fmt.Errorf("couldn't connect to your development container: %s", err.Error())
+		return fmt.Errorf("couldn't connect to your development container: %w", err)
 	}
 	go up.cleanCommand(ctx)
 

--- a/cmd/up/stignore.go
+++ b/cmd/up/stignore.go
@@ -162,7 +162,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 		}
 		c := linguist.GetSTIgnore(l)
 		if err := os.WriteFile(stignorePath, c, 0600); err != nil {
-			return fmt.Errorf("failed to write stignore file for '%s': %s", folder, err.Error())
+			return fmt.Errorf("failed to write stignore file for '%s': %w", folder, err)
 		}
 		return nil
 	}
@@ -170,24 +170,24 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 	oktetoLog.Information("Okteto requires a '.stignore' file to ignore file patterns that help optimize the synchronization service.")
 	stignoreDefaults, err := utils.AskYesNo("Do you want to infer defaults for the '.stignore' file? (otherwise, it will be left blank)", utils.YesNoDefault_Yes)
 	if err != nil {
-		return fmt.Errorf("failed to add '.stignore' to '%s': %s", folder, err.Error())
+		return fmt.Errorf("failed to add '.stignore' to '%s': %w", folder, err)
 	}
 
 	if !stignoreDefaults {
 		stignoreContent := ""
 		if err := os.WriteFile(stignorePath, []byte(stignoreContent), 0600); err != nil {
-			return fmt.Errorf("failed to create empty '%s': %s", stignorePath, err.Error())
+			return fmt.Errorf("failed to create empty '%s': %w", stignorePath, err)
 		}
 		return nil
 	}
 
 	language, err := manifest.GetLanguage("", folder)
 	if err != nil {
-		return fmt.Errorf("failed to get language for '%s': %s", folder, err.Error())
+		return fmt.Errorf("failed to get language for '%s': %w", folder, err)
 	}
 	c := linguist.GetSTIgnore(language)
 	if err := os.WriteFile(stignorePath, c, 0600); err != nil {
-		return fmt.Errorf("failed to write stignore file for '%s': %s", folder, err.Error())
+		return fmt.Errorf("failed to write stignore file for '%s': %w", folder, err)
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func askIfCreateStignoreDefaults(folder, stignorePath string) error {
 func checkIfStignoreHasGitFolder(stignorePath string) error {
 	stignoreBytes, err := os.ReadFile(stignorePath)
 	if err != nil {
-		return fmt.Errorf("failed to read '%s': %s", stignorePath, err.Error())
+		return fmt.Errorf("failed to read '%s': %w", stignorePath, err)
 	}
 	stignoreContent := string(stignoreBytes)
 	if strings.Contains(stignoreContent, ".git") {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -279,7 +279,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.IOController) *cobra.Command {
 
 			k8sClient, _, err := okteto.GetK8sClient()
 			if err != nil {
-				return fmt.Errorf("failed to load k8s client: %v", err)
+				return fmt.Errorf("failed to load k8s client: %w", err)
 			}
 
 			// if manifest v1 - either set autocreate: true or pass --deploy (okteto forces autocreate: true)

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -114,12 +114,12 @@ func LoadManifestRc(dev *model.Dev) error {
 	if filesystem.FileExists(defaultDevRcPath) {
 		devRc, err = model.GetRc(defaultDevRcPath)
 		if err != nil {
-			return fmt.Errorf("error while reading %s file: %s", defaultDevRcPath, err.Error())
+			return fmt.Errorf("error while reading %s file: %w", defaultDevRcPath, err)
 		}
 	} else if filesystem.FileExists(secondaryDevRcPath) {
 		devRc, err = model.GetRc(secondaryDevRcPath)
 		if err != nil {
-			return fmt.Errorf("error while reading %s file: %s", defaultDevRcPath, err.Error())
+			return fmt.Errorf("error while reading %s file: %w", defaultDevRcPath, err)
 		}
 	}
 

--- a/cmd/utils/upgrade.go
+++ b/cmd/utils/upgrade.go
@@ -58,7 +58,7 @@ func GetLatestVersionFromGithub() (string, error) {
 	ctx := context.Background()
 	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 10})
 	if err != nil {
-		return "", fmt.Errorf("fail to get releases from github: %s", err)
+		return "", fmt.Errorf("fail to get releases from github: %w", err)
 	}
 
 	for _, r := range releases {

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -338,7 +338,7 @@ For example:
 return nil, fmt.Errorf("get cache %s: %w", f.Name, err)
 
 // Just add context
-return nil, fmt.Errorf("saving cache %s: %v", f.Name, err)
+return nil, fmt.Errorf("saving cache %s: %s", f.Name, err)
 ```
 
 A few things to keep in mind when adding context:

--- a/integration/commands/build.go
+++ b/integration/commands/build.go
@@ -71,7 +71,7 @@ func RunOktetoBuild(oktetoPath string, buildOptions *BuildOptions) error {
 
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto build failed: \nerror: %s \noutput:\n %s", err.Error(), string(o))
+		return fmt.Errorf("okteto build failed: \nerror: %w \noutput:\n %s", err, string(o))
 	}
 	return nil
 }

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -67,7 +67,7 @@ func GetOktetoDeployCmdOutput(oktetoPath string, deployOptions *DeployOptions) (
 func RunOktetoDeploy(oktetoPath string, deployOptions *DeployOptions) error {
 	output, err := GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
 	if err != nil {
-		return fmt.Errorf("okteto deploy failed: %s - %s", string(output), err)
+		return fmt.Errorf("okteto deploy failed: %s - %w", string(output), err)
 	}
 	return err
 }
@@ -78,7 +78,7 @@ func RunOktetoDeployAndGetOutput(oktetoPath string, deployOptions *DeployOptions
 	log.Printf("Running '%s'", cmd.String())
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return string(o), fmt.Errorf("okteto deploy failed: %s - %s", string(o), err)
+		return string(o), fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto deploy success")
 	return string(o), nil
@@ -90,7 +90,7 @@ func RunOktetoDestroy(oktetoPath string, destroyOptions *DestroyOptions) error {
 	cmd := getDestroyCmd(oktetoPath, destroyOptions)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto deploy failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto destroy success")
 	return nil
@@ -102,7 +102,7 @@ func RunOktetoDestroyAndGetOutput(oktetoPath string, destroyOptions *DestroyOpti
 	log.Printf("Running '%s'", cmd.String())
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return string(o), fmt.Errorf("okteto deploy failed: %s - %s", string(o), err)
+		return string(o), fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto deploy success")
 	return string(o), nil
@@ -116,7 +116,7 @@ func RunOktetoDestroyRemote(oktetoPath string, destroyOptions *DestroyOptions) e
 
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto deploy --remote failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto deploy --remote failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto destroy success")
 	return nil

--- a/integration/commands/dev.go
+++ b/integration/commands/dev.go
@@ -60,7 +60,7 @@ func RunOktetoUp(oktetoPath string, upOptions *UpOptions) (*UpCommandProcessResu
 
 	log.Printf("Running up command: %s", cmd.String())
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("okteto up failed to start: %s", err)
+		return nil, fmt.Errorf("okteto up failed to start: %w", err)
 	}
 
 	wg.Add(1)
@@ -69,8 +69,8 @@ func RunOktetoUp(oktetoPath string, upOptions *UpOptions) (*UpCommandProcessResu
 		defer wg.Done()
 		if err := cmd.Wait(); err != nil {
 			if err != nil {
-				log.Printf("okteto up exited: %s.\nOutput:\n%s", err, out.String())
-				upErrorChannel <- fmt.Errorf("Okteto up exited before completion")
+				log.Printf("okteto up exited: %w.\nOutput:\n%s", err, out.String())
+				upErrorChannel <- fmt.Errorf("okteto up exited before completion")
 			}
 		}
 	}()
@@ -95,7 +95,7 @@ func RunOktetoUpAndWaitWithOutput(oktetoPath string, upOptions *UpOptions) (byte
 
 	log.Printf("Running up command: %s", cmd.String())
 	if err := cmd.Start(); err != nil {
-		return out, fmt.Errorf("okteto up failed to start: %s", err)
+		return out, fmt.Errorf("okteto up failed to start: %w", err)
 	}
 
 	err := cmd.Wait()
@@ -180,10 +180,10 @@ func RunOktetoDown(oktetoPath string, downOpts *DownOptions) error {
 	if err != nil {
 		m, err := os.ReadFile(downOpts.ManifestPath)
 		if err != nil {
-			return fmt.Errorf("okteto down failed: %s", err)
+			return fmt.Errorf("okteto down failed: %w", err)
 		}
 		log.Printf("manifest: \n%s\n", string(m))
-		return fmt.Errorf("okteto down failed: %s", err)
+		return fmt.Errorf("okteto down failed: %w", err)
 	}
 
 	return nil
@@ -207,7 +207,7 @@ func HasUpCommandFinished(pid int) bool {
 			}
 
 			if err != nil {
-				err = fmt.Errorf("error when finding process: %s", err)
+				err = fmt.Errorf("error when finding process: %w", err)
 			} else if found != nil {
 				err = fmt.Errorf("okteto up didn't exit after down")
 			}

--- a/integration/commands/endpoints.go
+++ b/integration/commands/endpoints.go
@@ -48,7 +48,7 @@ func RunOktetoEndpoints(oktetoPath string, endpointsOptions *EndpointOptions) ([
 
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return o, fmt.Errorf("okteto deploy failed: %s - %s", string(o), err)
+		return o, fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto deploy success")
 	return o, nil

--- a/integration/commands/exec.go
+++ b/integration/commands/exec.go
@@ -61,7 +61,7 @@ func RunExecCommand(oktetoPath string, execOptions *ExecOptions) (string, error)
 	bytes, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("okteto exec failed: %v - %s", err, string(bytes))
-		return "", fmt.Errorf("okteto exec failed: %v - %s", err, string(bytes))
+		return "", fmt.Errorf("okteto exec failed: %w - %s", err, string(bytes))
 	}
 	return string(bytes), nil
 }

--- a/integration/commands/namespace.go
+++ b/integration/commands/namespace.go
@@ -119,7 +119,7 @@ func RunOktetoDeleteNamespace(oktetoPath string, namespaceOpts *NamespaceOptions
 	}
 	o, err := deleteCMD.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto delete namespace failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto delete namespace failed: %s - %w", string(o), err)
 	}
 	return nil
 }

--- a/integration/commands/pipeline.go
+++ b/integration/commands/pipeline.go
@@ -121,7 +121,7 @@ func RunOktetoPipelineDestroy(oktetoPath string, destroyOptions *DestroyPipeline
 	}
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto deploy failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto destroy success")
 	return nil

--- a/integration/commands/preview.go
+++ b/integration/commands/preview.go
@@ -105,7 +105,7 @@ func RunOktetoPreviewDestroy(oktetoPath string, destroyOptions *DestroyPreviewOp
 	}
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto deploy failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto destroy success")
 	return nil

--- a/integration/commands/push.go
+++ b/integration/commands/push.go
@@ -38,7 +38,7 @@ func RunOktetoPush(oktetoPath, workdir string) error {
 
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto stack deploy failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto stack deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto stack deploy success")
 	return nil

--- a/integration/commands/stacks.go
+++ b/integration/commands/stacks.go
@@ -68,7 +68,7 @@ func RunOktetoStackDeploy(oktetoPath string, deployOptions *StackDeployOptions) 
 
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto stack deploy failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto stack deploy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto stack deploy success")
 	return nil
@@ -98,7 +98,7 @@ func RunOktetoStackDestroy(oktetoPath string, deployOptions *StackDestroyOptions
 
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("okteto stack destroy failed: %s - %s", string(o), err)
+		return fmt.Errorf("okteto stack destroy failed: %s - %w", string(o), err)
 	}
 	log.Printf("okteto stack destroy success")
 	return nil

--- a/integration/git.go
+++ b/integration/git.go
@@ -26,7 +26,7 @@ func CloneGitRepo(url string) error {
 	cmd := exec.Command("git", "clone", url)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("cloning git repo %s failed: %s - %s", url, string(o), err)
+		return fmt.Errorf("cloning git repo %s failed: %s - %w", url, string(o), err)
 	}
 	log.Printf("clone git repo %s success", url)
 	return nil
@@ -38,7 +38,7 @@ func CloneGitRepoWithBranch(url, branch string) error {
 	cmd := exec.Command("git", "clone", "--branch", branch, url)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("cloning git repo %s failed: %s - %s", url, string(o), err)
+		return fmt.Errorf("cloning git repo %s failed: %s - %w", url, string(o), err)
 	}
 	log.Printf("clone git repo %s success", url)
 	return nil

--- a/integration/k8s-client.go
+++ b/integration/k8s-client.go
@@ -183,7 +183,7 @@ func DestroyPod(ctx context.Context, ns, labelSelector string, c kubernetes.Inte
 
 	pods, err := c.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
-		return fmt.Errorf("failed to retrieve deployment %s pods: %s", labelSelector, err.Error())
+		return fmt.Errorf("failed to retrieve deployment %s pods: %w", labelSelector, err)
 	}
 	var zero int64 = 0
 	if len(pods.Items) == 0 {
@@ -197,7 +197,7 @@ func DestroyPod(ctx context.Context, ns, labelSelector string, c kubernetes.Inte
 			metav1.DeleteOptions{GracePeriodSeconds: &zero},
 		)
 		if err != nil {
-			return fmt.Errorf("error deleting pod %s: %s", pods.Items[idx].Name, err.Error())
+			return fmt.Errorf("error deleting pod %s: %w", pods.Items[idx].Name, err)
 		}
 	}
 

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -50,7 +50,7 @@ func GetOktetoPath() (string, error) {
 	}
 	output, err := RunOktetoVersion(oktetoPath)
 	if err != nil {
-		return "", fmt.Errorf("okteto version failed: %s - %s", output, err)
+		return "", fmt.Errorf("okteto version failed: %s - %w", output, err)
 	}
 	log.Println(output)
 	return oktetoPath, nil
@@ -74,7 +74,7 @@ func RunOktetoVersion(oktetoPath string) (string, error) {
 
 	o, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("okteto version failed: %s - %s", string(o), err)
+		return "", fmt.Errorf("okteto version failed: %s - %w", string(o), err)
 	}
 	return string(o), nil
 }

--- a/pkg/analytics/config.go
+++ b/pkg/analytics/config.go
@@ -120,7 +120,7 @@ func (a *Analytics) save() error {
 	}
 	marshalled, err := json.MarshalIndent(a, "", "\t")
 	if err != nil {
-		return fmt.Errorf("failed to generate analytics file: %s", err)
+		return fmt.Errorf("failed to generate analytics file: %w", err)
 	}
 
 	oktetoHome := config.GetOktetoHome()
@@ -132,12 +132,12 @@ func (a *Analytics) save() error {
 	if _, err := os.Stat(analyticsPath); err == nil {
 		err = os.Chmod(analyticsPath, 0600)
 		if err != nil {
-			return fmt.Errorf("couldn't change analytics permissions: %s", err)
+			return fmt.Errorf("couldn't change analytics permissions: %w", err)
 		}
 	}
 
 	if err := os.WriteFile(analyticsPath, marshalled, 0600); err != nil {
-		return fmt.Errorf("couldn't save analytics: %s", err)
+		return fmt.Errorf("couldn't save analytics: %w", err)
 	}
 
 	return nil

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -158,7 +158,7 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 	// create a temp folder - this will be remove once the build has finished
 	secretTempFolder := filepath.Join(config.GetOktetoHome(), ".secret")
 	if err := os.MkdirAll(secretTempFolder, 0700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", secretTempFolder, err)
+		return fmt.Errorf("failed to create %s: %w", secretTempFolder, err)
 	}
 	defer os.RemoveAll(secretTempFolder)
 
@@ -488,7 +488,7 @@ func createTempFileWithExpandedEnvsAtSource(fs afero.Fs, sourceFile, tempFolder 
 
 		// save expanded to temp file
 		if _, err = writer.Write([]byte(fmt.Sprintf("%s\n", srcContent))); err != nil {
-			return "", fmt.Errorf("unable to write to temp file: %s", err)
+			return "", fmt.Errorf("unable to write to temp file: %w", err)
 		}
 		writer.Flush()
 	}

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -225,7 +225,7 @@ func getBuildkitClient(ctx context.Context, okctx OktetoContextInterface) (*clie
 		c, err := getClientForOktetoCluster(ctx, builder, okctx.GetCurrentToken())
 		if err != nil {
 			oktetoLog.Infof("failed to create okteto build client: %s", err)
-			return nil, fmt.Errorf("failed to create the builder client: %v", err)
+			return nil, fmt.Errorf("failed to create the builder client: %w", err)
 		}
 
 		return c, nil

--- a/pkg/cmd/build/errors.go
+++ b/pkg/cmd/build/errors.go
@@ -49,7 +49,7 @@ func getErrorMessage(err error, tag string) error {
 		}
 	case isPullAccessDenied(err):
 		err = oktetoErrors.UserError{
-			E:    fmt.Errorf("error building image: failed to pull image '%s'. The repository is not accessible or it does not exist.", imageTag),
+			E:    fmt.Errorf("error building image: failed to pull image '%s'. The repository is not accessible or it does not exist", imageTag),
 			Hint: fmt.Sprintf("Please verify the name of the image '%s' to make sure it exists.", imageTag),
 		}
 	default:
@@ -58,7 +58,7 @@ func getErrorMessage(err error, tag string) error {
 			return cmdErr
 		}
 		err = oktetoErrors.UserError{
-			E: fmt.Errorf("error building image '%s': %s", tag, err.Error()),
+			E: fmt.Errorf("error building image '%s': %w", tag, err),
 		}
 	}
 	return err

--- a/pkg/cmd/build/file.go
+++ b/pkg/cmd/build/file.go
@@ -59,7 +59,7 @@ func getTranslatedDockerFile(filename string, okCtx OktetoContextInterface) (str
 
 	dockerfileTmpFolder := filepath.Join(config.GetOktetoHome(), ".dockerfile")
 	if err := os.MkdirAll(dockerfileTmpFolder, 0700); err != nil {
-		return "", fmt.Errorf("failed to create %s: %s", dockerfileTmpFolder, err)
+		return "", fmt.Errorf("failed to create %s: %w", dockerfileTmpFolder, err)
 	}
 
 	tmpFile, err := os.CreateTemp(dockerfileTmpFolder, "buildkit-")
@@ -85,7 +85,7 @@ func getTranslatedDockerFile(filename string, okCtx OktetoContextInterface) (str
 		}
 		_, err = datawriter.WriteString(translatedLine + "\n")
 		if err != nil {
-			return "", fmt.Errorf("failed to write dockerfile: %s", err)
+			return "", fmt.Errorf("failed to write dockerfile: %w", err)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -159,7 +159,7 @@ func CreateDockerfileWithVolumeMounts(image string, volumes []model.StackVolume)
 	build.Context = ctx
 	dockerfileTmpFolder := filepath.Join(config.GetOktetoHome(), ".dockerfile")
 	if err := os.MkdirAll(dockerfileTmpFolder, 0700); err != nil {
-		return build, fmt.Errorf("failed to create %s: %s", dockerfileTmpFolder, err)
+		return build, fmt.Errorf("failed to create %s: %w", dockerfileTmpFolder, err)
 	}
 
 	tmpFile, err := os.CreateTemp(dockerfileTmpFolder, "buildkit-")
@@ -172,7 +172,7 @@ func CreateDockerfileWithVolumeMounts(image string, volumes []model.StackVolume)
 
 	_, err = datawriter.Write([]byte(fmt.Sprintf("FROM %s\n", image)))
 	if err != nil {
-		return build, fmt.Errorf("failed to write dockerfile: %s", err)
+		return build, fmt.Errorf("failed to write dockerfile: %w", err)
 	}
 	for _, volume := range volumes {
 		_, err = datawriter.Write([]byte(fmt.Sprintf("COPY %s %s\n", filepath.ToSlash(volume.LocalPath), volume.RemotePath)))

--- a/pkg/cmd/doctor/run.go
+++ b/pkg/cmd/doctor/run.go
@@ -109,7 +109,7 @@ func Run(ctx context.Context, dev *model.Dev, devPath string, c *kubernetes.Clie
 	}
 	if err := z.Archive(files, archiveName); err != nil {
 		oktetoLog.Infof("error while archiving: %s", err)
-		return "", fmt.Errorf("couldn't create archive '%s', please try again: %s", archiveName, err)
+		return "", fmt.Errorf("couldn't create archive '%s', please try again: %w", archiveName, err)
 	}
 
 	return archiveName, nil
@@ -118,7 +118,7 @@ func Run(ctx context.Context, dev *model.Dev, devPath string, c *kubernetes.Clie
 func generateSummaryFile() (string, error) {
 	tempdir, err := os.MkdirTemp("", "")
 	if err != nil {
-		return "", fmt.Errorf("error creating temp dir: %s", err)
+		return "", fmt.Errorf("error creating temp dir: %w", err)
 	}
 	summaryPath := filepath.Join(tempdir, "okteto-summary.txt")
 	fileSummary, err := os.OpenFile(summaryPath, os.O_RDWR|os.O_CREATE, 0600)
@@ -302,7 +302,7 @@ func generateRemoteSyncthingLogsFile(ctx context.Context, dev *model.Dev, c *kub
 
 	tempdir, err := os.MkdirTemp("", "")
 	if err != nil {
-		return "", fmt.Errorf("error creating temp dir: %s", err)
+		return "", fmt.Errorf("error creating temp dir: %w", err)
 	}
 	remoteLogsPath := filepath.Join(tempdir, "remote-syncthing.log")
 	fileRemoteLog, err := os.OpenFile(remoteLogsPath, os.O_RDWR|os.O_CREATE, 0600)

--- a/pkg/cmd/stack/destroy.go
+++ b/pkg/cmd/stack/destroy.go
@@ -41,7 +41,7 @@ import (
 func Destroy(ctx context.Context, s *model.Stack, removeVolumes bool, timeout time.Duration) error {
 	c, _, err := okteto.GetK8sClient()
 	if err != nil {
-		return fmt.Errorf("failed to load your local Kubeconfig: %s", err)
+		return fmt.Errorf("failed to load your local Kubeconfig: %w", err)
 	}
 
 	cfg := translateConfigMap(s)
@@ -143,10 +143,10 @@ func destroyDeployments(ctx context.Context, s *model.Stack, c kubernetes.Interf
 			continue
 		}
 		if err := deployments.Destroy(ctx, dList[i].Name, dList[i].Namespace, c); err != nil {
-			return fmt.Errorf("error destroying deployment of service '%s': %s", dList[i].Name, err)
+			return fmt.Errorf("error destroying deployment of service '%s': %w", dList[i].Name, err)
 		}
 		if err := services.Destroy(ctx, dList[i].Name, dList[i].Namespace, c); err != nil {
-			return fmt.Errorf("error destroying service '%s': %s", dList[i].Name, err)
+			return fmt.Errorf("error destroying service '%s': %w", dList[i].Name, err)
 		}
 		if _, ok := s.Services[dList[i].Name]; ok {
 			oktetoLog.Success("Destroyed previous service '%s'", dList[i].Name)
@@ -167,10 +167,10 @@ func destroyStatefulsets(ctx context.Context, s *model.Stack, c kubernetes.Inter
 			continue
 		}
 		if err := statefulsets.Destroy(ctx, sfsList[i].Name, sfsList[i].Namespace, c); err != nil {
-			return fmt.Errorf("error destroying statefulset of service '%s': %s", sfsList[i].Name, err)
+			return fmt.Errorf("error destroying statefulset of service '%s': %w", sfsList[i].Name, err)
 		}
 		if err := services.Destroy(ctx, sfsList[i].Name, sfsList[i].Namespace, c); err != nil {
-			return fmt.Errorf("error destroying service '%s': %s", sfsList[i].Name, err)
+			return fmt.Errorf("error destroying service '%s': %w", sfsList[i].Name, err)
 		}
 		if _, ok := s.Services[sfsList[i].Name]; ok {
 			oktetoLog.Success("Destroyed previous service '%s'", sfsList[i].Name)
@@ -190,10 +190,10 @@ func destroyJobs(ctx context.Context, s *model.Stack, c kubernetes.Interface) er
 			continue
 		}
 		if err := jobs.Destroy(ctx, jobsList[i].Name, jobsList[i].Namespace, c); err != nil {
-			return fmt.Errorf("error destroying job of service '%s': %s", jobsList[i].Name, err)
+			return fmt.Errorf("error destroying job of service '%s': %w", jobsList[i].Name, err)
 		}
 		if err := services.Destroy(ctx, jobsList[i].Name, jobsList[i].Namespace, c); err != nil {
-			return fmt.Errorf("error destroying service '%s': %s", jobsList[i].Name, err)
+			return fmt.Errorf("error destroying service '%s': %w", jobsList[i].Name, err)
 		}
 		oktetoLog.StopSpinner()
 		if _, ok := s.Services[jobsList[i].Name]; ok {
@@ -209,7 +209,7 @@ func destroyJobs(ctx context.Context, s *model.Stack, c kubernetes.Interface) er
 func destroyIngresses(ctx context.Context, s *model.Stack, c kubernetes.Interface) error {
 	iClient, err := ingresses.GetClient(c)
 	if err != nil {
-		return fmt.Errorf("error getting ingress client: %s", err.Error())
+		return fmt.Errorf("error getting ingress client: %w", err)
 	}
 
 	iList, err := iClient.List(ctx, s.Namespace, s.GetLabelSelector())
@@ -241,7 +241,7 @@ func destroyIngresses(ctx context.Context, s *model.Stack, c kubernetes.Interfac
 			continue
 		}
 		if err := iClient.Destroy(ctx, iList[i].GetName(), iList[i].GetNamespace()); err != nil {
-			return fmt.Errorf("error destroying ingress '%s': %s", iList[i].GetName(), err)
+			return fmt.Errorf("error destroying ingress '%s': %w", iList[i].GetName(), err)
 		}
 		oktetoLog.Success("Endpoint '%s' destroyed", iList[i].GetName())
 	}
@@ -275,7 +275,7 @@ func destroyStackVolumes(ctx context.Context, s *model.Stack, c *kubernetes.Clie
 	for _, v := range vList {
 		if v.Labels[model.StackNameLabel] == format.ResourceK8sMetaString(s.Name) {
 			if err := volumes.Destroy(ctx, v.Name, v.Namespace, c, timeout); err != nil {
-				return fmt.Errorf("error destroying volume '%s': %s", v.Name, err)
+				return fmt.Errorf("error destroying volume '%s': %w", v.Name, err)
 			}
 			oktetoLog.Success("Volume '%s' destroyed", v.Name)
 		}

--- a/pkg/cmd/stack/endpoints.go
+++ b/pkg/cmd/stack/endpoints.go
@@ -28,7 +28,7 @@ import (
 func ListEndpoints(ctx context.Context, stack *model.Stack) error {
 	c, _, err := okteto.GetK8sClient()
 	if err != nil {
-		return fmt.Errorf("failed to load your local Kubeconfig: %s", err)
+		return fmt.Errorf("failed to load your local Kubeconfig: %w", err)
 	}
 	iClient, err := ingresses.GetClient(c)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,7 +137,7 @@ func UpdateStateFile(devName, devNamespace string, state UpState) error {
 
 	oktetoLog.Infof("updating file '%s'", s)
 	if err := os.WriteFile(s, []byte(state), 0600); err != nil {
-		return fmt.Errorf("failed to update state file: %s", err)
+		return fmt.Errorf("failed to update state file: %w", err)
 	}
 	oktetoLog.Infof("file '%s' updated successfully", s)
 

--- a/pkg/divert/weaver/ingresses.go
+++ b/pkg/divert/weaver/ingresses.go
@@ -71,7 +71,7 @@ func (d *Driver) divertIngress(ctx context.Context, name string) error {
 	for _, rule := range in.Spec.Rules {
 		for _, path := range rule.IngressRuleValue.HTTP.Paths {
 			if err := d.divertService(ctx, path.Backend.Service.Name); err != nil {
-				return fmt.Errorf("error diverting ingress '%s/%s' service '%s': %v", in.Namespace, in.Name, path.Backend.Service.Name, err)
+				return fmt.Errorf("error diverting ingress '%s/%s' service '%s': %w", in.Namespace, in.Name, path.Backend.Service.Name, err)
 			}
 		}
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -30,7 +30,7 @@ type Environment []Var
 func ExpandEnv(value string) (string, error) {
 	result, err := envsubst.String(value)
 	if err != nil {
-		return "", fmt.Errorf("error expanding environment on '%s': %s", value, err.Error())
+		return "", fmt.Errorf("error expanding environment on '%s': %w", value, err)
 	}
 	return result, nil
 }

--- a/pkg/externalresource/control.go
+++ b/pkg/externalresource/control.go
@@ -43,7 +43,7 @@ func NewExternalK8sControl(cfg *rest.Config) *K8sControl {
 func (c *K8sControl) Deploy(ctx context.Context, name, ns string, er *ExternalResource) error {
 	k8sclient, err := c.ClientProvider(c.Cfg)
 	if err != nil {
-		return fmt.Errorf("error creating external CRD client: %s", err.Error())
+		return fmt.Errorf("error creating external CRD client: %w", err)
 	}
 
 	externalResourceCRD := translate(name, ns, er, time.Now())

--- a/pkg/k8s/apps/deployments.go
+++ b/pkg/k8s/apps/deployments.go
@@ -127,7 +127,7 @@ func (i *DeploymentApp) RestoreOriginal() error {
 	oktetoLog.Info("deprecated devmodeoff behavior")
 	dOrig := &appsv1.Deployment{}
 	if err := json.Unmarshal([]byte(manifest), dOrig); err != nil {
-		return fmt.Errorf("malformed manifest: %v", err)
+		return fmt.Errorf("malformed manifest: %w", err)
 	}
 	i.d = dOrig
 	return nil

--- a/pkg/k8s/apps/statefulsets.go
+++ b/pkg/k8s/apps/statefulsets.go
@@ -116,7 +116,7 @@ func (i *StatefulSetApp) RestoreOriginal() error {
 	oktetoLog.Info("depreccated devmodeoff behavior")
 	sfsOrig := &appsv1.StatefulSet{}
 	if err := json.Unmarshal([]byte(manifest), sfsOrig); err != nil {
-		return fmt.Errorf("malformed manifest: %v", err)
+		return fmt.Errorf("malformed manifest: %w", err)
 	}
 	i.sfs = sfsOrig
 	return nil

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -233,7 +233,7 @@ func Destroy(ctx context.Context, name, namespace string, c kubernetes.Interface
 		if oktetoErrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting kubernetes deployment: %s", err)
+		return fmt.Errorf("error deleting kubernetes deployment: %w", err)
 	}
 	oktetoLog.Infof("deployment '%s' deleted", name)
 	return nil

--- a/pkg/k8s/ingresses/crud.go
+++ b/pkg/k8s/ingresses/crud.go
@@ -122,14 +122,14 @@ func (iClient *Client) Destroy(ctx context.Context, name, namespace string) erro
 	if iClient.isV1 {
 		err := iClient.c.NetworkingV1().Ingresses(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 		if err != nil && !oktetoErrors.IsNotFound(err) {
-			return fmt.Errorf("error deleting kubernetes ingress: %s", err)
+			return fmt.Errorf("error deleting kubernetes ingress: %w", err)
 		}
 		return nil
 	}
 
 	err := iClient.c.NetworkingV1beta1().Ingresses(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil && !oktetoErrors.IsNotFound(err) {
-		return fmt.Errorf("error deleting kubernetes ingress: %s", err)
+		return fmt.Errorf("error deleting kubernetes ingress: %w", err)
 	}
 	return nil
 }
@@ -204,7 +204,7 @@ func (i Ingress) GetAnnotations() map[string]string {
 func (iClient *Client) Deploy(ctx context.Context, ingress *Ingress) error {
 	if _, err := iClient.Get(ctx, ingress.GetName(), ingress.GetNamespace()); err != nil {
 		if !oktetoErrors.IsNotFound(err) {
-			return fmt.Errorf("error getting ingress '%s': %v", ingress.GetName(), err)
+			return fmt.Errorf("error getting ingress '%s': %w", ingress.GetName(), err)
 		}
 		if err := iClient.Create(ctx, ingress); err != nil {
 			return err

--- a/pkg/k8s/ingressesv1/crud.go
+++ b/pkg/k8s/ingressesv1/crud.go
@@ -27,14 +27,14 @@ import (
 func Deploy(ctx context.Context, i *networkingv1.Ingress, c kubernetes.Interface) error {
 	old, err := Get(ctx, i.Name, i.Namespace, c)
 	if err != nil && !oktetoErrors.IsNotFound(err) {
-		return fmt.Errorf("error getting kubernetes ingress: %s", err)
+		return fmt.Errorf("error getting kubernetes ingress: %w", err)
 	}
 
 	if old == nil || old.Name == "" {
 		oktetoLog.Infof("creating ingress '%s'", i.Name)
 		_, err = c.NetworkingV1().Ingresses(i.Namespace).Create(ctx, i, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("error creating kubernetes ingress: %s", err)
+			return fmt.Errorf("error creating kubernetes ingress: %w", err)
 		}
 		oktetoLog.Infof("created ingress '%s'", i.Name)
 	} else {
@@ -44,7 +44,7 @@ func Deploy(ctx context.Context, i *networkingv1.Ingress, c kubernetes.Interface
 		old.Spec = i.Spec
 		_, err = c.NetworkingV1().Ingresses(i.Namespace).Update(ctx, old, metav1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("error updating kubernetes ingress: %s", err)
+			return fmt.Errorf("error updating kubernetes ingress: %w", err)
 		}
 		oktetoLog.Infof("updated ingress '%s'.", i.Name)
 	}
@@ -77,7 +77,7 @@ func Destroy(ctx context.Context, name, namespace string, c kubernetes.Interface
 		if oktetoErrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting kubernetes ingress: %s", err)
+		return fmt.Errorf("error deleting kubernetes ingress: %w", err)
 	}
 	oktetoLog.Infof("Ingress '%s' deleted", name)
 	return nil

--- a/pkg/k8s/jobs/crud.go
+++ b/pkg/k8s/jobs/crud.go
@@ -60,7 +60,7 @@ func Destroy(ctx context.Context, name, namespace string, c kubernetes.Interface
 		if oktetoErrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting kubernetes job: %s", err)
+		return fmt.Errorf("error deleting kubernetes job: %w", err)
 	}
 	oktetoLog.Infof("job '%s' deleted", name)
 	return nil

--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -195,7 +195,7 @@ func (n *Namespaces) DestroySFSVolumes(ctx context.Context, ns string, opts Dele
 
 	ssList, err := statefulsets.List(ctx, ns, opts.LabelSelector, n.k8sClient)
 	if err != nil {
-		return fmt.Errorf("error getting statefulsets: %s", err)
+		return fmt.Errorf("error getting statefulsets: %w", err)
 	}
 	for _, ss := range ssList {
 		for _, pvcTemplate := range ss.Spec.VolumeClaimTemplates {
@@ -220,7 +220,7 @@ func (n *Namespaces) DestroySFSVolumes(ctx context.Context, ns string, opts Dele
 	deployedByNotExistSelector := labels.NewSelector().Add(*deployedByNotExist).String()
 	vList, err := volumes.List(ctx, ns, deployedByNotExistSelector, n.k8sClient)
 	if err != nil {
-		return fmt.Errorf("error getting volumes: %s", err)
+		return fmt.Errorf("error getting volumes: %w", err)
 	}
 	for _, v := range vList {
 		if v.Annotations[resourcePolicyAnnotation] == keepPolicy {

--- a/pkg/k8s/pods/pod.go
+++ b/pkg/k8s/pods/pod.go
@@ -318,7 +318,7 @@ func Restart(ctx context.Context, dev *model.Dev, c *kubernetes.Clientset, sn st
 			if strings.Contains(err.Error(), "not found") {
 				return nil
 			}
-			return fmt.Errorf("error deleting kubernetes service: %s", err)
+			return fmt.Errorf("error deleting kubernetes service: %w", err)
 		}
 	}
 
@@ -356,7 +356,7 @@ func waitUntilRunning(ctx context.Context, namespace, selector string, c *kubern
 				allRunning = false
 				notready[pods.Items[i].GetName()] = true
 			} else if phase == apiv1.PodFailed {
-				return fmt.Errorf("Pod %s failed to start", pods.Items[i].Name)
+				return fmt.Errorf("pod %s failed to start", pods.Items[i].Name)
 			} else if phase == apiv1.PodRunning {
 				if isRunning(&pods.Items[i]) {
 					if _, ok := notready[pods.Items[i].GetName()]; ok {
@@ -386,7 +386,7 @@ func waitUntilRunning(ctx context.Context, namespace, selector string, c *kubern
 		pods = append(pods, k)
 	}
 
-	return fmt.Errorf("Pod(s) %s didn't restart after 60 seconds", strings.Join(pods, ","))
+	return fmt.Errorf("pod(s) %s didn't restart after 60 seconds", strings.Join(pods, ","))
 }
 
 func isRunning(p *apiv1.Pod) bool {

--- a/pkg/k8s/replicasets/replicaset.go
+++ b/pkg/k8s/replicasets/replicaset.go
@@ -28,7 +28,7 @@ import (
 func GetReplicaSetByDeployment(ctx context.Context, d *appsv1.Deployment, c kubernetes.Interface) (*appsv1.ReplicaSet, error) {
 	rsList, err := c.AppsV1().ReplicaSets(d.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get replicasets: %v", err)
+		return nil, fmt.Errorf("failed to get replicasets: %w", err)
 	}
 
 	for i := range rsList.Items {

--- a/pkg/k8s/secrets/crud.go
+++ b/pkg/k8s/secrets/crud.go
@@ -59,12 +59,12 @@ func Create(ctx context.Context, dev *model.Dev, c kubernetes.Interface, s *sync
 
 	sct, err := Get(ctx, secretName, dev.Namespace, c)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return fmt.Errorf("error getting kubernetes secret: %s", err)
+		return fmt.Errorf("error getting kubernetes secret: %w", err)
 	}
 
 	config, err := getConfigXML(s)
 	if err != nil {
-		return fmt.Errorf("error generating syncthing configuration: %s", err)
+		return fmt.Errorf("error generating syncthing configuration: %w", err)
 	}
 	data := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -85,7 +85,7 @@ func Create(ctx context.Context, dev *model.Dev, c kubernetes.Interface, s *sync
 	for _, s := range dev.Secrets {
 		content, err := os.ReadFile(s.LocalPath)
 		if err != nil {
-			return fmt.Errorf("error reading secret '%s': %s", s.LocalPath, err)
+			return fmt.Errorf("error reading secret '%s': %w", s.LocalPath, err)
 		}
 		if strings.Contains(s.GetKeyName(), "stignore") {
 			idx++
@@ -99,14 +99,14 @@ func Create(ctx context.Context, dev *model.Dev, c kubernetes.Interface, s *sync
 	if sct.Name == "" {
 		_, err := c.CoreV1().Secrets(dev.Namespace).Create(ctx, data, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("error creating kubernetes sync secret: %s", err)
+			return fmt.Errorf("error creating kubernetes sync secret: %w", err)
 		}
 
 		oktetoLog.Infof("created okteto secret '%s'", secretName)
 	} else {
 		_, err := c.CoreV1().Secrets(dev.Namespace).Update(ctx, data, metav1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("error updating kubernetes okteto secret: %s", err)
+			return fmt.Errorf("error updating kubernetes okteto secret: %w", err)
 		}
 		oktetoLog.Infof("updated okteto secret '%s'", secretName)
 	}

--- a/pkg/k8s/services/crud.go
+++ b/pkg/k8s/services/crud.go
@@ -36,14 +36,14 @@ func CreateDev(ctx context.Context, dev *model.Dev, c kubernetes.Interface) erro
 func Deploy(ctx context.Context, s *apiv1.Service, c kubernetes.Interface) error {
 	old, err := Get(ctx, s.Name, s.Namespace, c)
 	if err != nil && !oktetoErrors.IsNotFound(err) {
-		return fmt.Errorf("error getting kubernetes service: %s", err)
+		return fmt.Errorf("error getting kubernetes service: %w", err)
 	}
 
 	if old == nil || old.Name == "" {
 		oktetoLog.Infof("creating service '%s'", s.Name)
 		_, err = c.CoreV1().Services(s.Namespace).Create(ctx, s, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("error creating kubernetes service: %s", err)
+			return fmt.Errorf("error creating kubernetes service: %w", err)
 		}
 		oktetoLog.Infof("created service '%s'", s.Name)
 	} else {
@@ -54,7 +54,7 @@ func Deploy(ctx context.Context, s *apiv1.Service, c kubernetes.Interface) error
 		old.Spec.Selector = s.Spec.Selector
 		_, err = c.CoreV1().Services(s.Namespace).Update(ctx, old, metav1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("error updating kubernetes service: %s", err)
+			return fmt.Errorf("error updating kubernetes service: %w", err)
 		}
 		oktetoLog.Infof("updated service '%s'.", s.Name)
 	}
@@ -99,7 +99,7 @@ func Destroy(ctx context.Context, name, namespace string, c kubernetes.Interface
 			oktetoLog.Infof("service '%s' was already deleted.", name)
 			return nil
 		}
-		return fmt.Errorf("error deleting kubernetes service: %s", err)
+		return fmt.Errorf("error deleting kubernetes service: %w", err)
 	}
 	oktetoLog.Infof("service '%s' deleted", name)
 	return nil
@@ -138,13 +138,13 @@ func GetServiceNameByLabel(ctx context.Context, namespace string, c kubernetes.I
 	}
 	foundServices := serviceList.Items
 	if len(foundServices) == 0 {
-		return "", fmt.Errorf("Could not find any service with the following labels: '%s'.", labels)
+		return "", fmt.Errorf("could not find any service with the following labels: '%s'", labels)
 	} else if len(foundServices) == 1 {
 		serviceInfo := foundServices[0].ObjectMeta
 		return serviceInfo.Name, nil
 	}
 	servicesNames := GetServicesNamesFromList(serviceList)
-	return "", fmt.Errorf("Services [%s] have the following labels: '%s'.\nPlease specify the one you want to forward by name or use more specific labels.", servicesNames, labels)
+	return "", fmt.Errorf("services [%s] have the following labels: '%s'.\nPlease specify the one you want to forward by name or use more specific labels", servicesNames, labels)
 }
 
 func GetServicesNamesFromList(serviceList *apiv1.ServiceList) string {

--- a/pkg/k8s/statefulsets/crud.go
+++ b/pkg/k8s/statefulsets/crud.go
@@ -154,7 +154,7 @@ func Destroy(ctx context.Context, name, namespace string, c kubernetes.Interface
 		if oktetoErrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("error deleting kubernetes job: %s", err)
+		return fmt.Errorf("error deleting kubernetes job: %w", err)
 	}
 	oktetoLog.Infof("statefulset '%s' deleted", name)
 	return nil

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -50,13 +50,13 @@ func CreateForDev(ctx context.Context, dev *model.Dev, c kubernetes.Interface, d
 	pvcForDev := translate(dev)
 	k8Volume, err := vClient.Get(ctx, pvcForDev.Name, metav1.GetOptions{})
 	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return fmt.Errorf("error getting kubernetes volume claim: %s", err)
+		return fmt.Errorf("error getting kubernetes volume claim: %w", err)
 	}
 	if k8Volume.Name == "" {
 		oktetoLog.Infof("creating volume claim '%s'", pvcForDev.Name)
 		_, err = vClient.Create(ctx, pvcForDev, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("error creating kubernetes volume claim: %s", err)
+			return fmt.Errorf("error creating kubernetes volume claim: %w", err)
 		}
 	} else {
 		if err := checkPVCValues(k8Volume, dev, devPath); err != nil {
@@ -216,7 +216,7 @@ func DestroyWithoutTimeout(ctx context.Context, name, namespace string, c kubern
 	err := vClient.Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		if !oktetoErrors.IsNotFound(err) {
-			return fmt.Errorf("error deleting kubernetes volume: %s", err)
+			return fmt.Errorf("error deleting kubernetes volume: %w", err)
 		}
 	}
 

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -579,7 +579,7 @@ func (dev *Dev) SetDefaults() error {
 	if os.Getenv(OktetoRescanIntervalEnvVar) != "" {
 		rescanInterval, err := strconv.Atoi(os.Getenv(OktetoRescanIntervalEnvVar))
 		if err != nil {
-			return fmt.Errorf("cannot parse 'OKTETO_RESCAN_INTERVAL' into an integer: %s", err.Error())
+			return fmt.Errorf("cannot parse 'OKTETO_RESCAN_INTERVAL' into an integer: %w", err)
 		}
 		dev.Sync.RescanInterval = rescanInterval
 	} else if dev.Sync.RescanInterval == 0 {
@@ -704,7 +704,7 @@ func (dev *Dev) expandEnvFiles() error {
 
 		envMap, err := godotenv.ParseWithLookup(f, os.LookupEnv)
 		if err != nil {
-			return fmt.Errorf("error parsing env_file %s: %s", filename, err.Error())
+			return fmt.Errorf("error parsing env_file %s: %w", filename, err)
 		}
 
 		for _, e := range dev.Environment {
@@ -858,7 +858,7 @@ func validateSecrets(secrets []Secret) error {
 		}
 
 		if _, ok := seen[s.GetFileName()]; ok {
-			return fmt.Errorf("Secrets with the same basename '%s' are not supported", s.GetFileName())
+			return fmt.Errorf("secrets with the same basename '%s' are not supported", s.GetFileName())
 		}
 		seen[s.GetFileName()] = true
 	}

--- a/pkg/model/forward/forward.go
+++ b/pkg/model/forward/forward.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 )
 
-const MalformedPortForward = "Wrong port-forward syntax '%s', must be of the form 'localPort:remotePort' or 'localPort:serviceName:remotePort'"
+const MalformedPortForward = "wrong port-forward syntax '%s', must be of the form 'localPort:remotePort' or 'localPort:serviceName:remotePort'"
 
 // Forward represents a port forwarding definition
 type Forward struct {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -862,19 +862,19 @@ func (m *Manifest) setDefaults() error {
 			d.Name = dName
 		}
 		if err := d.expandEnvVars(); err != nil {
-			return fmt.Errorf("Error on dev '%s': %s", d.Name, err)
+			return fmt.Errorf("error on dev '%s': %w", d.Name, err)
 		}
 		for _, s := range d.Services {
 			if err := s.expandEnvVars(); err != nil {
-				return fmt.Errorf("Error on dev '%s': %s", d.Name, err)
+				return fmt.Errorf("error on dev '%s': %w", d.Name, err)
 			}
 			if err := s.validateForExtraFields(); err != nil {
-				return fmt.Errorf("Error on dev '%s': %s", d.Name, err)
+				return fmt.Errorf("error on dev '%s': %w", d.Name, err)
 			}
 		}
 
 		if err := d.SetDefaults(); err != nil {
-			return fmt.Errorf("Error on dev '%s': %s", d.Name, err)
+			return fmt.Errorf("error on dev '%s': %w", d.Name, err)
 		}
 
 		d.translateDeprecatedMetadataFields()

--- a/pkg/model/manifest_friendly_err.go
+++ b/pkg/model/manifest_friendly_err.go
@@ -151,7 +151,7 @@ func fieldsNotExistingRule() *suggest.Rule {
 
 	transform := func(e error) error {
 		newErr := re.ReplaceAllString(e.Error(), "field '$1' is not a property of")
-		return fmt.Errorf("%s", newErr)
+		return errors.New(newErr)
 	}
 
 	return suggest.NewRule(condition, transform)

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -450,7 +450,7 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if len(parts) == secretWithModeLength {
 		mode, err := strconv.ParseInt(parts[2], 8, 32)
 		if err != nil {
-			return fmt.Errorf("error parsing secret '%s' mode: %s", parts[0], err)
+			return fmt.Errorf("error parsing secret '%s' mode: %w", parts[0], err)
 		}
 		s.Mode = int32(mode)
 	} else {
@@ -478,16 +478,16 @@ func (f *Reverse) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	maxReverseParts := 2
 	parts := strings.SplitN(raw, ":", maxReverseParts)
 	if len(parts) != maxReverseParts {
-		return fmt.Errorf("Wrong port-forward syntax '%s', must be of the form 'localPort:RemotePort'", raw)
+		return fmt.Errorf("wrong port-forward syntax '%s', must be of the form 'localPort:RemotePort'", raw)
 	}
 	remotePort, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return fmt.Errorf("Cannot convert remote port '%s' in reverse '%s'", parts[0], raw)
+		return fmt.Errorf("cannot convert remote port '%s' in reverse '%s'", parts[0], raw)
 	}
 
 	localPort, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return fmt.Errorf("Cannot convert local port '%s' in reverse '%s'", parts[1], raw)
+		return fmt.Errorf("cannot convert local port '%s' in reverse '%s'", parts[1], raw)
 	}
 
 	f.Local = localPort

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -447,17 +447,17 @@ func (svc *Service) ToDev(svcName string) (*Dev, error) {
 func (s *Stack) Validate() error {
 	// in case name is coming from option "name" at deploy this could not be sanitized
 	if err := validateStackName(format.ResourceK8sMetaString(s.Name)); err != nil {
-		return fmt.Errorf("Invalid compose name: %s", err)
+		return fmt.Errorf("invalid compose name: %w", err)
 	}
 	if len(s.Services) == 0 {
-		return fmt.Errorf("Invalid stack: 'services' cannot be empty")
+		return fmt.Errorf("invalid stack: 'services' cannot be empty")
 	}
 
 	for endpointName, endpoint := range s.Endpoints {
 		for _, endpointRule := range endpoint.Rules {
 			if service, ok := s.Services[endpointRule.Service]; ok {
 				if !IsPortInService(endpointRule.Port, service.Ports) {
-					return fmt.Errorf("Invalid endpoint '%s': service '%s' does not have port '%d'.", endpointName, endpointRule.Service, endpointRule.Port)
+					return fmt.Errorf("invalid endpoint '%s': service '%s' does not have port '%d'", endpointName, endpointRule.Service, endpointRule.Port)
 				}
 			}
 		}
@@ -469,11 +469,11 @@ func (s *Stack) Validate() error {
 	}
 	for name, svc := range s.Services {
 		if err := validateStackName(name); err != nil {
-			return fmt.Errorf("Invalid service name '%s': %s", name, err)
+			return fmt.Errorf("invalid service name '%s': %s", name, err)
 		}
 
 		if svc.Image == "" && svc.Build == nil {
-			return fmt.Errorf(fmt.Sprintf("Invalid service '%s': image cannot be empty", name))
+			return fmt.Errorf("invalid service '%s': image cannot be empty", name)
 		}
 
 		for _, v := range svc.VolumeMounts {
@@ -484,7 +484,7 @@ func (s *Stack) Validate() error {
 				s.Warnings.VolumeMountWarnings = append(s.Warnings.VolumeMountWarnings, fmt.Sprintf("[%s]: volume '%s:%s' will be ignored. You can synchronize code to your containers using 'okteto up'. More information available here: https://okteto.com/docs/reference/cli/#up", name, v.LocalPath, v.RemotePath))
 			}
 			if !strings.HasPrefix(v.RemotePath, "/") {
-				return fmt.Errorf(fmt.Sprintf("Invalid volume '%s' in service '%s': must be an absolute path", v.ToString(), name))
+				return fmt.Errorf("invalid volume '%s' in service '%s': must be an absolute path", v.ToString(), name)
 			}
 		}
 		svc.ignoreSyncVolumes()
@@ -525,7 +525,7 @@ type errDependsOnUndefined struct {
 }
 
 func (e *errDependsOnUndefined) Error() string {
-	return fmt.Errorf("%w: Service '%s' depends on service '%s' which is undefined.", errDependsOn, e.svc, e.dependentSvc).Error()
+	return fmt.Errorf("%w: Service '%s' depends on service '%s' which is undefined", errDependsOn, e.svc, e.dependentSvc).Error()
 }
 
 func (e *errDependsOnUndefined) Unwrap() error {
@@ -554,7 +554,7 @@ func (cs ComposeServices) ValidateDependsOn(svcs []string) error {
 	dependencyCycle := getDependentCyclic(cs.toGraph())
 	if len(dependencyCycle) > 0 {
 		svcsDependents := fmt.Sprintf("%s and %s", strings.Join(dependencyCycle[:len(dependencyCycle)-1], ", "), dependencyCycle[len(dependencyCycle)-1])
-		return fmt.Errorf("%w: There was a cyclic dependendecy between %s.", errDependsOn, svcsDependents)
+		return fmt.Errorf("%w: There was a cyclic dependendecy between %s", errDependsOn, svcsDependents)
 	}
 	return nil
 }
@@ -905,7 +905,7 @@ func setEnvironmentFromFile(svc *Service, filename string) error {
 
 	envMap, err := godotenv.ParseWithLookup(f, os.LookupEnv)
 	if err != nil {
-		return fmt.Errorf("error parsing env_file %s: %s", filename, err.Error())
+		return fmt.Errorf("error parsing env_file %s: %w", filename, err)
 	}
 
 	for _, e := range svc.Environment {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -407,7 +407,7 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 
 	if stack.IsCompose {
 		if len(serviceRaw.Args.Values) > 0 {
-			return nil, fmt.Errorf("Unsupported field for services.%s: 'args'", svcName)
+			return nil, fmt.Errorf("unsupported field for services.%s: 'args'", svcName)
 		}
 		svc.Entrypoint.Values = serviceRaw.Entrypoint.Values
 		svc.Command.Values = serviceRaw.Command.Values
@@ -418,7 +418,7 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 
 	} else { // isOktetoStack
 		if len(serviceRaw.Entrypoint.Values) > 0 {
-			return nil, fmt.Errorf("Unsupported field for services.%s: 'entrypoint'", svcName)
+			return nil, fmt.Errorf("unsupported field for services.%s: 'entrypoint'", svcName)
 		}
 		svc.Entrypoint.Values = serviceRaw.Command.Values
 		if len(serviceRaw.Command.Values) == 1 {
@@ -711,13 +711,13 @@ func expandRangePorts(ports []PortRaw) []PortRaw {
 func validatePort(newPort PortRaw, ports []Port) error {
 	for _, p := range ports {
 		if newPort.ContainerPort == p.HostPort {
-			return fmt.Errorf("Container port '%d' is already declared as host port in port '%d:%d'", newPort.ContainerPort, p.HostPort, p.ContainerPort)
+			return fmt.Errorf("container port '%d' is already declared as host port in port '%d:%d'", newPort.ContainerPort, p.HostPort, p.ContainerPort)
 		}
 		if newPort.HostPort == p.ContainerPort {
 			if p.HostPort == 0 {
-				return fmt.Errorf("Host port '%d' is already declared as container port in port '%d'", newPort.HostPort, p.ContainerPort)
+				return fmt.Errorf("host port '%d' is already declared as container port in port '%d'", newPort.HostPort, p.ContainerPort)
 			} else {
-				return fmt.Errorf("Host port '%d' is already declared as container port in port '%d:%d'", newPort.HostPort, p.HostPort, p.ContainerPort)
+				return fmt.Errorf("host port '%d' is already declared as container port in port '%d:%d'", newPort.HostPort, p.HostPort, p.ContainerPort)
 			}
 		}
 	}
@@ -805,22 +805,22 @@ func (sc *StackSecurityContext) UnmarshalYAML(unmarshal func(interface{}) error)
 			securityContextLength := 2
 			parts := strings.Split(rawSecurityContext, ":")
 			if len(parts) != securityContextLength {
-				return fmt.Errorf("SecurityContext '%s' is malformed. Only 'dddd:dddd' is supported", rawSecurityContext)
+				return fmt.Errorf("securityContext '%s' is malformed. Only 'dddd:dddd' is supported", rawSecurityContext)
 			}
 			runAsUser, err := strconv.ParseInt(parts[0], 10, 64)
 			if err != nil {
-				return fmt.Errorf("Can not obtain UID from '%s'", parts[0])
+				return fmt.Errorf("cannot obtain UID from '%s'", parts[0])
 			}
 			runAsGroup, err := strconv.ParseInt(parts[1], 10, 64)
 			if err != nil {
-				return fmt.Errorf("Can not obtain GID from '%s'", parts[1])
+				return fmt.Errorf("cannot obtain GID from '%s'", parts[1])
 			}
 			sc.RunAsUser = &runAsUser
 			sc.RunAsGroup = &runAsGroup
 		} else {
 			runAsUser, err := strconv.ParseInt(rawSecurityContext, 10, 64)
 			if err != nil {
-				return fmt.Errorf("Can not obtain UID from '%s'", rawSecurityContext)
+				return fmt.Errorf("cannot obtain UID from '%s'", rawSecurityContext)
 			}
 			sc.RunAsUser = &runAsUser
 		}
@@ -912,7 +912,7 @@ func getRangePorts(portString string) (int32, int32, apiv1.Protocol, error) {
 		rangePortsLength := 2
 		rangeSplitted := strings.Split(portString, "-")
 		if len(rangeSplitted) != rangePortsLength {
-			return 0, 0, "", fmt.Errorf("Can not convert '%s' to a port.", portString)
+			return 0, 0, "", fmt.Errorf("cannot convert '%s' to a port.", portString)
 		}
 		fromString, toString := rangeSplitted[0], rangeSplitted[1]
 		toString, protocol, err := getPortAndProtocol(toString, portString)
@@ -935,7 +935,7 @@ func getRangePorts(portString string) (int32, int32, apiv1.Protocol, error) {
 func getPortFromString(portString, originalPortString string) (int32, error) {
 	port, err := strconv.ParseInt(portString, 10, 32)
 	if err != nil {
-		return 0, fmt.Errorf("Can not convert '%s' to a port: %s is not a number", originalPortString, portString)
+		return 0, fmt.Errorf("cannot convert '%s' to a port: %s is not a number", originalPortString, portString)
 	}
 	return int32(port), nil
 }
@@ -947,12 +947,12 @@ func getPortAndProtocol(portString, originalPortString string) (string, apiv1.Pr
 		protocolLength := 2
 		portProtocolSplitted := strings.Split(portString, "/")
 		if len(portProtocolSplitted) != protocolLength {
-			return "", protocol, fmt.Errorf("Can not convert '%s' to a port.", originalPortString)
+			return "", protocol, fmt.Errorf("cannot convert '%s' to a port", originalPortString)
 		}
 		portString = portProtocolSplitted[0]
 		protocol, err = getProtocol(portProtocolSplitted[1])
 		if err != nil {
-			return "", protocol, fmt.Errorf("Can not convert '%s' to a port: %s", originalPortString, err.Error())
+			return "", protocol, fmt.Errorf("cannot convert '%s' to a port: %w", originalPortString, err)
 		}
 	}
 	return portString, protocol, nil
@@ -977,12 +977,12 @@ func getPortWithMapping(p *PortRaw, portString string) error {
 		return err
 	}
 	if (p.ContainerFrom - p.ContainerTo) != (p.HostFrom - p.HostTo) {
-		return fmt.Errorf("Can not convert '%s' to a port: Ranges must be of the same length", portString)
+		return fmt.Errorf("cannot convert '%s' to a port: Ranges must be of the same length", portString)
 	}
 
 	if p.ContainerFrom == 0 {
 		if strings.Contains(hostPortString, ":") {
-			return fmt.Errorf("Can not convert '%s' to a port: Host IP is not allowed", portString)
+			return fmt.Errorf("cannot convert '%s' to a port: Host IP is not allowed", portString)
 		}
 
 		p.HostPort, err = getPortFromString(hostPortString, portString)
@@ -1039,7 +1039,7 @@ func getRestartPolicy(svcName string, deployInfo *DeployInfoRaw, restartPolicy s
 	case "on-failure":
 		return apiv1.RestartPolicyOnFailure, nil
 	default:
-		return apiv1.RestartPolicyAlways, fmt.Errorf("Cannot create container for service %s: invalid restart policy '%s'", svcName, restart)
+		return apiv1.RestartPolicyAlways, fmt.Errorf("cannot create container for service %s: invalid restart policy '%s'", svcName, restart)
 	}
 }
 func unmarshalDeployResources(deployInfo *DeployInfoRaw, resources *StackResources, cpuCount, cpus, memLimit, memReservation Quantity) *StackResources {
@@ -1624,7 +1624,7 @@ func validateExtensions(stack StackRaw) error {
 
 	for svcName, svc := range stack.Services {
 		if svc == nil {
-			return fmt.Errorf("%s: %w", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrServiceEmpty)
+			return fmt.Errorf("%w: %w", oktetoErrors.ErrInvalidManifest, oktetoErrors.ErrServiceEmpty)
 		}
 		for extension := range svc.Extensions {
 			nonValidFields = append(nonValidFields, fmt.Sprintf("services[%s].%s", svcName, extension))
@@ -1636,9 +1636,9 @@ func validateExtensions(stack StackRaw) error {
 		}
 	}
 	if len(nonValidFields) == 1 {
-		return fmt.Errorf("Invalid compose manifest: Field '%s' is not supported.\n    More information is available here: https://okteto.com/docs/reference/compose/", nonValidFields[0])
+		return fmt.Errorf("invalid compose manifest: Field '%s' is not supported.\n    More information is available here: https://okteto.com/docs/reference/compose/", nonValidFields[0])
 	} else if len(nonValidFields) > 1 {
-		return fmt.Errorf(`Invalid compose manifest: The following fields are not supported.
+		return fmt.Errorf(`invalid compose manifest: The following fields are not supported.
     - %s
     More information is available here: https://okteto.com/docs/reference/compose/`, strings.Join(nonValidFields, "\n    - "))
 	}

--- a/pkg/model/utils.go
+++ b/pkg/model/utils.go
@@ -30,7 +30,7 @@ type graph map[string][]string
 func GetValidNameFromFolder(folder string) (string, error) {
 	dir, err := filepath.Abs(folder)
 	if err != nil {
-		return "", fmt.Errorf("error inferring name: %s", err)
+		return "", fmt.Errorf("error inferring name: %w", err)
 	}
 	if folder == ".okteto" {
 		dir = filepath.Dir(dir)

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -344,12 +344,12 @@ func (*ContextConfigWriter) Write() error {
 	if _, err := os.Stat(contextConfigPath); err == nil {
 		err = os.Chmod(contextConfigPath, 0600)
 		if err != nil {
-			return fmt.Errorf("couldn't change context permissions: %s", err)
+			return fmt.Errorf("couldn't change context permissions: %w", err)
 		}
 	}
 
 	if err := os.WriteFile(contextConfigPath, marshalled, 0600); err != nil {
-		return fmt.Errorf("couldn't save context: %s", err)
+		return fmt.Errorf("couldn't save context: %w", err)
 	}
 
 	return nil

--- a/pkg/ssh/client.go
+++ b/pkg/ssh/client.go
@@ -32,12 +32,12 @@ func getPrivateKey() (ssh.Signer, error) {
 	_, private := getKeyPaths()
 	buf, err := os.ReadFile(private)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load private key: %s", err)
+		return nil, fmt.Errorf("failed to load private key: %w", err)
 	}
 
 	key, err := ssh.ParsePrivateKey(buf)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key: %s", err)
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
 	}
 
 	return key, nil

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -231,7 +231,7 @@ func (config *sshConfig) writeToFilepath(p string) error {
 	var mode os.FileMode
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to get info on %s: %s", p, err)
+			return fmt.Errorf("failed to get info on %s: %w", p, err)
 		}
 
 		// default for ssh_config
@@ -243,7 +243,7 @@ func (config *sshConfig) writeToFilepath(p string) error {
 	dir := filepath.Dir(p)
 	temp, err := os.CreateTemp(dir, "")
 	if err != nil {
-		return fmt.Errorf("failed to create temporary config file: %s", err)
+		return fmt.Errorf("failed to create temporary config file: %w", err)
 	}
 
 	defer os.Remove(temp.Name())
@@ -257,15 +257,15 @@ func (config *sshConfig) writeToFilepath(p string) error {
 	}
 
 	if err := os.Chmod(temp.Name(), mode); err != nil {
-		return fmt.Errorf("failed to set permissions to %s: %s", temp.Name(), err)
+		return fmt.Errorf("failed to set permissions to %s: %w", temp.Name(), err)
 	}
 
 	if _, err := getConfig(temp.Name()); err != nil {
-		return fmt.Errorf("new config is not valid: %s", err)
+		return fmt.Errorf("new config is not valid: %w", err)
 	}
 
 	if err := os.Rename(temp.Name(), p); err != nil {
-		return fmt.Errorf("failed to move %s to %s: %s", temp.Name(), p, err)
+		return fmt.Errorf("failed to move %s to %s: %w", temp.Name(), p, err)
 	}
 
 	return nil

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -36,7 +36,7 @@ import (
 func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Reader, outW, errW io.Writer, command []string) error {
 	sshConfig, err := getSSHClientConfig()
 	if err != nil {
-		return fmt.Errorf("failed to get SSH configuration: %s", err)
+		return fmt.Errorf("failed to get SSH configuration: %w", err)
 	}
 
 	// dockerterm.StdStreams() configures the terminal on windows
@@ -54,7 +54,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to connect to SSH server: %s", err)
+		return fmt.Errorf("failed to connect to SSH server: %w", err)
 	}
 	defer func() {
 		if err := connection.Close(); err != nil {
@@ -75,7 +75,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 
 	session, err := connection.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed to create SSH session: %s", err)
+		return fmt.Errorf("failed to create SSH session: %w", err)
 	}
 	defer func() {
 		if err := session.Close(); err != nil {
@@ -121,7 +121,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 		}()
 
 		if err := session.RequestPty("xterm-256color", height, width, modes); err != nil {
-			return fmt.Errorf("request for pseudo terminal failed: %s", err)
+			return fmt.Errorf("request for pseudo terminal failed: %w", err)
 		}
 	}
 
@@ -139,13 +139,13 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 
 	stdin, err := session.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("unable to setup stdin for session: %v", err)
+		return fmt.Errorf("unable to setup stdin for session: %w", err)
 	}
 	Copy(inR, stdin)
 
 	stdout, err := session.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("unable to setup stdout for session: %v", err)
+		return fmt.Errorf("unable to setup stdout for session: %w", err)
 	}
 
 	go func() {
@@ -156,7 +156,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 
 	stderr, err := session.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("unable to setup stderr for session: %v", err)
+		return fmt.Errorf("unable to setup stderr for session: %w", err)
 	}
 
 	go func() {

--- a/pkg/ssh/key.go
+++ b/pkg/ssh/key.go
@@ -62,22 +62,22 @@ func GenerateKeys() error {
 func generate(public, private string, bitSize int) error {
 	privateKey, err := generatePrivateKey(bitSize)
 	if err != nil {
-		return fmt.Errorf("failed to generate private SSH key: %s", err)
+		return fmt.Errorf("failed to generate private SSH key: %w", err)
 	}
 
 	publicKeyBytes, err := generatePublicKey(&privateKey.PublicKey)
 	if err != nil {
-		return fmt.Errorf("failed to generate public SSH key: %s", err)
+		return fmt.Errorf("failed to generate public SSH key: %w", err)
 	}
 
 	privateKeyBytes := encodePrivateKeyToPEM(privateKey)
 
 	if err := os.WriteFile(public, publicKeyBytes, 0600); err != nil {
-		return fmt.Errorf("failed to write public SSH key: %s", err)
+		return fmt.Errorf("failed to write public SSH key: %w", err)
 	}
 
 	if err := os.WriteFile(private, privateKeyBytes, 0600); err != nil {
-		return fmt.Errorf("failed to write private SSH key: %s", err)
+		return fmt.Errorf("failed to write private SSH key: %w", err)
 	}
 
 	oktetoLog.Infof("created ssh keypair at  %s and %s", public, private)

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -144,7 +144,7 @@ func (fm *ForwardManager) Start(devPod, namespace string) error {
 
 		c, err := getSSHClientConfig()
 		if err != nil {
-			return fmt.Errorf("failed to get SSH configuration: %s", err)
+			return fmt.Errorf("failed to get SSH configuration: %w", err)
 		}
 
 		oktetoLog.Infof("starting SSH connection pool on %s", fm.sshAddr)

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -138,7 +138,7 @@ func getConfig(path string) (*sshConfig, error) {
 			}, nil
 		}
 
-		return nil, fmt.Errorf("can't open %s: %s", path, err)
+		return nil, fmt.Errorf("can't open %s: %w", path, err)
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
@@ -148,7 +148,7 @@ func getConfig(path string) (*sshConfig, error) {
 
 	cfg, err := parse(f)
 	if err != nil {
-		return nil, fmt.Errorf("fail to decode %s: %s", path, err)
+		return nil, fmt.Errorf("fail to decode %s: %w", path, err)
 	}
 
 	return cfg, nil

--- a/pkg/syncthing/install.go
+++ b/pkg/syncthing/install.go
@@ -77,19 +77,19 @@ func Install(p getter.ProgressTracker) error {
 	defer os.RemoveAll(dir)
 
 	if err := client.Get(); err != nil {
-		return fmt.Errorf("failed to download syncthing from %s: %s", client.Src, err)
+		return fmt.Errorf("failed to download syncthing from %s: %w", client.Src, err)
 	}
 
 	i := getInstallPath()
 	b := getBinaryPathInDownload(dir, downloadURL)
 
 	if _, err := os.Stat(b); err != nil {
-		return fmt.Errorf("%s didn't include the syncthing binary: %s", downloadURL, err)
+		return fmt.Errorf("%s didn't include the syncthing binary: %w", downloadURL, err)
 	}
 
 	// skipcq GSC-G302 syncthing is a binary so it needs exec permissions
 	if err := os.Chmod(b, 0700); err != nil {
-		return fmt.Errorf("failed to set permissions to %s: %s", b, err)
+		return fmt.Errorf("failed to set permissions to %s: %w", b, err)
 	}
 
 	if filesystem.FileExists(i) {
@@ -99,7 +99,7 @@ func Install(p getter.ProgressTracker) error {
 	}
 
 	if err := filesystem.CopyFile(b, i); err != nil {
-		return fmt.Errorf("failed to write %s: %s", i, err)
+		return fmt.Errorf("failed to write %s: %w", i, err)
 	}
 
 	oktetoLog.Infof("downloaded syncthing %s to %s", syncthingVersion, i)
@@ -168,7 +168,7 @@ func parseVersionFromOutput(output []byte) (*semver.Version, error) {
 
 	s, err := semver.NewVersion(v)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse the current syncthing version `%s`: %s", v, err)
+		return nil, fmt.Errorf("failed to parse the current syncthing version `%s`: %w", v, err)
 	}
 
 	return s, nil

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -262,7 +262,7 @@ func New(dev *model.Dev) (*Syncthing, error) {
 
 func (s *Syncthing) initConfig() error {
 	if err := os.MkdirAll(s.Home, 0700); err != nil {
-		return fmt.Errorf("failed to create %s: %s", s.Home, err)
+		return fmt.Errorf("failed to create %s: %w", s.Home, err)
 	}
 
 	if err := s.UpdateConfig(); err != nil {
@@ -852,11 +852,11 @@ func (s *Syncthing) SoftTerminate() error {
 	}
 	p, err := process.NewProcess(int32(s.pid))
 	if err != nil {
-		return fmt.Errorf("error getting syncthing process %d: %s", s.pid, err.Error())
+		return fmt.Errorf("error getting syncthing process %d: %w", s.pid, err)
 	}
 	oktetoLog.Infof("terminating syncthing %d without wait", s.pid)
 	if err := terminate(p, false); err != nil {
-		return fmt.Errorf("error terminating syncthing %d without wait: %s", p.Pid, err.Error())
+		return fmt.Errorf("error terminating syncthing %d without wait: %w", p.Pid, err)
 	}
 	oktetoLog.Infof("terminated syncthing %d without wait", s.pid)
 	return nil


### PR DESCRIPTION
# Proposed changes

Fixes LAKE-174

- Changes all the fmt.Errorf("%s/q/v, error.String())  to wrap them correctly
- Following with [effective go](https://go.dev/doc/effective_go#errors) best practices remove errors first letter capitalisation and remove the trailing dot from them.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
