### PR TITLE
fix: panic in okteto up caused by already closed readyChan

### DIFF
--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -65,6 +65,18 @@ func (a *active) stop() {
 
 func (a *active) closeReady() {
 	if a != nil && a.readyChan != nil {
+		// This recover() is a defensive approach needed to prevent panics in "okteto up".
+		// After the update of k8s dependencies (PR: https://github.com/okteto/okteto/pull/4087)
+		// The CLI started to panic when closing a.readyChan because already closed.
+		// After investigating, it seems that the dependency under the hood is also closing the channel, however
+		// this is not a new behavior, that part of the library was already like this. An alternative approach
+		// would be removing the call to close() but it's less risky to use recover.
+		defer func() {
+			if r := recover(); r != nil {
+				oktetoLog.Debugf("Recovering from already closed channel: %s", r)
+			}
+		}()
+
 		close(a.readyChan)
 		a.readyChan = nil
 	}


### PR DESCRIPTION
# Proposed changes

This change is required to fix a panic occurring in `okteto up` when losing connection to the pod. In particular, it's very easy to reproduce if the internet connection is lost. It's not as frequent if the pod gets killed in k8s. Prior to this change, we upgraded k8s dependencies in the CLI which has brought some changes introduced in the forwarding logic. In particular, related to how the library handles and returns errors if the connection is lost. This was causing a panic on our side, because we were trying to close a channel that the library already closes. However, in certain scenarios, the library does not close the channel and we should close it on our side to avoid leaking in the goroutine and create possible issues considering that this affects `okteto up` which is a long-running command, which may be badly affected by such issues.

## How to validate

1. Use `okteto up`
1. Disconnect your internet and observe the reconnection process to kick-in
1. Observe how the CLI does not panic
1. Now repeat with Okteto CLI `2.24.0-beta.2` and observe the panic (without this change)

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
