### PR TITLE
fix: panic in okteto build caused by nil `oc.Store`

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -224,6 +224,9 @@ func getOktetoContext(ctx context.Context, options *types.BuildOptions) (*okteto
 	}
 
 	oktetoContext, err := contextCMD.NewContextCommand().RunStateless(ctx, ctxOpts)
+	if err != nil {
+		return nil, err
+	}
 
 	if oktetoContext.IsOkteto() && ctxOpts.Namespace != "" {
 		ocfg := defaultOktetoClientCfg(oktetoContext)


### PR DESCRIPTION
# Proposed changes

This panic was caught before releasing `2.24` as part of our manual testing, and it would occur if a request fails to assemble the okteto context. That would leave `oc.Store` as `nil` so every call to `IsOkteto` would trigger a panic.

## How to validate

1. Go offline (ie. Turn-off the wifi)
1. Run `okteto build`
1. Observe the panic

Repeat using this change and notice the panic does not occurr

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
