### PR TITLE
Backport: fix: missing trailing slash in IsGlobalRegistry

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -107,7 +107,7 @@ func (or OktetoRegistry) IsOktetoRegistry(image string) bool {
 
 func (or OktetoRegistry) IsGlobalRegistry(image string) bool {
 	expandedImage := or.imageCtrl.expandImageRegistries(image)
-	expandedGlobalImage := fmt.Sprintf("%s/%s", or.config.GetRegistryURL(), or.imageCtrl.config.GetGlobalNamespace())
+	expandedGlobalImage := fmt.Sprintf("%s/%s/", or.config.GetRegistryURL(), or.imageCtrl.config.GetGlobalNamespace())
 	return strings.HasPrefix(expandedImage, expandedGlobalImage)
 }
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -571,6 +571,18 @@ func Test_IsGlobal(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "avoid false positives when global namespace is same as dev namespace prefix",
+			input: input{
+				image: "this.is.my.okteto.registry/test-user000/image",
+				config: FakeConfig{
+					RegistryURL:        "this.is.my.okteto.registry",
+					GlobalNamespace:    "test",
+					IsOktetoClusterCfg: true,
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

Backporting to `2.23` a fix which was done in `master` within a bigger PR (see https://github.com/okteto/okteto/pull/4051/files#diff-cb61d8f79451b9541de4a8cc0811523a68d15452b2f5971c7618ea5b423cf4ecR111)

The issue is that by not having the trailing slash, the global namespace can be confused with the prefix of a dev namespace (if they start with he same chars).

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
