### PR TITLE
fix: add test for missing trailing slash in IsGlobalRegistry

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -107,8 +107,8 @@ func (or OktetoRegistry) IsOktetoRegistry(image string) bool {
 
 func (or OktetoRegistry) IsGlobalRegistry(image string) bool {
 	expandedImage := or.imageCtrl.expandImageRegistries(image)
-	expandedGlobalImage := fmt.Sprintf("%s/%s", or.config.GetRegistryURL(), or.imageCtrl.config.GetGlobalNamespace())
-	return strings.HasPrefix(expandedImage, fmt.Sprintf("%s/", expandedGlobalImage))
+	expandedGlobalImage := fmt.Sprintf("%s/%s/", or.config.GetRegistryURL(), or.imageCtrl.config.GetGlobalNamespace())
+	return strings.HasPrefix(expandedImage, expandedGlobalImage)
 }
 
 // GetImageTag returns the image tag to build for a given services

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -572,6 +572,18 @@ func Test_IsGlobal(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "avoid false positives when global namespace is same as dev namespace prefix",
+			input: input{
+				image: "this.is.my.okteto.registry/test-user000/image",
+				config: FakeConfig{
+					RegistryURL:        "this.is.my.okteto.registry",
+					GlobalNamespace:    "test",
+					IsOktetoClusterCfg: true,
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

This PR is to add a unit test that was backported for the `2.23` in this PR (https://github.com/okteto/okteto/pull/4117/files). Also, I think it's easier to add the `/` in the line above without repeating the `fmt.Sprintf`.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
