### PR TITLE
feat: expand build secrets

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -88,7 +88,7 @@ type OktetoBuilder struct {
 	buildEnvironments map[string]string
 
 	ioCtrl *io.IOController
-	// lock is a mutex to provide builEnvironments map safe concurrency
+	// lock is a mutex to provide buildEnvironments map safe concurrency
 	lock sync.RWMutex
 }
 

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -99,7 +99,7 @@ func (i *Info) expandManifestBuildArgs(previousImageArgs map[string]string) (err
 func (i *Info) expandSecrets() (err error) {
 	for k, v := range i.Secrets {
 		val := v
-		if strings.HasPrefix(v, "~/") {
+		if strings.HasPrefix(val, "~/") {
 			home, err := os.UserHomeDir()
 			if err != nil {
 				return err

--- a/pkg/build/manifest_section_test.go
+++ b/pkg/build/manifest_section_test.go
@@ -60,7 +60,7 @@ func TestValidate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "succesfull valdation",
+			name: "successful validation",
 			input: &ManifestBuild{
 				"testSvc": &Info{
 					DependsOn: DependsOn{


### PR DESCRIPTION
# Proposed changes

Fixes: LAKE-153

With this change we allow using env vars in build secrets and also include support for path expansion (ie `~/`).

## How to validate

1. Use https://github.com/okteto/movies-frontend
1. Modify the okteto manifest `frontend` build as follows:
```yaml
build:
  frontend:
    context: .
    dockerfile: Dockerfile
    secrets:
      with_home_var: ${HOME}/.okteto/context/config.json
      with_tilde: ~/.okteto/context/config.json
```
1. Modify the `Dockerfile` adding the following commands at the end:
```
RUN --mount=type=secret,id=with_home_var,target=/etc/secrets/with_home_var \
    cat /etc/secrets/with_home_var

RUN --mount=type=secret,id=with_tilde,target=/etc/secrets/with_tilde \
    cat /etc/secrets/with_tilde
```
1. Now run `okteto build --progress plain --no-cache`
1. Observe the output of the JSON repeated twice in the logs

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
