### PR TITLE
docs: refactor helper usage

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -49,7 +49,7 @@ func Exec() *cobra.Command {
 	execFlags := &execFlags{}
 
 	cmd := &cobra.Command{
-		Use:   "exec <command>",
+		Use:   "exec [service] <command>",
 		Short: "Execute a command in your development container",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -94,7 +94,7 @@ type UpOptions struct {
 func Up(at analyticsTrackerInterface, ioCtrl *io.IOController) *cobra.Command {
 	upOptions := &UpOptions{}
 	cmd := &cobra.Command{
-		Use:   "up [svc]",
+		Use:   "up [service]",
 		Short: "Launch your development environment",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#up"),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# Proposed changes

Fixes LAKE-152

Unify the helper for 'okteto up' and 'okteto exec'

## How to validate

1. Run `okteto up --help`
1. Run `okteto exec --help`
1. See that usage has the same terms

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
