### PR TITLE
feat: always refresh kubetoken on okteto up errors

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -735,18 +735,16 @@ func (up *upContext) activateLoop() {
 		if err != nil {
 			oktetoLog.Infof("activate failed with: %s", err)
 
-			if err == oktetoErrors.ErrLostSyncthing {
-				isTransientError = false
-				iter = 0
+			oktetoLog.Info("updating kubeconfig token")
+			if err := up.tokenUpdater.UpdateKubeConfigToken(); err != nil {
+				oktetoLog.Infof("error updating k8s token: %w", err)
+				isTransientError = true
 				continue
 			}
 
-			if errors.Is(err, okteto.ErrK8sUnauthorised) {
-				oktetoLog.Info("updating kubeconfig token")
-				if err := up.tokenUpdater.UpdateKubeConfigToken(); err != nil {
-					up.Exit <- fmt.Errorf("error updating k8s token: %w", err)
-					return
-				}
+			if err == oktetoErrors.ErrLostSyncthing {
+				isTransientError = false
+				iter = 0
 				continue
 			}
 


### PR DESCRIPTION
# Proposed changes

With this change we always request a new kubetoken for any error occurred during an `okteto up` session. The intent is to make sure we never hit expiration issues.

## How to validate

1. Run `okteto up -l debug` for any service
1. Simulate the disconnection from the pod either by killing the pod or going offline
1. Inspect the logs and observe the log `updating kubeconfig token` being printed

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
