### PR TITLE
fix: multi tag bullds

### DIFF
--- a/cmd/build/v1/build.go
+++ b/cmd/build/v1/build.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -120,11 +121,14 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 		ob.IoCtrl.Out().Success("Build succeeded")
 		ob.IoCtrl.Out().Infof("Your image won't be pushed. To push your image specify the flag '-t'.")
 	} else {
-		displayTag := options.Tag
-		if options.DevTag != "" {
-			displayTag = options.DevTag
+		tags := strings.Split(options.Tag, ",")
+		for _, tag := range tags {
+			displayTag := tag
+			if options.DevTag != "" {
+				displayTag = options.DevTag
+			}
+			ob.IoCtrl.Out().Success("Image '%s' successfully pushed", displayTag)
 		}
-		ob.IoCtrl.Out().Success("Image '%s' successfully pushed", displayTag)
 	}
 
 	analytics.TrackBuild(true)

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -377,14 +377,18 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 	if err := bc.V1Builder.Build(ctx, buildOptions); err != nil {
 		return "", err
 	}
-	// check if the image is pushed to the dev registry if DevTag is set
-	reference := buildOptions.Tag
-	if buildOptions.DevTag != "" {
-		reference = buildOptions.DevTag
-	}
-	imageTagWithDigest, err := bc.Registry.GetImageTagWithDigest(reference)
-	if err != nil {
-		return "", fmt.Errorf("error accessing image at registry %s: %w", reference, err)
+	var imageTagWithDigest string
+	tags := strings.Split(buildOptions.Tag, ",")
+	for _, tag := range tags {
+		// check if the image is pushed to the dev registry if DevTag is set
+		reference := tag
+		if buildOptions.DevTag != "" {
+			reference = buildOptions.DevTag
+		}
+		imageTagWithDigest, err = bc.Registry.GetImageTagWithDigest(reference)
+		if err != nil {
+			return "", fmt.Errorf("error accessing image at registry %s: %w", reference, err)
+		}
 	}
 	return imageTagWithDigest, nil
 }


### PR DESCRIPTION
# Proposed changes

Fixes # (issue)

- A bug while building several images at once. Code was not prepared to check if the images were pushed correctly and even that they were we were returning an error


| **Before** | **After** |
|------------|-----------|
|   <img width="1416" alt="Screenshot 2024-01-12 at 14 59 53" src="https://github.com/okteto/okteto/assets/25170843/6656ed1d-ae6b-45f3-b499-1aa4e7f574a2"> | <img width="1220" alt="Screenshot 2024-01-12 at 15 03 01" src="https://github.com/okteto/okteto/assets/25170843/1dd88525-3b79-4604-8af3-260a0e453755"> |

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Clone okteto/movies
2. Run `okteto build api -t octet.dev/api:7,okteto.dev/aa:6,okteto.dev/api:5`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
\