### PR TITLE
docs: rename svc to service in helper

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -39,7 +39,7 @@ type doctorOptions struct {
 func Doctor() *cobra.Command {
 	doctorOpts := &doctorOptions{}
 	cmd := &cobra.Command{
-		Use:   "doctor [svc]",
+		Use:   "doctor [service]",
 		Short: "Generate a zip file with the okteto logs",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#doctor"),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -45,7 +45,7 @@ func Down() *cobra.Command {
 	var all bool
 
 	cmd := &cobra.Command{
-		Use:   "down [svc]",
+		Use:   "down [service]",
 		Short: "Deactivate your development container",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#down"),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -59,7 +59,7 @@ func Push(ctx context.Context) *cobra.Command {
 	pushOpts := &pushOptions{}
 	cmd := &cobra.Command{
 		Hidden: true,
-		Use:    "push [svc]",
+		Use:    "push [service]",
 		Short:  "Build, push and redeploy source code to the target app",
 		Args:   utils.MaximumNArgsAccepted(1, "https://www.okteto.com/docs/0.10/reference/cli/#push"),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -38,7 +38,7 @@ func Restart() *cobra.Command {
 	var devPath string
 
 	cmd := &cobra.Command{
-		Use:    "restart [svc]",
+		Use:    "restart [service]",
 		Short:  "Restart the deployments listed in the services field of a development container",
 		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#restart"),
 		Hidden: true,


### PR DESCRIPTION
# Proposed changes

In `up` we have recently renamed `svc` to `service`, I think I reads better and for consistency we should update the other cmds.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
