### PR TITLE
fix: statefulset reconnection error

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -441,7 +441,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
     More information about configuring your persistent volume at https://okteto.com/docs/reference/manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
 					}
 				}
-				if e.Type == "Warning" {
+				if e.Type == "Warning" && strings.Contains(e.Message, "container veth name provided (eth0) already exists") {
 					oktetoLog.Infof("pod event: %s:%s:%s", e.Reason, e.Type, e.Message)
 					continue
 				}

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -441,6 +441,10 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
     More information about configuring your persistent volume at https://okteto.com/docs/reference/manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
 					}
 				}
+				if e.Type == "Warning" {
+					oktetoLog.Infof("pod event: %s:%s:%s", e.Reason, e.Type, e.Message)
+					continue
+				}
 				return fmt.Errorf(e.Message)
 			case "SuccessfulAttachVolume":
 				failedSchedulingEvent = nil


### PR DESCRIPTION
# Proposed changes

Fixes LAKE-190

When we run okteto up on an statefulset and delete the okteto pod the CLI was failing with the following error:
`Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "785f6301a9bf82f6209dca5c9e9a5856965ba91d7769c714ec757ef106e5f33f": plugin type="gke" failed (add): container veth name provided (eth0) already exists
`
In order to fix this, I've captured the error and if it's a warning and related to the vet name provision. We could be retrying all the warnings but I've opted to not retry all in case there is a warning that we need to fail. 

## How to validate

1. Create the following sfs.yml:
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: e2etest
spec:
  serviceName: e2etest
  replicas: 1
  selector:
    matchLabels:
      app: e2etest
  template:
    metadata:
      labels:
        app: e2etest
    spec:
      terminationGracePeriodSeconds: 1
      containers:
      - name: test
        image: python:alpine
        ports:
        - containerPort: 8080
        workingDir: /usr/src/app
        env:
          - name: VAR
            value: value1
        command:
            - sh
            - -c
            - "echo -n $VAR > var.html && python -m http.server 8080"
---
apiVersion: v1
kind: Service
metadata:
  name: e2etest
  annotations:
    dev.okteto.com/auto-ingress: "true"
spec:
  type: ClusterIP
  ports:
  - name: e2etest
    port: 8080
  selector:
    app: e2etest
```
2 Run `kubectl apply -f sfs.yml`
3 Create the following `okteto.yml`:
```yaml
dev:
  e2etest:
    image: python:alpine
    command:
    - sh
    - -c
    - "echo -n $VAR > var.html && python -m http.server 8080"
    workdir: /usr/src/app
    sync:
    - .:/usr/src/app
    forward:
    - 8086:8080
```

4 Run `okteto up`
5 When the okteto up session is up and running run `kubectl delete pod e2etest-okteto-0`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
