### PR TITLE
fix: remote with parent folders

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -168,6 +168,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 
 	buildInfo := &build.Info{
 		Dockerfile: dockerfile,
+		Context:    cwd,
 	}
 
 	// undo modification of CWD for Build command
@@ -328,7 +329,7 @@ func getDeployFlags(opts *Options) ([]string, error) {
 	}
 
 	if opts.ManifestPathFlag != "" {
-		deployFlags = append(deployFlags, fmt.Sprintf("--file %s", opts.ManifestPathFlag))
+		deployFlags = append(deployFlags, fmt.Sprintf("--file %s", opts.ManifestPath))
 	}
 
 	if len(opts.Variables) > 0 {

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -329,7 +329,15 @@ func getDeployFlags(opts *Options) ([]string, error) {
 	}
 
 	if opts.ManifestPathFlag != "" {
-		deployFlags = append(deployFlags, fmt.Sprintf("--file %s", filepath.Base(opts.ManifestPathFlag)))
+		lastFolder := filepath.Base(filepath.Dir(opts.ManifestPathFlag))
+		if lastFolder == ".okteto" {
+			path := filepath.Clean(opts.ManifestPathFlag)
+			parts := strings.Split(path, string(filepath.Separator))
+
+			deployFlags = append(deployFlags, fmt.Sprintf("--file %s", filepath.Join(parts[len(parts)-2:]...)))
+		} else {
+			deployFlags = append(deployFlags, fmt.Sprintf("--file %s", filepath.Base(opts.ManifestPathFlag)))
+		}
 	}
 
 	if len(opts.Variables) > 0 {
@@ -435,5 +443,10 @@ func (rd *remoteDeployCommand) getContextPath(cwd, manifestPath string) string {
 	if fInfo.IsDir() {
 		return path
 	}
-	return filepath.Dir(path)
+
+	possibleCtx := filepath.Dir(path)
+	if strings.HasSuffix(possibleCtx, ".okteto") {
+		return filepath.Dir(possibleCtx)
+	}
+	return possibleCtx
 }

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -351,7 +351,7 @@ func TestGetDeployFlags(t *testing.T) {
 					Timeout:          5 * time.Minute,
 				},
 			},
-			expected: []string{"--file .okteto/test", "--timeout 5m0s"},
+			expected: []string{fmt.Sprintf("--file %s", filepath.Clean(".okteto/test")), "--timeout 5m0s"},
 		},
 		{
 			name: "variables set",

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -610,3 +610,41 @@ func TestGetExtraHosts(t *testing.T) {
 		})
 	}
 }
+func TestGetContextPath(t *testing.T) {
+	cwd := "/path/to/current/directory"
+
+	rd := remoteDeployCommand{
+		fs: afero.NewMemMapFs(),
+	}
+
+	t.Run("Manifest path is empty", func(t *testing.T) {
+		expected := cwd
+		result := rd.getContextPath(cwd, "")
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("Manifest path is a absolute path and directory", func(t *testing.T) {
+		manifestPath := "/path/to/current/directory"
+		expected := manifestPath
+		rd.fs = afero.NewMemMapFs()
+		rd.fs.MkdirAll(manifestPath, 0755)
+		result := rd.getContextPath(cwd, manifestPath)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("Manifest path is a file and absolute path", func(t *testing.T) {
+		manifestPath := "/path/to/current/directory/file.yaml"
+		expected := "/path/to/current/directory"
+		rd.fs = afero.NewMemMapFs()
+		rd.fs.MkdirAll(expected, 0755)
+		rd.fs.Create(manifestPath)
+		result := rd.getContextPath(cwd, manifestPath)
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("Manifest path does not exist", func(t *testing.T) {
+		expected := cwd
+		result := rd.getContextPath(cwd, "nonexistent.yaml")
+		assert.Equal(t, expected, result)
+	})
+}

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -336,6 +336,7 @@ func TestGetDeployFlags(t *testing.T) {
 			config: config{
 				opts: &Options{
 					ManifestPathFlag: "/hello/this/is/a/test",
+					ManifestPath:     "/hello/this/is/a/test",
 					Timeout:          5 * time.Minute,
 				},
 			},

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -340,7 +340,7 @@ func TestGetDeployFlags(t *testing.T) {
 					Timeout:          5 * time.Minute,
 				},
 			},
-			expected: []string{"--file /hello/this/is/a/test", "--timeout 5m0s"},
+			expected: []string{"--file test", "--timeout 5m0s"},
 		},
 		{
 			name: "variables set",

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -400,7 +400,7 @@ func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	parentFolder := filepath.Join(dir, "app")
+	parentFolder := filepath.Join(dir, "test-parent")
 
 	testNamespace := integration.GetTestNamespace("TestDeployRemoteParent", user)
 	namespaceOpts := &commands.NamespaceOptions{

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -392,6 +392,55 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 	require.True(t, k8sErrors.IsNotFound(err))
 }
 
+// TestDeployRemoteOktetoManifest tests the following scenario:
+// - Deploying a okteto manifest in remote with a build locally
+func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	parentFolder := filepath.Join(dir, "app")
+
+	testNamespace := integration.GetTestNamespace("TestDeployRemoteParent", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
+
+	require.NoError(t, createOktetoManifestWithDeployRemote(dir))
+	require.NoError(t, createAppDockerfileWithCache(dir))
+	require.NoError(t, os.Mkdir(parentFolder, 0700))
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:      parentFolder,
+		Namespace:    testNamespace,
+		OktetoHome:   dir,
+		Token:        token,
+		ManifestPath: filepath.Clean("../okteto.yml"),
+	}
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+
+	// Test that image has been built
+	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okteto.Context().Registry, testNamespace)))
+
+	destroyOptions := &commands.DestroyOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+	}
+	require.NoError(t, commands.RunOktetoDestroyRemote(oktetoPath, destroyOptions))
+
+	_, err = integration.GetDeployment(context.Background(), testNamespace, "my-dep", c)
+	require.True(t, k8sErrors.IsNotFound(err))
+}
+
 func isImageBuilt(image string) bool {
 	reg := registry.NewOktetoRegistry(okteto.Config{})
 	if _, err := reg.GetImageTagWithDigest(image); err == nil {


### PR DESCRIPTION
# Proposed changes

Fixes LAKE-191

We were using the path that the user was introducing in the --file. We should be using ManifestPath relative to the root project instead. This PR fixes that


## How to validate

1. Run cd api
1. Run okteto deploy -f ../okteto.yml  --remote

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
