### PR TITLE
update golangci goheader config for 2024

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,8 +34,8 @@ linters-settings:
       - fieldalignment
   goheader:
     values:
-      const:
-        YEAR: '2023'
+      regexp:
+        YEAR: 2023|2024
     template-path: .copyright-header.tmpl
   gomnd:
     checks:


### PR DESCRIPTION
Updating golangci because files created in 2024 should have the YEAR updated but currently it fails because th year is fixed.

Another option would be using `{{ YEAR-RANGE }}` but it would require updating all files.