### PR TITLE
fix okteto up double shutdown when interrupting with ctrl+c

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -52,12 +52,7 @@ func (up *upContext) activate() error {
 	up.Sy = nil
 	up.Forwarder = nil
 	defer func() {
-		if up.Dev.IsHybridModeEnabled() {
-			// interrupt signal handler already performs a graceful shutdown
-			if !up.interruptReceived {
-				up.shutdown()
-			}
-		} else {
+		if !up.interruptReceived {
 			up.shutdown()
 		}
 	}()


### PR DESCRIPTION
# Proposed changes

This change fixes a behavior that would occur when interrupting `oketo up` sessions at specific moments of its execution. In particular, while activating the session.

The bug occurs because when we intercept the `CTRL+C` in [up.go](https://github.com/okteto/okteto/blob/master/cmd/up/up.go#L671-L675) we initiate the shutdown sequence while at the same time, in [activate.go](https://github.com/okteto/okteto/blob/master/cmd/up/activate.go#L61) we also initiate the same shutdown sequence, without checking if we received an interrupt signal, which means that the shutdown would be already happening. This causes the shutdown function to be executed twice. As part of the shutdown code, we stop the k8s port forwarders, used for SSH, causing the code to attemp closing a channel twice, causing the panic below:


```
panic: close of closed channel

goroutine 1 [running]:
github.com/okteto/okteto/pkg/k8s/forward.(*active).stop(0x140022d30e0)
	github.com/okteto/okteto/pkg/k8s/forward/manager.go:63 +0x70
github.com/okteto/okteto/pkg/k8s/forward.(*PortForwardManager).Stop(0x140007a2e70)
	github.com/okteto/okteto/pkg/k8s/forward/manager.go:176 +0x34
github.com/okteto/okteto/pkg/ssh.(*ForwardManager).Stop(0x1400142af00?)
	github.com/okteto/okteto/pkg/ssh/manager.go:196 +0x3c
github.com/okteto/okteto/cmd/up.(*upContext).shutdown(0x140013da300)
	github.com/okteto/okteto/cmd/up/up.go:952 +0x2f4
github.com/okteto/okteto/cmd/up.(*upContext).start(0x140013da300)
	github.com/okteto/okteto/cmd/up/up.go:674 +0x800
github.com/okteto/okteto/cmd/up.Up.func1(0x140013bd700?, {0x14001439360, 0x0, 0x2})
	github.com/okteto/okteto/cmd/up/up.go:399 +0x1a8c
github.com/spf13/cobra.(*Command).execute(0x140014d2f00, {0x14001439340, 0x2, 0x2})
	github.com/spf13/cobra@v1.7.0/command.go:940 +0x658
github.com/spf13/cobra.(*Command).ExecuteC(0x14000262600)
	github.com/spf13/cobra@v1.7.0/command.go:1068 +0x320
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.7.0/command.go:992
main.main()
	github.com/okteto/okteto/main.go:178 +0xca4
❯
```

What helped me identify the problem was finding in the logs, repeated twice the logs for "terminating syncthing" and "stopping forwarders".

```
^CINFO[0016] CTRL+C received, starting shutdown sequence
INFO[0016] starting shutdown sequence
INFO[0016] sent cancellation signal
INFO[0016] stopping syncthing
INFO[0016] call to syncthing.WaitForCompletion canceled
INFO[0016] ssh forward localhost:60613->0.0.0.0:22000 -> done
INFO[0016] ssh forward localhost:60614->0.0.0.0:8384 -> done
INFO[0016] starting shutdown sequence
INFO[0016] sent cancellation signal
INFO[0016] ssh forward localhost:60613->0.0.0.0:22000 -> data transfer failed: read tcp 127.0.0.1:60613->127.0.0.1:22000: read: connection reset by peer
INFO[0016] stopping syncthing
INFO[0016] terminating syncthing 10781 without wait
INFO[0016] terminating syncthing 10781 without wait
INFO[0016] terminated syncthing 10781 without wait
INFO[0016] terminated syncthing 10781 without wait
INFO[0016] stopping forwarders
INFO[0016] stopping forwarders
close stopChan!!!!!
close stopChan!!!!!
INFO[0016] stopped k8s forwarder
DEBU[0016] Error closing remote connection: EOF
INFO[0016] stopped SSH forward manager
INFO[0016] completed shutdown sequence
INFO[0016]
```

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Run `okteto up` in [movies-frontend](https://github.com/okteto/movies-frontend) (or any other project)
1. Stop the session before the command is executed (for `movies-frontend`, before `yarn start` and `webpack` start)
1. If you interrupt at the right moment, the CLI will cause a panic.

To facilitate reproducting the error, you can also break the `synthing` ping call, this will cause a loop of retries, so you can run `okteto up -l debug` and notice when that occurs, and interrupt there, having higher changes of reproducing the bug. To break the Ping, just modify the endpoint to a 404. Search for `s.APICall(ctx, "rest/system/ping"`.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
