### PR TITLE
rename launch to deploy

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -70,7 +70,7 @@ func Exec() *cobra.Command {
 			if len(activeDevMode) == 0 {
 				return oktetoErrors.UserError{
 					E:    fmt.Errorf("development containers not found in namespace '%s'", manifest.Namespace),
-					Hint: "Run 'okteto up' to launch your development container or use 'okteto context' to change your current context",
+					Hint: "Run 'okteto up' to deploy your development container or use 'okteto context' to change your current context",
 				}
 			}
 
@@ -107,7 +107,7 @@ func Exec() *cobra.Command {
 			if oktetoErrors.IsNotFound(err) {
 				return oktetoErrors.UserError{
 					E:    fmt.Errorf("development container not found in namespace '%s'", dev.Namespace),
-					Hint: "Run 'okteto up' to launch your development container or use 'okteto context' to change your current context",
+					Hint: "Run 'okteto up' to deploy your development container or use 'okteto context' to change your current context",
 				}
 			}
 

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -138,7 +138,7 @@ func (mc *ManifestCommand) RunInitV2(ctx context.Context, opts *InitOpts) (*mode
 		isDeployed := pipeline.IsDeployed(ctx, manifest.Name, namespace, c)
 		deployAnswer := false
 		if !isDeployed && !opts.AutoDeploy {
-			deployAnswer, err = utils.AskYesNo("Do you want to launch your development environment?", utils.YesNoDefault_Yes)
+			deployAnswer, err = utils.AskYesNo("Do you want to deploy your development environment?", utils.YesNoDefault_Yes)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -95,7 +95,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.IOController) *cobra.Command {
 	upOptions := &UpOptions{}
 	cmd := &cobra.Command{
 		Use:   "up [service]",
-		Short: "Launch your development environment",
+		Short: "Deploy your development environment",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#up"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -332,7 +332,7 @@ func AskIfDeploy(name, namespace string) error {
 	if !deploy {
 		return oktetoErrors.UserError{
 			E:    fmt.Errorf("deployment %s doesn't exist in namespace %s", name, namespace),
-			Hint: "Launch your application first or use 'okteto namespace' to select a different namespace and try again",
+			Hint: "Deploy your application first or use 'okteto namespace' to select a different namespace and try again",
 		}
 	}
 	return nil


### PR DESCRIPTION
# Proposed changes

As the title says, this PR changes the word "Launch" to "Deploy" in different places.
