### PR TITLE
lint(revive): enable and fix rule EXC0014

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,7 +95,6 @@ linters:
 
 issues:
   include:
-    #- EXC0012  # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
     - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,11 @@ linters-settings:
       - int
       - make
       - '\.WithTimeout'
+  revive:
+    rules:
+      - name: exported
+        arguments:
+          - disableStutteringCheck
 
 # All possible linters can be found https://golangci-lint.run/usage/linters/
 linters:
@@ -86,8 +91,13 @@ linters:
     - bodyclose
     - durationcheck
     - exhaustive
+    - revive
 
 issues:
+  include:
+    #- EXC0012  # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
+    - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
+
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -95,7 +95,7 @@ linters:
 
 issues:
   include:
-    - EXC0014  # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
+    - EXC0014 # EXC0014 revive: comment on exported (.+) should be of the form "(.+)..."
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-issues-per-linter: 0

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -44,7 +44,7 @@ func NewCommand() (*NamespaceCommand, error) {
 	}, nil
 }
 
-// NewCommand creates a namespace command for use in further operations
+// NewCommandStateless creates a namespace command for use in further operations
 func NewCommandStateless(c *okteto.OktetoClient) *NamespaceCommand {
 	return &NamespaceCommand{
 		ctxCmd:            contextCMD.NewContextCommand(),

--- a/cmd/utils/okteto.go
+++ b/cmd/utils/okteto.go
@@ -76,7 +76,7 @@ func ShouldCreateNamespace(ctx context.Context, ns string) (bool, error) {
 	return ShouldCreateNamespaceStateless(ctx, ns, c)
 }
 
-// ShouldCreateNamespace checks if the user has access to the namespace.
+// ShouldCreateNamespaceStateless checks if the user has access to the namespace.
 // If not, ask the user if he wants to create it
 func ShouldCreateNamespaceStateless(ctx context.Context, ns string, c *okteto.OktetoClient) (bool, error) {
 	hasAccess, err := HasAccessToOktetoClusterNamespace(ctx, ns, c)

--- a/integration/commands/endpoints.go
+++ b/integration/commands/endpoints.go
@@ -20,7 +20,7 @@ import (
 	"os/exec"
 )
 
-// DeployOptions defines the options that can be added to a deploy command
+// EndpointOptions defines the options that can be added to a deploy command
 type EndpointOptions struct {
 	Workdir    string
 	Output     string
@@ -28,7 +28,7 @@ type EndpointOptions struct {
 	OktetoHome string
 }
 
-// RunOktetoDeploy runs an okteto deploy command
+// RunOktetoEndpoints runs an okteto deploy command
 func RunOktetoEndpoints(oktetoPath string, endpointsOptions *EndpointOptions) ([]byte, error) {
 	cmd := exec.Command(oktetoPath, "endpoints")
 	cmd.Env = os.Environ()

--- a/pkg/analytics/up.go
+++ b/pkg/analytics/up.go
@@ -150,17 +150,17 @@ func (u *UpMetricsMetadata) ErrSync() {
 	u.errSync = true
 }
 
-// ErrResetDatabase sets to true the property errResetDatabase
+// ErrSyncResetDatabase sets to true the property errResetDatabase
 func (u *UpMetricsMetadata) ErrSyncResetDatabase() {
 	u.errSyncResetDatabase = true
 }
 
-// ErrResetDatabase sets to true the property errResetDatabase
+// ErrSyncInsufficientSpace sets to true the property errResetDatabase
 func (u *UpMetricsMetadata) ErrSyncInsufficientSpace() {
 	u.errSyncInsufficientSpace = true
 }
 
-// ErrResetDatabase sets to true the property errResetDatabase
+// ErrSyncLostSyncthing sets to true the property errResetDatabase
 func (u *UpMetricsMetadata) ErrSyncLostSyncthing() {
 	u.errSyncLostSyncthing = true
 }

--- a/pkg/discovery/compose.go
+++ b/pkg/discovery/compose.go
@@ -55,7 +55,7 @@ func GetComposePath(wd string) (string, error) {
 	return "", ErrComposeFileNotFound
 }
 
-// GetComposePath returns a compose file if exists, error otherwise
+// GetComposePathWithFilesystem returns a compose file if exists, error otherwise
 func GetComposePathWithFilesystem(wd string, fs afero.Fs) (string, error) {
 	for _, possibleStackManifest := range possibleComposeManifests {
 		manifestPath := filepath.Join(wd, filepath.Join(possibleStackManifest...))

--- a/pkg/discovery/helm.go
+++ b/pkg/discovery/helm.go
@@ -42,7 +42,7 @@ func GetHelmChartPath(cwd string) (string, error) {
 	return "", ErrHelmChartNotFound
 }
 
-// GetHelmChartPath returns a helm chart directory if exists, error otherwise
+// GetHelmChartPathWithFilesystem returns a helm chart directory if exists, error otherwise
 func GetHelmChartPathWithFilesystem(cwd string, fs afero.Fs) (string, error) {
 	// Files will be checked in the order defined in the list
 	for _, chartDir := range possibleHelmChartsSubPaths {

--- a/pkg/discovery/k8s.go
+++ b/pkg/discovery/k8s.go
@@ -50,7 +50,7 @@ func GetK8sManifestPath(cwd string) (string, error) {
 	return "", ErrK8sManifestNotFound
 }
 
-// GetK8sManifestPath returns a k8s manifest file if exists, error otherwise
+// GetK8sManifestPathWithFilesystem returns a k8s manifest file if exists, error otherwise
 func GetK8sManifestPathWithFilesystem(cwd string, fs afero.Fs) (string, error) {
 	// Files will be checked in the order defined in the list
 	for _, name := range possibleK8sManifestSubPaths {

--- a/pkg/divert/weaver/divert.go
+++ b/pkg/divert/weaver/divert.go
@@ -68,8 +68,8 @@ func (d *Driver) Deploy(ctx context.Context) error {
 	return nil
 }
 
-// nolint:unparam
 // Destroy implements from the interface diver.Driver
+// nolint:unparam
 func (d *Driver) Destroy(_ context.Context) error {
 	oktetoLog.Success("Divert from '%s' successfully destroyed", d.divert.Namespace)
 	return nil

--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -117,7 +117,7 @@ func (n *Namespaces) DestroyWithLabel(ctx context.Context, ns string, opts Delet
 		LabelSelector: opts.LabelSelector,
 	}
 
-	trip, err := NewTrip(n.restConfig, &Options{
+	trip, err := newTrip(n.restConfig, &Options{
 		Namespace:   ns,
 		Parallelism: parallelism,
 		List:        listOptions,
@@ -141,7 +141,7 @@ func (n *Namespaces) DestroyWithLabel(ctx context.Context, ns string, opts Delet
 		logrus.SetLevel(prevLevel)
 	}()
 
-	return trip.Wander(ctx, TravelerFunc(func(obj runtime.Object) error {
+	return trip.wander(ctx, TravelerFunc(func(obj runtime.Object) error {
 		m, err := meta.Accessor(obj)
 		if err != nil {
 			return err
@@ -241,7 +241,7 @@ func (n *Namespaces) DestroySFSVolumes(ctx context.Context, ns string, opts Dele
 }
 
 // Below functions were added to remove "github.com/ibuildthecloud/finalizers" as a dependency
-func NewTrip(restConfig *rest.Config, opts *Options) (*Trip, error) {
+func newTrip(restConfig *rest.Config, opts *Options) (*Trip, error) {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -279,7 +279,7 @@ func NewTrip(restConfig *rest.Config, opts *Options) (*Trip, error) {
 	}, nil
 }
 
-func (t *Trip) Wander(ctx context.Context, traveler Traveler) error {
+func (t *Trip) wander(ctx context.Context, traveler Traveler) error {
 	_, apis, err := t.k8s.Discovery().ServerGroupsAndResources()
 	if err != nil {
 		return err

--- a/pkg/log/io/out.go
+++ b/pkg/log/io/out.go
@@ -100,7 +100,7 @@ func (l *OutputController) Printf(format string, args ...any) {
 	fmt.Fprint(l.out, string(bytes))
 }
 
-// Info prints a information message to the user
+// Infof prints a information message to the user
 func (l *OutputController) Infof(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
 	msg = l.decorator.Information(msg)

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -129,7 +129,7 @@ func NewOktetoClient(opts ...Option) (*OktetoClient, error) {
 	return newOktetoClientFromGraphqlClient(u, httpClient)
 }
 
-// NewOktetoClient creates a new client to connect with Okteto API
+// NewOktetoClientStateless creates a new client to connect with Okteto API
 func NewOktetoClientStateless(ocfg *OktetoClientCfg, opts ...Option) (*OktetoClient, error) {
 	for _, opt := range opts {
 		opt(ocfg)

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -195,7 +195,7 @@ func (lg *LocalGit) GetLatestCommit(ctx context.Context, gitPath, dirPath string
 	return string(output), nil
 }
 
-// GetLatestCommit returns the latest commit of the repository at the given path
+// Diff returns the diff of the repository at the given path
 func (lg *LocalGit) Diff(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
 	if fixAttempt > 1 {
 		return "", errLocalGitCannotGetCommitTooManyAttempts

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -208,8 +208,8 @@ func (fm *ForwardManager) TransformLabelsToServiceName(f forwardModel.Forward) (
 	return f, nil
 }
 
-// nolint:unparam
 // StartGlobalForwarding implements from the interface types.forwarder
+// nolint:unparam
 func (fm *ForwardManager) StartGlobalForwarding() error {
 	for _, gf := range fm.globalForwards {
 		gf.pool = fm.pool


### PR DESCRIPTION
# Proposed changes

This PR introduces a new linter `revive` with only one rule enabled for now: `EXC0014`.

```
# EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments
- comment on exported (.+) should be of the form "(.+)..."
```
