### PR TITLE
fix: panic on race condition

### DIFF
--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -146,7 +146,9 @@ func (p *PortForwardManager) Start(devPod, namespace string) error {
 			if !errors.Is(err, portforward.ErrLostConnectionToPod) {
 				p.activeDev.closeReady()
 			}
-			p.activeDev.err = err
+			if p.activeDev != nil {
+				p.activeDev.err = err
+			}
 		}
 	}()
 

--- a/pkg/k8s/forward/manager.go
+++ b/pkg/k8s/forward/manager.go
@@ -143,10 +143,10 @@ func (p *PortForwardManager) Start(devPod, namespace string) error {
 		err := devPF.ForwardPorts()
 		if err != nil {
 			oktetoLog.Infof("k8s forwarding to dev pod finished with errors: %s", err)
-			if !errors.Is(err, portforward.ErrLostConnectionToPod) {
-				p.activeDev.closeReady()
-			}
 			if p.activeDev != nil {
+				if !errors.Is(err, portforward.ErrLostConnectionToPod) {
+					p.activeDev.closeReady()
+				}
 				p.activeDev.err = err
 			}
 		}


### PR DESCRIPTION
# Proposed changes

Fixes a panic that was caused by a race condition when the port forward SSH handshake fails. It was stopping the forward manager [here](https://github.com/okteto/okteto/blob/master/pkg/ssh/manager.go#L162) and we were accessing to a nil reference [here](https://github.com/okteto/okteto/blob/master/pkg/k8s/forward/manager.go#L149)

The new error will indicate to check the logs if the secrets didn't have permissions or a clear error if the SSH port forwarding fails.

![Screenshot 2024-01-23 at 18 53 09](https://github.com/okteto/okteto/assets/25170843/bcfba771-ea9e-40b4-9b46-ec23d47655cb)

The error is caused because the user doesn't have permissions to write on the okteto folder. The user must match with the repo folder 


## Reproduction steps

1. Connect with another user to the terminal that has permissions on your user (`sudo su`)
2. Create a new repository belonging to the user (`gh repo clone okteto/movies`) or copy an existing one (`cp -r /pat/to/movies .`)
3. Return to your user
4. Enter in the new repo that belongs to another user (`cd movies`)
5. Run `okteto up`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines


EDIT: Add reproduction steps and an explanation for the error