### PR TITLE
fix: missing whitespace on spinner

### DIFF
--- a/pkg/log/io/spinner.go
+++ b/pkg/log/io/spinner.go
@@ -94,7 +94,7 @@ func (s *ttySpinner) preUpdateFunc() func(spinner *sp.Spinner) {
 		if err != nil {
 			return
 		}
-		spinner.Suffix = s.calculateSuffix(width)
+		spinner.Suffix = " " + s.calculateSuffix(width)
 	}
 }
 

--- a/pkg/log/io/spinner_test.go
+++ b/pkg/log/io/spinner_test.go
@@ -50,13 +50,13 @@ func TestPreUpdateFunc(t *testing.T) {
 			name:     "width is 10",
 			width:    10,
 			err:      nil,
-			expected: "Test",
+			expected: " Test",
 		},
 		{
 			name:     "error getting terminal width",
 			width:    0,
 			err:      fmt.Errorf("error getting terminal width"),
-			expected: "Test",
+			expected: " Test",
 		},
 	}
 	for _, tc := range tt {
@@ -66,7 +66,7 @@ func TestPreUpdateFunc(t *testing.T) {
 			}
 
 			okSpinner.preUpdateFunc()(okSpinner.Spinner)
-			assert.Equal(t, "Test", okSpinner.Spinner.Suffix)
+			assert.Equal(t, tc.expected, okSpinner.Spinner.Suffix)
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

Before:
<img width="944" alt="Screenshot 2024-01-24 at 16 45 59" src="https://github.com/okteto/okteto/assets/25170843/21279202-3064-4000-8a0b-a9e956c005e6">
After
<img width="948" alt="Screenshot 2024-01-24 at 16 52 31" src="https://github.com/okteto/okteto/assets/25170843/c563132e-0742-4059-a369-29d5c84d02ed">


## How to validate

1. Run `okteto deploy` on `okteto/movies`
1. See that missing whitespace on the spinner while checking images


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

