### PR TITLE
fix: integration test after linter refactor

### DIFF
--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -428,7 +428,7 @@ func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
 	// Test that image has been built
-	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okteto.Context().Registry, testNamespace)))
+	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okteto.GetContext().Registry, testNamespace)))
 
 	destroyOptions := &commands.DestroyOptions{
 		Workdir:    dir,


### PR DESCRIPTION
# Proposed changes

[PR 4141](https://github.com/okteto/okteto/pull/4141) introduced `revive` as linter and refactored the codebase, however [another PR](https://github.com/okteto/okteto/pull/4128) was merged and now the integration tests are failing. This PR should fix the integration tests.

