### PR TITLE
fix: log k8s request before any return

### DIFF
--- a/pkg/okteto/k8s.go
+++ b/pkg/okteto/k8s.go
@@ -69,14 +69,14 @@ func newTokenRotationTransport(rt http.RoundTripper, k8sLogger *ioCtrl.K8sLogger
 // RoundTrip to wrap http 401 status code in response
 func (t *tokenRotationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.rt.RoundTrip(req)
+	if t.k8sLogger != nil && t.k8sLogger.IsEnabled() {
+		t.k8sLogger.Log(resp.StatusCode, req.Method, req.URL.String())
+	}
 	if err != nil {
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrK8sUnauthorised
-	}
-	if t.k8sLogger != nil && t.k8sLogger.IsEnabled() {
-		t.k8sLogger.Log(resp.StatusCode, req.Method, req.URL.String())
 	}
 	return resp, err
 }


### PR DESCRIPTION
# Proposed changes

I've noticed that in case of error, some k8s requests might be not be logged because we return earlier than the log itself. This will fix it.