### PR TITLE
fix: avoid panic in k8s logger if resp is nil

### DIFF
--- a/pkg/okteto/k8s.go
+++ b/pkg/okteto/k8s.go
@@ -70,7 +70,11 @@ func newTokenRotationTransport(rt http.RoundTripper, k8sLogger *ioCtrl.K8sLogger
 func (t *tokenRotationTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.rt.RoundTrip(req)
 	if t.k8sLogger != nil && t.k8sLogger.IsEnabled() {
-		t.k8sLogger.Log(resp.StatusCode, req.Method, req.URL.String())
+		var statusCode int
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		t.k8sLogger.Log(statusCode, req.Method, req.URL.String())
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Proposed changes

In case of `nil` resp, it would cause a panic. To reproduce, break all requests by adding an extra line in the first line of the RoundTrip func:

```
req.URL.Path = "broken"
```

and execute the CLI with `OKTETO_K8S_REQUESTS_LOGGER_ENABLED=true`.