### PR TITLE
fix: logger on different output formats

### DIFF
--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -163,6 +163,10 @@ func (t *trace) display(progress string) {
 					oktetoLog.Infof("could not parse %s: %w", log, err)
 					continue
 				}
+				if text.Stage == "" {
+					oktetoLog.Infof("received log without stage: %s", text.Message)
+					continue
+				}
 				oktetoLog.SetStage(text.Stage)
 				switch text.Stage {
 				case "done":

--- a/pkg/log/io/out.go
+++ b/pkg/log/io/out.go
@@ -152,7 +152,7 @@ func (l *OutputController) Spinner(msg string) OktetoSpinner {
 	if isTTY && !disableSpinner {
 		l.spinner = newTTYSpinner(msg)
 	} else {
-		l.spinner = newNoSpinner(msg)
+		l.spinner = newNoSpinner(msg, l)
 	}
 	return l.spinner
 }

--- a/pkg/log/io/out_test.go
+++ b/pkg/log/io/out_test.go
@@ -42,7 +42,7 @@ func TestSetOutputFormatOutput(t *testing.T) {
 func TestPrintln(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	l := newOutputController(buffer)
-	l.spinner = newNoSpinner("test")
+	l.spinner = newNoSpinner("test", l)
 
 	l.SetOutputFormat("tty")
 	l.Println("test")
@@ -74,7 +74,7 @@ func TestPrintln(t *testing.T) {
 func TestPrint(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	l := newOutputController(buffer)
-	l.spinner = newNoSpinner("test")
+	l.spinner = newNoSpinner("test", l)
 
 	l.SetOutputFormat("tty")
 	l.Print("test")
@@ -107,7 +107,7 @@ func TestPrintf(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	l := newOutputController(buffer)
 
-	l.spinner = newNoSpinner("test")
+	l.spinner = newNoSpinner("test", l)
 
 	l.SetOutputFormat("tty")
 	l.Printf("%s", "test")
@@ -140,7 +140,7 @@ func TestInfof(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	l := newOutputController(buffer)
 
-	l.spinner = newNoSpinner("test")
+	l.spinner = newNoSpinner("test", l)
 
 	l.SetOutputFormat("tty")
 	l.Infof("%s", "test")
@@ -173,7 +173,7 @@ func TestSuccess(t *testing.T) {
 	buffer := bytes.NewBuffer([]byte{})
 	l := newOutputController(buffer)
 
-	l.spinner = newNoSpinner("test")
+	l.spinner = newNoSpinner("test", l)
 
 	l.SetOutputFormat("tty")
 	l.Success("%s", "test")
@@ -242,4 +242,8 @@ func TestSpinner(t *testing.T) {
 	t.Setenv(OktetoDisableSpinnerEnvVar, "test")
 	sp = l.Spinner("enabled")
 	require.IsType(t, &ttySpinner{}, sp)
+
+	l.formatter = &jsonFormatter{}
+	sp = l.Spinner("json")
+	require.Nil(t, sp)
 }

--- a/pkg/log/io/spinner.go
+++ b/pkg/log/io/spinner.go
@@ -14,7 +14,6 @@
 package io
 
 import (
-	"fmt"
 	"os"
 	"time"
 	"unicode"
@@ -116,19 +115,21 @@ func (s *ttySpinner) calculateSuffix(width int) string {
 
 // noSpinner is the spinner for the no tty modes
 type noSpinner struct {
-	msg string
+	msg              string
+	OutputController *OutputController
 }
 
 // newNoSpinner creates a new noSpinner
-func newNoSpinner(msg string) *noSpinner {
+func newNoSpinner(msg string, l *OutputController) *noSpinner {
 	return &noSpinner{
-		msg: ucFirst(msg),
+		msg:              ucFirst(msg),
+		OutputController: l,
 	}
 }
 
 // Start starts the spinner
 func (s *noSpinner) Start() {
-	fmt.Println(s.msg)
+	s.OutputController.Println(s.msg)
 }
 
 // Stop stops the spinner

--- a/pkg/log/io/spinner.go
+++ b/pkg/log/io/spinner.go
@@ -94,7 +94,7 @@ func (s *ttySpinner) preUpdateFunc() func(spinner *sp.Spinner) {
 		if err != nil {
 			return
 		}
-		spinner.Suffix = s.calculateSuffix(width)
+		spinner.Suffix = " " + s.calculateSuffix(width)
 	}
 }
 

--- a/pkg/log/io/spinner_test.go
+++ b/pkg/log/io/spinner_test.go
@@ -30,7 +30,8 @@ func TestTTYSpinner(t *testing.T) {
 }
 
 func TestNoSpinner(t *testing.T) {
-	sp := newNoSpinner("test")
+	oc := newOutputController(nil)
+	sp := newNoSpinner("test", oc)
 
 	sp.Start()
 	sp.Stop()

--- a/pkg/log/io/spinner_test.go
+++ b/pkg/log/io/spinner_test.go
@@ -50,13 +50,13 @@ func TestPreUpdateFunc(t *testing.T) {
 			name:     "width is 10",
 			width:    10,
 			err:      nil,
-			expected: "Test",
+			expected: " Test",
 		},
 		{
 			name:     "error getting terminal width",
 			width:    0,
 			err:      fmt.Errorf("error getting terminal width"),
-			expected: "Test",
+			expected: " Test",
 		},
 	}
 	for _, tc := range tt {
@@ -66,7 +66,7 @@ func TestPreUpdateFunc(t *testing.T) {
 			}
 
 			okSpinner.preUpdateFunc()(okSpinner.Spinner)
-			assert.Equal(t, "Test", okSpinner.Spinner.Suffix)
+			assert.Equal(t, tc.expected, okSpinner.Spinner.Suffix)
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

- Fix a bug when deploying on remote. We were showing a message of `Running stage ''`:

| Before | After |
|----------|----------|
|  <img width="778" alt="Screenshot 2024-01-25 at 15 50 25" src="https://github.com/okteto/okteto/assets/25170843/0e60fb18-9fba-4dea-9cb5-25bdf25a52e4">  |  <img width="985" alt="Screenshot 2024-01-25 at 15 50 57" src="https://github.com/okteto/okteto/assets/25170843/cb35a575-66b9-46ad-8a31-1658c426f2b7">  |

- Fix a bug on json format while checking images to build

| Before | After |
|----------|----------|
|  <img width="1321" alt="Screenshot 2024-01-25 at 15 53 32" src="https://github.com/okteto/okteto/assets/25170843/95fcbd04-5670-4dbb-ba4a-e65fa471abd2">  |  <img width="1284" alt="Screenshot 2024-01-25 at 15 54 17" src="https://github.com/okteto/okteto/assets/25170843/2391242c-0feb-43eb-84f4-127db3302617"> |

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
