### PR TITLE
Improve experience for overnight `okteto up` sessions, and syntching timeouts

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -134,7 +134,7 @@ func (up *upContext) activate() error {
 	}
 
 	if err := up.devMode(ctx, app, create); err != nil {
-		if oktetoErrors.IsTransient(err) {
+		if up.isTransient(err) {
 			return err
 		}
 		if _, ok := err.(oktetoErrors.UserError); ok {

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -176,6 +176,7 @@ func (up *upContext) activate() error {
 
 	// success means all context is ready to run the activation
 	up.success = true
+	up.unhandledTransientRetryCount = 0
 
 	go func() {
 		output := <-up.cleaned

--- a/cmd/up/errors.go
+++ b/cmd/up/errors.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
 // isTransient is an extension of the oktetoErrors.IsTransient, this variant is used to add transient errors dynamically
@@ -33,6 +34,7 @@ func (up *upContext) isTransient(err error) bool {
 			return true
 		}
 		if !isTransientErr && up.unhandledTransientRetryCount < up.unhandledTransientMaxRetries {
+			oktetoLog.Debugf("handling error as transient because okteto up was successfully running before, but it's now failing with: %v (%d of %d)", err, up.unhandledTransientRetryCount, up.unhandledTransientMaxRetries)
 			up.unhandledTransientRetryCount++
 			return true
 		}

--- a/cmd/up/errors.go
+++ b/cmd/up/errors.go
@@ -1,0 +1,36 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"strings"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+)
+
+// isTransient is an extension of the oktetoErrors.IsTransient, this variant is used to add transient errors dynamically
+// based on the state of the upContext, in particular, if the up session was successfully started once before any retry
+func (up *upContext) isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if up.success {
+		if strings.Contains(err.Error(), "syncthing local=false didn't respond after") {
+			return true
+		}
+	}
+
+	return oktetoErrors.IsTransient(err)
+}

--- a/cmd/up/errors.go
+++ b/cmd/up/errors.go
@@ -14,8 +14,9 @@
 package up
 
 import (
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"strings"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 )
 
 // isTransient is an extension of the oktetoErrors.IsTransient, this variant is used to add transient errors dynamically

--- a/cmd/up/errors.go
+++ b/cmd/up/errors.go
@@ -14,9 +14,8 @@
 package up
 
 import (
-	"strings"
-
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"strings"
 )
 
 // isTransient is an extension of the oktetoErrors.IsTransient, this variant is used to add transient errors dynamically
@@ -26,16 +25,17 @@ func (up *upContext) isTransient(err error) bool {
 		return false
 	}
 
+	isTransientErr := oktetoErrors.IsTransient(err)
+
 	if up.success {
 		if strings.Contains(err.Error(), "syncthing local=false didn't respond after") {
 			return true
 		}
-		if up.transientRetryCount < up.transientMaxRetries {
-			up.transientRetryCount++
+		if !isTransientErr && up.unhandledTransientRetryCount < up.unhandledTransientMaxRetries {
+			up.unhandledTransientRetryCount++
 			return true
 		}
 	}
 
-	up.transientRetryCount = 0
-	return oktetoErrors.IsTransient(err)
+	return isTransientErr
 }

--- a/cmd/up/errors.go
+++ b/cmd/up/errors.go
@@ -30,7 +30,12 @@ func (up *upContext) isTransient(err error) bool {
 		if strings.Contains(err.Error(), "syncthing local=false didn't respond after") {
 			return true
 		}
+		if up.transientRetryCount < up.transientMaxRetries {
+			up.transientRetryCount++
+			return true
+		}
 	}
 
+	up.transientRetryCount = 0
 	return oktetoErrors.IsTransient(err)
 }

--- a/cmd/up/errors_test.go
+++ b/cmd/up/errors_test.go
@@ -66,6 +66,30 @@ func Test_isTransient(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "success true - retry any error",
+			input: input{
+				err: assert.AnError,
+				up: &upContext{
+					success:             true,
+					transientMaxRetries: 5,
+					transientRetryCount: 0,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "success false - max retries exceeded",
+			input: input{
+				err: assert.AnError,
+				up: &upContext{
+					success:             true,
+					transientMaxRetries: 5,
+					transientRetryCount: 5,
+				},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/up/errors_test.go
+++ b/cmd/up/errors_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isTransient(t *testing.T) {
+	type input struct {
+		up  *upContext
+		err error
+	}
+	tests := []struct {
+		input    input
+		name     string
+		expected bool
+	}{
+		{
+			name: "nil error",
+			input: input{
+				err: nil,
+				up:  &upContext{},
+			},
+			expected: false,
+		},
+		{
+			name: "non transient error",
+			input: input{
+				err: assert.AnError,
+				up:  &upContext{},
+			},
+			expected: false,
+		},
+		{
+			name: "success false - syncthing local=false didn't respond after",
+			input: input{
+				err: errors.New("syncthing local=false didn't respond after 1m0s"),
+				up: &upContext{
+					success: false,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "success true - syncthing local=false didn't respond after",
+			input: input{
+				err: errors.New("syncthing local=false didn't respond after 1m0s"),
+				up: &upContext{
+					success: true,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.input.up.isTransient(tt.input.err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -116,7 +116,7 @@ func (up *upContext) startSyncthing(ctx context.Context) error {
 
 	if err := up.Sy.WaitForPing(ctx, false); err != nil {
 		oktetoLog.Infof("failed to ping syncthing: %s", err.Error())
-		if oktetoErrors.IsTransient(err) {
+		if up.isTransient(err) {
 			return err
 		}
 		return up.checkOktetoStartError(ctx, "Failed to connect to the synchronization service")

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -81,6 +81,9 @@ type upContext struct {
 	resetSyncthing        bool
 	isTerm                bool
 	interruptReceived     bool
+
+	transientMaxRetries int
+	transientRetryCount int
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -82,8 +82,8 @@ type upContext struct {
 	isTerm                bool
 	interruptReceived     bool
 
-	transientMaxRetries int
-	transientRetryCount int
+	unhandledTransientMaxRetries int
+	unhandledTransientRetryCount int
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -253,20 +253,21 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.IOController, k8sLogger *io.K8s
 			}
 
 			up := &upContext{
-				Manifest:            oktetoManifest,
-				Dev:                 nil,
-				Exit:                make(chan error, 1),
-				resetSyncthing:      upOptions.Reset,
-				StartTime:           time.Now(),
-				Registry:            registry.NewOktetoRegistry(okteto.Config{}),
-				Options:             upOptions,
-				Fs:                  afero.NewOsFs(),
-				analyticsTracker:    at,
-				analyticsMeta:       upMeta,
-				K8sClientProvider:   okteto.NewK8sClientProviderWithLogger(k8sLogger),
-				tokenUpdater:        newTokenUpdaterController(),
-				builder:             buildv2.NewBuilderFromScratch(at, ioCtrl),
-				transientMaxRetries: 100,
+				Manifest:                     oktetoManifest,
+				Dev:                          nil,
+				Exit:                         make(chan error, 1),
+				resetSyncthing:               upOptions.Reset,
+				StartTime:                    time.Now(),
+				Registry:                     registry.NewOktetoRegistry(okteto.Config{}),
+				Options:                      upOptions,
+				Fs:                           afero.NewOsFs(),
+				analyticsTracker:             at,
+				analyticsMeta:                upMeta,
+				K8sClientProvider:            okteto.NewK8sClientProviderWithLogger(k8sLogger),
+				tokenUpdater:                 newTokenUpdaterController(),
+				builder:                      buildv2.NewBuilderFromScratch(at, ioCtrl),
+				unhandledTransientMaxRetries: 100,
+				unhandledTransientRetryCount: 0,
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -253,19 +253,20 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.IOController, k8sLogger *io.K8s
 			}
 
 			up := &upContext{
-				Manifest:          oktetoManifest,
-				Dev:               nil,
-				Exit:              make(chan error, 1),
-				resetSyncthing:    upOptions.Reset,
-				StartTime:         time.Now(),
-				Registry:          registry.NewOktetoRegistry(okteto.Config{}),
-				Options:           upOptions,
-				Fs:                afero.NewOsFs(),
-				analyticsTracker:  at,
-				analyticsMeta:     upMeta,
-				K8sClientProvider: okteto.NewK8sClientProviderWithLogger(k8sLogger),
-				tokenUpdater:      newTokenUpdaterController(),
-				builder:           buildv2.NewBuilderFromScratch(at, ioCtrl),
+				Manifest:            oktetoManifest,
+				Dev:                 nil,
+				Exit:                make(chan error, 1),
+				resetSyncthing:      upOptions.Reset,
+				StartTime:           time.Now(),
+				Registry:            registry.NewOktetoRegistry(okteto.Config{}),
+				Options:             upOptions,
+				Fs:                  afero.NewOsFs(),
+				analyticsTracker:    at,
+				analyticsMeta:       upMeta,
+				K8sClientProvider:   okteto.NewK8sClientProviderWithLogger(k8sLogger),
+				tokenUpdater:        newTokenUpdaterController(),
+				builder:             buildv2.NewBuilderFromScratch(at, ioCtrl),
+				transientMaxRetries: 100,
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -747,7 +747,7 @@ func (up *upContext) activateLoop() {
 				continue
 			}
 
-			if oktetoErrors.IsTransient(err) {
+			if up.isTransient(err) {
 				isTransientError = true
 				continue
 			}
@@ -768,7 +768,7 @@ func (up *upContext) waitUntilExitOrInterruptOrApply(ctx context.Context) error 
 			oktetoLog.Println()
 			if err != nil {
 				oktetoLog.Infof("command failed: %s", err)
-				if oktetoErrors.IsTransient(err) {
+				if up.isTransient(err) {
 					return err
 				}
 				return oktetoErrors.CommandError{

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -285,8 +285,7 @@ func IsTransient(err error) bool {
 		strings.Contains(err.Error(), "closing remote connection: EOF"),
 		strings.Contains(err.Error(), "request for pseudo terminal failed: eof"),
 		strings.Contains(err.Error(), "unable to upgrade connection"),
-		strings.Contains(err.Error(), "command execution failed: eof"),
-		strings.Contains(err.Error(), "syncthing local=false didn't respond after"):
+		strings.Contains(err.Error(), "command execution failed: eof"):
 		return true
 	default:
 		return false

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -285,7 +285,8 @@ func IsTransient(err error) bool {
 		strings.Contains(err.Error(), "closing remote connection: EOF"),
 		strings.Contains(err.Error(), "request for pseudo terminal failed: eof"),
 		strings.Contains(err.Error(), "unable to upgrade connection"),
-		strings.Contains(err.Error(), "command execution failed: eof"):
+		strings.Contains(err.Error(), "command execution failed: eof"),
+		strings.Contains(err.Error(), "syncthing local=false didn't respond after"):
 		return true
 	default:
 		return false

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -164,7 +164,7 @@ func TestIsTransient(t *testing.T) {
 		{
 			name:     "syncthing local=false didn't respond after",
 			err:      errors.New("syncthing local=false didn't respond after 1m0s"),
-			expected: true,
+			expected: false,
 		},
 	}
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,177 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		err      error
+		name     string
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non transient error",
+			err:      assert.AnError,
+			expected: false,
+		},
+		{
+			name:     "operation time out",
+			err:      errors.New("operation time out"),
+			expected: true,
+		},
+		{
+			name:     "operation timed out",
+			err:      errors.New("operation timed out"),
+			expected: true,
+		},
+		{
+			name:     "i/o timeout",
+			err:      errors.New("i/o timeout"),
+			expected: true,
+		},
+		{
+			name:     "unknown (get events)",
+			err:      errors.New("unknown (get events)"),
+			expected: true,
+		},
+		{
+			name:     "Client.Timeout exceeded while awaiting headers",
+			err:      errors.New("Client.Timeout exceeded while awaiting headers"),
+			expected: true,
+		},
+		{
+			name:     "can't assign requested address",
+			err:      errors.New("can't assign requested address"),
+			expected: true,
+		},
+		{
+			name:     "command exited without exit status or exit signal",
+			err:      errors.New("command exited without exit status or exit signal"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset by peer",
+			err:      errors.New("connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "client connection lost",
+			err:      errors.New("client connection lost"),
+			expected: true,
+		},
+		{
+			name:     "nodename nor servname provided, or not known",
+			err:      errors.New("nodename nor servname provided, or not known"),
+			expected: true,
+		},
+		{
+			name:     "no route to host",
+			err:      errors.New("no route to host"),
+			expected: true,
+		},
+		{
+			name:     "unexpected EOF",
+			err:      errors.New("unexpected EOF"),
+			expected: true,
+		},
+		{
+			name:     "TLS handshake timeout",
+			err:      errors.New("TLS handshake timeout"),
+			expected: true,
+		},
+		{
+			name:     "in the time allotted",
+			err:      errors.New("in the time allotted"),
+			expected: true,
+		},
+		{
+			name:     "broken pipe",
+			err:      errors.New("broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "No connection could be made",
+			err:      errors.New("No connection could be made"),
+			expected: true,
+		},
+		{
+			name:     "operation was canceled",
+			err:      errors.New("operation was canceled"),
+			expected: true,
+		},
+		{
+			name:     "network is unreachable",
+			err:      errors.New("network is unreachable"),
+			expected: true,
+		},
+		{
+			name:     "development container has been removed",
+			err:      errors.New("development container has been removed"),
+			expected: true,
+		},
+		{
+			name:     "unexpected packet in response to channel open",
+			err:      errors.New("unexpected packet in response to channel open"),
+			expected: true,
+		},
+		{
+			name:     "closing remote connection: EOF",
+			err:      errors.New("closing remote connection: EOF"),
+			expected: true,
+		},
+		{
+			name:     "request for pseudo terminal failed: eof",
+			err:      errors.New("request for pseudo terminal failed: eof"),
+			expected: true,
+		},
+		{
+			name:     "unable to upgrade connection",
+			err:      errors.New("unable to upgrade connection"),
+			expected: true,
+		},
+		{
+			name:     "command execution failed: eof",
+			err:      errors.New("command execution failed: eof"),
+			expected: true,
+		},
+		{
+			name:     "syncthing local=false didn't respond after",
+			err:      errors.New("syncthing local=false didn't respond after 1m0s"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsTransient(tt.err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -344,6 +344,7 @@ func (s *Syncthing) WaitForPing(ctx context.Context, local bool) error {
 		select {
 		case <-ticker.C:
 			if s.Ping(ctx, local) {
+				oktetoLog.Infof("syncthing local=%t is ready", local)
 				return nil
 			}
 			if retries%5 == 0 {


### PR DESCRIPTION
# Proposed changes

This change aims to improve the retry mechanism currently affecting some users. The problem is summarised as follows:

When leaving the `okteto up` running overnight, the OS will pause the okteto CLI and other processes, causing a disconnection from the pod. When this happens, syncthing remote is not reachable, because the k8s port forwarding is also unavailable, therefore users may experience a full disconnection when starting their working day in the morning because we do not consider transient the syncthing timeout error.

After discussing different approaches, we agreed that, making permanently transient the timeout error would be incorrect, because syntching can fail to start due to configuration issues (ie. permissions), but, if the `okteto up` sequence was successfully completed once, we can exclude that syntching has configuration issues to start again, so this proposed change, is making that specific error to be considered transient depening on the previous successful execution. 

Note: there is a scenario that we should consider in the future, to listen for deployments, and make sure that the dev container has not been updated outside of the `okteto up` sequence. It could be that a user successfully runs `okteto up`, then break syncthing with another command, then we would consider the syncthing's timeout error transient when it's not. I think it's quite an edge case that can be considered as follow-up from this PR.

## How to validate

To test this change, it's quite tricky because we need to make `okteto up` suceed once, then break syncthing and trigger a reconnection, making only the remote ping to fail, and verify that it's considered transient.

The way I tested is by making the ping path dynamic, so that based on time of when I was starting `okteto up`, and simulating a disconnection by killing the pod, when the CLI tries to reconnect, for remote, the ping path is a 404, so after a few retries, it would trigger the timeout.

1. Modify `syncthing.go` to use a variable for the ping path `rest/system/ping`
1. In the `Ping` func, based on time, change this value for remote:
```go
if !local {
	// change the following time based on the execution of your debug
	if time.Now().Hour() >= 16 && time.Now().Minute() >= 19 && time.Now().Minute() <= 24 {
		s.PingPath = "/wrong/path"
		// note: s.PingPath does not exist, and should be added to the Syncthing struct
	}
}
```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
