### PR TITLE
fix: json build output

### DIFF
--- a/pkg/log/io/formatter.go
+++ b/pkg/log/io/formatter.go
@@ -15,6 +15,8 @@ package io
 
 import (
 	"regexp"
+	"strings"
+	"unicode"
 
 	"github.com/sirupsen/logrus"
 )
@@ -85,6 +87,7 @@ func (f *jsonFormatter) SetStage(stage string) {
 
 // Format formats the message for the json
 func (f *jsonFormatter) format(msg string) ([]byte, error) {
+	msg = strings.TrimRightFunc(msg, unicode.IsSpace)
 	entry := &logrus.Entry{
 		Message: msg,
 		Level:   logrus.InfoLevel,

--- a/pkg/log/io/formatter_test.go
+++ b/pkg/log/io/formatter_test.go
@@ -59,7 +59,7 @@ func TestPlainFormatter(t *testing.T) {
 
 func TestJSONFormatter(t *testing.T) {
 	formatter := newJSONFormatter()
-	msg := "text message"
+	msg := "text message\n"
 	stage := "stage"
 	formatter.SetStage(stage)
 
@@ -69,7 +69,7 @@ func TestJSONFormatter(t *testing.T) {
 	jsonMessage := &jsonMessage{}
 	json.Unmarshal(output, jsonMessage)
 
-	assert.Equal(t, msg, jsonMessage.Message)
+	assert.Equal(t, "text message", jsonMessage.Message)
 	assert.Equal(t, stage, jsonMessage.Stage)
 	assert.Equal(t, "info", jsonMessage.Level)
 	assert.NotEmpty(t, jsonMessage.Timestamp)

--- a/pkg/log/io/out_test.go
+++ b/pkg/log/io/out_test.go
@@ -158,7 +158,7 @@ func TestInfof(t *testing.T) {
 	jsonMessage := &jsonMessage{}
 	err := json.Unmarshal(buffer.Bytes(), jsonMessage)
 	require.NoError(t, err)
-	require.Equal(t, "INFO: test\n", jsonMessage.Message)
+	require.Equal(t, "INFO: test", jsonMessage.Message)
 	require.Equal(t, "test", jsonMessage.Stage)
 	require.Equal(t, "info", jsonMessage.Level)
 	require.NotEmpty(t, jsonMessage.Timestamp)
@@ -191,7 +191,7 @@ func TestSuccess(t *testing.T) {
 	jsonMessage := &jsonMessage{}
 	err := json.Unmarshal(buffer.Bytes(), jsonMessage)
 	require.NoError(t, err)
-	require.Equal(t, "SUCCESS: test\n", jsonMessage.Message)
+	require.Equal(t, "SUCCESS: test", jsonMessage.Message)
 	require.Equal(t, "test", jsonMessage.Stage)
 	require.Equal(t, "info", jsonMessage.Level)
 	require.NotEmpty(t, jsonMessage.Timestamp)


### PR DESCRIPTION
# Proposed changes

Fixes build output deploying with the flag `--log-output json`

Detect if the line ends with a whitespace/tab/new line and remove it from the final message. The UI was rendering those spaces and was showing bad information

## How to validate

1. Run `okteto deploy --build --log-output json` on okteto/movies repo
1. Check that the build message doesn't contain `\n`


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
