### PR TITLE
fix: push script

### DIFF
--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -24,13 +24,12 @@
 
         
         beta_prerel_regex="^beta\.[0-9]+"
-        prerel="$(semver get prerel "${RELEASE_TAG}")"
-
+        prerel="$(semver get prerel "${RELEASE_TAG}" || true)"
         tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev"
         
         # if release tag is  not empty, push the stable image
         if [ -n "$RELEASE_TAG" ]; then
-                if [ -z "$prerel" ]; then 
+                if [ -n "$prerel" ]; then 
                         tags="${tags},okteto/okteto:stable"
                 elif [[ $prerel =~ $beta_prerel_regex ]]; then
                         tags="${tags},okteto/okteto:beta"


### PR DESCRIPTION
# Proposed changes

Fixes a bug where we were failing and pushing to the stable image

## How to validate

1. Run `docker run -it -v "$(pwd):/app" okteto/golang-ci:2.3.3 bash` from the root project of the CLI (same image as the one running in CI)
1. Comment the line that builds `okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${RELEASE_TAG}" -t ${tags} -f Dockerfile .`
1. Run `./app/scripts/ci/push-image.sh 1.2.1 as` and check that is pushing to stable
1. Run `./app/scripts/ci/push-image.sh 1.2.1-beta.1 as` and check that is pushing to beta 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
