### PR TITLE
fix: double warning on --insecure-skip-tls-verify

### DIFF
--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -40,12 +40,6 @@ To set your default context, run the ` + "`okteto context`" + ` command:
 This will prompt you to select one of your existing contexts or to create a new one.
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			// read parent PersistentPreRun if any and run them before current PersistentPreRun
-			if parent := cmd.Parent(); parent != nil {
-				if parent.PersistentPreRun != nil {
-					parent.PersistentPreRun(parent, args)
-				}
-			}
 			okteto.SetInsecureSkipTLSVerifyPolicy(ctxOptions.InsecureSkipTlsVerify)
 		},
 		RunE: Use().RunE,


### PR DESCRIPTION
# Proposed changes

DEV-139

We updated the cobra dependency and now the library takes care of all the parents `PersistentPreRuns`, so there is no need on having the code that we removed on this PR. 

TLDR: We have 2 duplicated log messages, one managed by us and another one by the cobra dependency. Now cobra is the one managing it

## How to validate

1. Run `okteto context use $URL --insecure-skip-tls-verify`
1. Check that there is no duplicated message

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
