### PR TITLE
Improve experience for overnight `okteto up` sessions, and syntching timeouts

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -176,7 +176,6 @@ func (up *upContext) activate() error {
 
 	// success means all context is ready to run the activation
 	up.success = true
-	up.unhandledTransientRetryCount = 0
 
 	go func() {
 		output := <-up.cleaned

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -134,7 +134,7 @@ func (up *upContext) activate() error {
 	}
 
 	if err := up.devMode(ctx, app, create); err != nil {
-		if oktetoErrors.IsTransient(err) {
+		if up.isTransient(err) {
 			return err
 		}
 		if _, ok := err.(oktetoErrors.UserError); ok {
@@ -176,6 +176,7 @@ func (up *upContext) activate() error {
 
 	// success means all context is ready to run the activation
 	up.success = true
+	up.unhandledTransientRetryCount = 0
 
 	go func() {
 		output := <-up.cleaned

--- a/cmd/up/errors.go
+++ b/cmd/up/errors.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
 // isTransient is an extension of the oktetoErrors.IsTransient, this variant is used to add transient errors dynamically
@@ -35,45 +34,12 @@ func (up *upContext) isTransient(err error) bool {
 	}
 
 	if up.success {
-		// it's important to check isFatalErr only after the first successful okteto up session, or we would retry
-		// non-recoverable errors such as non-zero exit status (e.g. 'dev.[svc].command' using a cmd not in path)
-		isFatalErr := isFatalAfterSuccessError(err)
-		if isFatalErr {
-			// non-recoverable, not worth retrying
-			return false
-		}
-
 		// if syncthing worked before (up.success == true) and it's failing now, it's worth retrying
 		if strings.Contains(err.Error(), "syncthing local=false didn't respond after") {
-			return true
-		}
-
-		// because there might be other errors like syncthing, we retry on any error for a while
-		if !isTransientErr && up.unhandledTransientRetryCount < up.unhandledTransientMaxRetries {
-			oktetoLog.Debugf("handling error as transient because okteto up was successfully running before, but it's now failing with: %v (%d of %d)", err, up.unhandledTransientRetryCount, up.unhandledTransientMaxRetries)
-			up.unhandledTransientRetryCount++
 			return true
 		}
 	}
 
 	// the error is not transient, the up session has not succeeded yet, so it's not worth retrying
 	return false
-}
-
-// isFatalAfterSuccessError checks if the error is non-recoverable, and it's used to stop the retry process
-func isFatalAfterSuccessError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	switch {
-
-	case
-		strings.Contains(err.Error(), "cannot get resource \"deployments\" in API group \"apps\" in the namespace"), // delete role binding
-		strings.Contains(err.Error(), "not found in namespace"),                                                     // namespace deleted
-		strings.Contains(err.Error(), "development container has been deactivated"):                                 // running `okteto down` while `okteto up` is running
-		return true
-	default:
-		return false
-	}
 }

--- a/cmd/up/errors.go
+++ b/cmd/up/errors.go
@@ -1,0 +1,79 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"strings"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+)
+
+// isTransient is an extension of the oktetoErrors.IsTransient, this variant is used to add transient errors dynamically
+// based on the state of the upContext, in particular, if the up session was successfully started once before any retry
+func (up *upContext) isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	isTransientErr := oktetoErrors.IsTransient(err)
+
+	// if we know the error is transient, we return early
+	if isTransientErr {
+		return true
+	}
+
+	if up.success {
+		// it's important to check isFatalErr only after the first successful okteto up session, or we would retry
+		// non-recoverable errors such as non-zero exit status (e.g. 'dev.[svc].command' using a cmd not in path)
+		isFatalErr := isFatalAfterSuccessError(err)
+		if isFatalErr {
+			// non-recoverable, not worth retrying
+			return false
+		}
+
+		// if syncthing worked before (up.success == true) and it's failing now, it's worth retrying
+		if strings.Contains(err.Error(), "syncthing local=false didn't respond after") {
+			return true
+		}
+
+		// because there might be other errors like syncthing, we retry on any error for a while
+		if !isTransientErr && up.unhandledTransientRetryCount < up.unhandledTransientMaxRetries {
+			oktetoLog.Debugf("handling error as transient because okteto up was successfully running before, but it's now failing with: %v (%d of %d)", err, up.unhandledTransientRetryCount, up.unhandledTransientMaxRetries)
+			up.unhandledTransientRetryCount++
+			return true
+		}
+	}
+
+	// the error is not transient, the up session has not succeeded yet, so it's not worth retrying
+	return false
+}
+
+// isFatalAfterSuccessError checks if the error is non-recoverable, and it's used to stop the retry process
+func isFatalAfterSuccessError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	switch {
+
+	case
+		strings.Contains(err.Error(), "cannot get resource \"deployments\" in API group \"apps\" in the namespace"), // delete role binding
+		strings.Contains(err.Error(), "not found in namespace"),                                                     // namespace deleted
+		strings.Contains(err.Error(), "development container has been deactivated"):                                 // running `okteto down` while `okteto up` is running
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/up/errors_test.go
+++ b/cmd/up/errors_test.go
@@ -110,28 +110,11 @@ func Test_isTransient(t *testing.T) {
 			},
 		},
 		{
-			name: "up.success true - retry any error",
-			input: input{
-				err: assert.AnError,
-				up: &upContext{
-					success:                      true,
-					unhandledTransientMaxRetries: 5,
-					unhandledTransientRetryCount: 3,
-				},
-			},
-			expected: expected{
-				isTransient:         true,
-				transientRetryCount: 4,
-			},
-		},
-		{
 			name: "up.success false - max retries exceeded",
 			input: input{
 				err: assert.AnError,
 				up: &upContext{
-					success:                      true,
-					unhandledTransientMaxRetries: 5,
-					unhandledTransientRetryCount: 5,
+					success: true,
 				},
 			},
 			expected: expected{
@@ -145,48 +128,6 @@ func Test_isTransient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			isTransientErr := tt.input.up.isTransient(tt.input.err)
 			assert.Equal(t, tt.expected.isTransient, isTransientErr)
-			assert.Equal(t, tt.expected.transientRetryCount, tt.input.up.unhandledTransientRetryCount)
-		})
-	}
-}
-
-func Test_isFatalAfterSuccessError(t *testing.T) {
-	tests := []struct {
-		err      error
-		name     string
-		expected bool
-	}{
-		{
-			name:     "nil error",
-			err:      nil,
-			expected: false,
-		},
-		{
-			name:     "recoverable error",
-			err:      errors.New("some transient error"),
-			expected: false,
-		},
-		{
-			name:     "non-recoverable error - deleted namespace",
-			err:      errors.New("application \"test\" not found in namespace \"testns\""),
-			expected: true,
-		},
-		{
-			name:     "non-recoverable error - deleted role binding",
-			err:      errors.New("cannot get resource \"deployments\" in API group \"apps\" in the namespace \"testns\": no matching resources found"),
-			expected: true,
-		},
-		{
-			name:     "non-recoverable error - okteto down while okteto up is running",
-			err:      errors.New("development container has been deactivated"),
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isFatalErr := isFatalAfterSuccessError(tt.err)
-			assert.Equal(t, tt.expected, isFatalErr)
 		})
 	}
 }

--- a/cmd/up/errors_test.go
+++ b/cmd/up/errors_test.go
@@ -1,0 +1,192 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isTransient(t *testing.T) {
+	type input struct {
+		up  *upContext
+		err error
+	}
+	type expected struct {
+		isTransient         bool
+		transientRetryCount int
+	}
+	tests := []struct {
+		input    input
+		name     string
+		expected expected
+	}{
+		{
+			name: "nil error",
+			input: input{
+				err: nil,
+				up:  &upContext{},
+			},
+			expected: expected{
+				isTransient: false,
+			},
+		},
+		{
+			name: "transient error - early return",
+			input: input{
+				err: errors.New("operation time out"),
+				up:  &upContext{},
+			},
+			expected: expected{
+				isTransient: true,
+			},
+		},
+		{
+			name: "up.success false - non transient error",
+			input: input{
+				err: assert.AnError,
+				up:  &upContext{},
+			},
+			expected: expected{
+				isTransient: false,
+			},
+		},
+		{
+			name: "up.success false - fatal error - namespace deleted",
+			input: input{
+				err: errors.New("application \"test\" not found in namespace \"testns\""),
+				up:  &upContext{},
+			},
+			expected: expected{
+				isTransient: false,
+			},
+		},
+		{
+			name: "up.success true - fatal error - namespace deleted",
+			input: input{
+				err: errors.New("application \"test\" not found in namespace \"testns\""),
+				up: &upContext{
+					success: true,
+				},
+			},
+			expected: expected{
+				isTransient: false,
+			},
+		},
+		{
+			name: "up.success false - syncthing local=false didn't respond after",
+			input: input{
+				err: errors.New("syncthing local=false didn't respond after 1m0s"),
+				up:  &upContext{},
+			},
+			expected: expected{
+				isTransient: false,
+			},
+		},
+		{
+			name: "up.success true - syncthing local=false didn't respond after",
+			input: input{
+				err: errors.New("syncthing local=false didn't respond after 1m0s"),
+				up: &upContext{
+					success: true,
+				},
+			},
+			expected: expected{
+				isTransient:         true,
+				transientRetryCount: 0,
+			},
+		},
+		{
+			name: "up.success true - retry any error",
+			input: input{
+				err: assert.AnError,
+				up: &upContext{
+					success:                      true,
+					unhandledTransientMaxRetries: 5,
+					unhandledTransientRetryCount: 3,
+				},
+			},
+			expected: expected{
+				isTransient:         true,
+				transientRetryCount: 4,
+			},
+		},
+		{
+			name: "up.success false - max retries exceeded",
+			input: input{
+				err: assert.AnError,
+				up: &upContext{
+					success:                      true,
+					unhandledTransientMaxRetries: 5,
+					unhandledTransientRetryCount: 5,
+				},
+			},
+			expected: expected{
+				isTransient:         false,
+				transientRetryCount: 5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isTransientErr := tt.input.up.isTransient(tt.input.err)
+			assert.Equal(t, tt.expected.isTransient, isTransientErr)
+			assert.Equal(t, tt.expected.transientRetryCount, tt.input.up.unhandledTransientRetryCount)
+		})
+	}
+}
+
+func Test_isFatalAfterSuccessError(t *testing.T) {
+	tests := []struct {
+		err      error
+		name     string
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "recoverable error",
+			err:      errors.New("some transient error"),
+			expected: false,
+		},
+		{
+			name:     "non-recoverable error - deleted namespace",
+			err:      errors.New("application \"test\" not found in namespace \"testns\""),
+			expected: true,
+		},
+		{
+			name:     "non-recoverable error - deleted role binding",
+			err:      errors.New("cannot get resource \"deployments\" in API group \"apps\" in the namespace \"testns\": no matching resources found"),
+			expected: true,
+		},
+		{
+			name:     "non-recoverable error - okteto down while okteto up is running",
+			err:      errors.New("development container has been deactivated"),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isFatalErr := isFatalAfterSuccessError(tt.err)
+			assert.Equal(t, tt.expected, isFatalErr)
+		})
+	}
+}

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -116,7 +116,7 @@ func (up *upContext) startSyncthing(ctx context.Context) error {
 
 	if err := up.Sy.WaitForPing(ctx, false); err != nil {
 		oktetoLog.Infof("failed to ping syncthing: %s", err.Error())
-		if oktetoErrors.IsTransient(err) {
+		if up.isTransient(err) {
 			return err
 		}
 		return up.checkOktetoStartError(ctx, "Failed to connect to the synchronization service")

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -81,6 +81,9 @@ type upContext struct {
 	resetSyncthing        bool
 	isTerm                bool
 	interruptReceived     bool
+
+	unhandledTransientMaxRetries int
+	unhandledTransientRetryCount int
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -81,9 +81,6 @@ type upContext struct {
 	resetSyncthing        bool
 	isTerm                bool
 	interruptReceived     bool
-
-	unhandledTransientMaxRetries int
-	unhandledTransientRetryCount int
 }
 
 // Forwarder is an interface for the port-forwarding features

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -253,21 +253,19 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLo
 			}
 
 			up := &upContext{
-				Manifest:                     oktetoManifest,
-				Dev:                          nil,
-				Exit:                         make(chan error, 1),
-				resetSyncthing:               upOptions.Reset,
-				StartTime:                    time.Now(),
-				Registry:                     registry.NewOktetoRegistry(okteto.Config{}),
-				Options:                      upOptions,
-				Fs:                           afero.NewOsFs(),
-				analyticsTracker:             at,
-				analyticsMeta:                upMeta,
-				K8sClientProvider:            okteto.NewK8sClientProviderWithLogger(k8sLogger),
-				tokenUpdater:                 newTokenUpdaterController(),
-				builder:                      buildv2.NewBuilderFromScratch(at, ioCtrl),
-				unhandledTransientMaxRetries: 100,
-				unhandledTransientRetryCount: 0,
+				Manifest:          oktetoManifest,
+				Dev:               nil,
+				Exit:              make(chan error, 1),
+				resetSyncthing:    upOptions.Reset,
+				StartTime:         time.Now(),
+				Registry:          registry.NewOktetoRegistry(okteto.Config{}),
+				Options:           upOptions,
+				Fs:                afero.NewOsFs(),
+				analyticsTracker:  at,
+				analyticsMeta:     upMeta,
+				K8sClientProvider: okteto.NewK8sClientProviderWithLogger(k8sLogger),
+				tokenUpdater:      newTokenUpdaterController(),
+				builder:           buildv2.NewBuilderFromScratch(at, ioCtrl),
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -253,19 +253,21 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLo
 			}
 
 			up := &upContext{
-				Manifest:          oktetoManifest,
-				Dev:               nil,
-				Exit:              make(chan error, 1),
-				resetSyncthing:    upOptions.Reset,
-				StartTime:         time.Now(),
-				Registry:          registry.NewOktetoRegistry(okteto.Config{}),
-				Options:           upOptions,
-				Fs:                afero.NewOsFs(),
-				analyticsTracker:  at,
-				analyticsMeta:     upMeta,
-				K8sClientProvider: okteto.NewK8sClientProviderWithLogger(k8sLogger),
-				tokenUpdater:      newTokenUpdaterController(),
-				builder:           buildv2.NewBuilderFromScratch(at, ioCtrl),
+				Manifest:                     oktetoManifest,
+				Dev:                          nil,
+				Exit:                         make(chan error, 1),
+				resetSyncthing:               upOptions.Reset,
+				StartTime:                    time.Now(),
+				Registry:                     registry.NewOktetoRegistry(okteto.Config{}),
+				Options:                      upOptions,
+				Fs:                           afero.NewOsFs(),
+				analyticsTracker:             at,
+				analyticsMeta:                upMeta,
+				K8sClientProvider:            okteto.NewK8sClientProviderWithLogger(k8sLogger),
+				tokenUpdater:                 newTokenUpdaterController(),
+				builder:                      buildv2.NewBuilderFromScratch(at, ioCtrl),
+				unhandledTransientMaxRetries: 100,
+				unhandledTransientRetryCount: 0,
 			}
 			up.inFd, up.isTerm = term.GetFdInfo(os.Stdin)
 			if up.isTerm {
@@ -748,7 +750,7 @@ func (up *upContext) activateLoop() {
 				continue
 			}
 
-			if oktetoErrors.IsTransient(err) {
+			if up.isTransient(err) {
 				isTransientError = true
 				continue
 			}
@@ -769,7 +771,7 @@ func (up *upContext) waitUntilExitOrInterruptOrApply(ctx context.Context) error 
 			oktetoLog.Println()
 			if err != nil {
 				oktetoLog.Infof("command failed: %s", err)
-				if oktetoErrors.IsTransient(err) {
+				if up.isTransient(err) {
 					return err
 				}
 				return oktetoErrors.CommandError{

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,177 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		err      error
+		name     string
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non transient error",
+			err:      assert.AnError,
+			expected: false,
+		},
+		{
+			name:     "operation time out",
+			err:      errors.New("operation time out"),
+			expected: true,
+		},
+		{
+			name:     "operation timed out",
+			err:      errors.New("operation timed out"),
+			expected: true,
+		},
+		{
+			name:     "i/o timeout",
+			err:      errors.New("i/o timeout"),
+			expected: true,
+		},
+		{
+			name:     "unknown (get events)",
+			err:      errors.New("unknown (get events)"),
+			expected: true,
+		},
+		{
+			name:     "Client.Timeout exceeded while awaiting headers",
+			err:      errors.New("Client.Timeout exceeded while awaiting headers"),
+			expected: true,
+		},
+		{
+			name:     "can't assign requested address",
+			err:      errors.New("can't assign requested address"),
+			expected: true,
+		},
+		{
+			name:     "command exited without exit status or exit signal",
+			err:      errors.New("command exited without exit status or exit signal"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset by peer",
+			err:      errors.New("connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "client connection lost",
+			err:      errors.New("client connection lost"),
+			expected: true,
+		},
+		{
+			name:     "nodename nor servname provided, or not known",
+			err:      errors.New("nodename nor servname provided, or not known"),
+			expected: true,
+		},
+		{
+			name:     "no route to host",
+			err:      errors.New("no route to host"),
+			expected: true,
+		},
+		{
+			name:     "unexpected EOF",
+			err:      errors.New("unexpected EOF"),
+			expected: true,
+		},
+		{
+			name:     "TLS handshake timeout",
+			err:      errors.New("TLS handshake timeout"),
+			expected: true,
+		},
+		{
+			name:     "in the time allotted",
+			err:      errors.New("in the time allotted"),
+			expected: true,
+		},
+		{
+			name:     "broken pipe",
+			err:      errors.New("broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "No connection could be made",
+			err:      errors.New("No connection could be made"),
+			expected: true,
+		},
+		{
+			name:     "operation was canceled",
+			err:      errors.New("operation was canceled"),
+			expected: true,
+		},
+		{
+			name:     "network is unreachable",
+			err:      errors.New("network is unreachable"),
+			expected: true,
+		},
+		{
+			name:     "development container has been removed",
+			err:      errors.New("development container has been removed"),
+			expected: true,
+		},
+		{
+			name:     "unexpected packet in response to channel open",
+			err:      errors.New("unexpected packet in response to channel open"),
+			expected: true,
+		},
+		{
+			name:     "closing remote connection: EOF",
+			err:      errors.New("closing remote connection: EOF"),
+			expected: true,
+		},
+		{
+			name:     "request for pseudo terminal failed: eof",
+			err:      errors.New("request for pseudo terminal failed: eof"),
+			expected: true,
+		},
+		{
+			name:     "unable to upgrade connection",
+			err:      errors.New("unable to upgrade connection"),
+			expected: true,
+		},
+		{
+			name:     "command execution failed: eof",
+			err:      errors.New("command execution failed: eof"),
+			expected: true,
+		},
+		{
+			name:     "syncthing local=false didn't respond after",
+			err:      errors.New("syncthing local=false didn't respond after 1m0s"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsTransient(tt.err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -344,6 +344,7 @@ func (s *Syncthing) WaitForPing(ctx context.Context, local bool) error {
 		select {
 		case <-ticker.C:
 			if s.Ping(ctx, local) {
+				oktetoLog.Infof("syncthing local=%t is ready", local)
 				return nil
 			}
 			if retries%5 == 0 {


### PR DESCRIPTION
# Proposed changes

This PR was already approved and merged: https://github.com/okteto/okteto/pull/4156

However it was reverted because E2E tests were failing: https://github.com/okteto/okteto/pull/4162

The tests were failing because the new behavior of `okteto up` is to retry 100 times before exiting and the tests were not ready for it.

Now I've added a new logic that checks if errors are non recoverable, for example by deleting the namespace in which the dev container is deployed.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
