### PR TITLE
fix: context insecure is maintained until deleted the context

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -355,6 +355,7 @@ func getLoggedUserContext(ctx context.Context, c *Command, ctxOptions *Options) 
 	ctxOptions.Token = user.Token
 
 	okteto.GetContext().Token = user.Token
+	okteto.SetInsecureSkipTLSVerifyPolicy(okteto.GetContext().IsStoredAsInsecure)
 
 	if ctxOptions.Namespace == "" {
 		ctxOptions.Namespace = user.Namespace

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -50,6 +50,7 @@ type Client struct {
 type ClientProvider struct{}
 
 var insecureSkipTLSVerify bool
+var onceInsecureWarning *sync.Once = &sync.Once{}
 var serverName string
 var strictTLSOnce sync.Once
 var errURLNotSet = errors.New("the okteto URL is not set")
@@ -465,11 +466,13 @@ func (c *Client) Endpoint() types.EndpointClientInterface {
 }
 
 func SetInsecureSkipTLSVerifyPolicy(isInsecure bool) {
-	oktetoLog.Debugf("insecure mode: %t", isInsecure)
-	if isInsecure {
-		oktetoLog.Warning("Insecure mode enabled")
-	}
-	insecureSkipTLSVerify = isInsecure
+	onceInsecureWarning.Do(func() {
+		oktetoLog.Debugf("insecure mode: %t", isInsecure)
+		if isInsecure {
+			oktetoLog.Warning("Insecure mode enabled")
+		}
+		insecureSkipTLSVerify = isInsecure
+	})
 }
 
 func IsInsecureSkipTLSVerifyPolicy() bool {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-26

If the context was set using the `--insecure-skip-tls-verify` flag other commands like kubeconfig or namespace where not using the property set before and was creating an invalid kubeconfig which causes failures.


## How to validate

1. Run `okteto context URL --insecure-skip-tls-verify`
1. Run cat `$HOME/.okteto/context/config.json` and check that `isInsecure` is set
1. Run `okteto ns`
1. Run cat `$HOME/.okteto/context/config.json` and check that `isInsecure` is set
1. Run `okteto kubeconfig`  
1. Run cat `$HOME/.okteto/context/config.json` and check that `isInsecure` is set

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
