### PR TITLE
fix: hybrid interruption

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -215,7 +215,7 @@ func executeExec(ctx context.Context, dev *model.Dev, args []string, k8sLogger *
 				return err
 			}
 
-			cmd, err := executor.GetCommandToExec(args)
+			cmd, err := executor.GetCommandToExec(ctx, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -59,16 +59,16 @@ type HybridExecCtx struct {
 }
 
 // GetCommandToExec returns the command to exec into the hybrid mode
-func (he *hybridExecutor) GetCommandToExec(cmd []string) (*exec.Cmd, error) {
+func (he *hybridExecutor) GetCommandToExec(ctx context.Context, cmd []string) (*exec.Cmd, error) {
 	var c *exec.Cmd
 	if runtime.GOOS != "windows" {
-		c = exec.Command(cmd[0], cmd[1:]...)
+		c = exec.CommandContext(ctx, cmd[0], cmd[1:]...)
 	} else {
 		binary, err := expandExecutableInCurrentDirectory(cmd[0], he.workdir)
 		if err != nil {
 			return nil, err
 		}
-		c = exec.Command(binary, cmd[1:]...)
+		c = exec.CommandContext(ctx, binary, cmd[1:]...)
 	}
 
 	c.Env = he.envs
@@ -428,7 +428,7 @@ func (up *upContext) RunCommand(ctx context.Context, cmd []string) error {
 				return err
 			}
 
-			cmd, err := executor.GetCommandToExec(cmd)
+			cmd, err := executor.GetCommandToExec(ctx, cmd)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-21

This is a first approach in order to show some information to the user. We can't reconnect to the tty because we are always getting the ttyou signal which causes that we can't log into the terminal no more. However I added the code in the wait for the command execution completion just in case we could find a way to unblock the tty.

## How to validate

1. Run an hybrid application
1. Delete the pod you are connected
1. See a proper error

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

