### PR TITLE
Add Branch column to preview environment list command output

### DIFF
--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -44,6 +44,7 @@ type previewOutput struct {
 	Scope    string   `json:"scope" yaml:"scope"`
 	Labels   []string `json:"labels" yaml:"labels"`
 	Sleeping bool     `json:"sleeping" yaml:"sleeping"`
+	Branch   string   `json:"branch" yaml:"branch"`
 }
 
 type listPreviewCommand struct {
@@ -136,7 +137,7 @@ func displayListPreviews(previews []previewOutput, outputFormat string) error {
 			return nil
 		}
 		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
-		fmt.Fprint(w, "Name\tScope\tSleeping\tLabels\n")
+		fmt.Fprint(w, "Name\tScope\tSleeping\tBranch\tLabels\n")
 		for _, preview := range previews {
 			output := getPreviewDefaultOutput(preview)
 			fmt.Fprint(w, output)
@@ -152,7 +153,7 @@ func getPreviewDefaultOutput(preview previewOutput) string {
 	if len(preview.Labels) > 0 {
 		previewLabels = strings.Join(preview.Labels, ", ")
 	}
-	return fmt.Sprintf("%s\t%s\t%v\t%s\n", preview.Name, preview.Scope, preview.Sleeping, previewLabels)
+	return fmt.Sprintf("%s\t%s\t%v\t%s\t%s\n", preview.Name, preview.Scope, preview.Sleeping, preview.Branch, previewLabels)
 }
 
 // getPreviewOutput transforms type.Preview into previewOutput type
@@ -164,6 +165,7 @@ func getPreviewOutput(previews []types.Preview) []previewOutput {
 			Scope:    p.Scope,
 			Sleeping: p.Sleeping,
 			Labels:   p.PreviewLabels,
+			Branch:   p.Branch,
 		}
 		previewSlice = append(previewSlice, previewOutput)
 	}

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -42,9 +42,9 @@ type listFlags struct {
 type previewOutput struct {
 	Name     string   `json:"name" yaml:"name"`
 	Scope    string   `json:"scope" yaml:"scope"`
+	Branch   string   `json:"branch" yaml:"branch"`
 	Labels   []string `json:"labels" yaml:"labels"`
 	Sleeping bool     `json:"sleeping" yaml:"sleeping"`
-	Branch   string   `json:"branch" yaml:"branch"`
 }
 
 type listPreviewCommand struct {

--- a/cmd/preview/list_test.go
+++ b/cmd/preview/list_test.go
@@ -121,8 +121,9 @@ func Test_getPreviewDefaultOutput(t *testing.T) {
 				Name:     "my-preview",
 				Scope:    "personal",
 				Sleeping: false,
+				Branch:   "test-branch",
 			},
-			expected: "my-preview\tpersonal\tfalse\t-\n",
+			expected: "my-preview\tpersonal\tfalse\ttest-branch\t-\n",
 		},
 		{
 			name: "preview with labels",
@@ -131,8 +132,9 @@ func Test_getPreviewDefaultOutput(t *testing.T) {
 				Scope:    "personal",
 				Sleeping: false,
 				Labels:   []string{"one", "two"},
+				Branch:   "test-branch",
 			},
-			expected: "my-preview\tpersonal\tfalse\tone, two\n",
+			expected: "my-preview\tpersonal\tfalse\ttest-branch\tone, two\n",
 		},
 	}
 
@@ -175,16 +177,18 @@ func Test_displayListPreviews(t *testing.T) {
 					Scope:    "personal",
 					Sleeping: true,
 					Labels:   []string{"test", "okteto"},
+					Branch:   "test-branch-1",
 				},
 				{
 					Name:     "test2",
 					Scope:    "global",
 					Sleeping: true,
+					Branch:   "test-branch-2",
 				},
 			},
-			expectedOutput: `Name   Scope     Sleeping  Labels
-test   personal  true      test, okteto
-test2  global    true      -
+			expectedOutput: `Name   Scope     Sleeping  Branch         Labels
+test   personal  true      test-branch-1  test, okteto
+test2  global    true      test-branch-2  -
 `,
 		},
 		{
@@ -196,14 +200,16 @@ test2  global    true      -
 					Scope:    "personal",
 					Sleeping: true,
 					Labels:   []string{"test", "okteto"},
+					Branch:   "test-branch-1",
 				},
 				{
 					Name:     "test2",
 					Scope:    "global",
 					Sleeping: true,
+					Branch:   "test-branch-2",
 				},
 			},
-			expectedOutput: "[\n {\n  \"name\": \"test\",\n  \"scope\": \"personal\",\n  \"labels\": [\n   \"test\",\n   \"okteto\"\n  ],\n  \"sleeping\": true\n },\n {\n  \"name\": \"test2\",\n  \"scope\": \"global\",\n  \"labels\": null,\n  \"sleeping\": true\n }\n]\n",
+			expectedOutput: "[\n {\n  \"name\": \"test\",\n  \"scope\": \"personal\",\n  \"labels\": [\n   \"test\",\n   \"okteto\"\n  ],\n  \"sleeping\": true,\n  \"branch\": \"test-branch-1\"\n },\n {\n  \"name\": \"test2\",\n  \"scope\": \"global\",\n  \"labels\": null,\n  \"sleeping\": true,\n  \"branch\": \"test-branch-2\"\n }\n]\n",
 		},
 		{
 			name:   "list - yaml format",
@@ -214,14 +220,16 @@ test2  global    true      -
 					Scope:    "personal",
 					Sleeping: true,
 					Labels:   []string{"test", "okteto"},
+					Branch:   "test-branch-1",
 				},
 				{
 					Name:     "test2",
 					Scope:    "global",
 					Sleeping: true,
+					Branch:   "test-branch-2",
 				},
 			},
-			expectedOutput: "- name: test\n  scope: personal\n  labels:\n  - test\n  - okteto\n  sleeping: true\n- name: test2\n  scope: global\n  labels: []\n  sleeping: true\n\n",
+			expectedOutput: "- name: test\n  scope: personal\n  labels:\n  - test\n  - okteto\n  sleeping: true\n  branch: test-branch-1\n- name: test2\n  scope: global\n  labels: []\n  sleeping: true\n  branch: test-branch-2\n\n",
 		},
 	}
 

--- a/cmd/preview/list_test.go
+++ b/cmd/preview/list_test.go
@@ -209,7 +209,7 @@ test2  global    true      test-branch-2  -
 					Branch:   "test-branch-2",
 				},
 			},
-			expectedOutput: "[\n {\n  \"name\": \"test\",\n  \"scope\": \"personal\",\n  \"labels\": [\n   \"test\",\n   \"okteto\"\n  ],\n  \"sleeping\": true,\n  \"branch\": \"test-branch-1\"\n },\n {\n  \"name\": \"test2\",\n  \"scope\": \"global\",\n  \"labels\": null,\n  \"sleeping\": true,\n  \"branch\": \"test-branch-2\"\n }\n]\n",
+			expectedOutput: "[\n {\n  \"name\": \"test\",\n  \"scope\": \"personal\",\n  \"branch\": \"test-branch-1\",\n  \"labels\": [\n   \"test\",\n   \"okteto\"\n  ],\n  \"sleeping\": true\n },\n {\n  \"name\": \"test2\",\n  \"scope\": \"global\",\n  \"branch\": \"test-branch-2\",\n  \"labels\": null,\n  \"sleeping\": true\n }\n]\n",
 		},
 		{
 			name:   "list - yaml format",
@@ -229,7 +229,7 @@ test2  global    true      test-branch-2  -
 					Branch:   "test-branch-2",
 				},
 			},
-			expectedOutput: "- name: test\n  scope: personal\n  labels:\n  - test\n  - okteto\n  sleeping: true\n  branch: test-branch-1\n- name: test2\n  scope: global\n  labels: []\n  sleeping: true\n  branch: test-branch-2\n\n",
+			expectedOutput: "- name: test\n  scope: personal\n  branch: test-branch-1\n  labels:\n  - test\n  - okteto\n  sleeping: true\n- name: test2\n  scope: global\n  branch: test-branch-2\n  labels: []\n  sleeping: true\n\n",
 		},
 	}
 

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -143,6 +143,7 @@ type previewEnv struct {
 	Scope         graphql.String
 	PreviewLabels []graphql.String
 	Sleeping      graphql.Boolean
+	Branch        graphql.String
 }
 
 type deployPreviewResponse struct {
@@ -279,6 +280,7 @@ func (c *previewClient) List(ctx context.Context, labels []string) ([]types.Prev
 			Sleeping:      bool(previewEnv.Sleeping),
 			Scope:         string(previewEnv.Scope),
 			PreviewLabels: labels,
+			Branch:        string(previewEnv.Branch),
 		})
 	}
 

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -141,9 +141,9 @@ type deprecatedPreviewEnv struct {
 type previewEnv struct {
 	Id            graphql.String
 	Scope         graphql.String
+	Branch        graphql.String
 	PreviewLabels []graphql.String
 	Sleeping      graphql.Boolean
-	Branch        graphql.String
 }
 
 type deployPreviewResponse struct {

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -310,6 +310,7 @@ func TestListPreview(t *testing.T) {
 								Id:       "test",
 								Sleeping: false,
 								Scope:    "test",
+								Branch:   "test-branch",
 							},
 						},
 					},
@@ -323,6 +324,7 @@ func TestListPreview(t *testing.T) {
 						Sleeping:      false,
 						Scope:         "test",
 						PreviewLabels: []string{},
+						Branch:        "test-branch",
 					},
 				},
 				err: nil,
@@ -342,6 +344,7 @@ func TestListPreview(t *testing.T) {
 								PreviewLabels: []graphql.String{
 									"value",
 								},
+								Branch: "test-branch",
 							},
 						},
 					},
@@ -357,6 +360,7 @@ func TestListPreview(t *testing.T) {
 						PreviewLabels: []string{
 							"value",
 						},
+						Branch: "test-branch",
 					},
 				},
 				err: nil,

--- a/pkg/types/preview.go
+++ b/pkg/types/preview.go
@@ -17,12 +17,12 @@ package types
 type Preview struct {
 	ID            string        `json:"id" yaml:"id"`
 	Scope         string        `json:"scope" yaml:"scope"`
+	Branch        string        `json:"branch" yaml:"branch"`
 	GitDeploys    []GitDeploy   `json:"gitDeploys"`
 	Statefulsets  []Statefulset `json:"statefulsets"`
 	Deployments   []Deployment  `json:"deployments"`
 	PreviewLabels []string      `json:"previewLabels" yaml:"previewLabels"`
 	Sleeping      bool          `json:"sleeping" yaml:"sleeping"`
-	Branch        string        `json:"branch" yaml:"branch"`
 }
 
 // PreviewResponse represents the response of a deployPreview

--- a/pkg/types/preview.go
+++ b/pkg/types/preview.go
@@ -22,6 +22,7 @@ type Preview struct {
 	Deployments   []Deployment  `json:"deployments"`
 	PreviewLabels []string      `json:"previewLabels" yaml:"previewLabels"`
 	Sleeping      bool          `json:"sleeping" yaml:"sleeping"`
+	Branch        string        `json:"branch" yaml:"branch"`
 }
 
 // PreviewResponse represents the response of a deployPreview


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/PROD-86

Customer requested that the `okteto preview list` command displays the branch of the preview environment.

## How to validate

Create a Preview Environment in your cluster using our documented approach here https://www.okteto.com/docs/preview/github/using-github-actions/

Then, with your CLI run the command `okteto preview list`.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
