### PR TITLE
Fix panic in `okteto up` when using remote deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,6 +289,7 @@ jobs:
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
+            $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
             go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
       - store_artifacts:
           path: C:\Users\circleci\.okteto

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -88,7 +88,9 @@ func (sh *serviceHasher) hashBuildContext(buildInfo *build.Info) (string, error)
 			return "", fmt.Errorf("could not get build context diff sha: %w", err)
 		}
 
+		sh.lock.Lock()
 		sh.buildContextCache[buildContext] = sh.hash(buildInfo, dirCommit, diffHash)
+		sh.lock.Unlock()
 	}
 
 	return sh.buildContextCache[buildContext], nil

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -290,7 +290,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLo
 				// the autocreate property is forced to be true
 				forceAutocreate = true
 			} else if upOptions.Deploy || (up.Manifest.IsV2 && !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Manifest.Namespace, k8sClient)) {
-				err := up.deployApp(ctx, k8sLogger)
+				err := up.deployApp(ctx, ioCtrl, k8sLogger)
 
 				// only allow error.ErrManifestFoundButNoDeployAndDependenciesCommands to go forward - autocreate property will deploy the app
 				if err != nil && !errors.Is(err, oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands) {
@@ -577,7 +577,7 @@ func getOverridedEnvVarsFromCmd(manifestEnvVars env.Environment, commandEnvVaria
 	return &overridedEnvVars, nil
 }
 
-func (up *upContext) deployApp(ctx context.Context, k8slogger *io.K8sLogger) error {
+func (up *upContext) deployApp(ctx context.Context, ioCtrl *io.Controller, k8slogger *io.K8sLogger) error {
 	k8sProvider := okteto.NewK8sClientProviderWithLogger(k8slogger)
 	pc, err := pipelineCMD.NewCommand()
 	if err != nil {
@@ -596,6 +596,7 @@ func (up *upContext) deployApp(ctx context.Context, k8slogger *io.K8sLogger) err
 		DeployWaiter:       deploy.NewDeployWaiter(k8sProvider, k8slogger),
 		EndpointGetter:     deploy.NewEndpointGetter,
 		AnalyticsTracker:   up.analyticsTracker,
+		IoCtrl:             ioCtrl,
 	}
 
 	startTime := time.Now()

--- a/integration/up/deploy_remote_test.go
+++ b/integration/up/deploy_remote_test.go
@@ -82,14 +82,18 @@ func TestUpWithDeployRemote(t *testing.T) {
 	require.NoError(t, writeFile(filepath.Join(dir, ".stignore"), stignoreContent))
 	require.NoError(t, createAppDockerfile(dir))
 
+	appName := "e2e"
 	upOptions := &commands.UpOptions{
-		Name:       "e2etest",
+		Name:       appName,
 		Namespace:  testNamespace,
 		Workdir:    dir,
 		Deploy:     true,
 		OktetoHome: dir,
 		Token:      token,
 	}
+
+	require.LessOrEqual(t, len(testNamespace+appName), 63)
+
 	upResult, err := commands.RunOktetoUp(oktetoPath, upOptions)
 	require.NoError(t, err)
 

--- a/integration/up/deploy_remote_test.go
+++ b/integration/up/deploy_remote_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+// +build integration
+
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"context"
+	"fmt"
+	"github.com/okteto/okteto/pkg/log/io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/okteto/okteto/integration"
+	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	oktetoManifestV2DeployRemote = `build:
+  app:
+    context: app
+    dockerfile: Dockerfile
+    image: okteto.dev/test:1.0.0
+deploy:
+  remote: true
+  commands:
+    - kubectl apply -f deployment.yaml
+dev:
+  e2etest:
+    image: ${OKTETO_BUILD_APP_IMAGE}
+    command: echo value1 > /usr/src/app/var.html && python -m http.server 8080
+    workdir: /usr/src/app
+    sync:
+    - .:/usr/src/app
+`
+)
+
+func TestUpWithDeployRemote(t *testing.T) {
+	t.Setenv("OKTETO_K8S_REQUESTS_LOGGER_ENABLED", "true")
+	// Prepare environment
+
+	dir := t.TempDir()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	testNamespace := integration.GetTestNamespace("TestUpWithDeployRemote", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
+
+	indexPath := filepath.Join(dir, "index.html")
+	require.NoError(t, writeFile(indexPath, testNamespace))
+	log.Printf("original 'index.html' content: %s", testNamespace)
+
+	require.NoError(t, writeFile(filepath.Join(dir, "deployment.yaml"), k8sManifestTemplate))
+	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), oktetoManifestV2DeployRemote))
+	require.NoError(t, writeFile(filepath.Join(dir, ".stignore"), stignoreContent))
+	require.NoError(t, createAppDockerfile(dir))
+
+	upOptions := &commands.UpOptions{
+		Name:       "e2etest",
+		Namespace:  testNamespace,
+		Workdir:    dir,
+		Deploy:     true,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	upResult, err := commands.RunOktetoUp(oktetoPath, upOptions)
+	require.NoError(t, err)
+
+	kubectlOpts := &commands.KubectlOptions{
+		Namespace:  testNamespace,
+		Name:       model.DevCloneName("e2etest"),
+		ConfigFile: filepath.Join(dir, ".kube", "config"),
+	}
+	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOpts, 1, timeout))
+
+	// Test that the app image has been created correctly
+	appDeployment, err := integration.GetDeployment(context.Background(), testNamespace, model.DevCloneName("e2etest"), c)
+	require.NoError(t, err)
+	appImageDev := fmt.Sprintf("%s/%s/test:1.0.0", okteto.GetContext().Registry, testNamespace)
+	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
+
+	indexRemoteEndpoint := fmt.Sprintf("https://e2etest-%s.%s/index.html", testNamespace, appsSubdomain)
+
+	// Test that the same content is on the remote and on local endpoint
+	require.Equal(t, integration.GetContentFromURL(indexRemoteEndpoint, timeout), testNamespace)
+
+	// Test that making a change gets reflected on remote
+	localupdatedContent := fmt.Sprintf("%s-updated-content", testNamespace)
+	require.NoError(t, writeFile(indexPath, localupdatedContent))
+	require.NoError(t, waitUntilUpdatedContent(indexRemoteEndpoint, localupdatedContent, timeout, upResult.ErrorChan))
+
+	// Test kill syncthing reconnection
+	require.NoError(t, killLocalSyncthing(upResult.Pid.Pid))
+	localSyncthingKilledContent := fmt.Sprintf("%s-kill-syncthing", testNamespace)
+	require.NoError(t, writeFile(indexPath, localSyncthingKilledContent))
+	require.NoError(t, waitUntilUpdatedContent(indexRemoteEndpoint, localSyncthingKilledContent, timeout, upResult.ErrorChan))
+
+	// Test destroy pod reconnection
+	require.NoError(t, integration.DestroyPod(context.Background(), testNamespace, "app=e2etest", c))
+	destroyPodContent := fmt.Sprintf("%s-destroy-pod", testNamespace)
+	require.NoError(t, writeFile(indexPath, destroyPodContent))
+	require.NoError(t, waitUntilUpdatedContent(indexRemoteEndpoint, destroyPodContent, timeout, upResult.ErrorChan))
+
+	// Test okteto down command
+	downOpts := &commands.DownOptions{
+		Namespace: testNamespace,
+		Workdir:   dir,
+		Token:     token,
+	}
+	require.NoError(t, commands.RunOktetoDown(oktetoPath, downOpts))
+
+	require.True(t, commands.HasUpCommandFinished(upResult.Pid.Pid))
+
+	k8sLogsFilePath := filepath.Join(dir, ".okteto", io.K8sLogsFileName)
+	require.FileExists(t, k8sLogsFilePath)
+	k8sLogs, err := os.ReadFile(k8sLogsFilePath)
+	require.NoError(t, err)
+	require.Contains(t, string(k8sLogs), fmt.Sprintf("running cmd: up --deploy=true --namespace=%s", testNamespace))
+}


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-147

`okteto up` would panic if the user attempted to remote deploy their service. To fix it, it was enough to pass the `ioCtrl` which was missing.

I've added a new integration test to cover this scenario. It's a copy of the existing test based on local deploy but I think it's worth having because they use very different deploy approaches.

Additionally, in the first commit, I've added a lock to prevent an additional panic that was occurring, about concurrent map writes happening in different goroutines.

## How to validate

To reproduce the bug follow these steps:

1. Using okteto `2.25.1`
1. Clone https://github.com/okteto/movies-frontend
1. Modify the `okteto.yml` to use remote deploy:
```
deploy:
  remote: true
  commands:
    - name: Deploy Frontend
      command: helm upgrade --install movies-frontend chart --set image=${OKTETO_BUILD_FRONTEND_IMAGE}
    - kubectl apply -f code.yml
```
1. Run `okteto up`
1. Notice the panic
1. Repeat the tests with the CLI built from this branch and notice how the `okteto up` succeeds.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
