### PR TITLE
[Integration Tests] Make namespace prefix shorter to avoid reaching hard limit of 63 chars on subdomain

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -109,7 +109,7 @@ func TestBuildCommandV1(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestBuildV1", user)
+	testNamespace := integration.GetTestNamespace("BuildV1", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -140,7 +140,7 @@ func TestBuildInferredDockerfile(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createDockerfile(dir))
 
-	testNamespace := integration.GetTestNamespace("TestBuildInferredDockerfile", user)
+	testNamespace := integration.GetTestNamespace("BuildInferredDockerfile", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -178,7 +178,7 @@ func TestBuildCommandV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestBuildV2", user)
+	testNamespace := integration.GetTestNamespace("BuildV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -217,7 +217,7 @@ func TestBuildCommandV2UsingDepot(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestBuildCommandV2UsingDepot", user)
+	testNamespace := integration.GetTestNamespace("BuildCommandV2UsingDepot", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -272,7 +272,7 @@ func TestBuildCommandV2OnlyOneService(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestPartialBuildV2", user)
+	testNamespace := integration.GetTestNamespace("PartialBuildV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -308,7 +308,7 @@ func TestBuildCommandV2SpecifyingServices(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestCompleteBuildV2", user)
+	testNamespace := integration.GetTestNamespace("CompleteBuildV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -348,7 +348,7 @@ func TestBuildCommandV2VolumeMounts(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestBuildVolumesV2", user)
+	testNamespace := integration.GetTestNamespace("BuildVolumesV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -387,7 +387,7 @@ func TestBuildCommandV2Secrets(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestBuildSecretsV2", user)
+	testNamespace := integration.GetTestNamespace("BuildSecretsV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -150,7 +150,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployCompose", user)
+	testNamespace := integration.GetTestNamespace("DeployCompose", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -230,7 +230,7 @@ func TestReDeployPipelineFromCompose(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestReDeployCompose", user)
+	testNamespace := integration.GetTestNamespace("ReDeployCompose", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -311,7 +311,7 @@ func TestDeployPipelineFromComposeOnlyOneSvc(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployPartialCompose", user)
+	testNamespace := integration.GetTestNamespace("DeployPartialCompose", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -372,7 +372,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createStacksScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployStacks", user)
+	testNamespace := integration.GetTestNamespace("DeployStacks", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -437,7 +437,7 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 	require.NoError(t, createComposeScenario(dir))
 	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), oktetoManifestV2WithCompose))
 
-	testNamespace := integration.GetTestNamespace("TestDeployComposeManifest", user)
+	testNamespace := integration.GetTestNamespace("DeployComposeManifest", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -519,7 +519,7 @@ services:
 	err = os.WriteFile(composePath, composeContent, 0600)
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestNotPanic", user)
+	testNamespace := integration.GetTestNamespace("NotPanic", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/helm_test.go
+++ b/integration/deploy/helm_test.go
@@ -103,7 +103,7 @@ func TestDeployPipelineFromHelm(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createHelmChart(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployHelm", user)
+	testNamespace := integration.GetTestNamespace("DeployHelm", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -147,7 +147,7 @@ func TestDeployFromHelmNameOK(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createHelmChart(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployFromHelmNameOK", user)
+	testNamespace := integration.GetTestNamespace("DeployFromHelmNameOK", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/k8s_manifest_test.go
+++ b/integration/deploy/k8s_manifest_test.go
@@ -89,7 +89,7 @@ func TestDeployDevEnvFromK8s(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployK8sFile", user)
+	testNamespace := integration.GetTestNamespace("DeployK8sFile", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -124,7 +124,7 @@ func TestDeployOktetoManifest(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployManifestV2", user)
+	testNamespace := integration.GetTestNamespace("DeployManifestV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -178,7 +178,7 @@ func TestRedeployOktetoManifestForImages(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("TestReDeploy", user)
+	testNamespace := integration.GetTestNamespace("ReDeploy", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -250,7 +250,7 @@ func TestDeployOktetoManifestWithDestroy(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployDestroy", user)
+	testNamespace := integration.GetTestNamespace("DeployDestroy", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -308,7 +308,7 @@ func TestDeployOktetoManifestExportCache(t *testing.T) {
 
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("TestDeployExportCache", user)
+	testNamespace := integration.GetTestNamespace("DeployExportCache", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -355,7 +355,7 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("TestDeployRemote", user)
+	testNamespace := integration.GetTestNamespace("DeployRemote", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -402,7 +402,7 @@ func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
 	dir := t.TempDir()
 	parentFolder := filepath.Join(dir, "test-parent")
 
-	testNamespace := integration.GetTestNamespace("TestDeployRemoteParent", user)
+	testNamespace := integration.GetTestNamespace("DeployRemoteParent", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -57,7 +57,7 @@ func TestDeployPipelineManifest(t *testing.T) {
 	require.NoError(t, createPipelineManifest(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployPipeline", user)
+	testNamespace := integration.GetTestNamespace("DeployPipeline", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		Token:      token,
@@ -102,7 +102,7 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	require.NoError(t, err)
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("TestDeploy", user)
+	testNamespace := integration.GetTestNamespace("Deploy", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/variables_test.go
+++ b/integration/deploy/variables_test.go
@@ -57,7 +57,7 @@ func TestDeployAndDestroyOktetoManifestWithEnv(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createOktetoManifestwithEnv(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployDestroyVars", user)
+	testNamespace := integration.GetTestNamespace("DeployDestroyVars", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deprecated/push/push_test.go
+++ b/integration/deprecated/push/push_test.go
@@ -92,7 +92,7 @@ func TestPush(t *testing.T) {
 	require.NoError(t, err)
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("TestPush", user)
+	testNamespace := integration.GetTestNamespace("Push", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -111,7 +111,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestPipeCompose", user)
+	testNamespace := integration.GetTestNamespace("PipeCompose", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -177,7 +177,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createStacksScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestPipeStacks", user)
+	testNamespace := integration.GetTestNamespace("PipeStacks", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -84,6 +84,8 @@ func GetTestNamespace(prefix, user string) string {
 	os := runtime.GOOS
 	if os == "windows" {
 		os = "win"
+	} else {
+		os = os[:3]
 	}
 	namespace := fmt.Sprintf("%s-%s-%d-%s", prefix, os, time.Now().Unix(), user)
 	return strings.ToLower(namespace)

--- a/integration/okteto/autowake_test.go
+++ b/integration/okteto/autowake_test.go
@@ -165,7 +165,7 @@ func TestAutoWakeFromURL(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestAutoWakeURL", user)
+	testNamespace := integration.GetTestNamespace("AutoWakeURL", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -229,7 +229,7 @@ func TestAutoWakeFromRunningUp(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestAutoWakeUp", user)
+	testNamespace := integration.GetTestNamespace("AutoWakeUp", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/build_test.go
+++ b/integration/okteto/build_test.go
@@ -51,7 +51,7 @@ func TestBuildReplaceSecretsInManifest(t *testing.T) {
 	require.NoError(t, createDockerfile(dir))
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
-	testNamespace := integration.GetTestNamespace("TestBuildWithSecrets", user)
+	testNamespace := integration.GetTestNamespace("BuildWithSecrets", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/dependencies_test.go
+++ b/integration/okteto/dependencies_test.go
@@ -45,7 +45,7 @@ func TestDependencies(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	testDeployNamespace := integration.GetTestNamespace("TestDeployDep", user)
+	testDeployNamespace := integration.GetTestNamespace("DeployDep", user)
 	namespaceDeployOpts := &commands.NamespaceOptions{
 		Namespace:  testDeployNamespace,
 		OktetoHome: dir,
@@ -54,7 +54,7 @@ func TestDependencies(t *testing.T) {
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceDeployOpts))
 	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceDeployOpts)
 
-	testNamespace := integration.GetTestNamespace("TestDependency", user)
+	testNamespace := integration.GetTestNamespace("Dependency", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -95,7 +95,7 @@ func TestDeploySuccessOutput(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestSuccessOutput", user)
+	testNamespace := integration.GetTestNamespace("SuccessOutput", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -161,7 +161,7 @@ func TestDeployWithNonSanitizedOK(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TestDeployWithNonSanitizedOK", user)
+	testNamespace := integration.GetTestNamespace("DeployWithNonSanitizedOK", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -196,7 +196,7 @@ func TestCmdFailOutput(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createCommandFailureManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("TestCmdFailOutput", user)
+	testNamespace := integration.GetTestNamespace("CmdFailOutput", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -261,7 +261,7 @@ func TestRemoteMaskVariables(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createCommandWitMaskValuesManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("TestRemoteMaskVariables", user)
+	testNamespace := integration.GetTestNamespace("RemoteMaskVariables", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -368,7 +368,7 @@ func TestComposeFailOutput(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createFailCompose(dir))
 
-	testNamespace := integration.GetTestNamespace("TestComposeFailOutput", user)
+	testNamespace := integration.GetTestNamespace("ComposeFailOutput", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/pipeline_test.go
+++ b/integration/okteto/pipeline_test.go
@@ -42,7 +42,7 @@ func TestPipelineCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	testNamespace := integration.GetTestNamespace("TestPipeline", user)
+	testNamespace := integration.GetTestNamespace("Pipeline", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -80,7 +80,7 @@ func TestPipelineDeployWithReuse(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	testNamespace := integration.GetTestNamespace("TestPipelineDeployWithReuse", user)
+	testNamespace := integration.GetTestNamespace("PipelineDeployWithReuse", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/preview_test.go
+++ b/integration/okteto/preview_test.go
@@ -31,7 +31,7 @@ func TestPreviewCommand(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestPreview", user)
+	testNamespace := integration.GetTestNamespace("Preview", user)
 	dir := t.TempDir()
 	previewOptions := &commands.DeployPreviewOptions{
 		Namespace:  testNamespace,

--- a/integration/up/autocreate_test.go
+++ b/integration/up/autocreate_test.go
@@ -95,7 +95,7 @@ func TestUpAutocreate(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpAutocreateV1", user)
+	testNamespace := integration.GetTestNamespace("UpAutocreateV1", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -183,7 +183,7 @@ func TestUpAutocreateV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpAutocreateV2", user)
+	testNamespace := integration.GetTestNamespace("UpAutocreateV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -271,7 +271,7 @@ func TestUpAutocreateV2WithBuild(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpAutocreateV2Build", user)
+	testNamespace := integration.GetTestNamespace("UpAutocreateV2Build", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/compose_test.go
+++ b/integration/up/compose_test.go
@@ -78,7 +78,7 @@ func TestUpCompose(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpCompose", user)
+	testNamespace := integration.GetTestNamespace("UpCompose", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/deploy_remote_test.go
+++ b/integration/up/deploy_remote_test.go
@@ -59,7 +59,7 @@ func TestUpWithDeployRemote(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpDeployRemote", user)
+	testNamespace := integration.GetTestNamespace("UpDeployRemote", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/deploy_test.go
+++ b/integration/up/deploy_test.go
@@ -60,7 +60,7 @@ func TestUpWithDeploy(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpWithDeploy", user)
+	testNamespace := integration.GetTestNamespace("UpWithDeploy", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/deployment_test.go
+++ b/integration/up/deployment_test.go
@@ -116,7 +116,7 @@ func TestUpDeploymentV1(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpDeploymentV1", user)
+	testNamespace := integration.GetTestNamespace("UpDeploymentV1", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -230,7 +230,7 @@ func TestUpDeploymentV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpDeploymentV2", user)
+	testNamespace := integration.GetTestNamespace("UpDeploymentV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/globalforward_test.go
+++ b/integration/up/globalforward_test.go
@@ -97,7 +97,7 @@ func TestUpGlobalForwarding(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestGlobalFwd", user)
+	testNamespace := integration.GetTestNamespace("GlobalFwd", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -103,7 +103,7 @@ func TestUpUsingHybridMode(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestHybridMode", user)
+	testNamespace := integration.GetTestNamespace("HybridMode", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/statefulset_test.go
+++ b/integration/up/statefulset_test.go
@@ -115,7 +115,7 @@ func TestUpStatefulsetV1(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpStatefulsetV1", user)
+	testNamespace := integration.GetTestNamespace("UpStatefulsetV1", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -228,7 +228,7 @@ func TestUpStatefulsetV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("TestUpStatefulsetV2", user)
+	testNamespace := integration.GetTestNamespace("UpStatefulsetV2", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,


### PR DESCRIPTION
# Proposed changes

Too often we're hitting issues with failing integration tests because the subdomain generated by `app name` + `namespace` is longer than 63 chars, which is an hard limit we have on subdomains.

The proposed change os to remove the prefix `Test` from all namespaces generated by integration tests.

The namespace name is already quite easy to recognize even if we remove such prefix.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
