### PR TITLE
fix: realpath on mac

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -49,7 +49,7 @@ const (
 
 // Command defines the build command
 type Command struct {
-	GetManifest func(path string) (*model.Manifest, error)
+	GetManifest func(path string, fs afero.Fs) (*model.Manifest, error)
 
 	Builder          buildCmd.OktetoBuilderInterface
 	Registry         registryInterface
@@ -153,7 +153,7 @@ func Build(ctx context.Context, ioCtrl *io.Controller, at analyticsTrackerInterf
 func (bc *Command) getBuilder(options *types.BuildOptions, okCtx *okteto.ContextStateless) (Builder, error) {
 	var builder Builder
 
-	manifest, err := bc.GetManifest(options.File)
+	manifest, err := bc.GetManifest(options.File, afero.NewOsFs())
 	if err != nil {
 		if options.File != "" && errors.Is(err, oktetoErrors.ErrInvalidManifest) && validateDockerfile(options.File) != nil {
 			return nil, err

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,21 +116,21 @@ var fakeManifestV2 *model.Manifest = &model.Manifest{
 	IsV2: true,
 }
 
-func getManifestWithError(_ string) (*model.Manifest, error) {
+func getManifestWithError(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return nil, assert.AnError
 }
 
-func getManifestWithInvalidManifestError(_ string) (*model.Manifest, error) {
+func getManifestWithInvalidManifestError(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return nil, oktetoErrors.ErrInvalidManifest
 }
 
-func getFakeManifestV1(_ string) (*model.Manifest, error) {
+func getFakeManifestV1(_ string, _ afero.Fs) (*model.Manifest, error) {
 	manifestV1 := *fakeManifestV2
 	manifestV1.IsV2 = false
 	return &manifestV1, nil
 }
 
-func getFakeManifestV2(_ string) (*model.Manifest, error) {
+func getFakeManifestV2(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return fakeManifestV2, nil
 }
 
@@ -216,7 +217,7 @@ func TestBuildIsManifestV2(t *testing.T) {
 		GetManifest: getFakeManifestV2,
 	}
 
-	manifest, err := bc.GetManifest("")
+	manifest, err := bc.GetManifest("", afero.NewMemMapFs())
 	assert.Nil(t, err)
 	assert.Equal(t, manifest, fakeManifestV2)
 }
@@ -226,7 +227,7 @@ func TestBuildFromDockerfile(t *testing.T) {
 		GetManifest: getManifestWithError,
 	}
 
-	manifest, err := bc.GetManifest("")
+	manifest, err := bc.GetManifest("", afero.NewMemMapFs())
 	assert.NotNil(t, err)
 	assert.Nil(t, manifest)
 }
@@ -236,7 +237,7 @@ func TestBuildErrIfInvalidManifest(t *testing.T) {
 		GetManifest: getManifestWithInvalidManifestError,
 	}
 
-	manifest, err := bc.GetManifest("")
+	manifest, err := bc.GetManifest("", afero.NewMemMapFs())
 	assert.NotNil(t, err)
 	assert.Nil(t, manifest)
 }

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -29,6 +29,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -140,7 +141,7 @@ func getCtxResource(path string) (*model.ContextResource, error) {
 }
 
 // LoadManifestWithContext loads context and then loads a manifest
-func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.Manifest, error) {
+func LoadManifestWithContext(ctx context.Context, opts ManifestOptions, fs afero.Fs) (*model.Manifest, error) {
 	ctxResource, err := model.GetContextResource(opts.Filename)
 	if err != nil {
 		return nil, err
@@ -163,12 +164,12 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 		return nil, err
 	}
 
-	manifest, err := model.GetManifestV1(opts.Filename)
+	manifest, err := model.GetManifestV1(opts.Filename, fs)
 	if err != nil {
 		if !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
 			return nil, err
 		}
-		manifest, err = model.GetManifestV2(opts.Filename)
+		manifest, err = model.GetManifestV2(opts.Filename, fs)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +190,7 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions) (*model.
 	return manifest, nil
 }
 
-func LoadStackWithContext(ctx context.Context, name, namespace string, stackPaths []string) (*model.Stack, error) {
+func LoadStackWithContext(ctx context.Context, name, namespace string, stackPaths []string, fs afero.Fs) (*model.Stack, error) {
 	ctxResource, err := utils.LoadStackContext(stackPaths)
 	if err != nil {
 		if name == "" {
@@ -212,7 +213,7 @@ func LoadStackWithContext(ctx context.Context, name, namespace string, stackPath
 		return nil, err
 	}
 
-	s, err := model.LoadStack(name, stackPaths, true)
+	s, err := model.LoadStack(name, stackPaths, true, fs)
 	if err != nil {
 		if name == "" {
 			return nil, err

--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -211,7 +212,7 @@ dependencies:
 				filename = ""
 			}
 
-			m, err := model.GetManifestV2(filename)
+			m, err := model.GetManifestV2(filename, afero.NewMemMapFs())
 			if tt.expectedErr {
 				assert.NotNil(t, err)
 			} else {

--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -187,6 +187,7 @@ dependencies:
 					},
 				},
 				External: externalresource.Section{},
+				Fs:       afero.NewOsFs(),
 			},
 		},
 		{

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -103,7 +103,7 @@ type getDeployerFunc func(
 
 // Command defines the config for deploying an app
 type Command struct {
-	GetManifest        func(path string) (*model.Manifest, error)
+	GetManifest        func(path string, fs afero.Fs) (*model.Manifest, error)
 	TempKubeconfigFile string
 	K8sClientProvider  okteto.K8sClientProviderWithLogger
 	Builder            builderInterface
@@ -274,7 +274,7 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Contro
 // RunDeploy runs the deploy sequence
 func (dc *Command) RunDeploy(ctx context.Context, deployOptions *Options) error {
 	oktetoLog.SetStage("Load manifest")
-	manifest, err := dc.GetManifest(deployOptions.ManifestPath)
+	manifest, err := dc.GetManifest(deployOptions.ManifestPath, dc.Fs)
 	if err != nil {
 		return err
 	}

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -771,23 +771,23 @@ func TestDeployWithoutErrors(t *testing.T) {
 	assert.Equal(t, pipeline.DeployedStatus, cfg.Data["status"])
 }
 
-func getManifestWithError(_ string) (*model.Manifest, error) {
+func getManifestWithError(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return nil, assert.AnError
 }
 
-func getFakeManifest(_ string) (*model.Manifest, error) {
+func getFakeManifest(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return fakeManifest, nil
 }
 
-func getErrorManifest(_ string) (*model.Manifest, error) {
+func getErrorManifest(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return errorManifest, nil
 }
 
-func getManifestWithNoDeployNorDependency(_ string) (*model.Manifest, error) {
+func getManifestWithNoDeployNorDependency(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return noDeployNorDependenciesManifest, nil
 }
 
-func getFakeManifestWithDependency(_ string) (*model.Manifest, error) {
+func getFakeManifestWithDependency(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return fakeManifestWithDependency, nil
 }
 

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -32,6 +32,7 @@ import (
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +58,7 @@ type k8sIngressClientProvider interface {
 }
 
 type EndpointGetter struct {
-	GetManifest     func(path string) (*model.Manifest, error)
+	GetManifest     func(path string, fs afero.Fs) (*model.Manifest, error)
 	endpointControl endpointControlInterface
 }
 
@@ -131,7 +132,7 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 			}
 
 			if options.Name == "" {
-				manifest, err := eg.GetManifest(options.ManifestPath)
+				manifest, err := eg.GetManifest(options.ManifestPath, afero.NewOsFs())
 				if err != nil {
 					return err
 				}

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	oktetoPath "github.com/okteto/okteto/pkg/path"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 )
@@ -94,7 +95,7 @@ type destroyCommand struct {
 	k8sClientProvider okteto.K8sClientProvider
 	ConfigMapHandler  configMapHandler
 	analyticsTracker  analyticsTrackerInterface
-	getManifest       func(path string) (*model.Manifest, error)
+	getManifest       func(path string, fs afero.Fs) (*model.Manifest, error)
 	oktetoClient      *okteto.Client
 	ioCtrl            *io.Controller
 	buildCtrl         buildCtrl
@@ -283,7 +284,7 @@ func (dc *destroyCommand) getDestroyer(ctx context.Context, opts *Options) (dest
 
 		oktetoLog.Info("Destroying all...")
 	} else {
-		manifest, err := dc.getManifest(opts.ManifestPath)
+		manifest, err := dc.getManifest(opts.ManifestPath, afero.NewOsFs())
 		if err != nil {
 			// Log error message but application can still be deleted
 			oktetoLog.Infof("could not find manifest file to be executed: %s", err)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -25,6 +25,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +52,7 @@ func Doctor(k8sLogger *io.K8sLogger) *cobra.Command {
 				return oktetoErrors.ErrNotInDevContainer
 			}
 
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: doctorOpts.DevPath, Namespace: doctorOpts.Namespace, K8sContext: doctorOpts.K8sContext})
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: doctorOpts.DevPath, Namespace: doctorOpts.Namespace, K8sContext: doctorOpts.K8sContext}, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -34,6 +34,7 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/syncthing"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 )
@@ -61,7 +62,7 @@ func Down(k8sLogsCtrl *io.K8sLogger) *cobra.Command {
 				}
 				devPath = model.GetManifestPathFromWorkdir(devPath, workdir)
 			}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -34,6 +34,7 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/ssh"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -57,7 +58,7 @@ func Exec(k8sLogger *io.K8sLogger) *cobra.Command {
 			defer cancel()
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: execFlags.manifestPath, Namespace: execFlags.namespace, K8sContext: execFlags.k8sContext}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stern/stern/stern"
 )
@@ -64,7 +65,7 @@ func Logs(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: options.ManifestPath, Namespace: options.Namespace, K8sContext: options.Context})
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: options.ManifestPath, Namespace: options.Namespace, K8sContext: options.Context}, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/manifest/init-v1_test.go
+++ b/cmd/manifest/init-v1_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
@@ -61,7 +62,7 @@ func TestRun(t *testing.T) {
 	_, err := os.Stat(stignorePath)
 	require.NoError(t, err)
 
-	manifest, err := utils.DeprecatedLoadManifest(p)
+	manifest, err := utils.DeprecatedLoadManifest(p, afero.NewMemMapFs())
 	require.NoError(t, err)
 
 	dev, err := utils.GetDevFromManifest(manifest, "")
@@ -82,7 +83,7 @@ func TestRun(t *testing.T) {
 		t.Fatalf("manifest wasn't overwritten: %s", err)
 	}
 
-	manifest, err = utils.DeprecatedLoadManifest(p)
+	manifest, err = utils.DeprecatedLoadManifest(p, afero.NewMemMapFs())
 	require.NoError(t, err)
 
 	dev, err = utils.GetDevFromManifest(manifest, "")

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -85,7 +85,7 @@ func (mc *Command) RunInitV2(ctx context.Context, opts *InitOpts) (*model.Manife
 	manifest := model.NewManifest()
 	var err error
 	if !opts.Overwrite {
-		manifest, err = model.GetManifestV2(opts.DevPath)
+		manifest, err = model.GetManifestV2(opts.DevPath, afero.NewOsFs())
 		if err != nil && !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
 			return nil, err
 		}
@@ -356,7 +356,7 @@ func getPathFromApp(wd, appName string) string {
 }
 
 func createFromCompose(composePath string) (*model.Manifest, error) {
-	stack, err := model.LoadStack("", []string{composePath}, true)
+	stack, err := model.LoadStack("", []string{composePath}, true, afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func inferBuildSectionFromDockerfiles(cwd string, dockerfiles []string) (build.M
 }
 
 func inferDeploySection(cwd string) (*model.DeployInfo, error) {
-	m, err := model.GetInferredManifest(cwd)
+	m, err := model.GetInferredManifest(cwd, afero.NewOsFs())
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +493,7 @@ func inferDevsSection(cwd string) (model.ManifestDevs, error) {
 		if !f.IsDir() {
 			continue
 		}
-		dev, err := model.GetManifestV2(f.Name())
+		dev, err := model.GetManifestV2(f.Name(), afero.NewOsFs())
 		if err != nil {
 			oktetoLog.Debugf("could not detect any okteto manifest on %s", f.Name())
 			continue
@@ -507,7 +507,7 @@ func inferDevsSection(cwd string) (model.ManifestDevs, error) {
 	return devs, nil
 }
 
-func (mc *Command) getManifest(path string) (*model.Manifest, error) {
+func (mc *Command) getManifest(path string, fs afero.Fs) (*model.Manifest, error) {
 	if mc.manifest != nil {
 		// Deepcopy so it does not get overwritten these changes
 		manifest := *mc.manifest
@@ -527,7 +527,7 @@ func (mc *Command) getManifest(path string) (*model.Manifest, error) {
 		manifest.Deploy = d
 		return &manifest, nil
 	}
-	return model.GetManifestV2(path)
+	return model.GetManifestV2(path, fs)
 }
 
 func configureAutoCreateDev(manifest *model.Manifest) error {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -38,6 +38,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 )
@@ -92,7 +93,7 @@ func Push(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			manifest, err := utils.DeprecatedLoadManifestOrDefault(pushOpts.DevPath, pushOpts.AppName)
+			manifest, err := utils.DeprecatedLoadManifestOrDefault(pushOpts.DevPath, pushOpts.AppName, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -28,6 +28,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +47,7 @@ func Restart() *cobra.Command {
 			ctx := context.Background()
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: devPath, Namespace: namespace, K8sContext: k8sContext}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -64,7 +65,7 @@ func deploy(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Contro
 				}
 				options.StackPaths[0] = model.GetManifestPathFromWorkdir(options.StackPaths[0], workdir)
 			}
-			s, err := contextCMD.LoadStackWithContext(ctx, options.Name, options.Namespace, options.StackPaths)
+			s, err := contextCMD.LoadStackWithContext(ctx, options.Name, options.Namespace, options.StackPaths, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/stack"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 				}
 				stackPath[0] = model.GetManifestPathFromWorkdir(stackPath[0], workdir)
 			}
-			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath)
+			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/stack/endpoints.go
+++ b/cmd/stack/endpoints.go
@@ -22,6 +22,7 @@ import (
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +39,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 		Short: "Show endpoints for a stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto stack endpoints' is deprecated and will be removed in a future version")
-			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath)
+			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -29,6 +29,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/syncthing"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +57,7 @@ func Status() *cobra.Command {
 			ctx := context.Background()
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: devPath, Namespace: namespace, K8sContext: k8sContext}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
 			if err != nil {
 				return err
 			}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -150,7 +150,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLo
 				upOptions.ManifestPath = uptManifestPath
 			}
 			manifestOpts := contextCMD.ManifestOptions{Filename: upOptions.ManifestPath, Namespace: upOptions.Namespace, K8sContext: upOptions.K8sContext}
-			oktetoManifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts)
+			oktetoManifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
 			if err != nil {
 				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.CloudURL).Error() {
 					return err
@@ -316,7 +316,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLo
 				dev.Command.Values = upOptions.commandToExecute
 			}
 
-			if err := dev.PreparePathsAndExpandEnvFiles(oktetoManifest.ManifestPath); err != nil {
+			if err := dev.PreparePathsAndExpandEnvFiles(oktetoManifest.ManifestPath, up.Fs); err != nil {
 				return fmt.Errorf("error in 'dev' section of your manifest: %w", err)
 			}
 
@@ -630,11 +630,11 @@ func (up *upContext) deployApp(ctx context.Context, ioCtrl *io.Controller, k8slo
 	return err
 }
 
-func (up *upContext) getManifest(path string) (*model.Manifest, error) {
+func (up *upContext) getManifest(path string, fs afero.Fs) (*model.Manifest, error) {
 	if up.Manifest != nil {
 		return up.Manifest, nil
 	}
-	return model.GetManifestV2(path)
+	return model.GetManifestV2(path, fs)
 }
 
 func (up *upContext) start() error {

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -34,6 +34,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -63,18 +64,18 @@ func LoadManifestContext(devPath string) (*model.ContextResource, error) {
 
 // DeprecatedLoadManifest loads an okteto manifest checking "yml" and "yaml".
 // Deprecated: use model.GetManifestV2 instead
-func DeprecatedLoadManifest(devPath string) (*model.Manifest, error) {
+func DeprecatedLoadManifest(devPath string, fs afero.Fs) (*model.Manifest, error) {
 	if !filesystem.FileExists(devPath) {
 		if devPath == DefaultManifest {
 			if filesystem.FileExists(secondaryManifest) {
-				return DeprecatedLoadManifest(secondaryManifest)
+				return DeprecatedLoadManifest(secondaryManifest, fs)
 			}
 		}
 
 		return nil, fmt.Errorf("'%s' does not exist. Generate it by executing 'okteto init'", devPath)
 	}
 
-	manifest, err := model.Get(devPath)
+	manifest, err := model.Get(devPath, fs)
 	if err != nil {
 		return nil, err
 	}
@@ -131,8 +132,8 @@ func LoadManifestRc(dev *model.Dev) error {
 
 // DeprecatedLoadManifestOrDefault loads an okteto manifest or a default one if does not exist
 // Deprecatd. It should only be used by `push` command that will be deleted on next major version. No new usages should be added
-func DeprecatedLoadManifestOrDefault(devPath, name string) (*model.Manifest, error) {
-	dev, err := DeprecatedLoadManifest(devPath)
+func DeprecatedLoadManifestOrDefault(devPath, name string, fs afero.Fs) (*model.Manifest, error) {
+	dev, err := DeprecatedLoadManifest(devPath, fs)
 	if err == nil {
 		return dev, nil
 	}

--- a/cmd/utils/dev_test.go
+++ b/cmd/utils/dev_test.go
@@ -24,6 +24,7 @@ import (
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,7 +78,7 @@ func Test_LoadManifestOrDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			def, err := DeprecatedLoadManifestOrDefault("/tmp/a-path", tt.deployment)
+			def, err := DeprecatedLoadManifestOrDefault("/tmp/a-path", tt.deployment, afero.NewMemMapFs())
 			if tt.expectErr {
 				if err == nil {
 					t.Fatal("expected error when loading")
@@ -113,7 +114,7 @@ func Test_LoadManifestOrDefault(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			loaded, err := DeprecatedLoadManifestOrDefault(f.Name(), "foo")
+			loaded, err := DeprecatedLoadManifestOrDefault(f.Name(), "foo", afero.NewMemMapFs())
 			if err != nil {
 				t.Fatalf("unexpected error when loading existing manifest: %s", err.Error())
 			}
@@ -129,7 +130,7 @@ func Test_LoadManifestOrDefault(t *testing.T) {
 		})
 	}
 	name := "demo-deployment"
-	def, err := DeprecatedLoadManifestOrDefault("/tmp/bad-path", name)
+	def, err := DeprecatedLoadManifestOrDefault("/tmp/bad-path", name, afero.NewMemMapFs())
 	if err != nil {
 		t.Fatal("default dev was not returned")
 	}
@@ -138,7 +139,7 @@ func Test_LoadManifestOrDefault(t *testing.T) {
 		t.Errorf("expected %s, got %s", name, def.Dev[name].Name)
 	}
 
-	_, err = DeprecatedLoadManifestOrDefault("/tmp/bad-path", "")
+	_, err = DeprecatedLoadManifestOrDefault("/tmp/bad-path", "", afero.NewMemMapFs())
 	if err == nil {
 		t.Error("expected error with empty deployment name")
 	}

--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/spf13/afero"
 )
 
 const (
@@ -55,7 +56,7 @@ func Test_multipleStack(t *testing.T) {
 	}
 	paths = append(paths, path)
 
-	stack, err := model.LoadStack("", paths, false)
+	stack, err := model.LoadStack("", paths, false, afero.NewMemMapFs())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +87,7 @@ func Test_multipleStack(t *testing.T) {
 	t.Setenv("OKTETO_BUILD_APP_IMAGE", "test")
 	svcResult.Image = "test"
 
-	stack, err = model.LoadStack("", paths, true)
+	stack, err = model.LoadStack("", paths, true, afero.NewMemMapFs())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +122,7 @@ func Test_overrideFileStack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stack, err := model.LoadStack("", paths, true)
+	stack, err := model.LoadStack("", paths, true, afero.NewMemMapFs())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/filesystem/realpath.go
+++ b/pkg/filesystem/realpath.go
@@ -1,0 +1,76 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+var errRealPathNotFound = errors.New("real path not found")
+
+// Realpath resolves the real path of a file.
+func Realpath(fs afero.Fs, fname string) (string, error) {
+	// Get the absolute path provided by the user
+	absPath, err := filepath.Abs(fname)
+	if err != nil {
+		return "", err
+	}
+
+	components := strings.Split(absPath, string(os.PathSeparator))
+	currentRealPath := ""
+
+	if components[0] == "" {
+		currentRealPath = string(os.PathSeparator)
+		components = components[1:]
+	}
+	for _, component := range components {
+		root := currentRealPath
+		var found bool
+		f, err := fs.Open(root)
+		if err != nil {
+			return "", errRealPathNotFound
+		}
+		isDir, err := afero.IsDir(fs, root)
+		if err != nil {
+			return "", errRealPathNotFound
+		}
+		if isDir {
+			files, err := f.Readdir(0)
+			if err != nil {
+				return "", errRealPathNotFound
+			}
+			for _, f := range files {
+				if strings.EqualFold(f.Name(), component) {
+					found = true
+					currentRealPath = filepath.Join(currentRealPath, f.Name())
+					break
+				}
+			}
+		}
+
+		if !found {
+			return "", errRealPathNotFound
+		}
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return currentRealPath, nil
+}

--- a/pkg/filesystem/realpath.go
+++ b/pkg/filesystem/realpath.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/afero"
@@ -39,6 +40,14 @@ func Realpath(fs afero.Fs, fname string) (string, error) {
 		currentRealPath = string(os.PathSeparator)
 		components = components[1:]
 	}
+	if runtime.GOOS == "windows" {
+		currentRealPath, err = filepath.Abs(string(os.PathSeparator))
+		if err != nil {
+			return "", err
+		}
+		components = components[1:]
+	}
+
 	for _, component := range components {
 		root := currentRealPath
 		var found bool

--- a/pkg/filesystem/realpath.go
+++ b/pkg/filesystem/realpath.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Okteto Authors
+// Copyright 2024 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/filesystem/realpath_test.go
+++ b/pkg/filesystem/realpath_test.go
@@ -24,8 +24,9 @@ import (
 
 func TestRealpath(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	testFilePath := filepath.Clean("/path/to/TestFile")
-	err := fs.MkdirAll(testFilePath, 0755)
+	testFilePath, err := filepath.Abs("/path/to/TestFile")
+	require.NoError(t, err)
+	err = fs.MkdirAll(testFilePath, 0755)
 	require.NoError(t, err)
 
 	tt := []struct {
@@ -56,9 +57,18 @@ func TestRealpath(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
-			realPath, err := Realpath(fs, test.path)
+			absInputPath, err := filepath.Abs(test.path)
+			require.NoError(t, err)
+
+			var absExpectedPath string
+			if test.expected != "" {
+				absExpectedPath, err = filepath.Abs(test.expected)
+				require.NoError(t, err)
+			}
+
+			realPath, err := Realpath(fs, absInputPath)
 			require.ErrorIs(t, err, test.expectedErr)
-			assert.Equal(t, test.expected, realPath)
+			assert.Equal(t, absExpectedPath, realPath)
 		})
 	}
 }

--- a/pkg/filesystem/realpath_test.go
+++ b/pkg/filesystem/realpath_test.go
@@ -14,6 +14,7 @@
 package filesystem
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
@@ -23,7 +24,7 @@ import (
 
 func TestRealpath(t *testing.T) {
 	fs := afero.NewMemMapFs()
-	testFilePath := "/path/to/TestFile"
+	testFilePath := filepath.Clean("/path/to/TestFile")
 	err := fs.MkdirAll(testFilePath, 0755)
 	require.NoError(t, err)
 
@@ -35,19 +36,19 @@ func TestRealpath(t *testing.T) {
 	}{
 		{
 			name:        "case insensitive match",
-			path:        "/patH/to/testfile",
-			expected:    "/path/to/TestFile",
+			path:        filepath.Clean("/patH/to/testfile"),
+			expected:    filepath.Clean("/path/to/TestFile"),
 			expectedErr: nil,
 		},
 		{
 			name:        "exact match",
-			path:        "/path/to/TestFile",
-			expected:    "/path/to/TestFile",
+			path:        filepath.Clean("/path/to/TestFile"),
+			expected:    filepath.Clean("/path/to/TestFile"),
 			expectedErr: nil,
 		},
 		{
 			name:        "not found",
-			path:        "/path/to/NotFound",
+			path:        filepath.Clean("/path/to/NotFound"),
 			expected:    "",
 			expectedErr: errRealPathNotFound,
 		},

--- a/pkg/filesystem/realpath_test.go
+++ b/pkg/filesystem/realpath_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Okteto Authors
+// Copyright 2024 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/filesystem/realpath_test.go
+++ b/pkg/filesystem/realpath_test.go
@@ -1,0 +1,63 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRealpath(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	testFilePath := "/path/to/TestFile"
+	err := fs.MkdirAll(testFilePath, 0755)
+	require.NoError(t, err)
+
+	tt := []struct {
+		name        string
+		path        string
+		expected    string
+		expectedErr error
+	}{
+		{
+			name:        "case insensitive match",
+			path:        "/patH/to/testfile",
+			expected:    "/path/to/TestFile",
+			expectedErr: nil,
+		},
+		{
+			name:        "exact match",
+			path:        "/path/to/TestFile",
+			expected:    "/path/to/TestFile",
+			expectedErr: nil,
+		},
+		{
+			name:        "not found",
+			path:        "/path/to/NotFound",
+			expected:    "",
+			expectedErr: errRealPathNotFound,
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			realPath, err := Realpath(fs, test.path)
+			require.ErrorIs(t, err, test.expectedErr)
+			assert.Equal(t, test.expected, realPath)
+		})
+	}
+}

--- a/pkg/filesystem/realpath_test.go
+++ b/pkg/filesystem/realpath_test.go
@@ -28,10 +28,10 @@ func TestRealpath(t *testing.T) {
 	require.NoError(t, err)
 
 	tt := []struct {
+		expectedErr error
 		name        string
 		path        string
 		expected    string
-		expectedErr error
 	}{
 		{
 			name:        "case insensitive match",

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -319,9 +319,7 @@ func (dev *Dev) loadVolumeAbsPaths(folder string, fs afero.Fs) {
 		dev.Volumes[i].LocalPath = loadAbsPath(folder, dev.Volumes[i].LocalPath, fs)
 	}
 	for i := range dev.Sync.Folders {
-		oktetoLog.Println("folder", dev.Sync.Folders[i].LocalPath)
 		dev.Sync.Folders[i].LocalPath = loadAbsPath(folder, dev.Sync.Folders[i].LocalPath, fs)
-		oktetoLog.Println("folder", dev.Sync.Folders[i].LocalPath)
 	}
 }
 

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/okteto/okteto/pkg/build"
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
 )
@@ -1540,7 +1541,7 @@ func TestPrepare(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.dev.PreparePathsAndExpandEnvFiles(tt.input.manifestPath)
+			err := tt.dev.PreparePathsAndExpandEnvFiles(tt.input.manifestPath, afero.NewMemMapFs())
 			if tt.expectedError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -94,23 +94,23 @@ var (
 
 // Manifest represents an okteto manifest
 type Manifest struct {
-	Name          string                   `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace     string                   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Context       string                   `json:"context,omitempty" yaml:"context,omitempty"`
-	Icon          string                   `json:"icon,omitempty" yaml:"icon,omitempty"`
-	ManifestPath  string                   `json:"-" yaml:"-"`
-	Deploy        *DeployInfo              `json:"deploy,omitempty" yaml:"deploy,omitempty"`
-	Dev           ManifestDevs             `json:"dev,omitempty" yaml:"dev,omitempty"`
-	Destroy       *DestroyInfo             `json:"destroy,omitempty" yaml:"destroy,omitempty"`
-	Build         build.ManifestBuild      `json:"build,omitempty" yaml:"build,omitempty"`
-	Dependencies  deps.ManifestSection     `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
-	GlobalForward []forward.GlobalForward  `json:"forward,omitempty" yaml:"forward,omitempty"`
-	External      externalresource.Section `json:"external,omitempty" yaml:"external,omitempty"`
+	Fs           afero.Fs                 `json:"-" yaml:"-"`
+	External     externalresource.Section `json:"external,omitempty" yaml:"external,omitempty"`
+	Dependencies deps.ManifestSection     `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Build        build.ManifestBuild      `json:"build,omitempty" yaml:"build,omitempty"`
+	Deploy       *DeployInfo              `json:"deploy,omitempty" yaml:"deploy,omitempty"`
+	Dev          ManifestDevs             `json:"dev,omitempty" yaml:"dev,omitempty"`
+	Name         string                   `json:"name,omitempty" yaml:"name,omitempty"`
+	Namespace    string                   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Context      string                   `json:"context,omitempty" yaml:"context,omitempty"`
+	Icon         string                   `json:"icon,omitempty" yaml:"icon,omitempty"`
+	ManifestPath string                   `json:"-" yaml:"-"`
+	Destroy      *DestroyInfo             `json:"destroy,omitempty" yaml:"destroy,omitempty"`
 
-	Type     Archetype `json:"-" yaml:"-"`
-	Manifest []byte    `json:"-" yaml:"-"`
-	IsV2     bool      `json:"-" yaml:"-"`
-	Fs       afero.Fs  `json:"-" yaml:"-"`
+	Type          Archetype               `json:"-" yaml:"-"`
+	GlobalForward []forward.GlobalForward `json:"forward,omitempty" yaml:"forward,omitempty"`
+	Manifest      []byte                  `json:"-" yaml:"-"`
+	IsV2          bool                    `json:"-" yaml:"-"`
 }
 
 // ManifestDevs defines all the dev section

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -125,6 +125,7 @@ func NewManifest() *Manifest {
 		Deploy:        &DeployInfo{},
 		GlobalForward: []forward.GlobalForward{},
 		External:      externalresource.Section{},
+		Fs:            afero.NewOsFs(),
 	}
 }
 
@@ -413,6 +414,7 @@ func getManifestFromFile(cwd, manifestPath string, fs afero.Fs) (*Manifest, erro
 			Dev:   ManifestDevs{},
 			Build: build.ManifestBuild{},
 			IsV2:  true,
+			Fs:    fs,
 		}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Unmarshalling compose...")
 
@@ -513,6 +515,7 @@ func GetInferredManifest(cwd string, fs afero.Fs) (*Manifest, error) {
 			Dev:   ManifestDevs{},
 			Build: build.ManifestBuild{},
 			IsV2:  true,
+			Fs:    fs,
 		}
 		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Unmarshalling compose...")
 		var stackFiles []string
@@ -552,6 +555,7 @@ func GetInferredManifest(cwd string, fs afero.Fs) (*Manifest, error) {
 			},
 			Dev:   ManifestDevs{},
 			Build: build.ManifestBuild{},
+			Fs:    fs,
 		}
 		return chartManifest, nil
 	}
@@ -576,6 +580,7 @@ func GetInferredManifest(cwd string, fs afero.Fs) (*Manifest, error) {
 			},
 			Dev:   ManifestDevs{},
 			Build: build.ManifestBuild{},
+			Fs:    fs,
 		}
 		return k8sManifest, nil
 	}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -149,6 +149,7 @@ func NewManifestFromStack(stack *Stack) *Manifest {
 		Dev:   ManifestDevs{},
 		Build: build.ManifestBuild{},
 		IsV2:  true,
+		Fs:    afero.NewOsFs(),
 	}
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1432,6 +1432,7 @@ func TestRead(t *testing.T) {
 				Type:          OktetoManifestType,
 				Manifest:      nil,
 				IsV2:          false,
+				Fs:            afero.NewOsFs(),
 			},
 		},
 		{
@@ -1462,6 +1463,7 @@ func TestRead(t *testing.T) {
 				Type:          OktetoManifestType,
 				Manifest:      []uint8{},
 				IsV2:          false,
+				Fs:            afero.NewOsFs(),
 			},
 		},
 		{
@@ -1569,6 +1571,7 @@ func TestRead(t *testing.T) {
     image: test-image
     context: ./test`),
 				IsV2: true,
+				Fs:   afero.NewOsFs(),
 			},
 			expectedErr: false,
 		},
@@ -1624,6 +1627,7 @@ func TestRead(t *testing.T) {
 				External:      externalresource.Section{},
 				Type:          OktetoManifestType,
 				IsV2:          true,
+				Fs:            afero.NewOsFs(),
 				Manifest: []byte(`deploy:
   divert:
     namespace: staging

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -875,7 +875,7 @@ sync:
 				}
 				assert.NoError(t, os.WriteFile(filepath.Join(dir, "docker-compose.yml"), tt.composeBytes, 0600))
 			}
-			_, err := getManifestFromFile(dir, file)
+			_, err := getManifestFromFile(dir, file, afero.NewMemMapFs())
 
 			assert.ErrorIs(t, err, tt.expectedErr)
 		})
@@ -1284,7 +1284,7 @@ func Test_getInferredManifestFromK8sManifestFile(t *testing.T) {
 			t.Fatalf("Error closing file %s: %s", fullpath, err)
 		}
 	}()
-	_, err = GetInferredManifest(wd)
+	_, err = GetInferredManifest(wd, afero.NewMemMapFs())
 	assert.NoError(t, err)
 }
 
@@ -1300,7 +1300,7 @@ func Test_getInferredManifestFromK8sManifestFolder(t *testing.T) {
 		}
 	}()
 
-	_, err = GetInferredManifest(wd)
+	_, err = GetInferredManifest(wd, afero.NewMemMapFs())
 	assert.NoError(t, err)
 }
 
@@ -1336,7 +1336,7 @@ func Test_getInferredManifestFromHelmPath(t *testing.T) {
 					}
 				}()
 			}
-			_, err := GetInferredManifest(wd)
+			_, err := GetInferredManifest(wd, afero.NewMemMapFs())
 			assert.NoError(t, err)
 		})
 	}
@@ -1344,7 +1344,7 @@ func Test_getInferredManifestFromHelmPath(t *testing.T) {
 
 func Test_getInferredManifestWhenNoManifestExist(t *testing.T) {
 	wd := t.TempDir()
-	result, err := GetInferredManifest(wd)
+	result, err := GetInferredManifest(wd, afero.NewMemMapFs())
 	assert.Empty(t, result)
 	assert.ErrorIs(t, err, oktetoErrors.ErrCouldNotInferAnyManifest)
 }

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -220,7 +220,9 @@ func Test_getStructKeys(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			keys := getStructKeys(tt.input)
-			assert.Equal(t, tt.expected, keys)
+			for k, v := range tt.expected {
+				assert.ElementsMatch(t, v, keys[k])
+			}
 		})
 	}
 }

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/spf13/afero"
 	"os"
 	"reflect"
 	"strings"
@@ -1069,6 +1070,7 @@ deploy:
 				Context:      "context-to-use",
 				IsV2:         true,
 				Type:         OktetoManifestType,
+				Fs:           afero.NewOsFs(),
 			},
 			isErrorExpected: false,
 		},
@@ -1234,6 +1236,7 @@ dev:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
+				Fs: afero.NewOsFs(),
 			},
 
 			isErrorExpected: false,
@@ -1319,6 +1322,7 @@ sync:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
+				Fs: afero.NewOsFs(),
 			},
 			isErrorExpected: false,
 		},
@@ -1442,6 +1446,7 @@ services:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
+				Fs: afero.NewOsFs(),
 			},
 			isErrorExpected: false,
 		},
@@ -1539,6 +1544,7 @@ dev:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
+				Fs: afero.NewOsFs(),
 			},
 			isErrorExpected: false,
 		},
@@ -1694,6 +1700,7 @@ dev:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
+				Fs: afero.NewOsFs(),
 			},
 			isErrorExpected: false,
 		},
@@ -1739,6 +1746,7 @@ deploy:
 						},
 					},
 				},
+				Fs: afero.NewOsFs(),
 			},
 			isErrorExpected: false,
 		},
@@ -1767,6 +1775,7 @@ devs:
 						},
 					},
 				},
+				Fs: afero.NewOsFs(),
 			},
 			isErrorExpected: false,
 		},

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -15,7 +15,6 @@ package model
 
 import (
 	"fmt"
-	"github.com/spf13/afero"
 	"os"
 	"reflect"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/model/utils"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -990,7 +991,7 @@ func TestStack_ExpandEnvsAtFileLevel(t *testing.T) {
 				t.Setenv(key, value)
 			}
 
-			stack, err := GetStackFromPath("test", tmpFile.Name(), false)
+			stack, err := GetStackFromPath("test", tmpFile.Name(), false, afero.NewMemMapFs())
 			if err != nil {
 				t.Fatalf("Error detected: %s", err.Error())
 			}


### PR DESCRIPTION
# Proposed changes

DEV-122

Create a new function to check the real name of the folders. This new code doesn't resolve symlinks, it just replaces the path name on OS with no sensitive paths 

## How to validate

1. Clone okteto/go-getting-started
1. Run cd go-Getting-StartEd
1. Run okteto up
1. Update some code from main locally and check that is updated on the remote

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
