### PR TITLE
refactor: rewrite error log

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -243,18 +243,14 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 		var cmdErr buildCmd.OktetoCommandErr
 		if errors.As(err, &cmdErr) {
 			oktetoLog.SetStage(cmdErr.Stage)
-			return oktetoErrors.UserError{
-				E: cmdErr.Err,
-			}
+			return fmt.Errorf("error deploying application")
 		}
 		oktetoLog.SetStage("remote deploy")
 		var userErr oktetoErrors.UserError
 		if errors.As(err, &userErr) {
 			return userErr
 		}
-		return oktetoErrors.UserError{
-			E: err,
-		}
+		return fmt.Errorf("error deploying application")
 	}
 	oktetoLog.SetStage("done")
 	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")


### PR DESCRIPTION
# Proposed changes

Fixes DEV-130

Rewrite remote log in order to show that the application failed instead of build failed

## How to validate

1. Run `gh repo clone okteto/go-getting-started`
1. Run `cd go-getting-started`
1. Add `exit 1` as a command in `okteto.yml`
1. Run `okteto deploy --remote`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
