### PR TITLE
fix smartbuild remote interaction

### DIFF
--- a/cmd/build/v1/build.go
+++ b/cmd/build/v1/build.go
@@ -117,9 +117,6 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 		tags := strings.Split(options.Tag, ",")
 		for _, tag := range tags {
 			displayTag := tag
-			if options.DevTag != "" {
-				displayTag = options.DevTag
-			}
 			ob.IoCtrl.Out().Success("Image '%s' successfully pushed", displayTag)
 		}
 	}

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -101,6 +101,7 @@ func (bc *OktetoBuilder) checkServiceToBuild(service string, manifest *model.Man
 		if err != nil {
 			bc.ioCtrl.Logger().Infof("error getting build hash: %s", err)
 		}
+			bc.ioCtrl.Logger().Debugf("build hash: %s", buildHash)
 	}
 
 	imageChecker := getImageChecker(buildInfo, bc.Config, bc.Registry, bc.smartBuildCtrl, bc.ioCtrl.Logger())

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -80,11 +80,13 @@ func (sh *serviceHasher) hashBuildContext(buildInfo *build.Info) (string, error)
 	if _, ok := sh.buildContextCache[buildContext]; !ok {
 		dirCommit, err := sh.gitRepoCtrl.GetLatestDirCommit(buildContext)
 		if err != nil {
+			oktetoLog.Infof("could not get build context sha: %s", err)
 			return "", fmt.Errorf("could not get build context sha: %w", err)
 		}
 
 		diffHash, err := sh.gitRepoCtrl.GetDiffHash(buildContext)
 		if err != nil {
+			oktetoLog.Infof("could not get build context diff sha: %s", err)
 			return "", fmt.Errorf("could not get build context diff sha: %w", err)
 		}
 
@@ -122,7 +124,9 @@ func (sh *serviceHasher) hash(buildInfo *build.Info, commitHash string, diff str
 	fmt.Fprintf(&b, "diff:%s;", diff)
 	fmt.Fprintf(&b, "image:%s;", buildInfo.Image)
 
-	oktetoBuildHash := sha256.Sum256([]byte(b.String()))
+	hashFrom := b.String()
+	oktetoLog.Infof("hashing build info: %s", hashFrom)
+	oktetoBuildHash := sha256.Sum256([]byte(hashFrom))
 	return hex.EncodeToString(oktetoBuildHash[:])
 }
 

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -110,8 +110,9 @@ func (i imageTagger) getImageReferencesForTagWithDefaults(manifestName, svcToBui
 		imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, tag)...)
 	}
 
-	imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, model.OktetoDefaultImageTag)...)
-
+	if len(imageReferences) == 0 {
+		imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, model.OktetoDefaultImageTag)...)
+	}
 	return imageReferences
 }
 

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -110,9 +110,9 @@ func (i imageTagger) getImageReferencesForTagWithDefaults(manifestName, svcToBui
 		imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, tag)...)
 	}
 
-	if len(imageReferences) == 0 {
-		imageReferences = append(imageReferences, i.getImageReferencesForTag(manifestName, svcToBuildName, model.OktetoDefaultImageTag)...)
-	}
+	sanitizedName := format.ResourceK8sMetaString(manifestName)
+	imageReferences = append(imageReferences, useReferenceTemplate(constants.DevRegistry, sanitizedName, svcToBuildName, model.OktetoDefaultImageTag))
+	fmt.Println(imageReferences)
 	return imageReferences
 }
 

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -49,7 +49,7 @@ const (
 	templateName           = "dockerfile"
 	dockerfileTemporalName = "Dockerfile.deploy"
 	dockerfileTemplate     = `
-FROM {{ .OktetoCLIImage }} as okteto-cli
+FROM jlopezbarb/cli:latest as okteto-cli
 
 FROM {{ .UserDeployImage }} as deploy
 

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -154,10 +154,6 @@ func (ImageCtrl) getExposedPortsFromCfg(cfg *containerv1.ConfigFile) []Port {
 }
 
 func GetDevTagFromGlobal(image string) string {
-	if !strings.HasPrefix(image, constants.GlobalRegistry) {
-		return ""
-	}
-
 	// separate image reference and tag eg: okteto.dev/image:tag
 	reference, _, found := strings.Cut(image, "@sha256")
 	if !found {
@@ -168,7 +164,8 @@ func GetDevTagFromGlobal(image string) string {
 	}
 
 	devReference := strings.Replace(reference, constants.GlobalRegistry, constants.DevRegistry, 1)
-	if devReference == reference {
+	returnableImage := fmt.Sprintf("%s:%s", devReference, model.OktetoDefaultImageTag)
+	if image == returnableImage {
 		return ""
 	}
 	return fmt.Sprintf("%s:%s", devReference, model.OktetoDefaultImageTag)

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -332,14 +332,19 @@ func Test_GetExpandedDevTagFromGlobal(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "is dev image",
+			name:     "is dev image with okteto tag",
 			input:    "okteto.dev/my-image:okteto",
 			expected: "",
 		},
 		{
+			name:     "is dev image with non okteto tag",
+			input:    "okteto.dev/my-image:thisisahash",
+			expected: "okteto.dev/my-image:okteto",
+		},
+		{
 			name:     "is dev image with sha",
 			input:    "okteto.dev/my-image@sha256:e78ad0d316485b7dbffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
-			expected: "",
+			expected: "okteto.dev/my-image:okteto",
 		},
 		{
 			name:     "is not okteto image",

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -259,8 +259,10 @@ func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
 		return "", untrackedFilesResponse.err
 	}
 
-	diffHash := sha256.Sum256([]byte(fmt.Sprintf("%s%s", diffResponse.diff, untrackedFilesResponse.untrackedFilesDiff)))
-	return fmt.Sprintf("%x", diffHash), nil
+	hashFrom := fmt.Sprintf("%s-%s", diffResponse.diff, untrackedFilesResponse.untrackedFilesDiff)
+	oktetoLog.Infof("hashing diff: %s", hashFrom)
+	diffHash := sha256.Sum256([]byte(hashFrom))
+	return hex.EncodeToString(diffHash[:]), nil
 }
 
 func (r gitRepoController) getUntrackedContent(files []string) (string, error) {

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -210,6 +210,10 @@ func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
 			diff: "",
 			err:  errTimeoutExceeded,
 		}
+		untrackedFilesCh <- untrackedFilesResponse{
+			untrackedFilesDiff: "",
+			err:                errTimeoutExceeded,
+		}
 	}()
 
 	// go func that calculates the diff using git diff

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -16,6 +16,7 @@ package repository
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -142,7 +143,7 @@ func (r gitRepoController) GetLatestDirCommit(contextDir string) (string, error)
 	timeoutCh := make(chan struct{})
 	ch := make(chan commitResponse)
 
-	timeout := 1 * time.Second
+	timeout := 5 * time.Second
 
 	go func() {
 		time.Sleep(timeout)
@@ -194,7 +195,7 @@ func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
 	diffCh := make(chan diffResponse)
 	untrackedFilesCh := make(chan untrackedFilesResponse)
 
-	timeout := 1 * time.Second
+	timeout := 5 * time.Second
 
 	repo, err := r.repoGetter.get(r.path)
 	if err != nil {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-156

- Add debug logs
- Fix encoding from hex to string
- Fix untracked content was not using the timeout
- Fix increase timeout from 1s to 5s (we could have problems with large repositories)
- Check okteto tag only if we don't have a hash tag (from project commit or context based)
- On remote don't recalculate the images (if there is no .git folder the result may differ)

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Build an image of the CLI `okteto build --build-arg VERSION_STRING=custom -t IMAGE .` 
1. Build CLI binary
1. Run okteto deploy on a repo using the remote

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
