### PR TITLE
[Hybrid] Improve process management 

### DIFF
--- a/cmd/up/up_unix.go
+++ b/cmd/up/up_unix.go
@@ -1,0 +1,29 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package up
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func getSendToBackgroundSignals() chan os.Signal {
+	goToBg := make(chan os.Signal, 1)
+	signal.Notify(goToBg, syscall.SIGTTIN, syscall.SIGTTOU)
+	return goToBg
+}

--- a/cmd/up/up_windows.go
+++ b/cmd/up/up_windows.go
@@ -1,0 +1,25 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package up
+
+import (
+	"os"
+)
+
+func getSendToBackgroundSignals() chan os.Signal {
+	return nil
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"os"
+)
+
+type Interface interface {
+	Getpid() int
+	Find() error
+	Signal(os.Signal) error
+	Wait() (*os.ProcessState, error)
+	Kill() error
+}
+
+type Process struct {
+	process *os.Process
+	pid     int
+}
+
+func New(pid int) Interface {
+	return &Process{
+		pid: pid,
+	}
+}
+
+func (p *Process) Getpid() int {
+	return p.pid
+}
+
+func (p *Process) Find() error {
+	osProcess, err := os.FindProcess(p.pid)
+	if err != nil {
+		return err
+	}
+	p.process = osProcess
+	return nil
+}
+
+func (p *Process) Signal(signal os.Signal) error {
+	return p.process.Signal(signal)
+}
+
+func (p *Process) Wait() (*os.ProcessState, error) {
+	return p.process.Wait()
+}

--- a/pkg/process/process_unix.go
+++ b/pkg/process/process_unix.go
@@ -1,0 +1,73 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package process
+
+import (
+	"errors"
+	"syscall"
+	"time"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+)
+
+// Kill attempts to gracefully shut down the process, wait for the process to exit and if it doesn't, it kills it
+func (p *Process) Kill() error {
+	err := p.Find()
+	if err != nil {
+		oktetoLog.Debugf("process not running: %d", p.pid)
+		return nil
+	}
+
+	// attempt to gracefully terminate the process
+	if err := p.Signal(syscall.SIGTERM); err != nil {
+		oktetoLog.Debugf("error in graceful termination of process: %d", p.pid)
+		return err
+	}
+
+	// create a channel to listen for when the process exits
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.Wait()
+		done <- err
+	}()
+
+	timer := time.NewTimer(3 * time.Second)
+
+	select {
+	case <-timer.C:
+		oktetoLog.Debugf("graceful termination timed out, killing process: %d", p.pid)
+		timer.Stop()
+		// if the process is still running, kill it
+		if err := p.Signal(syscall.SIGKILL); err != nil {
+			oktetoLog.Debugf("error in killing process %d: %v", p.pid, err)
+			return err
+		}
+		err := p.Find()
+		if err != nil {
+			oktetoLog.Debugf("process %d cannot be : %v", p.pid, err)
+			return err
+		}
+		oktetoLog.Debugf("process terminated successfully: %d", p.pid)
+	case err := <-done:
+		if errors.Is(err, syscall.ECHILD) {
+			timer.Stop()
+			oktetoLog.Debugf("process terminated successfully: %d, %v", p.pid, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/process/process_windows.go
+++ b/pkg/process/process_windows.go
@@ -1,0 +1,30 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package process
+
+import (
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+)
+
+func (p *Process) Kill() error {
+	err := p.Find()
+	if err != nil {
+		oktetoLog.Debugf("process not running: %d", p.pid)
+		return nil
+	}
+	return p.process.Kill()
+}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-21

This PR fixes 2 things:

1. Currently on Windows hybrid mode keeps child processes running.
2. Currently, on Linux/Mac the restart cause the CLI to end in the background (only for processes such as `bash`, `sh`, etc).

The new logic is:

1. On Windows, do not use `SIGTERM` because it's not supported, but always use `SIGKILL`.
2. On Unix, attempt to gracefully shut down the process, in case the process does not terminate itself in 3 seconds, Okteto CLI will terminate it with `SIGKILL`.

Notes:
- the `3 seconds` is arbitrary, it's unpredictable how long a process could take to gracefully terminate itself (for example: something like `npm` is very quick but a database might take longer)

## How to validate

On both Mac and Windows:

1. `git clone git@github.com:andreafalzetti/hybrid-test.git`
1. `cd hybridapp && npm install` 
1. `okteto up`
1. Kill the pod: `k delete pod -n <NS> $(kubectl get pod -n <NS> --no-headers -o custom-columns=":metadata.name" | grep hybridapp-okteto-)`
1. Watch the service restart on the same port (`8080`)

Change the `command` in `okteto.yml` to be `bash` and repeat the test above.

To test the timeout logic, I've written and used this program as the `command` of the manifest of the repo example:

Once executed, this program will ignore `SIGTERM` (try doing `kil -SIGTERM <PID>` and see). It can only be terminated with `CTRL+C` or `SIGKILL`

```go
package main

import (
	"os"
	"os/signal"
	"syscall"
)

func main() {
	// Ignore SIGTERM signal
	signal.Ignore(syscall.SIGTERM)

	// Create a channel to receive signals
	sigChan := make(chan os.Signal, 1)
	// Register SIGKILL signal to channel (Note: SIGKILL cannot be caught or ignored)
	signal.Notify(sigChan, syscall.SIGKILL)

	// Block and wait for signals
	<-sigChan
}



```

If you look at the `okteto.log` you should see something like:

```
time="2024-02-19T17:07:10+01:00" level=debug msg="terminating process: 9482" action=ac1bfac3-9e65-433c-a3c4-877c8e107a7f version=437a0962
time="2024-02-19T17:07:13+01:00" level=debug msg="graceful termination timed out, killing process: 9482" action=ac1bfac3-9e65-433c-a3c4-877c8e107a7f version=437a0962
time="2024-02-19T17:07:13+01:00" level=debug msg="process terminated successfully: 9482" action=ac1bfac3-9e65-433c-a3c4-877c8e107a7f version=437a0962
```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
