### PR TITLE
Fix logs for some errors. %w is not a valid verb when printing strings. That is only valid for error wrapping when creating an error

### DIFF
--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -54,12 +54,12 @@ type loggerInfo interface {
 func getConfig(registry configRegistryInterface, gitRepo configRepositoryInterface, l loggerInfo) oktetoBuilderConfig {
 	hasAccess, err := registry.HasGlobalPushAccess()
 	if err != nil {
-		l.Infof("error trying to access globalPushAccess: %w", err)
+		l.Infof("error trying to access globalPushAccess: %s", err)
 	}
 
 	isClean, err := gitRepo.IsClean()
 	if err != nil {
-		l.Infof("error trying to get directory: %w", err)
+		l.Infof("error trying to get directory: %s", err)
 	}
 
 	return oktetoBuilderConfig{
@@ -75,12 +75,12 @@ func getConfig(registry configRegistryInterface, gitRepo configRepositoryInterfa
 func getConfigStateless(registry configRegistryInterface, gitRepo configRepositoryInterface, l loggerInfo, isOkteto bool) oktetoBuilderConfig {
 	hasAccess, err := registry.HasGlobalPushAccess()
 	if err != nil {
-		l.Infof("error trying to access globalPushAccess: %w", err)
+		l.Infof("error trying to access globalPushAccess: %s", err)
 	}
 
 	isClean, err := gitRepo.IsClean()
 	if err != nil {
-		l.Infof("error trying to get directory: %w", err)
+		l.Infof("error trying to get directory: %s", err)
 	}
 
 	return oktetoBuilderConfig{
@@ -128,7 +128,7 @@ func (oc oktetoBuilderConfig) IsCleanProject() bool {
 func (oc oktetoBuilderConfig) GetGitCommit() string {
 	commitSHA, err := oc.repository.GetSHA()
 	if err != nil {
-		oktetoLog.Infof("could not get repository sha: %w", err)
+		oktetoLog.Infof("could not get repository sha: %s", err)
 	}
 	return commitSHA
 }

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -191,7 +191,7 @@ func (ld *localDeployer) runDeploySection(ctx context.Context, opts *Options) er
 
 	defer func() {
 		if err := ld.Fs.RemoveAll(filepath.Dir(oktetoEnvFile.Name())); err != nil {
-			oktetoLog.Infof("error removing okteto env file dir: %w", err)
+			oktetoLog.Infof("error removing okteto env file dir: %s", err)
 		}
 	}()
 

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -162,7 +162,7 @@ func (rd *remoteDeployCommand) deploy(ctx context.Context, deployOptions *Option
 
 	defer func() {
 		if err := rd.fs.Remove(dockerfile); err != nil {
-			oktetoLog.Infof("error removing dockerfile: %w", err)
+			oktetoLog.Infof("error removing dockerfile: %s", err)
 		}
 	}()
 

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -165,7 +165,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 
 	defer func() {
 		if err := rd.fs.Remove(dockerfile); err != nil {
-			oktetoLog.Infof("error removing dockerfile: %w", err)
+			oktetoLog.Infof("error removing dockerfile: %s", err)
 		}
 	}()
 

--- a/cmd/up/pid.go
+++ b/cmd/up/pid.go
@@ -121,7 +121,7 @@ func (pc pidController) delete() {
 	}
 
 	if err := pc.watcher.Close(); err != nil {
-		oktetoLog.Infof("could not close watcher: %w", err)
+		oktetoLog.Infof("could not close watcher: %s", err)
 	}
 
 	if strconv.Itoa(pid) != filePID {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -710,7 +710,7 @@ func (up *upContext) activateLoop() {
 			<-up.ShutdownCompleted
 			pidFromFile, err := up.pidController.get()
 			if err != nil {
-				oktetoLog.Infof("error getting pid: %w")
+				oktetoLog.Infof("error getting pid: %s", err)
 			}
 			if pidFromFile != strconv.Itoa(os.Getpid()) {
 				if up.Dev.IsHybridModeEnabled() {
@@ -738,7 +738,7 @@ func (up *upContext) activateLoop() {
 
 			oktetoLog.Info("updating kubeconfig token")
 			if err := up.tokenUpdater.UpdateKubeConfigToken(); err != nil {
-				oktetoLog.Infof("error updating k8s token: %w", err)
+				oktetoLog.Infof("error updating k8s token: %s", err)
 				isTransientError = true
 				continue
 			}

--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -158,7 +158,7 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 			return nil, err
 		}
 		if user, pass, err := ap.externalAuth(originalHost, ap.authContext.isOktetoContext(), c); err != nil {
-			oktetoLog.Debugf("failed to load external auth for %s: %w", req.Host, err.Error())
+			oktetoLog.Debugf("failed to load external auth for %s: %s", req.Host, err.Error())
 		} else {
 			res.Username = user
 			res.Secret = pass

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -160,7 +160,7 @@ func (t *trace) display(progress string) {
 			for _, log := range v.logs {
 				var text oktetoLog.JSONLogFormat
 				if err := json.Unmarshal([]byte(log), &text); err != nil {
-					oktetoLog.Infof("could not parse %s: %w", log, err)
+					oktetoLog.Infof("could not parse %s: %s", log, err)
 					continue
 				}
 				if text.Stage == "" {

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -559,7 +559,7 @@ func isAnyPortAvailable(ctx context.Context, svc *model.Service, stack *model.St
 		}
 	}
 	if err := forwarder.Start(podName, stack.Namespace); err != nil {
-		oktetoLog.Infof("could not start port-forward: %w", err)
+		oktetoLog.Infof("could not start port-forward: %s", err)
 	}
 	defer forwarder.Stop()
 	for _, port := range portsToTest {
@@ -841,7 +841,7 @@ func addImageMetadataToSvc(svc *model.Service) {
 		reg := registry.NewOktetoRegistry(okteto.Config{})
 		imageMetadata, err := reg.GetImageMetadata(svc.Image)
 		if err != nil {
-			oktetoLog.Infof("could not add image metadata: %w", err)
+			oktetoLog.Infof("could not add image metadata: %s", err)
 			return
 		}
 

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -788,14 +788,14 @@ func getUpdateStrategy(svc *model.Service, strategy updateStrategyGetter) update
 		if err == nil {
 			return result
 		}
-		oktetoLog.Debugf("invalid strategy: %w", err)
+		oktetoLog.Debugf("invalid strategy: %s", err)
 	}
 	if result := getUpdateStrategyByEnvVar(); result != "" {
 		err := strategy.validate(result)
 		if err == nil {
 			return result
 		}
-		oktetoLog.Debugf("invalid strategy: %w", err)
+		oktetoLog.Debugf("invalid strategy: %s", err)
 	}
 	return strategy.getDefault()
 }

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -72,7 +72,7 @@ func CreateForDev(ctx context.Context, dev *model.Dev, c kubernetes.Interface, d
 			if !isDynamicallyProvisionedPVCError(err, pvcForDev.Name) {
 				return fmt.Errorf("error updating kubernetes volume claim: %w", err)
 			}
-			oktetoLog.Debug("could not update pvc in namespace %s: %w", dev.Namespace, err)
+			oktetoLog.Debug("could not update pvc in namespace %s: %s", dev.Namespace, err)
 			oktetoLog.Warning(`Could not increase the size of the dev volume from %s to %s:
 try running 'okteto down -v' and 'okteto up', or talk to your administrator
 (the PVC's storage class must support 'allowVolumeExpansion' to be able to upscale dev volumes).`,

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -144,7 +144,7 @@ func (ImageCtrl) getExposedPortsFromCfg(cfg *containerv1.ConfigFile) []Port {
 			port = port[:slashIndx]
 			portInt, err := strconv.ParseInt(port, 10, 32)
 			if err != nil {
-				oktetoLog.Debugf("could not parse exposed port %s: %w", port, err)
+				oktetoLog.Debugf("could not parse exposed port %s: %s", port, err)
 				continue
 			}
 			result = append(result, Port{ContainerPort: int32(portInt), Protocol: apiv1.ProtocolTCP})

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -54,7 +54,7 @@ func (r repositoryURL) String() string {
 func getURLFromPath(path string) repositoryURL {
 	url, err := giturls.Parse(path)
 	if err != nil {
-		oktetoLog.Infof("could not parse url: %w", err)
+		oktetoLog.Infof("could not parse url: %s", err)
 	}
 
 	return repositoryURL{

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -92,7 +92,6 @@ func (fm *ForwardManager) canAdd(localPort int, checkAvailable bool) error {
 		}
 
 		return fmt.Errorf("local port %d is already in-use in your local machine: %w", localPort, oktetoErrors.ErrPortAlreadyAllocated)
-		// return fmt.Errorf("local port %d is already in-use in your local machine", localPort)
 	}
 
 	return nil


### PR DESCRIPTION
# Proposed changes

When running the CLI with debug log level, there are a lot of messages that are not formatter correctly. You can see things like 

```
INFO[0014] could not parse : %!w(*json.SyntaxError=&{unexpected end of JSON input 0})
```

```
DEBU[0007] failed to load external auth for https://index.docker.io/v1/: %!w(string=credentials not found in native keychain)
```

```
invalid version string: a041fe26, using latest: %!s(<nil>)
```

This is mainly because in a lot of places we are logging errors using verb `%w`, but that is not a valid verb when printing strings. Valid verbs are available [here](https://pkg.go.dev/fmt#hdr-Printing). `%w` is only valid when formatting and error with `fmt.Errorf` or similar.

Same logs than above after my changes:

```
INFO[0007] could not parse : unexpected end of JSON input
```

```
DEBU[0006] failed to load external auth for https://index.docker.io/v1/: credentials not found in native keychain
```

```
INFO[0003] invalid version string: a041fe26, using latest
```

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Execute some remote deploy without and with my changes and you should see how some logs with invalid format are gone

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
