### PR TITLE
Update links to docs to map the new docs structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Today, most developers try to either run parts of the infrastructure locally or 
 
 ## How it works
 
-Okteto allows you to develop inside a container. When you run `okteto up` your Kubernetes deployment is replaced by a development container that contains your development tools (e.g. maven and jdk, or npm, python, go compiler, debuggers, etc). This development container can be any [docker image](https://okteto.com/docs/reference/development-environments/). The development container inherits the same secrets, configmaps, volumes or any other configuration value of the original Kubernetes deployment.
+Okteto allows you to develop inside a container. When you run `okteto up` your Kubernetes deployment is replaced by a development container that contains your development tools (e.g. maven and jdk, or npm, python, go compiler, debuggers, etc). This development container can use any [docker image](https://okteto.com/docs/development/images/). The development container inherits the same secrets, configmaps, volumes or any other configuration value of the original Kubernetes deployment.
 
 In addition to that, `okteto up` will:
 
@@ -25,7 +25,7 @@ In addition to that, `okteto up` will:
 1. Automatic local and remote port forwarding using [SSH](https://okteto.com/docs/reference/ssh-server/), so you can access your cluster services via `localhost` or connect a remote debugger.
 1. Give you an interactive terminal to your development container, so you can build, test, and run your application as you would from a local terminal.
 
-All of this (and more) can be configured via a [simple YAML manifest](https://okteto.com/docs/reference/manifest/).
+All of this (and more) can be configured via a [simple YAML manifest](https://okteto.com/docs/reference/okteto-manifest/).
 
 The end result is that the remote cluster is seen by your IDE and tools as a local filesystem/environment. You keep writing your code on your local IDE and as soon as you save a file, the change goes to the development container, and your application instantly updates (taking advantage of any hot-reload mechanism you already have). This whole process happens in an instant. No docker images need to be created and no Kubernetes manifests need to be applied to the cluster.
 
@@ -44,9 +44,9 @@ The end result is that the remote cluster is seen by your IDE and tools as a loc
 
 ## Getting started
 
-All you need to get started is to [install the Okteto CLI](https://www.okteto.com/docs/getting-started/#installing-okteto-cli) and have access to a Kubernetes cluster.
+All you need to get started is to [install the Okteto CLI](https://www.okteto.com/docs/get-started/install-okteto-cli/) and have access to a Kubernetes cluster.
 
-Okteto CLI works with **any** Kubernetes cluster. If it's your first time using it, we'd recommend you [try it](https://www.okteto.com/docs/getting-started/) with the [Okteto Platform](https://cloud.okteto.com/) for a complete holistic developer experience. If you want to try it out with any other K8s cluster, you can also check out [this article](https://www.okteto.com/blog/developing-microservices-by-hot-reloading-on-kubernetes-clusters/) as a guide.
+Okteto CLI works with **any** Kubernetes cluster. If it's your first time using it, we'd recommend you [try it](https://www.okteto.com/docs/get-started/install-okteto-cli/) with the [Okteto Platform](https://www.okteto.com/docs) for a complete holistic developer experience. If you want to try it out with any other K8s cluster, you can also check out [this article](https://www.okteto.com/blog/developing-microservices-by-hot-reloading-on-kubernetes-clusters/) as a guide.
 
 We created a [few guides to help you get started](https://github.com/okteto/samples) with `okteto` and your favorite programming language.
 
@@ -56,9 +56,9 @@ Okteto is released into three channels: stable, beta, and dev. By default when o
 
 ## Useful links
 
-- [Getting started](https://www.okteto.com/docs/getting-started/)
-- [CLI reference](https://okteto.com/docs/reference/cli)
-- [Okteto manifest reference](https://okteto.com/docs/reference/manifest/)
+- [Getting started](https://www.okteto.com/docs/get-started/install-okteto-cli/)
+- [CLI reference](https://okteto.com/docs/reference/okteto-cli)
+- [Okteto manifest reference](https://okteto.com/docs/reference/okteto-manifest/)
 - [Samples](https://github.com/okteto/samples)
 - Frequently asked questions ([FAQs](https://okteto.com/docs/reference/faqs/))
 - [Known issues](https://okteto.com/docs/reference/known-issues/)

--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -24,7 +24,7 @@ import (
 func Analytics() *cobra.Command {
 	var disable bool
 	cmd := &cobra.Command{
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#analytics"),
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#analytics"),
 		Use:   "analytics",
 		Short: "Enable / Disable analytics",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -92,7 +92,7 @@ func NewBuildCommand(ioCtrl *io.Controller, analyticsTracker analyticsTrackerInt
 
 const (
 	maxV1CommandArgs = 1
-	docsURL          = "https://okteto.com/docs/reference/cli/#build"
+	docsURL          = "https://okteto.com/docs/reference/okteto-cli/#build"
 )
 
 // Build build and optionally push a Docker image

--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -26,7 +26,7 @@ func Context(okClientProvider oktetoClientProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "context",
 		Aliases: []string{"ctx"},
-		Args:    utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#context"),
+		Args:    utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#context"),
 		Short:   "Set the default context",
 		Long: `Set the default context
 

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -90,7 +90,7 @@ func CreateCMD() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "create [cluster-url]",
-		Args:   utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/cli/#context"),
+		Args:   utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#context"),
 		Short:  "Add a context",
 		Long: `Add a context
 

--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -29,7 +29,7 @@ import (
 func DeleteCMD() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Args:  utils.MinimumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#delete"),
+		Args:  utils.MinimumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#delete"),
 		Short: "Delete one or more contexts",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			for idx, arg := range args {

--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -33,7 +33,7 @@ func List() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Args:    utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#list"),
+		Args:    utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#list"),
 		Short:   "List available contexts",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -31,7 +31,7 @@ func Show() *cobra.Command {
 	var includeToken bool
 	cmd := &cobra.Command{
 		Use:   "show",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#show"),
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#show"),
 		Short: "Print the current context",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -59,7 +59,7 @@ func UpdateKubeconfigCMD(okClientProvider oktetoClientProvider) *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "update-kubeconfig",
-		Args:   utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
+		Args:   utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#kubeconfig"),
 		Short:  "Download credentials for the Kubernetes cluster selected via 'okteto context'",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/context/use-namespace.go
+++ b/cmd/context/use-namespace.go
@@ -29,7 +29,7 @@ func UseNamespace() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "use-namespace [name]",
-		Args:   utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/cli/#use-1"),
+		Args:   utils.ExactArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#use-1"),
 		Short:  "Set the namespace of the okteto context",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto context use-namespace' is deprecated in favor of 'okteto namespace', and will be removed in a future version")

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -41,7 +41,7 @@ func Use() *cobra.Command {
 	ctxOptions := &Options{}
 	cmd := &cobra.Command{
 		Use:   "use [<url>|Kubernetes context]",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#use"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#use"),
 		Short: "Set the default context",
 		Long: `Set the default context
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -304,7 +304,7 @@ func (dc *Command) RunDeploy(ctx context.Context, deployOptions *Options) error 
 
 	topLevelGitDir, err := repository.FindTopLevelGitDir(cwd, dc.Fs)
 	if err != nil {
-		oktetoLog.Warning("Repository not detected: the env vars '%s' and '%s' might not be available: %s.\n    For more information, check out: https://www.okteto.com/docs/manifest/okteto-variables/#default-environment-variables", constants.OktetoGitBranchEnvVar, constants.OktetoGitCommitEnvVar, err.Error())
+		oktetoLog.Warning("Repository not detected: the env vars '%s' and '%s' might not be available: %s.\n    For more information, check out: https://www.okteto.com/docs/core/okteto-variables/#default-environment-variables", constants.OktetoGitBranchEnvVar, constants.OktetoGitCommitEnvVar, err.Error())
 	}
 
 	if topLevelGitDir != "" {

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -264,7 +264,7 @@ func (dc *EndpointGetter) showEndpoints(ctx context.Context, opts *EndpointsOpti
 		}
 	default:
 		if len(eps) == 0 {
-			oktetoLog.Information("There are no available endpoints for '%s'.\n    Follow this link to know more about how to create public endpoints for your application:\n    https://www.okteto.com/docs/core/ingress/automatic-ssl", opts.Name)
+			oktetoLog.Information("There are no available endpoints for '%s'.\n    Follow this link to know more about how to create public endpoints for your application:\n    https://www.okteto.com/docs/core/endpoints/automatic-ssl", opts.Name)
 		} else {
 			oktetoLog.Information("Endpoints available:")
 			oktetoLog.Printf("  - %s\n", strings.Join(eps, "\n  - "))

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -111,7 +111,7 @@ func Destroy(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Contr
 		Use:   "destroy",
 		Short: `Destroy everything created by the 'okteto deploy' command`,
 		Long:  `Destroy everything created by the 'okteto deploy' command. You can also include a 'destroy' section in your okteto manifest with a list of custom commands to be executed on destroy`,
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#destroy"),
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.ManifestPath != "" {
 				// if path is absolute, its transformed to rel from root

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -43,7 +43,7 @@ func Doctor(k8sLogger *io.K8sLogger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "doctor [service]",
 		Short: "Generate a zip file with the okteto logs",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#doctor"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#doctor"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Info("starting doctor command")
 			ctx := context.Background()

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -50,7 +50,7 @@ func Down(k8sLogsCtrl *io.K8sLogger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "down [service]",
 		Short: "Deactivate your development container",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#down"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#down"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -115,7 +115,7 @@ func Exec(k8sLogger *io.K8sLogger) *cobra.Command {
 
 			return err
 		},
-		Args: utils.MinimumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#exec"),
+		Args: utils.MinimumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#exec"),
 	}
 
 	cmd.Flags().StringVarP(&execFlags.manifestPath, "file", "f", utils.DefaultManifest, "path to the manifest file")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,7 +37,7 @@ func Init(at analyticsTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
 	opts := &manifest.InitOpts{}
 	cmd := &cobra.Command{
 		Use:   "init",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#init"),
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#init"),
 		Short: "Automatically generate your okteto manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -35,7 +35,7 @@ func Kubeconfig(okClientProvider oktetoClientProvider) *cobra.Command {
 
 Generated kubeconfig file uses a credential plugin to get the cluster credentials via Okteto backend that requires the Okteto CLI to be in the PATH. Learn more about how to use the Kubernetes credentials at https://www.okteto.com/docs/core/credentials/kubernetes-credentials#using-your-kubernetes-credentials.
 `,
-		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#kubeconfig"),
+		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#kubeconfig"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return context.UpdateKubeconfigCMD(okClientProvider).RunE(cmd, args)
 		},

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -31,7 +31,7 @@ func Login() *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "login [url]",
-		Args:   utils.MaximumNArgsAccepted(1, "https://www.okteto.com/docs/reference/cli/#context"),
+		Args:   utils.MaximumNArgsAccepted(1, "https://www.okteto.com/docs/reference/okteto-cli/#context"),
 		Short:  "Log into Okteto",
 		Long: `Log into Okteto
 
@@ -48,7 +48,7 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning(`'okteto login' is deprecated in favor of 'okteto context', and will be removed in a future version.
-    Learn more about okteto context at https://okteto.com/docs/reference/cli/#context`)
+    Learn more about okteto context at https://okteto.com/docs/reference/okteto-cli/#context`)
 
 			ctxOptions := contextCMD.Options{
 				IsCtxCommand: true,

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -123,7 +123,7 @@ func Logs(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 			}
 			return nil
 		},
-		Args: utils.MaximumNArgsAccepted(1, "https://www.okteto.com/docs/reference/cli/#logs"),
+		Args: utils.MaximumNArgsAccepted(1, "https://www.okteto.com/docs/reference/okteto-cli/#logs"),
 	}
 
 	cmd.Flags().BoolVarP(&options.All, "all", "a", false, "fetch logs from the whole namespace")

--- a/cmd/manifest/init-v1.go
+++ b/cmd/manifest/init-v1.go
@@ -46,7 +46,7 @@ const (
 func (*Command) RunInitV1(ctx context.Context, opts *InitOpts) error {
 	oktetoLog.Println("This command walks you through creating an okteto manifest.")
 	oktetoLog.Println("It only covers the most common items, and tries to guess sensible defaults.")
-	oktetoLog.Println("See https://okteto.com/docs/reference/manifest/ for the official documentation about the okteto manifest.")
+	oktetoLog.Println("See https://okteto.com/docs/reference/okteto-manifest/ for the official documentation about the okteto manifest.")
 
 	if err := validateDevPath(opts.DevPath, opts.Overwrite); err != nil {
 		return err

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -61,7 +61,7 @@ func Namespace(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 		Use:     "namespace",
 		Short:   "Configure the current namespace of the okteto context",
 		Aliases: []string{"ns"},
-		Args:    utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#namespace"),
+		Args:    utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#namespace"),
 		RunE:    Use(ctx).RunE,
 	}
 	cmd.Flags().BoolVarP(&options.personal, "personal", "", false, "Load personal account")

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -42,7 +42,7 @@ func Use(ctx context.Context) *cobra.Command {
 		Use:     "use [namespace]",
 		Short:   "Configure the current namespace of the okteto context",
 		Aliases: []string{"ns"},
-		Args:    utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#use-1"),
+		Args:    utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#use-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace := ""
 			if len(args) > 0 {

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -86,7 +86,7 @@ func deploy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy an okteto pipeline",
-		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/cli/#deploy-1"),
+		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctxResource := &model.ContextResource{}
 			if err := ctxResource.UpdateNamespace(flags.namespace); err != nil {

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -57,7 +57,7 @@ func destroy(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy an okteto pipeline",
-		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/cli/#destroy-1"),
+		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#destroy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctxResource := &model.ContextResource{}
 			if err := ctxResource.UpdateNamespace(flags.namespace); err != nil {

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -56,7 +56,7 @@ func Pipeline(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
 		Short: "Pipeline management commands",
-		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/cli/#pipeline"),
+		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#pipeline"),
 	}
 	cmd.AddCommand(deploy(ctx))
 	cmd.AddCommand(destroy(ctx))

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -126,7 +126,7 @@ func Push(ctx context.Context) *cobra.Command {
 			if pushOpts.AutoDeploy {
 				oktetoLog.Warning(`The 'deploy' flag is deprecated and will be removed in a future version.
     Set the 'autocreate' field in your okteto manifest to get the same behavior.
-    More information is available here: https://okteto.com/docs/reference/cli#up`)
+    More information is available here: https://okteto.com/docs/reference/okteto-cli#up`)
 			}
 
 			if !dev.Autocreate {
@@ -171,7 +171,7 @@ func runPush(ctx context.Context, dev *model.Dev, pushOpts *pushOptions, c *kube
 				E: fmt.Errorf("application '%s' not found in namespace '%s'", dev.Name, dev.Namespace),
 				Hint: `Verify that your application is running and your okteto context is pointing to the right namespace
     Or set the 'autocreate' field in your okteto manifest if you want to create a standalone development container
-    More information is available here: https://okteto.com/docs/reference/cli#up`,
+    More information is available here: https://okteto.com/docs/reference/okteto-cli#up`,
 			}
 		}
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -41,7 +41,7 @@ func Restart() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "restart [service]",
 		Short:  "Restart the deployments listed in the services field of a development container",
-		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#restart"),
+		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#restart"),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -31,7 +31,7 @@ func Stack(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Control
 	cmd := &cobra.Command{
 		Use:    "stack",
 		Short:  "Stack management commands",
-		Args:   utils.NoArgsAccepted("https://www.okteto.com/docs/reference/cli/#deploy"),
+		Args:   utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy"),
 		Hidden: true,
 	}
 	cmd.AddCommand(deploy(ctx, at, ioCtrl))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -47,7 +47,7 @@ func Status() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Status of the synchronization process",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#status"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#status"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if okteto.InDevContainer() {

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -378,7 +378,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
 			// this provides 2 min for "FailedScheduling" to resolve by themselves
 			if strings.Contains(failedSchedulingEvent.Message, "Insufficient cpu") || strings.Contains(failedSchedulingEvent.Message, "Insufficient memory") {
 				return oktetoErrors.UserError{E: fmt.Errorf("insufficient resources"),
-					Hint: "Increase cluster resources or timeout of resources. More information is available here: https://okteto.com/docs/reference/manifest/#timeout-time-optional"}
+					Hint: "Increase cluster resources or timeout of resources. More information is available here: https://okteto.com/docs/reference/okteto-manifest/#timeout-time-optional"}
 			}
 			return fmt.Errorf(failedSchedulingEvent.Message)
 		}
@@ -433,7 +433,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
 						E: fmt.Errorf("there is no space left in persistent volume"),
 						Hint: fmt.Sprintf(`Okteto volume is full.
     Increase your persistent volume size, run '%s' and try 'okteto up' again.
-    More information about configuring your persistent volume at https://okteto.com/docs/reference/manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
+    More information about configuring your persistent volume at https://okteto.com/docs/reference/okteto-manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
 					}
 				}
 				if e.Type == "Warning" && strings.Contains(e.Message, "container veth name provided (eth0) already exists") {

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -65,7 +65,7 @@ import (
 const (
 	ReconnectingMessage = "Trying to reconnect to your cluster. File synchronization will automatically resume when the connection improves."
 
-	composeVolumesUrl = "https://www.okteto.com/docs/reference/compose/#volumes-string-optional"
+	composeVolumesUrl = "https://www.okteto.com/docs/reference/docker-compose/#volumes-string-optional"
 )
 
 var (
@@ -97,7 +97,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLo
 	cmd := &cobra.Command{
 		Use:   "up [service]",
 		Short: "Deploy your development environment",
-		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/cli/#up"),
+		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#up"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {
 				return oktetoErrors.ErrNotInDevContainer
@@ -433,7 +433,7 @@ func Up(at analyticsTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLo
 func (o *Options) AddArgs(cmd *cobra.Command, args []string) error {
 
 	maxV1Args := 1
-	docsURL := "https://okteto.com/docs/reference/cli/#up"
+	docsURL := "https://okteto.com/docs/reference/okteto-cli/#up"
 	if len(args) > maxV1Args {
 		if err := cmd.Help(); err != nil {
 			oktetoLog.Infof("could not show help: %s", err)
@@ -552,7 +552,7 @@ func getOverridedEnvVarsFromCmd(manifestEnvVars env.Environment, commandEnvVaria
 		kv := strings.SplitN(v, "=", varsLength)
 		if len(kv) != varsLength {
 			if kv[0] == "" {
-				return nil, fmt.Errorf("invalid variable value '%s': please review the accepted formats at https://www.okteto.com/docs/reference/manifest/#environment-string-optional ", v)
+				return nil, fmt.Errorf("invalid variable value '%s': please review the accepted formats at https://www.okteto.com/docs/reference/okteto-manifest/#environment-string-optional ", v)
 			}
 			kv = append(kv, os.Getenv(kv[0]))
 		}
@@ -912,14 +912,14 @@ func (up *upContext) getInsufficientSpaceError(err error) error {
 			E: err,
 			Hint: fmt.Sprintf(`Okteto volume is full.
     Increase your persistent volume size, run '%s' and try 'okteto up' again.
-    More information about configuring your persistent volume at https://okteto.com/docs/reference/manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
+    More information about configuring your persistent volume at https://okteto.com/docs/reference/okteto-manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
 		}
 	}
 	return oktetoErrors.UserError{
 		E: err,
 		Hint: `The synchronization service is running out of space.
     Enable persistent volumes in your okteto manifest and try again.
-    More information about configuring your persistent volume at https://okteto.com/docs/reference/manifest/#persistentvolume-object-optional`,
+    More information about configuring your persistent volume at https://okteto.com/docs/reference/okteto-manifest/#persistentvolume-object-optional`,
 	}
 
 }

--- a/cmd/utils/dev.go
+++ b/cmd/utils/dev.go
@@ -398,7 +398,7 @@ func GetApp(ctx context.Context, dev *model.Dev, c kubernetes.Interface, isRetry
 			E: fmt.Errorf("application '%s' not found in namespace '%s'", dev.Name, dev.Namespace),
 			Hint: `Verify that your application is running and your okteto context is pointing to the right namespace
     Or set the 'autocreate' field in your okteto manifest if you want to create a standalone development container
-    More information is available here: https://okteto.com/docs/reference/cli/#up`,
+    More information is available here: https://okteto.com/docs/reference/okteto-cli/#up`,
 		}
 	}
 	return app, false, nil

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,7 +28,7 @@ func Version() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "View the version of the okteto binary",
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/cli/#version"),
+		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#version"),
 		RunE:  Show().RunE,
 	}
 	cmd.AddCommand(Update())

--- a/docs/how-does-it-work.md
+++ b/docs/how-does-it-work.md
@@ -6,7 +6,7 @@ Okteto helps you move your development environment into any Kubernetes cluster. 
 
 When you run `okteto up`, okteto scales to zero the **api** deployment and creates a mirror deployment **api-okteto**. This deployment is a copy of the **api** deployment manifest with the following development-time improvements:
 
-- Okteto overrides the container-level configuration of the **api-okteto** deployment with the values defined in your [okteto manifest](https://okteto.com/docs/reference/manifest/). A typical example of this is to replace the production container image with one that contains your development runtime.
+- Okteto overrides the container-level configuration of the **api-okteto** deployment with the values defined in your [okteto manifest](https://okteto.com/docs/reference/okteto-manifest/). A typical example of this is to replace the production container image with one that contains your development runtime.
 - A bidirectional file [synchronization service](https://okteto.com/docs/reference/file-synchronization/) is started to keep your changes up to date between your local filesystem and your development container.
 - Automatic local and remote port forwarding using [SSH](https://okteto.com/docs/reference/ssh-server/). This allows you to do things like access your cluster services via `localhost` or connect a remote debugger.
 - A watcher service to keep the definition of **api-okteto** up to date with **api**

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -56,7 +56,7 @@ func (*Controller) AuthenticateToOktetoCluster(ctx context.Context, oktetoURL, t
 		if err != nil {
 			return nil, oktetoErrors.UserError{
 				E:    fmt.Errorf("couldn't authenticate to okteto context: %w", err),
-				Hint: "Try to set the context using the 'token' flag: https://www.okteto.com/docs/reference/cli/#context",
+				Hint: "Try to set the context using the 'token' flag: https://www.okteto.com/docs/reference/okteto-cli/#context",
 			}
 		}
 		if user.New {
@@ -85,7 +85,7 @@ func WithBrowser(ctx context.Context, oktetoURL string) (*types.User, error) {
 		if strings.Contains(err.Error(), "executable file not found in $PATH") {
 			return nil, oktetoErrors.UserError{
 				E:    fmt.Errorf("no browser could be found"),
-				Hint: "Use the '--token' flag to run this command in server mode. More information can be found here: https://www.okteto.com/docs/reference/cli/#context",
+				Hint: "Use the '--token' flag to run this command in server mode. More information can be found here: https://www.okteto.com/docs/reference/okteto-cli/#context",
 			}
 		}
 		oktetoLog.Errorf("Something went wrong opening your browser: %s\n", err)

--- a/pkg/k8s/apps/validation.go
+++ b/pkg/k8s/apps/validation.go
@@ -34,7 +34,7 @@ func ValidateMountPaths(spec *apiv1.PodSpec, dev *model.Dev) error {
 			if vm.MountPath == syncVolume.RemotePath {
 				return oktetoErrors.UserError{
 					E:    fmt.Errorf("'%s' is already defined as volume in %s", vm.MountPath, dev.Name),
-					Hint: `Disable the okteto persistent volume (https://okteto.com/docs/reference/manifest/#persistentvolume-object-optional) and try again`}
+					Hint: `Disable the okteto persistent volume (https://okteto.com/docs/reference/okteto-manifest/#persistentvolume-object-optional) and try again`}
 			}
 		}
 	}

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -156,7 +156,7 @@ const (
 	// this path is expected by remote
 	authorizedKeysPath = "/var/okteto/remote/authorized_keys"
 
-	syncFieldDocsURL = "https://okteto.com/docs/reference/manifest/#sync-string-required"
+	syncFieldDocsURL = "https://okteto.com/docs/reference/okteto-manifest/#sync-string-required"
 
 	// HelmSecretType indicates the type for secrets created by Helm
 	HelmSecretType = "helm.sh/release.v1"

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -1140,14 +1140,14 @@ func GetTimeout() (time.Duration, error) {
 
 func (dev *Dev) translateDeprecatedMetadataFields() {
 	if len(dev.Labels) > 0 {
-		oktetoLog.Warning("The field 'labels' is deprecated and will be removed in a future version. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)")
+		oktetoLog.Warning("The field 'labels' is deprecated and will be removed in a future version. Use the field 'selector' instead (https://okteto.com/docs/reference/okteto-manifest/#selector)")
 		for k, v := range dev.Labels {
 			dev.Selector[k] = v
 		}
 	}
 
 	if len(dev.Annotations) > 0 {
-		oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in a future version. Use the field 'metadata.annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)")
+		oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in a future version. Use the field 'metadata.annotations' instead (https://okteto.com/docs/reference/okteto-manifest/#metadata)")
 		for k, v := range dev.Annotations {
 			dev.Metadata.Annotations[k] = v
 		}
@@ -1161,7 +1161,7 @@ func (dev *Dev) translateDeprecatedMetadataFields() {
 		}
 
 		if len(s.Annotations) > 0 {
-			oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in a future version. Use the field '%s.metadata.annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)", s.Name)
+			oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in a future version. Use the field '%s.metadata.annotations' instead (https://okteto.com/docs/reference/okteto-manifest/#metadata)", s.Name)
 			for k, v := range s.Annotations {
 				dev.Services[indx].Metadata.Annotations[k] = v
 			}
@@ -1170,7 +1170,7 @@ func (dev *Dev) translateDeprecatedMetadataFields() {
 }
 
 func (service *Dev) validateForExtraFields() error {
-	errorMessage := "%q is not supported in Services. Please visit https://www.okteto.com/docs/reference/manifest/#services-object-optional for documentation"
+	errorMessage := "%q is not supported in Services. Please visit https://www.okteto.com/docs/reference/okteto-manifest/#services-object-optional for documentation"
 	if service.Username != "" {
 		return fmt.Errorf(errorMessage, "username")
 	}

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1393,7 +1393,7 @@ services:
         cpu: "500m"
     workdir: /app
     %s`, tt.value))
-			expected := fmt.Sprintf("error on dev 'deployment': %q is not supported in Services. Please visit https://www.okteto.com/docs/reference/manifest/#services-object-optional for documentation", tt.name)
+			expected := fmt.Sprintf("error on dev 'deployment': %q is not supported in Services. Please visit https://www.okteto.com/docs/reference/okteto-manifest/#services-object-optional for documentation", tt.name)
 
 			_, err := Read(manifest)
 			assert.NotNil(t, err)

--- a/pkg/model/devrc.go
+++ b/pkg/model/devrc.go
@@ -16,7 +16,6 @@ package model
 import (
 	"os"
 	"sort"
-	"strings"
 
 	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -75,7 +74,7 @@ func ReadRC(bytes []byte) (*DevRC, error) {
 
 func MergeDevWithDevRc(dev *Dev, devRc *DevRC) {
 	if len(devRc.Annotations) > 0 {
-		oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in a future version. Use the field 'metadata.Annotations' instead (https://okteto.com/docs/reference/manifest/#metadata)")
+		oktetoLog.Warning("The field 'annotations' is deprecated and will be removed in a future version. Use the field 'metadata.Annotations' instead (https://okteto.com/docs/reference/okteto-manifest/#metadata)")
 		for annotationKey, annotationValue := range devRc.Annotations {
 			dev.Metadata.Annotations[annotationKey] = annotationValue
 		}
@@ -99,7 +98,7 @@ func MergeDevWithDevRc(dev *Dev, devRc *DevRC) {
 
 	}
 	sort.SliceStable(dev.Environment, func(i, j int) bool {
-		return strings.Compare(dev.Environment[i].Name, dev.Environment[j].Name) < 0
+		return dev.Environment[i].Name < dev.Environment[j].Name
 	})
 
 	for _, fwd := range devRc.Forward {
@@ -126,7 +125,7 @@ func MergeDevWithDevRc(dev *Dev, devRc *DevRC) {
 	}
 
 	if len(devRc.Labels) > 0 {
-		oktetoLog.Warning("The field 'labels' is deprecated and will be removed in a future version. Use the field 'selector' instead (https://okteto.com/docs/reference/manifest/#selector)")
+		oktetoLog.Warning("The field 'labels' is deprecated and will be removed in a future version. Use the field 'selector' instead (https://okteto.com/docs/reference/okteto-manifest/#selector)")
 		for labelKey, labelValue := range devRc.Labels {
 			dev.Selector[labelKey] = labelValue
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -58,17 +58,17 @@ var (
 )
 
 const (
-	buildHeadComment = "The build section defines how to build the images of your development environment\nMore info: https://www.okteto.com/docs/reference/manifest/#build"
+	buildHeadComment = "The build section defines how to build the images of your development environment\nMore info: https://www.okteto.com/docs/reference/okteto-manifest/#build"
 	buildExample     = `build:
   my-service:
     context: .`
 	buildSvcEnvVars   = "You can use the following env vars to refer to this image in your deploy commands:\n - OKTETO_BUILD_%s_REGISTRY: image registry\n - OKTETO_BUILD_%s_REPOSITORY: image repo\n - OKTETO_BUILD_%s_IMAGE: image name\n - OKTETO_BUILD_%s_SHA: image tag sha256"
-	deployHeadComment = "The deploy section defines how to deploy your development environment\nMore info: https://www.okteto.com/docs/reference/manifest/#deploy"
+	deployHeadComment = "The deploy section defines how to deploy your development environment\nMore info: https://www.okteto.com/docs/reference/okteto-manifest/#deploy"
 	deployExample     = `deploy:
   commands:
   - name: Deploy
     command: echo 'Replace this line with the proper 'helm' or 'kubectl' commands to deploy your development environment'`
-	devHeadComment = "The dev section defines how to activate a development container\nMore info: https://www.okteto.com/docs/reference/manifest/#dev"
+	devHeadComment = "The dev section defines how to activate a development container\nMore info: https://www.okteto.com/docs/reference/okteto-manifest/#dev"
 	devExample     = `dev:
   sample:
     image: okteto/dev:latest
@@ -80,7 +80,7 @@ const (
       - name=$USER
     forward:
       - 8080:80`
-	dependenciesHeadComment = "The dependencies section defines other git repositories to be deployed as part of your development environment\nMore info: https://www.okteto.com/docs/reference/manifest/#dependencies"
+	dependenciesHeadComment = "The dependencies section defines other git repositories to be deployed as part of your development environment\nMore info: https://www.okteto.com/docs/reference/okteto-manifest/#dependencies"
 	dependenciesExample     = `dependencies:
   - https://github.com/okteto/sample`
 
@@ -678,7 +678,7 @@ func Read(bytes []byte) (*Manifest, error) {
 	for _, dev := range manifest.Dev {
 		if dev.Image != nil && (dev.Image.Context != "" || dev.Image.Dockerfile != "") && !hasShownWarning {
 			hasShownWarning = true
-			oktetoLog.Yellow(`The 'image' extended syntax is deprecated and will be removed in a future version. Define the images you want to build in the 'build' section of your manifest. More info at https://www.okteto.com/docs/reference/manifest/#build"`)
+			oktetoLog.Yellow(`The 'image' extended syntax is deprecated and will be removed in a future version. Define the images you want to build in the 'build' section of your manifest. More info at https://www.okteto.com/docs/reference/okteto-manifest/#build"`)
 		}
 
 	}

--- a/pkg/model/manifest_friendly_err.go
+++ b/pkg/model/manifest_friendly_err.go
@@ -116,7 +116,7 @@ func isYamlError(err error) bool {
 // addUrlToManifestDocs appends to the error the URL to the Okteto manifest ref docs
 func addUrlToManifestDocs() *suggest.Rule {
 	addUrl := func(e error) error {
-		docsURL := "https://www.okteto.com/docs/reference/manifest"
+		docsURL := "https://www.okteto.com/docs/reference/okteto-manifest"
 		errorWithUrlToDocs := fmt.Sprintf("%s\n    Check out the okteto manifest docs at: %s", e.Error(), docsURL)
 		return errors.New(errorWithUrlToDocs)
 	}

--- a/pkg/model/manifest_friendly_err_test.go
+++ b/pkg/model/manifest_friendly_err_test.go
@@ -67,14 +67,14 @@ func TestUserFriendlyError(t *testing.T) {
 			input: errors.New("yaml: some random error"),
 			expected: `your okteto manifest is not valid, please check the following errors:
 yaml: some random error
-    Check out the okteto manifest docs at: https://www.okteto.com/docs/reference/manifest`,
+    Check out the okteto manifest docs at: https://www.okteto.com/docs/reference/okteto-manifest`,
 		},
 		{
 			name:  "yaml errors with heading and link to docs",
 			input: errors.New("yaml: unmarshal errors:\n  line 4: field contest not found in type model.manifestRaw"),
 			expected: `your okteto manifest is not valid, please check the following errors:
      - line 4: field 'contest' is not a property of the okteto manifest. Did you mean "context"?
-    Check out the okteto manifest docs at: https://www.okteto.com/docs/reference/manifest`,
+    Check out the okteto manifest docs at: https://www.okteto.com/docs/reference/okteto-manifest`,
 		},
 	}
 

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -361,7 +361,7 @@ func ReadStack(bytes []byte, isCompose bool) (*Stack, error) {
 				_, _ = sb.WriteString(fmt.Sprintf("    - %s\n", e))
 			}
 
-			_, _ = sb.WriteString("    See https://okteto.com/docs/reference/compose/ for details")
+			_, _ = sb.WriteString("    See https://okteto.com/docs/reference/docker-compose/ for details")
 			return nil, errors.New(sb.String())
 		}
 		if errors.Is(err, oktetoErrors.ErrServiceEmpty) {
@@ -490,7 +490,7 @@ func (s *Stack) Validate() error {
 				continue
 			}
 			if _, err := filepath.Rel(wd, v.LocalPath); err != nil {
-				s.Warnings.VolumeMountWarnings = append(s.Warnings.VolumeMountWarnings, fmt.Sprintf("[%s]: volume '%s:%s' will be ignored. You can synchronize code to your containers using 'okteto up'. More information available here: https://okteto.com/docs/reference/cli/#up", name, v.LocalPath, v.RemotePath))
+				s.Warnings.VolumeMountWarnings = append(s.Warnings.VolumeMountWarnings, fmt.Sprintf("[%s]: volume '%s:%s' will be ignored. You can synchronize code to your containers using 'okteto up'. More information available here: https://okteto.com/docs/reference/okteto-cli/#up", name, v.LocalPath, v.RemotePath))
 			}
 			if !strings.HasPrefix(v.RemotePath, "/") {
 				return fmt.Errorf("invalid volume '%s' in service '%s': must be an absolute path", v.ToString(), name)

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -1589,11 +1589,11 @@ func validateExtensions(stack StackRaw) error {
 		}
 	}
 	if len(nonValidFields) == 1 {
-		return fmt.Errorf("invalid compose manifest: Field '%s' is not supported.\n    More information is available here: https://okteto.com/docs/reference/compose/", nonValidFields[0])
+		return fmt.Errorf("invalid compose manifest: Field '%s' is not supported.\n    More information is available here: https://okteto.com/docs/reference/docker-compose/", nonValidFields[0])
 	} else if len(nonValidFields) > 1 {
 		return fmt.Errorf(`invalid compose manifest: The following fields are not supported.
     - %s
-    More information is available here: https://okteto.com/docs/reference/compose/`, strings.Join(nonValidFields, "\n    - "))
+    More information is available here: https://okteto.com/docs/reference/docker-compose/`, strings.Join(nonValidFields, "\n    - "))
 	}
 	return nil
 }

--- a/pkg/ssh/exec.go
+++ b/pkg/ssh/exec.go
@@ -178,7 +178,7 @@ func Exec(ctx context.Context, iface string, remotePort int, tty bool, inR io.Re
 	}
 	if strings.Contains(err.Error(), "exit code 137") || strings.Contains(err.Error(), "exit status 137") {
 		oktetoLog.Yellow(`Insufficient memory. Please update your resources on your okteto manifest.
-More information is available here: https://okteto.com/docs/reference/manifest/#resources-object-optional`)
+More information is available here: https://okteto.com/docs/reference/okteto-manifest/#resources-object-optional`)
 	}
 
 	oktetoLog.Infof("command failed: %s", err)


### PR DESCRIPTION
I have reviewed our links to the docs to make sure they are working after the new docs structure.
None of the links where broken because of our netlify redirects, but I think it's better to use the current links