### PR TITLE
fix: clean manifest path in remote deploy to fix regression

### DIFF
--- a/cmd/build/v1/build.go
+++ b/cmd/build/v1/build.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-// OktetoBuilder It is a wrapper of basic.Builder to build an image specificied by a Dockerfile. a.k.a. Builder v1
+// OktetoBuilder It is a wrapper of basic.Builder to build an image specified by a Dockerfile. a.k.a. Builder v1
 // It mainly extends the basic.Builder with the ability to expand the image tag with the environment variables and
 // printing the corresponding output when the build finishes.
 type OktetoBuilder struct {

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -317,7 +317,7 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 	// build the services) so we would create a remote executor without certain files
 	// necessary for the later deployment which would cause an error when deploying
 	// remotely due to the lack of these files.
-	if err := remote.CreateDockerignoreFileWithFilesystem(cwd, tmpDir, cleanManifestPath(opts.ManifestPathFlag), rd.fs); err != nil {
+	if err := remote.CreateDockerignoreFileWithFilesystem(cwd, tmpDir, filesystem.CleanManifestPath(opts.ManifestPathFlag), rd.fs); err != nil {
 		return "", err
 	}
 
@@ -325,19 +325,6 @@ func (rd *remoteDeployCommand) createDockerfile(tmpDir string, opts *Options) (s
 		return "", err
 	}
 	return dockerfile.Name(), nil
-}
-
-// cleanManifestPath removes the path to the manifest file, in case the command was executed from a parent or child folder
-func cleanManifestPath(manifestPath string) string {
-	lastFolder := filepath.Base(filepath.Dir(manifestPath))
-	if lastFolder == ".okteto" {
-		path := filepath.Clean(manifestPath)
-		parts := strings.Split(path, string(filepath.Separator))
-
-		return filepath.Join(parts[len(parts)-2:]...)
-	} else {
-		return filepath.Base(manifestPath)
-	}
 }
 
 func getDeployFlags(opts *Options) ([]string, error) {
@@ -352,7 +339,7 @@ func getDeployFlags(opts *Options) ([]string, error) {
 	}
 
 	if opts.ManifestPathFlag != "" {
-		deployFlags = append(deployFlags, fmt.Sprintf("--file %s", cleanManifestPath(opts.ManifestPathFlag)))
+		deployFlags = append(deployFlags, fmt.Sprintf("--file %s", filesystem.CleanManifestPath(opts.ManifestPathFlag)))
 	}
 
 	if len(opts.Variables) > 0 {

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -725,39 +725,3 @@ func TestGetOriginalCWD(t *testing.T) {
 		require.Equal(t, expected, result)
 	})
 }
-
-func Test_cleanManifestPath(t *testing.T) {
-	var tests = []struct {
-		name     string
-		manifest string
-		expected string
-	}{
-		{
-			name:     "empty manifest",
-			manifest: "",
-			expected: ".",
-		},
-		{
-			name:     "absolute path to manifest file",
-			manifest: "/path/to/service/okteto.yml",
-			expected: "okteto.yml",
-		},
-		{
-			name:     "relative path to manifest file",
-			manifest: "./service/okteto.yml",
-			expected: "okteto.yml",
-		},
-		{
-			name:     "manifest within .okteto",
-			manifest: "/path/to/service/.okteto/okteto.yml",
-			expected: filepath.Clean(".okteto/okteto.yml"),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := cleanManifestPath(tt.manifest)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -724,5 +724,40 @@ func TestGetOriginalCWD(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expected, result)
 	})
+}
 
+func Test_cleanManifestPath(t *testing.T) {
+	var tests = []struct {
+		name     string
+		manifest string
+		expected string
+	}{
+		{
+			name:     "empty manifest",
+			manifest: "",
+			expected: ".",
+		},
+		{
+			name:     "absolute path to manifest file",
+			manifest: "/path/to/service/okteto.yml",
+			expected: "okteto.yml",
+		},
+		{
+			name:     "relative path to manifest file",
+			manifest: "./service/okteto.yml",
+			expected: "okteto.yml",
+		},
+		{
+			name:     "manifest within .okteto",
+			manifest: "/path/to/service/.okteto/okteto.yml",
+			expected: ".okteto/okteto.yml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cleanManifestPath(tt.manifest)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -750,7 +750,7 @@ func Test_cleanManifestPath(t *testing.T) {
 		{
 			name:     "manifest within .okteto",
 			manifest: "/path/to/service/.okteto/okteto.yml",
-			expected: ".okteto/okteto.yml",
+			expected: filepath.Clean(".okteto/okteto.yml"),
 		},
 	}
 

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -305,7 +305,7 @@ func (rd *remoteDestroyCommand) createDockerfile(tempDir string, opts *Options) 
 		return "", err
 	}
 
-	if err = remote.CreateDockerignoreFileWithFilesystem(cwd, tempDir, opts.ManifestPathFlag, rd.fs); err != nil {
+	if err = remote.CreateDockerignoreFileWithFilesystem(cwd, tempDir, filesystem.CleanManifestPath(opts.ManifestPathFlag), rd.fs); err != nil {
 		return "", err
 	}
 
@@ -345,15 +345,7 @@ func getDestroyFlags(opts *Options) []string {
 	}
 
 	if opts.ManifestPathFlag != "" {
-		lastFolder := filepath.Base(filepath.Dir(opts.ManifestPathFlag))
-		if lastFolder == ".okteto" {
-			path := filepath.Clean(opts.ManifestPathFlag)
-			parts := strings.Split(path, string(filepath.Separator))
-
-			deployFlags = append(deployFlags, fmt.Sprintf("--file %s", filepath.Join(parts[len(parts)-2:]...)))
-		} else {
-			deployFlags = append(deployFlags, fmt.Sprintf("--file %s", filepath.Base(opts.ManifestPathFlag)))
-		}
+		deployFlags = append(deployFlags, fmt.Sprintf("--file %s", filesystem.CleanManifestPath(opts.ManifestPathFlag)))
 	}
 
 	if opts.DestroyVolumes {

--- a/pkg/filesystem/manifest.go
+++ b/pkg/filesystem/manifest.go
@@ -1,0 +1,32 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// CleanManifestPath removes the path to the manifest file, in case the command was executed from a parent or child folder
+func CleanManifestPath(manifestPath string) string {
+	lastFolder := filepath.Base(filepath.Dir(manifestPath))
+	if lastFolder == ".okteto" {
+		path := filepath.Clean(manifestPath)
+		parts := strings.Split(path, string(filepath.Separator))
+
+		return filepath.Join(parts[len(parts)-2:]...)
+	} else {
+		return filepath.Base(manifestPath)
+	}
+}

--- a/pkg/filesystem/manifest_test.go
+++ b/pkg/filesystem/manifest_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesystem
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_cleanManifestPath(t *testing.T) {
+	var tests = []struct {
+		name     string
+		manifest string
+		expected string
+	}{
+		{
+			name:     "empty manifest",
+			manifest: "",
+			expected: ".",
+		},
+		{
+			name:     "absolute path to manifest file",
+			manifest: "/path/to/service/okteto.yml",
+			expected: "okteto.yml",
+		},
+		{
+			name:     "relative path to manifest file",
+			manifest: "./service/okteto.yml",
+			expected: "okteto.yml",
+		},
+		{
+			name:     "manifest within .okteto",
+			manifest: "/path/to/service/.okteto/okteto.yml",
+			expected: filepath.Clean(".okteto/okteto.yml"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CleanManifestPath(tt.manifest)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-199

## How to validate

1. Clone my test repo on the given branch: `git clone -b fix-dev-199 git@github.com:andreafalzetti/k8s-status-api.git`
1. Using the `2.25.1` reproduce the bug by running: `okteto up --deploy -f apps/service/okteto.yml`
1. Observe the error: `Okteto.yml file doesn't exist`
1. Now run the same command with the CLI from this branch
1. Notice how the `okteto up` session, works as expected

Repeat the steps for `destroy` and make sure it works as expected

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
