### PR TITLE
feat: add okteto local credentials by env var

### DIFF
--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -15,7 +15,6 @@ package build
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -144,10 +143,7 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 		return nil, err
 	}
 
-	credentials, err := ap.getOktetoCredentials(originalHost, c)
-	if err != nil {
-		return nil, fmt.Errorf("error getting credentials from okteto - %s", err)
-	}
+	credentials := ap.getOktetoCredentials(originalHost, c)
 
 	retrieveFromLocal := env.LoadBooleanOrDefault(oktetoLocalRegistryStoreEnabledEnvVarKey, true)
 	if !retrieveFromLocal {
@@ -177,7 +173,7 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 	return credentials, nil
 }
 
-func (ap *authProvider) getOktetoCredentials(host string, c *okteto.Client) (*auth.CredentialsResponse, error) {
+func (ap *authProvider) getOktetoCredentials(host string, c *okteto.Client) *auth.CredentialsResponse {
 	res := &auth.CredentialsResponse{}
 	if user, pass, err := ap.externalAuth(host, ap.authContext.isOktetoContext(), c); err != nil {
 		oktetoLog.Debugf("failed to load external auth for %s: %w", host, err.Error())
@@ -185,7 +181,7 @@ func (ap *authProvider) getOktetoCredentials(host string, c *okteto.Client) (*au
 		res.Username = user
 		res.Secret = pass
 	}
-	return res, nil
+	return res
 }
 
 func isErrCredentialsHelperNotAccessible(err error) bool {

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -82,7 +82,7 @@ type fakeContext struct{}
 
 func (fakeContext) isOktetoContext() bool                 { return true }
 func (fakeContext) getOktetoClientCfg() *okteto.ClientCfg { return nil }
-func (fakeContext) getExternalRegistryCreds(registryOrImage string, isOkteto bool, c *okteto.Client) (string, string, error) {
+func (fakeContext) getExternalRegistryCreds(string, bool, *okteto.Client) (string, string, error) {
 	return "", "", nil
 }
 
@@ -128,13 +128,13 @@ func TestCredentials(t *testing.T) {
 	oktetoRegistry = "okteto.registry.com"
 
 	tt := []struct {
-		name              string
 		credRequest       *auth.CredentialsRequest
-		envVarSet         bool
+		expected          *auth.CredentialsResponse
+		name              string
 		envVarValue       string
+		envVarSet         bool
 		localCredentials  bool
 		oktetoCredentials bool
-		expected          *auth.CredentialsResponse
 	}{
 		{
 			name: "okteto registry",

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -106,7 +106,7 @@ func TestGetOktetoCredentials(t *testing.T) {
 		{
 			name:     "error getting okteto credentials",
 			err:      assert.AnError,
-			expected: nil,
+			expected: &auth.CredentialsResponse{},
 		},
 	}
 	for _, tc := range tt {

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -87,11 +87,11 @@ func (fakeContext) getExternalRegistryCreds(registryOrImage string, isOkteto boo
 
 func TestGetOktetoCredentials(t *testing.T) {
 	tt := []struct {
+		err      error
+		expected *auth.CredentialsResponse
 		name     string
 		user     string
 		pass     string
-		err      error
-		expected *auth.CredentialsResponse
 	}{
 		{
 			name: "okteto credentials",
@@ -117,8 +117,7 @@ func TestGetOktetoCredentials(t *testing.T) {
 				},
 				authContext: &fakeContext{},
 			}
-			creds, err := ap.getOktetoCredentials("", nil)
-			require.NoError(t, err)
+			creds := ap.getOktetoCredentials("", nil)
 			require.Equal(t, tc.expected, creds)
 		})
 	}


### PR DESCRIPTION
# Proposed changes

DEV-175

- Adds a new environment variable `OKTETO_LOCAL_REGISTRY_STORE_ENABLED` that defaults to `true` if it's unset. If the value is false we are not retrieving credentials from local.  
- Add a new function `getOktetoCredentials` to retrieve credentials from the Okteto credentials store. (Created the function in order to start testing this path)
- Modified the `Credentials` function to utilize the `getOktetoCredentials` function. The code is basically is the same, but we add the `retrieveFromLocal` var in order to know if we should be getting the variables from local or just from the okteto registry. **In the future this boolean will change default to false**. 


## How to validate

There are different scenarios with different configurations. The best way to test it is to create a matrix with all the different configurations in all the different scenarios:

### Configurations

#### Credentials
1. Local credentials set but okteto credentials unset
2. okteto credentials set but local credentials unset
3. okteto credentials and local credentials set (You'll need two different docker accounts, and a private image)
4. okteto credentials and local credentials unset

#### `OKTETO_LOCAL_REGISTRY_STORE_ENABLED` env var
1. Env var set to true
2. Env var set to false
3. Env var unset

### Scenarios

All these scenarios asumes that the image that we are trying to access is a private image.

#### Access from Dockerfile

1. Create the following `Dockerfile`:
```Dockerfile
FROM {{ PRIVATE_IMAGE }}
RUN echo hello
```
2. Run `okteto build`

#### Push to a private image

1. Create the following `Dockerfile`:
```Dockerfile
FROM busybox
RUN echo hello
```
2. Run `okteto build -t {{ PRIVATE_IMAGE }}`

### Using remote from a private image
1. Create the following `okteto.yml`:
```yaml
deploy:
  image: {{ PRIVATE_IMAGE }}
  commands:
  - echo hello
```
2. Run `okteto deploy`

### Results

| Scenario | Configuration | `OKTETO_LOCAL_REGISTRY_STORE_ENABLED` | Local Credentials | Okteto Credentials | Expected Outcome |
|----------|----------------|----------------------------------------|-------------------|--------------------|------------------|
| Access from Dockerfile | 1              | true                                   | Set               | Unset              | Use local credentials |
|                        | 2              | true                                   | Unset             | Set                | Use Okteto credentials |
|                        | 3              | true                                   | Set               | Set                | Use local credentials |
|                        | 4              | true                                   | Unset             | Unset              | **Fail** |
|                        | 5              | false                                  | Set               | Unset              | **Fail** |
|                        | 6              | false                                  | Unset             | Set                | Use Okteto credentials |
|                        | 7              | false                                  | Set               | Set                | Use Okteto credentials |
|                        | 8              | false                                  | Unset             | Unset              | **Fail** |
|                        | 9              | unset                                  | Set               | Unset              | Use local credentials |
|                        | 10             | unset                                  | Unset             | Set                | Use Okteto credentials |
|                        | 11             | unset                                  | Set               | Set                | Use local credentials |
|                        | 12             | unset                                  | Unset             | Unset              | Use local credentials |
| Push to a private image | 1              | true                                   | Set               | Unset              | Use local credentials |
|                        | 2              | true                                   | Unset             | Set                | Use Okteto credentials |
|                        | 3              | true                                   | Set               | Set                | Use local credentials |
|                        | 4              | true                                   | Unset             | Unset              | **Fail** |
|                        | 5              | false                                  | Set               | Unset              | **Fail** |
|                        | 6              | false                                  | Unset             | Set                | Use Okteto credentials |
|                        | 7              | false                                  | Set               | Set                | Use Okteto credentials |
|                        | 8              | false                                  | Unset             | Unset              | **Fail** |
|                        | 9              | unset                                  | Set               | Unset              | Use local credentials |
|                        | 10             | unset                                  | Unset             | Set                | Use Okteto credentials |
|                        | 11             | unset                                  | Set               | Set                | Use local credentials |
|                        | 12             | unset                                  | Unset             | Unset              | Use local credentials |
| Using remote from a private image | 1              | true                                   | Set               | Unset              | Use local credentials |
|                        | 2              | true                                   | Unset             | Set                | Use Okteto credentials |
|                        | 3              | true                                   | Set               | Set                | Use local credentials |
|                        | 4              | true                                   | Unset             | Unset              | **Fail** |
|                        | 5              | false                                  | Set               | Unset              | **Fail** |
|                        | 6              | false                                  | Unset             | Set                | Use Okteto credentials |
|                        | 7              | false                                  | Set               | Set                | Use Okteto credentials |
|                        | 8              | false                                  | Unset             | Unset              | **Fail** |
|                        | 9              | unset                                  | Set               | Unset              | Use local credentials |
|                        | 10             | unset                                  | Unset             | Set                | Use Okteto credentials |
|                        | 11             | unset                                  | Set               | Set                | Use local credentials |
|                        | 12             | unset                                  | Unset             | Unset              | Use local credentials |

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
