### PR TITLE
fix: getContextPath when manifestpath is subdir

### DIFF
--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -281,8 +281,18 @@ func TestRemoteDeployWithBadSshAgent(t *testing.T) {
 }
 
 func TestGetDeployFlags(t *testing.T) {
+	fakeCwd, _ := filepath.Abs("/")
+	fakeFsFn := func() afero.Fs {
+		fs := afero.NewMemMapFs()
+		rootPath, _ := filepath.Abs("/")
+		_ = fs.MkdirAll(rootPath, 0755)
+		return fs
+	}
+
 	type config struct {
-		opts *Options
+		opts   *Options
+		fakeFs func() afero.Fs
+		cwd    string
 	}
 	var tests = []struct {
 		name      string
@@ -296,6 +306,8 @@ func TestGetDeployFlags(t *testing.T) {
 				opts: &Options{
 					Timeout: 2 * time.Minute,
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected: []string{"--timeout 2m0s"},
 		},
@@ -306,6 +318,8 @@ func TestGetDeployFlags(t *testing.T) {
 					Name:    "test",
 					Timeout: 5 * time.Minute,
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected: []string{"--name \"test\"", "--timeout 5m0s"},
 		},
@@ -316,6 +330,8 @@ func TestGetDeployFlags(t *testing.T) {
 					Name:    "this is a test",
 					Timeout: 5 * time.Minute,
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected: []string{"--name \"this is a test\"", "--timeout 5m0s"},
 		},
@@ -326,6 +342,8 @@ func TestGetDeployFlags(t *testing.T) {
 					Namespace: "test",
 					Timeout:   5 * time.Minute,
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected: []string{"--namespace test", "--timeout 5m0s"},
 		},
@@ -336,6 +354,13 @@ func TestGetDeployFlags(t *testing.T) {
 					ManifestPathFlag: "/hello/this/is/a/test",
 					ManifestPath:     "/hello/this/is/a/test",
 					Timeout:          5 * time.Minute,
+				},
+				cwd: fakeCwd,
+				fakeFs: func() afero.Fs {
+					fs := afero.NewMemMapFs()
+					path, _ := filepath.Abs("/hello/this/is/a/test")
+					_ = afero.WriteFile(fs, path, []byte{}, 0644)
+					return fs
 				},
 			},
 			expected: []string{"--file test", "--timeout 5m0s"},
@@ -348,8 +373,34 @@ func TestGetDeployFlags(t *testing.T) {
 					ManifestPath:     "/hello/this/is/a/.okteto/test",
 					Timeout:          5 * time.Minute,
 				},
+				cwd: fakeCwd,
+				fakeFs: func() afero.Fs {
+					fs := afero.NewMemMapFs()
+					path, _ := filepath.Abs("/hello/this/is/a/.okteto/test")
+					_ = afero.WriteFile(fs, path, []byte{}, 0644)
+					return fs
+				},
 			},
 			expected: []string{fmt.Sprintf("--file %s", filepath.Clean(".okteto/test")), "--timeout 5m0s"},
+		},
+		{
+			name: "manifest path set as directory",
+			config: config{
+				opts: &Options{
+					Name:             "test",
+					ManifestPathFlag: "/hello/this/is/a/folder",
+					ManifestPath:     "/hello/this/is/a/folder",
+					Timeout:          5 * time.Minute,
+				},
+				cwd: fakeCwd,
+				fakeFs: func() afero.Fs {
+					fs := afero.NewMemMapFs()
+					path, _ := filepath.Abs("/hello/this/is/a/folder")
+					_ = fs.MkdirAll(path, 0755)
+					return fs
+				},
+			},
+			expected: []string{"--name \"test\"", "--timeout 5m0s"},
 		},
 		{
 			name: "variables set",
@@ -361,6 +412,8 @@ func TestGetDeployFlags(t *testing.T) {
 					},
 					Timeout: 5 * time.Minute,
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected: []string{"--var a=\"b\" --var c=\"d\"", "--timeout 5m0s"},
 		},
@@ -371,6 +424,8 @@ func TestGetDeployFlags(t *testing.T) {
 					Wait:    true,
 					Timeout: 5 * time.Minute,
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected: []string{"--wait", "--timeout 5m0s"},
 		},
@@ -380,6 +435,8 @@ func TestGetDeployFlags(t *testing.T) {
 				opts: &Options{
 					Variables: []string{"test=multi word value"},
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected: []string{"--var test=\"multi word value\"", "--timeout 0s"},
 		},
@@ -389,6 +446,8 @@ func TestGetDeployFlags(t *testing.T) {
 				opts: &Options{
 					Variables: []string{"test -> multi word value"},
 				},
+				cwd:    fakeCwd,
+				fakeFs: fakeFsFn,
 			},
 			expected:  nil,
 			expectErr: true,
@@ -397,9 +456,11 @@ func TestGetDeployFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			flags, err := getDeployFlags(tt.config.opts)
+			flags, err := getDeployFlags(tt.config.opts, tt.config.cwd, tt.config.fakeFs())
 			if tt.expectErr {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 			assert.Equal(t, tt.expected, flags)
 		})
@@ -432,6 +493,7 @@ func TestCreateDockerfile(t *testing.T) {
 		{
 			name: "OS can't access working directory",
 			config: config{
+				opts: &Options{},
 				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
 					Getter: assert.AnError,
 				},
@@ -620,7 +682,7 @@ func TestGetExtraHosts(t *testing.T) {
 	}
 }
 func TestGetContextPath(t *testing.T) {
-	cwd := filepath.Clean("/path/to/current/directory")
+	cwd, _ := filepath.Abs("/path/to/current/directory")
 
 	rd := remoteDeployCommand{
 		fs: afero.NewMemMapFs(),
@@ -633,7 +695,7 @@ func TestGetContextPath(t *testing.T) {
 	})
 
 	t.Run("Manifest path is a absolute path and directory", func(t *testing.T) {
-		manifestPath := filepath.Clean("/path/to/current/directory")
+		manifestPath, _ := filepath.Abs("/path/to/current/directory")
 		expected := manifestPath
 		rd.fs = afero.NewMemMapFs()
 		rd.fs.MkdirAll(manifestPath, 0755)
@@ -642,8 +704,8 @@ func TestGetContextPath(t *testing.T) {
 	})
 
 	t.Run("Manifest path is a file and absolute path", func(t *testing.T) {
-		manifestPath := filepath.Clean("/path/to/current/directory/file.yaml")
-		expected := filepath.Clean("/path/to/current/directory")
+		manifestPath, _ := filepath.Abs("/path/to/current/directory/file.yaml")
+		expected, _ := filepath.Abs("/path/to/current/directory")
 		rd.fs = afero.NewMemMapFs()
 		rd.fs.MkdirAll(expected, 0755)
 		rd.fs.Create(manifestPath)
@@ -652,8 +714,8 @@ func TestGetContextPath(t *testing.T) {
 	})
 
 	t.Run("Manifest path is pointing to a file in the .okteto folder and absolute path", func(t *testing.T) {
-		manifestPath := filepath.Clean("/path/to/current/directory/.okteto/file.yaml")
-		expected := filepath.Clean("/path/to/current/directory")
+		manifestPath, _ := filepath.Abs("/path/to/current/directory/.okteto/file.yaml")
+		expected, _ := filepath.Abs("/path/to/current/directory")
 		rd.fs = afero.NewMemMapFs()
 		rd.fs.MkdirAll(expected, 0755)
 		rd.fs.Create(manifestPath)

--- a/pkg/filesystem/manifest.go
+++ b/pkg/filesystem/manifest.go
@@ -24,7 +24,10 @@ func CleanManifestPath(manifestPath string) string {
 	if lastFolder == ".okteto" {
 		path := filepath.Clean(manifestPath)
 		parts := strings.Split(path, string(filepath.Separator))
-
+		minParts := 2
+		if len(parts) < minParts {
+			return parts[0]
+		}
 		return filepath.Join(parts[len(parts)-2:]...)
 	} else {
 		return filepath.Base(manifestPath)

--- a/pkg/filesystem/manifest_test.go
+++ b/pkg/filesystem/manifest_test.go
@@ -46,6 +46,11 @@ func Test_cleanManifestPath(t *testing.T) {
 			manifest: "/path/to/service/.okteto/okteto.yml",
 			expected: filepath.Clean(".okteto/okteto.yml"),
 		},
+		{
+			name:     "manifest within .okteto/",
+			manifest: ".okteto/",
+			expected: filepath.Clean(".okteto"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-199

This is a follow-up PR to https://github.com/okteto/okteto/pull/4195

In `2.25` we've identified a regression when running: `okteto deploy -f apps/service` where `service` is the folder containing the `okteto.yml` and in the manifest we set `deploy.remote: true`.

The CLI would fail with:

```
 i  Running stage 'Internal server error'
 x  Service file doesn't exist
```

With this change, the CLI should be able to find the manifest correctly.

Additionally, this PR also fixes a panic in the function `CleanManifestPath`

If you execute: ` okd deploy -f .okteto/` you would get:

```
 i  Using andreafalzetti-tests @ product.okteto.dev as context
 i  Build section is not defined in your okteto manifest
panic: runtime error: slice bounds out of range [-1:]

goroutine 33 [running]:
github.com/okteto/okteto/pkg/filesystem.CleanManifestPath({0x16f053405, 0x8})
	github.com/okteto/okteto/pkg/filesystem/manifest.go:28 +0xe0
github.com/okteto/okteto/cmd/deploy.getDeployFlags(0x14000184900)
	github.com/okteto/okteto/cmd/deploy/remote.go:342 +0x1dc
github.com/okteto/okteto/cmd/deploy.(*remoteDeployCommand).createDockerfile(0x140002a0900, {0x140019dad00, 0x3a}, 0x14000184900)
	github.com/okteto/okteto/cmd/deploy/remote.go:288 +0x20c
github.com/okteto/okteto/cmd/deploy.(*remoteDeployCommand).deploy(0x140002a0900, {0x1044d6120, 0x106215c08}, 0x14000184900)
	github.com/okteto/okteto/cmd/deploy/remote.go:172 +0xfc
github.com/okteto/okteto/cmd/deploy.(*Command).RunDeploy(0x140000d5960, {0x1044d6120, 0x106215c08}, 0x14000184900)
	github.com/okteto/okteto/cmd/deploy/deploy.go:383 +0x854
github.com/okteto/okteto/cmd/deploy.Deploy.func1.1()
	github.com/okteto/okteto/cmd/deploy/deploy.go:233 +0x58
created by github.com/okteto/okteto/cmd/deploy.Deploy.func1 in goroutine 1
	github.com/okteto/okteto/cmd/deploy/deploy.go:232 +0x774
```

## How to validate

1. Clone my test repo on the given branch: `git clone -b fix-dev-199 git@github.com:andreafalzetti/k8s-status-api.git`
1. Using the `2.25.1` reproduce the bug by running: `okteto deploy -f apps/service`
1. Observe the error: ` x  Service file doesn't exist`
1. Now run the same command with the CLI from this branch
1. Notice how the `okteto deploy -f apps/service` works as expected

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
