### PR TITLE
DEV-186: Refactor deploy remote command to execute the minimum in the remote

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,9 @@ commands:
     steps:
       - run:
           name: Run up integration tests
-          command: make integration-up
+          command: |
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: 'true'
 
@@ -309,6 +311,7 @@ jobs:
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
             $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
+            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
             go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
       - store_artifacts:
           path: C:\Users\circleci\.okteto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build CLI image
           command: |
-            okteto build --platform "linux/arm64,linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:${CIRCLE_SHA1}
+            okteto build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:${CIRCLE_SHA1}
       - integration-build
       - integration-deploy
       - integration-up
@@ -263,7 +263,7 @@ jobs:
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build CLI image windows
           command: |
-            "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/arm64,linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:$env:CIRCLE_SHA1
+            & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:$env:CIRCLE_SHA1
       - run:
           name: Run deprecated integration tests
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,10 @@ commands:
     steps:
       - run:
           name: Run deploy integration tests
-          command: make integration-deploy
+          # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
+          command: |
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.dev/cli:${CIRCLE_SHA1}
+            make integration-deploy
 
   integration-up:
     steps:
@@ -178,6 +181,13 @@ jobs:
             chmod +x /usr/local/bin/kubectl
             cp $(pwd)/artifacts/bin/okteto-Linux-x86_64 /usr/local/bin/okteto
             /usr/local/bin/okteto login --token ${API_STAGING_TOKEN}
+      - run:
+          # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
+          # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
+          # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
+          name: Build CLI image
+          command: |
+            okteto build --platform "linux/arm64,linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:${CIRCLE_SHA1}
       - integration-build
       - integration-deploy
       - integration-up
@@ -248,6 +258,13 @@ jobs:
             & "$($HOME)\project\artifacts\bin\okteto.exe" login --token $env:API_STAGING_TOKEN
             & "$($HOME)\project\artifacts\bin\okteto.exe" kubeconfig
       - run:
+          # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
+          # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
+          # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
+          name: Build CLI image windows
+          command: |
+            "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/arm64,linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:$env:CIRCLE_SHA1
+      - run:
           name: Run deprecated integration tests
           environment:
             OKTETO_URL: https://staging.okteto.dev/
@@ -275,10 +292,12 @@ jobs:
             OKTETO_URL: https://staging.okteto.dev/
             OKTETO_SKIP_CLEANUP: 'true'
             OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+          # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
             $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
+            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.dev/cli:$env:CIRCLE_SHA1"
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
       - run:
           name: Run up integration tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
           name: Run deploy integration tests
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
-            export OKTETO_REMOTE_CLI_IMAGE=okteto.dev/cli:${CIRCLE_SHA1}
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             make integration-deploy
 
   integration-up:
@@ -187,7 +187,7 @@ jobs:
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build CLI image
           command: |
-            okteto build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:${CIRCLE_SHA1}
+            okteto build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       - integration-build
       - integration-deploy
       - integration-up
@@ -263,7 +263,7 @@ jobs:
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build CLI image windows
           command: |
-            & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.dev/cli:$env:CIRCLE_SHA1
+            & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
       - run:
           name: Run deprecated integration tests
           environment:
@@ -297,7 +297,7 @@ jobs:
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
             $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
-            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.dev/cli:$env:CIRCLE_SHA1"
+            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
       - run:
           name: Run up integration tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,9 @@ commands:
     steps:
       - run:
           name: Run okteto integration tests
-          command: make integration-okteto
+          command: |
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            make integration-okteto
 
   integration-deprecated:
     steps:

--- a/cmd/deploy/build.go
+++ b/cmd/deploy/build.go
@@ -1,0 +1,104 @@
+package deploy
+
+import (
+	"context"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/types"
+)
+
+// buildImages it collects all the images that need to be built during the deploy phase and builds them
+func buildImages(ctx context.Context, builder builderInterface, deployOptions *Options) error {
+	var stackServicesWithBuild map[string]bool
+
+	if stack := deployOptions.Manifest.GetStack(); stack != nil {
+		stackServicesWithBuild = stack.GetServicesWithBuildSection()
+	}
+
+	allServicesWithBuildSection := deployOptions.Manifest.GetBuildServices()
+	oktetoManifestServicesWithBuild := setDifference(allServicesWithBuildSection, stackServicesWithBuild) // Warning: this way of getting the oktetoManifestServicesWithBuild is highly dependent on the manifest struct as it is now. We are assuming that: *okteto* manifest build = manifest build - stack build section
+	servicesToDeployWithBuild := setIntersection(allServicesWithBuildSection, sliceToSet(deployOptions.servicesToDeploy))
+	// We need to build:
+	// - All the services that have a build section defined in the *okteto* manifest
+	// - Services from *deployOptions.servicesToDeploy* that have a build section
+
+	servicesToBuildSet := setUnion(oktetoManifestServicesWithBuild, servicesToDeployWithBuild)
+
+	if deployOptions.Build {
+		buildOptions := &types.BuildOptions{
+			EnableStages: true,
+			Manifest:     deployOptions.Manifest,
+			CommandArgs:  setToSlice(servicesToBuildSet),
+		}
+		oktetoLog.Debug("force build from manifest definition")
+		if errBuild := builder.Build(ctx, buildOptions); errBuild != nil {
+			return errBuild
+		}
+	} else {
+		servicesToBuild, err := builder.GetServicesToBuild(ctx, deployOptions.Manifest, setToSlice(servicesToBuildSet))
+		if err != nil {
+			return err
+		}
+
+		if len(servicesToBuild) != 0 {
+			buildOptions := &types.BuildOptions{
+				EnableStages: true,
+				Manifest:     deployOptions.Manifest,
+				CommandArgs:  servicesToBuild,
+			}
+
+			if errBuild := builder.Build(ctx, buildOptions); errBuild != nil {
+				return errBuild
+			}
+		}
+	}
+
+	return nil
+}
+
+func sliceToSet[T comparable](slice []T) map[T]bool {
+	set := make(map[T]bool)
+	for _, value := range slice {
+		set[value] = true
+	}
+	return set
+}
+
+func setToSlice[T comparable](set map[T]bool) []T {
+	slice := make([]T, 0, len(set))
+	for value := range set {
+		slice = append(slice, value)
+	}
+	return slice
+}
+
+func setIntersection[T comparable](set1, set2 map[T]bool) map[T]bool {
+	intersection := make(map[T]bool)
+	for value := range set1 {
+		if _, ok := set2[value]; ok {
+			intersection[value] = true
+		}
+	}
+	return intersection
+}
+
+func setUnion[T comparable](set1, set2 map[T]bool) map[T]bool {
+	union := make(map[T]bool)
+	for value := range set1 {
+		union[value] = true
+	}
+	for value := range set2 {
+		union[value] = true
+	}
+	return union
+}
+
+func setDifference[T comparable](set1, set2 map[T]bool) map[T]bool {
+	difference := make(map[T]bool)
+	for value := range set1 {
+		if _, ok := set2[value]; !ok {
+			difference[value] = true
+		}
+	}
+	return difference
+}

--- a/cmd/deploy/build.go
+++ b/cmd/deploy/build.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deploy
 
 import (

--- a/cmd/deploy/build_test.go
+++ b/cmd/deploy/build_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deploy
 
 import (

--- a/cmd/deploy/build_test.go
+++ b/cmd/deploy/build_test.go
@@ -1,0 +1,136 @@
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/build"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildImages(t *testing.T) {
+	testCases := []struct {
+		expectedError        error
+		builder              *fakeV2Builder
+		stack                *model.Stack
+		name                 string
+		buildServices        []string
+		servicesToDeploy     []string
+		servicesAlreadyBuilt []string
+		expectedImages       []string
+		build                bool
+	}{
+		{
+			name: "everything",
+			builder: &fakeV2Builder{
+				servicesAlreadyBuilt: []string{"manifest B", "stack A"},
+			},
+			build:         false,
+			buildServices: []string{"manifest A", "manifest B", "stack A", "stack B"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"stack A":             {Build: &build.Info{}},
+				"stack B":             {Build: &build.Info{}},
+				"stack without build": {},
+			}},
+			servicesToDeploy: []string{"stack A", "stack without build"},
+			expectedError:    nil,
+			expectedImages:   []string{"manifest A"},
+		},
+		{
+			name:             "nil stack",
+			builder:          &fakeV2Builder{},
+			build:            false,
+			buildServices:    []string{"manifest A", "manifest B"},
+			stack:            nil,
+			servicesToDeploy: []string{"manifest A"},
+			expectedError:    nil,
+			expectedImages:   []string{"manifest A", "manifest B"},
+		},
+		{
+			name: "no services to deploy",
+			builder: &fakeV2Builder{
+				servicesAlreadyBuilt: []string{"stack"},
+			},
+			build:         false,
+			buildServices: []string{"manifest", "stack"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"stack": {Build: &build.Info{}},
+			}},
+			servicesToDeploy: []string{},
+			expectedError:    nil,
+			expectedImages:   []string{"manifest"},
+		},
+		{
+			name:          "no services already built",
+			builder:       &fakeV2Builder{},
+			build:         false,
+			buildServices: []string{"manifest A", "stack B", "stack C"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"stack B": {Build: &build.Info{}},
+				"stack C": {Build: &build.Info{}},
+			}},
+			servicesToDeploy: []string{"manifest A", "stack C"},
+			expectedError:    nil,
+			expectedImages:   []string{"manifest A", "stack C"},
+		},
+		{
+			name: "force build",
+			builder: &fakeV2Builder{
+				servicesAlreadyBuilt: []string{"should be ignored since build is forced", "manifest A", "stack B"},
+			},
+			build:         true,
+			buildServices: []string{"manifest A", "manifest B", "stack A", "stack B"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"stack A": {Build: &build.Info{}},
+				"stack B": {Build: &build.Info{}},
+			}},
+			servicesToDeploy: []string{"stack A", "stack B"},
+			expectedError:    nil,
+			expectedImages:   []string{"manifest A", "manifest B", "stack A", "stack B"},
+		},
+		{
+			name: "force build specific services",
+			builder: &fakeV2Builder{
+				servicesAlreadyBuilt: []string{"should be ignored since build is forced", "manifest A", "stack B"},
+			},
+			build:         true,
+			buildServices: []string{"manifest A", "manifest B", "stack A", "stack B"},
+			stack: &model.Stack{Services: map[string]*model.Service{
+				"stack A":             {Build: &build.Info{}},
+				"stack B":             {Build: &build.Info{}},
+				"stack without build": {},
+			}},
+			servicesToDeploy: []string{"stack A", "stack without build"},
+			expectedError:    nil,
+			expectedImages:   []string{"manifest A", "manifest B", "stack A"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			deployOptions := &Options{
+				Build: testCase.build,
+				Manifest: &model.Manifest{
+					Build: build.ManifestBuild{},
+					Deploy: &model.DeployInfo{
+						ComposeSection: &model.ComposeSectionInfo{
+							Stack: testCase.stack,
+						},
+					},
+				},
+				servicesToDeploy: testCase.servicesToDeploy,
+			}
+
+			for _, service := range testCase.buildServices {
+				deployOptions.Manifest.Build[service] = &build.Info{}
+			}
+
+			err := buildImages(context.Background(), testCase.builder, deployOptions)
+			assert.Equal(t, testCase.expectedError, err)
+			assert.Equal(t, sliceToSet(testCase.expectedImages), sliceToSet(testCase.builder.buildOptionsStorage.CommandArgs))
+		})
+	}
+
+}

--- a/cmd/deploy/cfghandler.go
+++ b/cmd/deploy/cfghandler.go
@@ -30,7 +30,7 @@ import (
 type configMapHandler interface {
 	translateConfigMapAndDeploy(context.Context, *pipeline.CfgData) (*apiv1.ConfigMap, error)
 	updateConfigMap(context.Context, *apiv1.ConfigMap, *pipeline.CfgData, error) error
-	updateEnvsFromCommands(context.Context, string, string, []string) error
+	UpdateEnvsFromCommands(context.Context, string, string, []string) error
 	getConfigmapVariablesEncoded(ctx context.Context, name, namespace string) (string, error)
 }
 
@@ -101,7 +101,7 @@ func (ch *defaultConfigMapHandler) updateConfigMap(ctx context.Context, cfg *api
 }
 
 // updateEnvsFromCommands update config map by adding envs generated in OKTETO_ENV as data fields
-func (ch *defaultConfigMapHandler) updateEnvsFromCommands(ctx context.Context, name, namespace string, envs []string) error {
+func (ch *defaultConfigMapHandler) UpdateEnvsFromCommands(ctx context.Context, name, namespace string, envs []string) error {
 	c, _, err := ch.k8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ch.k8slogger)
 	if err != nil {
 		return err
@@ -138,6 +138,6 @@ func (*deployInsideDeployConfigMapHandler) updateConfigMap(_ context.Context, _ 
 // updateEnvs with the receiver deployInsideDeployConfigMapHandler doesn't do anything
 // because we have to  control the cfmap in the main execution. If both handled the configmap we will be
 // overwritten the cfmap and leave it in a inconsistent status
-func (*deployInsideDeployConfigMapHandler) updateEnvsFromCommands(_ context.Context, _ string, _ string, _ []string) error {
+func (*deployInsideDeployConfigMapHandler) UpdateEnvsFromCommands(_ context.Context, _ string, _ string, _ []string) error {
 	return nil
 }

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -369,7 +369,6 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	oktetoLog.DisableMasking()
 	oktetoLog.SetStage("done")
 	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
-	oktetoLog.SetStage("")
 
 	if err != nil {
 		if err == oktetoErrors.ErrIntSig {
@@ -378,6 +377,11 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		err = oktetoErrors.UserError{E: err}
 		data.Status = pipeline.ErrorStatus
 	} else {
+		// This has to be set only when the command succeeds for the case in which the deploy is executed within an
+		// installer. When running in installer, if the command fails, and we set an empty stage, we would display
+		// a stage with "Internal Server Error" duplicating the message we already display on error. For that reason,
+		// we should not set empty stage on error.
+		oktetoLog.SetStage("")
 		hasDeployed, err := pipeline.HasDeployedSomething(ctx, deployOptions.Name, deployOptions.Manifest.Namespace, c)
 		if err != nil {
 			return err

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -676,7 +676,7 @@ func (dc *Command) deployStack(ctx context.Context, opts *Options) error {
 
 	divertDriver := divert.NewNoop()
 	if opts.Manifest.Deploy.Divert != nil {
-		divertDriver, err = divert.New(opts.Manifest.Deploy.Divert, "", "", c)
+		divertDriver, err = divert.New(opts.Manifest.Deploy.Divert, opts.Manifest.Name, opts.Manifest.Namespace, c)
 		if err != nil {
 			return err
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -116,14 +116,14 @@ type Command struct {
 	IoCtrl            *io.Controller
 	K8sLogger         *io.K8sLogger
 
-	PipelineType       model.Archetype
-	isRemote           bool
-	runningInInstaller bool
-
+	PipelineType model.Archetype
 	// onCleanUp is a list of functions to be executed when the execution is interrupted. This is a hack
 	// to be able to call to deployer's cleanUp function as the deployer is gotten at runtime.
 	// This can probably be improved using context cancellation
 	onCleanUp []cleanUpFunc
+
+	isRemote           bool
+	runningInInstaller bool
 }
 
 type analyticsTrackerInterface interface {
@@ -260,7 +260,7 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Contro
 	return cmd
 }
 
-// RunDeploy runs the deploy sequence
+// Run runs the deploy sequence
 func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	oktetoLog.SetStage("Load manifest")
 	manifest, err := dc.GetManifest(deployOptions.ManifestPath, dc.Fs)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -673,7 +673,7 @@ func (dc *Command) deployStack(ctx context.Context, opts *Options) error {
 		return err
 	}
 
-	var divertDriver divert.Driver = divert.NewNoop()
+	divertDriver := divert.NewNoop()
 	if opts.Manifest.Deploy.Divert != nil {
 		divertDriver, err = divert.New(opts.Manifest.Deploy.Divert, "", "", c)
 		if err != nil {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -367,6 +367,9 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	oktetoLog.EnableMasking()
 	err = dc.deploy(ctx, deployOptions, cwd, c)
 	oktetoLog.DisableMasking()
+	oktetoLog.SetStage("done")
+	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
+	oktetoLog.SetStage("")
 
 	if err != nil {
 		if err == oktetoErrors.ErrIntSig {
@@ -375,12 +378,6 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		err = oktetoErrors.UserError{E: err}
 		data.Status = pipeline.ErrorStatus
 	} else {
-		// This has to be done only when the deployment is successful to make sure nothing else is displayed in the UI
-		// When the deploy has any error, the final stage is different and set internally by "updateConfigMap" function.
-		// This can be revisited when we improve the logs
-		oktetoLog.SetStage("done")
-		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
-		oktetoLog.SetStage("")
 		hasDeployed, err := pipeline.HasDeployedSomething(ctx, deployOptions.Name, deployOptions.Manifest.Namespace, c)
 		if err != nil {
 			return err

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -730,7 +730,7 @@ func (*Command) getDependencyEnvVars(environGetter environGetter) map[string]str
 	varsParts := 2
 	result := map[string]string{}
 	for _, e := range environGetter() {
-		pair := strings.SplitN(e, "=", 2)
+		pair := strings.SplitN(e, "=", varsParts)
 		if len(pair) != varsParts {
 			// If a variables doesn't have left and right side we just skip it
 			continue

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -818,7 +818,7 @@ func TestTrackDeploy(t *testing.T) {
 }
 
 func TestShouldRunInRemoteDeploy(t *testing.T) {
-	var tempManifest *model.Manifest = &model.Manifest{
+	tempManifest := &model.Manifest{
 		Deploy: &model.DeployInfo{
 			Remote: true,
 			Image:  "some-image",

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -965,9 +965,9 @@ func TestOktetoManifestPathFlag(t *testing.T) {
 
 func TestGetDependencyEnvVars(t *testing.T) {
 	tt := []struct {
-		name          string
 		environGetter environGetter
 		expected      map[string]string
+		name          string
 	}{
 		{
 			name: "WithEmptyEnvironment",

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -16,7 +16,6 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +33,6 @@ import (
 	"github.com/okteto/okteto/pkg/deps"
 	"github.com/okteto/okteto/pkg/divert"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/format"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
 	"github.com/okteto/okteto/pkg/log/io"
@@ -44,6 +42,7 @@ import (
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
@@ -199,7 +198,7 @@ func (f *fakeCmapHandler) updateConfigMap(context.Context, *apiv1.ConfigMap, *pi
 	return nil
 }
 
-func (f *fakeCmapHandler) updateEnvsFromCommands(context.Context, string, string, []string) error {
+func (f *fakeCmapHandler) UpdateEnvsFromCommands(context.Context, string, string, []string) error {
 	return f.errUpdatingWithEnvs
 }
 
@@ -277,61 +276,69 @@ func (*fakeV2Builder) GetBuildEnvVars() map[string]string {
 	return nil
 }
 
-func TestDeployWithErrorChangingKubeConfig(t *testing.T) {
-	p := &fakeProxy{}
-	e := &fakeExecutor{}
-	okteto.CurrentStore = &okteto.ContextStore{
-		Contexts: map[string]*okteto.Context{
-			"test": {
-				Namespace: "test",
-			},
-		},
-		CurrentContext: "test",
-	}
-	c := &localDeployer{
-		Proxy:    p,
-		Executor: e,
-		Kubeconfig: &fakeKubeConfig{
-			errOnModify: assert.AnError,
-		},
-		K8sClientProvider: test.NewFakeK8sProvider(),
-	}
-	ctx := context.Background()
-	opts := &Options{
-		Name:         "movies",
-		ManifestPath: "",
-		Variables:    []string{},
-	}
-
-	err := c.deploy(ctx, opts)
-
-	assert.Error(t, err)
-	// No command was executed
-	assert.Len(t, e.executed, 0)
-	// Proxy wasn't started
-	assert.False(t, p.started)
-}
-
 type fakeDeployer struct {
-	proxy                   *fakeProxy
-	executor                *fakeExecutor
-	kubeconfig              *fakeKubeConfig
-	fs                      afero.Fs
-	k8sClientProvider       *test.FakeK8sProvider
-	externalControlProvider fakeExternalControlProvider
+	mock.Mock
 }
 
-func (d fakeDeployer) Get(_ context.Context, _ *Options, _ builderInterface, cmapHandler configMapHandler, _ okteto.K8sClientProviderWithLogger, _ kubeConfigHandler, _ portGetterFunc, _ *io.Controller, _ *io.K8sLogger) (deployerInterface, error) {
-	return &localDeployer{
-		Proxy:              d.proxy,
-		Executor:           d.executor,
-		Kubeconfig:         d.kubeconfig,
-		Fs:                 d.fs,
-		K8sClientProvider:  d.k8sClientProvider,
-		GetExternalControl: d.externalControlProvider.getFakeExternalControl,
-		ConfigMapHandler:   cmapHandler,
+func getManifestWithError(_ string, _ afero.Fs) (*model.Manifest, error) {
+	return nil, assert.AnError
+}
+
+func getFakeManifest(_ string, _ afero.Fs) (*model.Manifest, error) {
+	return fakeManifest, nil
+}
+
+func getErrorManifest(_ string, _ afero.Fs) (*model.Manifest, error) {
+	return errorManifest, nil
+}
+
+func getManifestWithNoDeployNorDependency(_ string, _ afero.Fs) (*model.Manifest, error) {
+	return noDeployNorDependenciesManifest, nil
+}
+
+func getFakeManifestWithDependency(_ string, _ afero.Fs) (*model.Manifest, error) {
+	return fakeManifestWithDependency, nil
+}
+
+type fakeEndpointControl struct {
+	err       error
+	endpoints []string
+}
+
+func (f *fakeEndpointControl) List(_ context.Context, _ *EndpointsOptions, _ string) ([]string, error) {
+	return f.endpoints, f.err
+}
+
+func getFakeEndpoint(_ *io.K8sLogger) (EndpointGetter, error) {
+	return EndpointGetter{
+		endpointControl: &fakeEndpointControl{},
 	}, nil
 }
+
+func (f *fakeDeployer) Get(ctx context.Context,
+	opts *Options,
+	buildEnvVarsGetter buildEnvVarsGetter,
+	cmapHandler configMapHandler,
+	k8sProvider okteto.K8sClientProviderWithLogger,
+	ioCtrl *io.Controller,
+	k8Logger *io.K8sLogger,
+) (Deployer, error) {
+	args := f.Called(ctx, opts, buildEnvVarsGetter, cmapHandler, k8sProvider, ioCtrl, k8Logger)
+	return args.Get(0).(Deployer), args.Error(1)
+}
+
+func (f *fakeDeployer) Deploy(ctx context.Context, opts *Options) error {
+	args := f.Called(ctx, opts)
+	return args.Error(0)
+}
+
+func (f *fakeDeployer) CleanUp(ctx context.Context, err error) {
+	f.Called(ctx, err)
+}
+
+type fakeAnalyticsTracker struct{}
+
+func (fakeAnalyticsTracker) TrackImageBuild(...*analytics.ImageBuildMetadata) {}
 
 func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 	okteto.CurrentStore = &okteto.ContextStore{
@@ -342,12 +349,7 @@ func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 		},
 		CurrentContext: "test",
 	}
-	fakeDeployer := &fakeDeployer{
-		proxy:      &fakeProxy{},
-		executor:   &fakeExecutor{},
-		kubeconfig: &fakeKubeConfig{},
-		fs:         afero.NewMemMapFs(),
-	}
+	fakeDeployer := &fakeDeployer{}
 	c := &Command{
 		GetManifest:       getManifestWithError,
 		GetDeployer:       fakeDeployer.Get,
@@ -360,22 +362,15 @@ func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 		Variables:    []string{},
 	}
 
-	err := c.RunDeploy(ctx, opts)
+	err := c.Run(ctx, opts)
 
+	// Verify the deploy phase is not even reached
+	fakeDeployer.AssertNotCalled(t, "Get")
 	assert.Error(t, err)
-	// No command was executed
-	assert.Len(t, fakeDeployer.executor.executed, 0)
-	// Proxy wasn't started
-	assert.False(t, fakeDeployer.proxy.started)
 }
 
 func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
-	fakeDeployer := &fakeDeployer{
-		proxy:      &fakeProxy{},
-		executor:   &fakeExecutor{},
-		kubeconfig: &fakeKubeConfig{},
-		fs:         afero.NewMemMapFs(),
-	}
+	fakeDeployer := &fakeDeployer{}
 	okteto.CurrentStore = &okteto.ContextStore{
 		Contexts: map[string]*okteto.Context{
 			"test": {
@@ -396,31 +391,45 @@ func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
 		Variables:    []string{},
 	}
 
-	err := c.RunDeploy(ctx, opts)
+	err := c.Run(ctx, opts)
 
 	assert.ErrorIs(t, err, oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands)
-
-	// No command was executed
-	assert.Len(t, fakeDeployer.executor.executed, 0)
-	// Proxy wasn't started
-	assert.False(t, fakeDeployer.proxy.started)
+	// Verify the deploy phase is not even reached
+	fakeDeployer.AssertNotCalled(t, "Get")
 }
 
-type fakeAnalyticsTracker struct{}
+func TestDeployWithServicesToBuildWithoutComposeSection(t *testing.T) {
+	fakeDeployer := &fakeDeployer{}
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+			},
+		},
+		CurrentContext: "test",
+	}
+	c := &Command{
+		GetManifest:       getFakeManifest,
+		GetDeployer:       fakeDeployer.Get,
+		K8sClientProvider: test.NewFakeK8sProvider(),
+	}
+	ctx := context.Background()
+	opts := &Options{
+		Name:             "movies",
+		ManifestPath:     "",
+		Variables:        []string{},
+		servicesToDeploy: []string{"service1"},
+	}
 
-func (fakeAnalyticsTracker) TrackImageBuild(...*analytics.ImageBuildMetadata) {}
+	err := c.Run(ctx, opts)
+
+	assert.ErrorIs(t, err, oktetoErrors.ErrDeployCantDeploySvcsIfNotCompose)
+	// Verify the deploy phase is not even reached
+	fakeDeployer.AssertNotCalled(t, "Get")
+}
 
 func TestCreateConfigMapWithBuildError(t *testing.T) {
 	fakeK8sClientProvider := test.NewFakeK8sProvider()
-	fakeDeployer := &fakeDeployer{
-		proxy: &fakeProxy{},
-		executor: &fakeExecutor{
-			err: assert.AnError,
-		},
-		kubeconfig:        &fakeKubeConfig{},
-		fs:                afero.NewMemMapFs(),
-		k8sClientProvider: fakeK8sClientProvider,
-	}
 	opts := &Options{
 		Name:         "testErr",
 		ManifestPath: "",
@@ -444,7 +453,6 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 	}
 	c := &Command{
 		GetManifest:       getErrorManifest,
-		GetDeployer:       fakeDeployer.Get,
 		Builder:           buildv2.NewBuilder(builder, reg, io.NewIOController(), fakeTracker, okCtx, nil),
 		K8sClientProvider: fakeK8sClientProvider,
 		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider, nil),
@@ -453,7 +461,7 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := c.RunDeploy(ctx, opts)
+	err := c.Run(ctx, opts)
 
 	// we should get a build error because Dockerfile does not exist
 	assert.True(t, strings.Contains(err.Error(), oktetoErrors.InvalidDockerfile))
@@ -501,18 +509,10 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 	assert.NotEmpty(t, cfg.Annotations[constants.LastUpdatedAnnotation])
 }
 
-func TestDeployWithErrorExecutingCommands(t *testing.T) {
+func TestDeployWithErrorDeploying(t *testing.T) {
 	fakeOs := afero.NewMemMapFs()
 	fakeK8sClientProvider := test.NewFakeK8sProvider()
-	fakeDeployer := &fakeDeployer{
-		proxy: &fakeProxy{},
-		executor: &fakeExecutor{
-			err: assert.AnError,
-		},
-		kubeconfig:        &fakeKubeConfig{},
-		fs:                fakeOs,
-		k8sClientProvider: fakeK8sClientProvider,
-	}
+	fakeDeployer := &fakeDeployer{}
 	okteto.CurrentStore = &okteto.ContextStore{
 		Contexts: map[string]*okteto.Context{
 			"test": {
@@ -536,17 +536,28 @@ func TestDeployWithErrorExecutingCommands(t *testing.T) {
 		Variables:    []string{},
 	}
 
-	err := c.RunDeploy(ctx, opts)
+	fakeDeployer.On(
+		"Get",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(fakeDeployer, nil)
+
+	expectedOpts := &Options{
+		Name:         "movies",
+		ManifestPath: "",
+		Variables:    []string{},
+		Manifest:     fakeManifest,
+	}
+	fakeDeployer.On("Deploy", mock.Anything, expectedOpts).Return(assert.AnError)
+
+	err := c.Run(ctx, opts)
 
 	assert.Error(t, err)
-	// No command was executed
-	assert.Len(t, fakeDeployer.executor.executed, 1)
-	// Check expected commands were executed
-	assert.Equal(t, fakeManifest.Deploy.Commands[0], fakeDeployer.executor.executed[0])
-	// Proxy started
-	assert.True(t, fakeDeployer.proxy.started)
-	// Proxy shutdown
-	assert.True(t, fakeDeployer.proxy.shutdown)
 
 	// check if configmap has been created
 	fakeClient, _, err := c.K8sClientProvider.ProvideWithLogger(clientcmdapi.NewConfig(), nil)
@@ -557,6 +568,8 @@ func TestDeployWithErrorExecutingCommands(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, pipeline.ErrorStatus, cfg.Data["status"])
+
+	fakeDeployer.AssertExpectations(t)
 }
 
 func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
@@ -580,15 +593,7 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 			},
 		},
 	})
-	fakeDeployer := &fakeDeployer{
-		proxy: &fakeProxy{
-			errOnShutdown: assert.AnError,
-		},
-		executor:          &fakeExecutor{},
-		kubeconfig:        &fakeKubeConfig{},
-		fs:                afero.NewMemMapFs(),
-		k8sClientProvider: fakeK8sClientProvider,
-	}
+	fakeDeployer := &fakeDeployer{}
 
 	okteto.CurrentStore = &okteto.ContextStore{
 		Contexts: map[string]*okteto.Context{
@@ -608,13 +613,12 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	err := c.RunDeploy(ctx, opts)
+	err := c.Run(ctx, opts)
 
 	assert.Error(t, err)
-	// No command was executed
-	assert.Len(t, fakeDeployer.executor.executed, 0)
-	// Proxy didn't start
-	assert.False(t, fakeDeployer.proxy.started)
+
+	// Verify the deploy phase is not even reached
+	fakeDeployer.AssertNotCalled(t, "Get")
 
 	// check if configmap has been created
 	fakeClient, _, err := c.K8sClientProvider.ProvideWithLogger(clientcmdapi.NewConfig(), nil)
@@ -624,80 +628,6 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 	cfg, err := configmaps.Get(ctx, pipeline.TranslatePipelineName(opts.Name), okteto.GetContext().Namespace, fakeClient)
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
-}
-
-func TestDeployWithErrorShuttingdownProxy(t *testing.T) {
-	fakeOs := afero.NewMemMapFs()
-	fakeK8sClientProvider := test.NewFakeK8sProvider(&v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				model.DeployedByLabel: "movies",
-			},
-			Namespace: "test",
-		},
-	})
-	fakeExternalControlProvider := fakeExternalControlProvider{
-		control: &fakeExternalControl{},
-	}
-	fakeDeployer := &fakeDeployer{
-		proxy: &fakeProxy{
-			errOnShutdown: assert.AnError,
-		},
-		executor:                &fakeExecutor{},
-		kubeconfig:              &fakeKubeConfig{},
-		fs:                      fakeOs,
-		k8sClientProvider:       fakeK8sClientProvider,
-		externalControlProvider: fakeExternalControlProvider,
-	}
-
-	okteto.CurrentStore = &okteto.ContextStore{
-		Contexts: map[string]*okteto.Context{
-			"test": {
-				Namespace: "test",
-				Cfg:       clientcmdapi.NewConfig(),
-			},
-		},
-		CurrentContext: "test",
-	}
-	c := &Command{
-		GetManifest:        getFakeManifest,
-		GetDeployer:        fakeDeployer.Get,
-		GetExternalControl: fakeExternalControlProvider.getFakeExternalControl,
-		K8sClientProvider:  fakeK8sClientProvider,
-		EndpointGetter:     getFakeEndpoint,
-		CfgMapHandler:      newDefaultConfigMapHandler(fakeK8sClientProvider, nil),
-		Fs:                 fakeOs,
-		Builder:            &fakeV2Builder{},
-	}
-	ctx := context.Background()
-
-	opts := &Options{
-		Name:         "movies",
-		ManifestPath: "",
-		Variables:    []string{},
-	}
-
-	err := c.RunDeploy(ctx, opts)
-
-	assert.NoError(t, err)
-	// No command was executed
-	assert.Len(t, fakeDeployer.executor.executed, 3)
-	// Check expected commands were executed
-	assert.Equal(t, fakeManifest.Deploy.Commands, fakeDeployer.executor.executed)
-	// Proxy started
-	assert.True(t, fakeDeployer.proxy.started)
-	// Proxy wasn't shutdown
-	assert.False(t, fakeDeployer.proxy.shutdown)
-
-	// check if configmap has been created
-	fakeClient, _, err := c.K8sClientProvider.ProvideWithLogger(clientcmdapi.NewConfig(), nil)
-	if err != nil {
-		t.Fatal("could not create fake k8s client")
-	}
-	cfg, err := configmaps.Get(ctx, pipeline.TranslatePipelineName(opts.Name), okteto.GetContext().Namespace, fakeClient)
-	assert.Nil(t, err)
-	assert.NotNil(t, cfg)
-	assert.Equal(t, pipeline.DeployedStatus, cfg.Data["status"])
 }
 
 func TestDeployWithoutErrors(t *testing.T) {
@@ -710,17 +640,7 @@ func TestDeployWithoutErrors(t *testing.T) {
 			Namespace: "test",
 		},
 	})
-	fakeExternalControlProvider := fakeExternalControlProvider{
-		control: &fakeExternalControl{},
-	}
-	fakeDeployer := &fakeDeployer{
-		proxy:                   &fakeProxy{},
-		executor:                &fakeExecutor{},
-		kubeconfig:              &fakeKubeConfig{},
-		fs:                      fakeOs,
-		k8sClientProvider:       fakeK8sClientProvider,
-		externalControlProvider: fakeExternalControlProvider,
-	}
+	fakeDeployer := &fakeDeployer{}
 
 	okteto.CurrentStore = &okteto.ContextStore{
 		Contexts: map[string]*okteto.Context{
@@ -732,14 +652,13 @@ func TestDeployWithoutErrors(t *testing.T) {
 	}
 
 	c := &Command{
-		GetManifest:        getFakeManifest,
-		K8sClientProvider:  fakeK8sClientProvider,
-		EndpointGetter:     getFakeEndpoint,
-		GetExternalControl: fakeExternalControlProvider.getFakeExternalControl,
-		Fs:                 fakeOs,
-		CfgMapHandler:      newDefaultConfigMapHandler(fakeK8sClientProvider, nil),
-		GetDeployer:        fakeDeployer.Get,
-		Builder:            &fakeV2Builder{},
+		GetManifest:       getFakeManifest,
+		K8sClientProvider: fakeK8sClientProvider,
+		EndpointGetter:    getFakeEndpoint,
+		Fs:                fakeOs,
+		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider, nil),
+		GetDeployer:       fakeDeployer.Get,
+		Builder:           &fakeV2Builder{},
 	}
 	ctx := context.Background()
 	opts := &Options{
@@ -748,17 +667,28 @@ func TestDeployWithoutErrors(t *testing.T) {
 		Variables:    []string{},
 	}
 
-	err := c.RunDeploy(ctx, opts)
+	fakeDeployer.On(
+		"Get",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(fakeDeployer, nil)
+
+	expectedOpts := &Options{
+		Name:         "movies",
+		ManifestPath: "",
+		Variables:    []string{},
+		Manifest:     fakeManifest,
+	}
+	fakeDeployer.On("Deploy", mock.Anything, expectedOpts).Return(nil)
+
+	err := c.Run(ctx, opts)
 
 	assert.NoError(t, err)
-	// No command was executed
-	assert.Len(t, fakeDeployer.executor.executed, 3)
-	// Check expected commands were executed
-	assert.Equal(t, fakeManifest.Deploy.Commands, fakeDeployer.executor.executed)
-	// Proxy started
-	assert.True(t, fakeDeployer.proxy.started)
-	// Proxy was shutdown
-	assert.True(t, fakeDeployer.proxy.shutdown)
 
 	// check if configmap has been created
 	fakeClient, _, err := c.K8sClientProvider.ProvideWithLogger(clientcmdapi.NewConfig(), nil)
@@ -769,283 +699,6 @@ func TestDeployWithoutErrors(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)
 	assert.Equal(t, pipeline.DeployedStatus, cfg.Data["status"])
-}
-
-func getManifestWithError(_ string, _ afero.Fs) (*model.Manifest, error) {
-	return nil, assert.AnError
-}
-
-func getFakeManifest(_ string, _ afero.Fs) (*model.Manifest, error) {
-	return fakeManifest, nil
-}
-
-func getErrorManifest(_ string, _ afero.Fs) (*model.Manifest, error) {
-	return errorManifest, nil
-}
-
-func getManifestWithNoDeployNorDependency(_ string, _ afero.Fs) (*model.Manifest, error) {
-	return noDeployNorDependenciesManifest, nil
-}
-
-func getFakeManifestWithDependency(_ string, _ afero.Fs) (*model.Manifest, error) {
-	return fakeManifestWithDependency, nil
-}
-
-func TestBuildImages(t *testing.T) {
-	testCases := []struct {
-		expectedError        error
-		builder              *fakeV2Builder
-		stack                *model.Stack
-		name                 string
-		buildServices        []string
-		servicesToDeploy     []string
-		servicesAlreadyBuilt []string
-		expectedImages       []string
-		build                bool
-	}{
-		{
-			name: "everything",
-			builder: &fakeV2Builder{
-				servicesAlreadyBuilt: []string{"manifest B", "stack A"},
-			},
-			build:         false,
-			buildServices: []string{"manifest A", "manifest B", "stack A", "stack B"},
-			stack: &model.Stack{Services: map[string]*model.Service{
-				"stack A":             {Build: &build.Info{}},
-				"stack B":             {Build: &build.Info{}},
-				"stack without build": {},
-			}},
-			servicesToDeploy: []string{"stack A", "stack without build"},
-			expectedError:    nil,
-			expectedImages:   []string{"manifest A"},
-		},
-		{
-			name:             "nil stack",
-			builder:          &fakeV2Builder{},
-			build:            false,
-			buildServices:    []string{"manifest A", "manifest B"},
-			stack:            nil,
-			servicesToDeploy: []string{"manifest A"},
-			expectedError:    nil,
-			expectedImages:   []string{"manifest A", "manifest B"},
-		},
-		{
-			name: "no services to deploy",
-			builder: &fakeV2Builder{
-				servicesAlreadyBuilt: []string{"stack"},
-			},
-			build:         false,
-			buildServices: []string{"manifest", "stack"},
-			stack: &model.Stack{Services: map[string]*model.Service{
-				"stack": {Build: &build.Info{}},
-			}},
-			servicesToDeploy: []string{},
-			expectedError:    nil,
-			expectedImages:   []string{"manifest"},
-		},
-		{
-			name:          "no services already built",
-			builder:       &fakeV2Builder{},
-			build:         false,
-			buildServices: []string{"manifest A", "stack B", "stack C"},
-			stack: &model.Stack{Services: map[string]*model.Service{
-				"stack B": {Build: &build.Info{}},
-				"stack C": {Build: &build.Info{}},
-			}},
-			servicesToDeploy: []string{"manifest A", "stack C"},
-			expectedError:    nil,
-			expectedImages:   []string{"manifest A", "stack C"},
-		},
-		{
-			name: "force build",
-			builder: &fakeV2Builder{
-				servicesAlreadyBuilt: []string{"should be ignored since build is forced", "manifest A", "stack B"},
-			},
-			build:         true,
-			buildServices: []string{"manifest A", "manifest B", "stack A", "stack B"},
-			stack: &model.Stack{Services: map[string]*model.Service{
-				"stack A": {Build: &build.Info{}},
-				"stack B": {Build: &build.Info{}},
-			}},
-			servicesToDeploy: []string{"stack A", "stack B"},
-			expectedError:    nil,
-			expectedImages:   []string{"manifest A", "manifest B", "stack A", "stack B"},
-		},
-		{
-			name: "force build specific services",
-			builder: &fakeV2Builder{
-				servicesAlreadyBuilt: []string{"should be ignored since build is forced", "manifest A", "stack B"},
-			},
-			build:         true,
-			buildServices: []string{"manifest A", "manifest B", "stack A", "stack B"},
-			stack: &model.Stack{Services: map[string]*model.Service{
-				"stack A":             {Build: &build.Info{}},
-				"stack B":             {Build: &build.Info{}},
-				"stack without build": {},
-			}},
-			servicesToDeploy: []string{"stack A", "stack without build"},
-			expectedError:    nil,
-			expectedImages:   []string{"manifest A", "manifest B", "stack A"},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-
-			deployOptions := &Options{
-				Build: testCase.build,
-				Manifest: &model.Manifest{
-					Build: build.ManifestBuild{},
-					Deploy: &model.DeployInfo{
-						ComposeSection: &model.ComposeSectionInfo{
-							Stack: testCase.stack,
-						},
-					},
-				},
-				servicesToDeploy: testCase.servicesToDeploy,
-			}
-
-			for _, service := range testCase.buildServices {
-				deployOptions.Manifest.Build[service] = &build.Info{}
-			}
-
-			err := buildImages(context.Background(), testCase.builder, deployOptions)
-			assert.Equal(t, testCase.expectedError, err)
-			assert.Equal(t, sliceToSet(testCase.expectedImages), sliceToSet(testCase.builder.buildOptionsStorage.CommandArgs))
-		})
-	}
-
-}
-
-type fakeExternalControl struct {
-	err       error
-	externals []externalresource.ExternalResource
-}
-
-type fakeExternalControlProvider struct {
-	control ExternalResourceInterface
-}
-
-func (f *fakeExternalControl) Deploy(_ context.Context, _ string, _ string, _ *externalresource.ExternalResource) error {
-	return f.err
-}
-
-func (f *fakeExternalControl) List(ctx context.Context, ns string, labelSelector string) ([]externalresource.ExternalResource, error) {
-	return f.externals, f.err
-}
-
-func (f *fakeExternalControl) Validate(_ context.Context, _ string, _ string, _ *externalresource.ExternalResource) error {
-	return f.err
-}
-
-func (f *fakeExternalControlProvider) getFakeExternalControl(_ *rest.Config) ExternalResourceInterface {
-	return f.control
-}
-
-type fakeEndpointControl struct {
-	err       error
-	endpoints []string
-}
-
-func (f *fakeEndpointControl) List(_ context.Context, _ *EndpointsOptions, _ string) ([]string, error) {
-	return f.endpoints, f.err
-}
-
-func getFakeEndpoint(_ *io.K8sLogger) (EndpointGetter, error) {
-	return EndpointGetter{
-		endpointControl: &fakeEndpointControl{},
-	}, nil
-}
-
-func TestDeployExternals(t *testing.T) {
-	ctx := context.Background()
-	okteto.CurrentStore = &okteto.ContextStore{
-		Contexts: map[string]*okteto.Context{
-			"test": {
-				Namespace: "test",
-				IsOkteto:  true,
-			},
-		},
-		CurrentContext: "test",
-	}
-	testCases := []struct {
-		control     ExternalResourceInterface
-		options     *Options
-		name        string
-		expectedErr bool
-	}{
-		{
-			name: "no externals to deploy",
-			options: &Options{
-				Manifest: &model.Manifest{
-					Deploy:   &model.DeployInfo{},
-					External: nil,
-				},
-			},
-			control: &fakeExternalControl{},
-		},
-		{
-			name: "deploy external",
-			options: &Options{
-				Manifest: &model.Manifest{
-					Deploy: &model.DeployInfo{},
-					External: externalresource.Section{
-						"test": &externalresource.ExternalResource{
-							Icon: "myIcon",
-							Notes: &externalresource.Notes{
-								Path: "/some/path",
-							},
-							Endpoints: []*externalresource.ExternalEndpoint{},
-						},
-					},
-				},
-			},
-			control: &fakeExternalControl{},
-		},
-		{
-			name: "error when deploy external",
-			options: &Options{
-				Manifest: &model.Manifest{
-					Deploy: &model.DeployInfo{},
-					External: externalresource.Section{
-						"test": &externalresource.ExternalResource{
-							Icon: "myIcon",
-							Notes: &externalresource.Notes{
-								Path: "/some/path",
-							},
-							Endpoints: []*externalresource.ExternalEndpoint{},
-						},
-					},
-				},
-			},
-			control: &fakeExternalControl{
-				err: assert.AnError,
-			},
-			expectedErr: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-
-			cp := fakeExternalControlProvider{
-				control: tc.control,
-			}
-
-			ld := localDeployer{
-				ConfigMapHandler:   &fakeCmapHandler{},
-				GetExternalControl: cp.getFakeExternalControl,
-				Fs:                 afero.NewMemMapFs(),
-				K8sClientProvider:  test.NewFakeK8sProvider(),
-			}
-
-			if tc.expectedErr {
-				assert.Error(t, ld.runDeploySection(ctx, tc.options))
-			} else {
-				assert.NoError(t, ld.runDeploySection(ctx, tc.options))
-			}
-		})
-	}
 }
 
 func TestGetDefaultTimeout(t *testing.T) {
@@ -1096,6 +749,16 @@ func TestDeployDependencies(t *testing.T) {
 			"b": &deps.Dependency{},
 		},
 	}
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	type config struct {
 		pipelineErr error
 	}
@@ -1135,26 +798,15 @@ func TestDeployOnlyDependencies(t *testing.T) {
 		},
 	})
 
-	fakeExternalControlProvider := fakeExternalControlProvider{
-		control: &fakeExternalControl{},
-	}
-	fakeDeployer := &fakeDeployer{
-		proxy:                   &fakeProxy{},
-		executor:                &fakeExecutor{},
-		kubeconfig:              &fakeKubeConfig{},
-		fs:                      fakeOs,
-		k8sClientProvider:       fakeK8sClientProvider,
-		externalControlProvider: fakeExternalControlProvider,
-	}
+	fakeDeployer := &fakeDeployer{}
 
 	c := &Command{
-		PipelineCMD:        fakePipelineDeployer{nil},
-		GetManifest:        getFakeManifestWithDependency,
-		K8sClientProvider:  fakeK8sClientProvider,
-		GetExternalControl: fakeExternalControlProvider.getFakeExternalControl,
-		Fs:                 fakeOs,
-		CfgMapHandler:      newDefaultConfigMapHandler(fakeK8sClientProvider, nil),
-		GetDeployer:        fakeDeployer.Get,
+		PipelineCMD:       fakePipelineDeployer{nil},
+		GetManifest:       getFakeManifestWithDependency,
+		K8sClientProvider: fakeK8sClientProvider,
+		Fs:                fakeOs,
+		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sClientProvider, nil),
+		GetDeployer:       fakeDeployer.Get,
 	}
 	ctx := context.Background()
 	opts := &Options{
@@ -1192,7 +844,7 @@ func TestDeployOnlyDependencies(t *testing.T) {
 				CurrentContext: "test",
 			}
 
-			err := c.RunDeploy(ctx, opts)
+			err := c.Run(ctx, opts)
 
 			require.ErrorIs(t, err, tc.expecterErr)
 		})
@@ -1272,7 +924,7 @@ func TestShouldRunInRemoteDeploy(t *testing.T) {
 			opts: &Options{
 				RunInRemote: false,
 			},
-			remoteDeploy: "",
+			remoteDeploy: "true",
 			remoteForce:  "",
 			expected:     false,
 		},
@@ -1325,10 +977,10 @@ func TestShouldRunInRemoteDeploy(t *testing.T) {
 		{
 			Name: "Okteto_Force_Remote env is set to True",
 			opts: &Options{
-				RunInRemote: true,
+				RunInRemote: false,
 			},
 			remoteDeploy: "",
-			remoteForce:  "",
+			remoteForce:  "true",
 			expected:     true,
 		},
 		{
@@ -1392,61 +1044,6 @@ func TestOktetoManifestPathFlag(t *testing.T) {
 			}
 			err = checkOktetoManifestPathFlag(opts, fs)
 			assert.Equal(t, tt.expectedErr, err)
-		})
-	}
-}
-
-func Test_GetDeployer(t *testing.T) {
-	dnsErr := &net.DNSError{
-		IsNotFound: true,
-	}
-	tests := []struct {
-		expectedErr error
-		opts        *Options
-		portGetter  func(string) (int, error)
-		name        string
-		isUserErr   bool
-	}{
-		{
-			name: "local deployer returns port user error",
-			opts: &Options{},
-			portGetter: func(_ string) (int, error) {
-				return 0, dnsErr
-			},
-			expectedErr: dnsErr,
-			isUserErr:   true,
-		},
-		{
-			name: "local deployer returns other error",
-			opts: &Options{},
-			portGetter: func(_ string) (int, error) {
-				return 0, assert.AnError
-			},
-			expectedErr: assert.AnError,
-		},
-		{
-			name: "local deployer returned",
-			opts: &Options{},
-			portGetter: func(_ string) (int, error) {
-				return 123456, nil
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
-			got, err := GetDeployer(ctx, tt.opts, nil, &fakeCmapHandler{}, &fakeK8sProvider{}, &fakeKubeConfig{
-				config: &rest.Config{},
-			}, tt.portGetter, io.NewIOController(), nil)
-
-			if tt.expectedErr == nil {
-				require.NotNil(t, got)
-			}
-
-			require.ErrorIs(t, err, tt.expectedErr)
-			_, ok := err.(oktetoErrors.UserError)
-			require.True(t, tt.isUserErr == ok)
 		})
 	}
 }

--- a/cmd/deploy/local.go
+++ b/cmd/deploy/local.go
@@ -15,391 +15,64 @@ package deploy
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
-	"github.com/compose-spec/godotenv"
-	stackCMD "github.com/okteto/okteto/cmd/stack"
-	"github.com/okteto/okteto/cmd/utils/executor"
-	"github.com/okteto/okteto/pkg/cmd/stack"
-	"github.com/okteto/okteto/pkg/constants"
-	"github.com/okteto/okteto/pkg/devenvironment"
-	"github.com/okteto/okteto/pkg/divert"
+	"github.com/okteto/okteto/pkg/deployable"
 	"github.com/okteto/okteto/pkg/externalresource"
-	"github.com/okteto/okteto/pkg/format"
-	"github.com/okteto/okteto/pkg/k8s/ingresses"
-	kconfig "github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
-	"github.com/okteto/okteto/pkg/okteto"
-	"github.com/spf13/afero"
-	"k8s.io/client-go/rest"
 )
 
+type runner interface {
+	RunDeploy(ctx context.Context, params deployable.DeployParameters) error
+	CleanUp(ctx context.Context, err error)
+}
+
 type localDeployer struct {
-	deployWaiter       Waiter
-	Proxy              proxyInterface
-	Kubeconfig         kubeConfigHandler
-	ConfigMapHandler   configMapHandler
-	Executor           executor.ManifestExecutor
-	K8sClientProvider  okteto.K8sClientProviderWithLogger
-	Fs                 afero.Fs
-	DivertDriver       divert.Driver
-	GetExternalControl func(cfg *rest.Config) ExternalResourceInterface
-	k8sLogger          *io.K8sLogger
-	TempKubeconfigFile string
-	isRemote           bool
+	runner runner
 }
 
-// newLocalDeployer initializes a local deployer from a name and a boolean indicating if we should run with bash or not
-func newLocalDeployer(ctx context.Context, options *Options, cmapHandler configMapHandler, k8sProvider okteto.K8sClientProviderWithLogger, kubeconfig kubeConfigHandler, portGetter portGetterFunc, k8sLogger *io.K8sLogger) (*localDeployer, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get the current working directory: %w", err)
-	}
-	tempKubeconfigName := options.Name
-	if tempKubeconfigName == "" {
-		c, _, err := k8sProvider.ProvideWithLogger(okteto.GetContext().Cfg, k8sLogger)
-		if err != nil {
-			return nil, err
-		}
-		inferer := devenvironment.NewNameInferer(c)
-		tempKubeconfigName = inferer.InferName(ctx, cwd, okteto.GetContext().Namespace, options.ManifestPathFlag)
-		if err != nil {
-			return nil, fmt.Errorf("could not infer environment name")
-		}
-	}
-
-	proxy, err := NewProxy(kubeconfig, portGetter)
-	if err != nil {
-		oktetoLog.Infof("could not configure local proxy: %s", err)
-		return nil, err
-	}
-
+func newLocalDeployer(runner runner) *localDeployer {
 	return &localDeployer{
-		Kubeconfig:         kubeconfig,
-		Executor:           executor.NewExecutor(oktetoLog.GetOutputFormat(), options.RunWithoutBash, ""),
-		ConfigMapHandler:   cmapHandler,
-		Proxy:              proxy,
-		TempKubeconfigFile: GetTempKubeConfigFile(tempKubeconfigName),
-		K8sClientProvider:  k8sProvider,
-		GetExternalControl: NewDeployExternalK8sControl,
-		deployWaiter:       NewDeployWaiter(k8sProvider, k8sLogger),
-		isRemote:           true,
-		Fs:                 afero.NewOsFs(),
-		k8sLogger:          k8sLogger,
-	}, nil
+		runner: runner,
+	}
 }
 
-func (ld *localDeployer) deploy(ctx context.Context, deployOptions *Options) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get the current working directory: %w", err)
-	}
-
-	// We need to create a client that doesn't go through the proxy to create
-	// the configmap without the deployedByLabel
-	c, _, err := ld.K8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ld.k8sLogger)
-	if err != nil {
-		return err
-	}
-
-	// Injecting the PROXY into the kubeconfig file
-	oktetoLog.Debugf("creating temporal kubeconfig file '%s'", ld.TempKubeconfigFile)
-	if err := ld.Kubeconfig.Modify(ld.Proxy.GetPort(), ld.Proxy.GetToken(), ld.TempKubeconfigFile); err != nil {
-		oktetoLog.Infof("could not create temporal kubeconfig %s", err)
-		return err
-	}
-
-	if err := setDeployOptionsValuesFromManifest(ctx, deployOptions, cwd, c, ld.k8sLogger); err != nil {
-		return err
-	}
-
-	ld.Proxy.SetName(format.ResourceK8sMetaString(deployOptions.Name))
-	if deployOptions.Manifest.Deploy.Divert != nil {
-		driver, err := divert.New(deployOptions.Manifest, c)
-		if err != nil {
-			return err
+func (ld *localDeployer) Deploy(ctx context.Context, deployOptions *Options) error {
+	if deployOptions.Manifest == nil {
+		deployOptions.Manifest = &model.Manifest{
+			Deploy:   &model.DeployInfo{},
+			External: externalresource.Section{},
 		}
-		ld.Proxy.SetDivert(driver)
-		ld.DivertDriver = driver
+
+	}
+	if deployOptions.Manifest.Deploy == nil {
+		deployOptions.Manifest.Deploy = &model.DeployInfo{}
 	}
 
-	os.Setenv(constants.OktetoNameEnvVar, deployOptions.Name)
-
-	if err := setDeployOptionsValuesFromManifest(ctx, deployOptions, cwd, c, ld.k8sLogger); err != nil {
-		return err
+	params := deployable.DeployParameters{
+		Name:         deployOptions.Name,
+		Namespace:    deployOptions.Manifest.Namespace,
+		Variables:    deployOptions.Variables,
+		ManifestPath: deployOptions.Manifest.ManifestPath,
+		Deployable: deployable.Entity{
+			Commands: deployOptions.Manifest.Deploy.Commands,
+			Divert:   deployOptions.Manifest.Deploy.Divert,
+			External: deployOptions.Manifest.External,
+		},
 	}
 
-	oktetoLog.SetStage("")
-
-	// starting PROXY
-	oktetoLog.Debugf("starting server on %d", ld.Proxy.GetPort())
-	ld.Proxy.Start()
-
-	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Deploying '%s'...", deployOptions.Name)
-
-	defer ld.cleanUp(ctx, nil)
-
-	keyValueVarParts := 2
-	for _, variable := range deployOptions.Variables {
-		varParts := strings.SplitN(variable, "=", keyValueVarParts)
-		if len(varParts) >= keyValueVarParts && strings.TrimSpace(varParts[1]) != "" {
-			oktetoLog.AddMaskedWord(varParts[1])
-		}
+	err := ld.runner.RunDeploy(ctx, params)
+	// If this returns in error, we need to set the stage to "done" as the error was already logged
+	// and prevent duplication of messages when the error is handled. This is a special case when
+	// the execution is happening locally. This has to be revisited when we improve the logs
+	if err != nil {
+		oktetoLog.SetStage("done")
+		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
 	}
-	deployOptions.Variables = append(
-		deployOptions.Variables,
-		// Set KUBECONFIG environment variable as environment for the commands to be executed
-		fmt.Sprintf("%s=%s", constants.KubeConfigEnvVar, ld.TempKubeconfigFile),
-		// Set OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT env variable, so all okteto commands ran inside this deploy
-		// know they are running inside another okteto deploy
-		fmt.Sprintf("%s=true", constants.OktetoWithinDeployCommandContextEnvVar),
-		// Set OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE env variable, so all the Okteto commands executed within this command execution
-		// should not overwrite the server and the credentials in the kubeconfig
-		fmt.Sprintf("%s=true", constants.OktetoSkipConfigCredentialsUpdate),
-		// Set OKTETO_DISABLE_SPINNER=true env variable, so all the Okteto commands disable spinner which leads to errors
-		fmt.Sprintf("%s=true", oktetoLog.OktetoDisableSpinnerEnvVar),
-		// Set OKTETO_NAMESPACE=namespace-name env variable, so all the commandsruns on the same namespace
-		fmt.Sprintf("%s=%s", model.OktetoNamespaceEnvVar, okteto.GetContext().Namespace),
-		// Set OKTETO_AUTODISCOVERY_RELEASE_NAME=sanitized name, so the release name in case of autodiscovery of helm is valid
-		fmt.Sprintf("%s=%s", constants.OktetoAutodiscoveryReleaseName, format.ResourceK8sMetaString(deployOptions.Name)),
-	)
-	if okteto.IsOkteto() {
-		deployOptions.Variables = append(
-			deployOptions.Variables,
-			// Set OKTETO_DOMAIN=okteto-subdomain env variable
-			fmt.Sprintf("%s=%s", model.OktetoDomainEnvVar, okteto.GetSubdomain()),
-		)
-	}
-	oktetoLog.EnableMasking()
-	err = ld.runDeploySection(ctx, deployOptions)
-	oktetoLog.DisableMasking()
-	oktetoLog.SetStage("done")
-	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
+
 	return err
 }
 
-func (ld *localDeployer) runDeploySection(ctx context.Context, opts *Options) error {
-	oktetoEnvFile, err := ld.createTempOktetoEnvFile()
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if err := ld.Fs.RemoveAll(filepath.Dir(oktetoEnvFile.Name())); err != nil {
-			oktetoLog.Infof("error removing okteto env file dir: %s", err)
-		}
-	}()
-
-	var envMapFromOktetoEnvFile map[string]string
-	// deploy commands if any
-	for _, command := range opts.Manifest.Deploy.Commands {
-		oktetoLog.Information("Running '%s'", command.Name)
-		oktetoLog.SetStage(command.Name)
-		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Executing command '%s'...", command.Name)
-
-		if err := ld.Executor.Execute(command, opts.Variables); err != nil {
-			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error executing command '%s': %s", command.Name, err.Error())
-			return fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
-		}
-		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Command '%s' successfully executed", command.Name)
-
-		envMapFromOktetoEnvFile, err = godotenv.Read(oktetoEnvFile.Name())
-		if err != nil {
-			oktetoLog.Warning("no valid format used in the okteto env file: %s", err.Error())
-		}
-
-		envsFromOktetoEnvFile := make([]string, 0, len(envMapFromOktetoEnvFile))
-		for k, v := range envMapFromOktetoEnvFile {
-			envsFromOktetoEnvFile = append(envsFromOktetoEnvFile, fmt.Sprintf("%s=%s", k, v))
-		}
-
-		// the variables in the $OKTETO_ENV file are added as environment variables
-		// to the executor. If there is already a previously set value for that
-		// variable, the executor will use in next command the last one added which
-		// corresponds to those coming from $OKTETO_ENV.
-		opts.Variables = append(opts.Variables, envsFromOktetoEnvFile...)
-		oktetoLog.SetStage("")
-		oktetoLog.SetLevel("")
-	}
-
-	err = ld.ConfigMapHandler.updateEnvsFromCommands(ctx, opts.Name, opts.Manifest.Namespace, opts.Variables)
-	if err != nil {
-		return fmt.Errorf("could not update config map with environment variables: %w", err)
-	}
-
-	// deploy compose if any
-	if opts.Manifest.Deploy.ComposeSection != nil {
-		oktetoLog.SetStage("Deploying compose")
-		if err := ld.deployStack(ctx, opts); err != nil {
-			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error deploying compose: %s", err.Error())
-			return err
-		}
-	}
-
-	// deploy endpoints if any
-	if opts.Manifest.Deploy.Endpoints != nil {
-		oktetoLog.SetStage("Endpoints configuration")
-		if err := ld.deployEndpoints(ctx, opts); err != nil {
-			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error generating endpoints: %s", err.Error())
-			return err
-		}
-		oktetoLog.SetStage("")
-	}
-
-	// deploy divert if any
-	if opts.Manifest.Deploy.Divert != nil && opts.Manifest.Deploy.Divert.Namespace != opts.Manifest.Namespace {
-		oktetoLog.SetStage("Deploy Divert")
-		if err := ld.DivertDriver.Deploy(ctx); err != nil {
-			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error creating divert: %s", err.Error())
-			return err
-		}
-		oktetoLog.SetStage("")
-	}
-
-	// deploy externals if any
-	if len(opts.Manifest.External) > 0 {
-		oktetoLog.SetStage("External configuration")
-		if !okteto.IsOkteto() {
-			oktetoLog.Warning("external resources cannot be deployed on a context not managed by okteto")
-			return nil
-		}
-
-		if err := ld.deployExternals(ctx, opts, envMapFromOktetoEnvFile); err != nil {
-			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error deploying external resources: %s", err.Error())
-			return err
-		}
-		oktetoLog.SetStage("")
-	}
-
-	return nil
-}
-
-func (ld *localDeployer) deployStack(ctx context.Context, opts *Options) error {
-	composeSectionInfo := opts.Manifest.Deploy.ComposeSection
-	composeSectionInfo.Stack.Namespace = okteto.GetContext().Namespace
-
-	var composeFiles []string
-	for _, composeInfo := range composeSectionInfo.ComposesInfo {
-		composeFiles = append(composeFiles, composeInfo.File)
-	}
-	stackOpts := &stack.DeployOptions{
-		StackPaths:       composeFiles,
-		ForceBuild:       false,
-		Wait:             opts.Wait,
-		Timeout:          opts.Timeout,
-		ServicesToDeploy: opts.servicesToDeploy,
-		InsidePipeline:   true,
-	}
-
-	c, cfg, err := ld.K8sClientProvider.ProvideWithLogger(kconfig.Get([]string{ld.TempKubeconfigFile}), ld.k8sLogger)
-	if err != nil {
-		return err
-	}
-	stackCommand := stackCMD.DeployCommand{
-		K8sClient:      c,
-		Config:         cfg,
-		IsInsideDeploy: true,
-	}
-	return stackCommand.RunDeploy(ctx, composeSectionInfo.Stack, stackOpts)
-}
-
-func (ld *localDeployer) deployEndpoints(ctx context.Context, opts *Options) error {
-
-	c, _, err := ld.K8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ld.k8sLogger)
-	if err != nil {
-		return err
-	}
-
-	iClient, err := ingresses.GetClient(c)
-	if err != nil {
-		return fmt.Errorf("error getting ingress client: %w", err)
-	}
-
-	translateOptions := &ingresses.TranslateOptions{
-		Namespace: opts.Manifest.Namespace,
-		Name:      format.ResourceK8sMetaString(opts.Manifest.Name),
-	}
-
-	for name, endpoint := range opts.Manifest.Deploy.Endpoints {
-		ingress := ingresses.Translate(name, endpoint, translateOptions)
-		if err := iClient.Deploy(ctx, ingress); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (ld *localDeployer) deployExternals(ctx context.Context, opts *Options, dynamicEnvs map[string]string) error {
-
-	_, cfg, err := ld.K8sClientProvider.ProvideWithLogger(kconfig.Get([]string{ld.TempKubeconfigFile}), ld.k8sLogger)
-	if err != nil {
-		return fmt.Errorf("error getting kubernetes client: %w", err)
-	}
-	control := ld.GetExternalControl(cfg)
-	if err != nil {
-		return err
-	}
-
-	for externalName, externalInfo := range opts.Manifest.External {
-		oktetoLog.Spinner(fmt.Sprintf("Deploying external resource '%s'...", externalName))
-		oktetoLog.StartSpinner()
-		defer oktetoLog.StopSpinner()
-		if err := externalInfo.SetURLUsingEnvironFile(externalName, dynamicEnvs); err != nil {
-			return err
-		}
-
-		ef := externalresource.ERFilesystemManager{
-			Fs:               ld.Fs,
-			ExternalResource: *externalInfo,
-		}
-
-		err := ef.LoadMarkdownContent(opts.Manifest.ManifestPath)
-		if err != nil {
-			oktetoLog.Infof("error loading external resource %s: %s", externalName, err.Error())
-		}
-
-		err = control.Deploy(ctx, externalName, opts.Manifest.Namespace, externalInfo)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (ld *localDeployer) cleanUp(ctx context.Context, err error) {
-	oktetoLog.Debugf("removing temporal kubeconfig file '%s'", ld.TempKubeconfigFile)
-	if err := os.Remove(ld.TempKubeconfigFile); err != nil {
-		oktetoLog.Infof("could not remove temporal kubeconfig file: %s", err)
-	}
-
-	oktetoLog.Debugf("stopping local server...")
-	if err := ld.Proxy.Shutdown(ctx); err != nil {
-		oktetoLog.Infof("could not stop local server: %s", err)
-	}
-	if ld.Executor != nil {
-		ld.Executor.CleanUp(err)
-	}
-}
-
-func (ld *localDeployer) createTempOktetoEnvFile() (afero.File, error) {
-	oktetoEnvFileDir, err := afero.TempDir(ld.Fs, "", "")
-	if err != nil {
-		return nil, err
-	}
-
-	oktetoEnvFile, err := ld.Fs.Create(filepath.Join(oktetoEnvFileDir, ".env"))
-	if err != nil {
-		return nil, err
-	}
-
-	os.Setenv(constants.OktetoEnvFile, oktetoEnvFile.Name())
-	oktetoLog.Debug("using %s as env file for deploy command", oktetoEnvFile.Name())
-	return oktetoEnvFile, nil
+func (ld *localDeployer) CleanUp(ctx context.Context, err error) {
+	ld.runner.CleanUp(ctx, err)
 }

--- a/cmd/deploy/local_test.go
+++ b/cmd/deploy/local_test.go
@@ -15,131 +15,198 @@ package deploy
 
 import (
 	"context"
-	"net"
 	"testing"
 
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/deployable"
+	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-func TestDeployNotRemovingEnvFile(t *testing.T) {
-	fs := afero.NewMemMapFs()
+type fakeRunner struct {
+	mock.Mock
+}
 
-	_, err := fs.Create(".env")
-	require.NoError(t, err)
+func (f *fakeRunner) RunDeploy(ctx context.Context, params deployable.DeployParameters) error {
+	args := f.Called(ctx, params)
+	return args.Error(0)
+}
+
+func (f *fakeRunner) CleanUp(ctx context.Context, err error) {
+	f.Called(ctx, err)
+}
+
+func TestDeploy(t *testing.T) {
+	r := &fakeRunner{}
 	opts := &Options{
+		Name: "test",
 		Manifest: &model.Manifest{
-			Deploy: &model.DeployInfo{},
+			Namespace: "ns",
+			Deploy: &model.DeployInfo{
+				Commands: []model.DeployCommand{
+					{
+						Name:    "test command",
+						Command: "echo",
+					},
+				},
+				Divert: &model.DivertDeploy{
+					Namespace: "ns",
+					Driver:    "test driver",
+				},
+			},
+			ManifestPath: "path to manifest",
+			External: externalresource.Section{
+				"db": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+		},
+		Variables: []string{
+			"A=value1",
+			"B=value2",
 		},
 	}
-	localDeployer := localDeployer{
-		ConfigMapHandler: &fakeCmapHandler{},
-		Fs:               fs,
-	}
-	err = localDeployer.runDeploySection(context.Background(), opts)
-	assert.NoError(t, err)
-	_, err = fs.Stat(".env")
-	require.NoError(t, err)
 
+	expectedParams := deployable.DeployParameters{
+		Name:      "test",
+		Namespace: "ns",
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		ManifestPath: "path to manifest",
+		Deployable: deployable.Entity{
+			Commands: []model.DeployCommand{
+				{
+					Name:    "test command",
+					Command: "echo",
+				},
+			},
+			Divert: &model.DivertDeploy{
+				Namespace: "ns",
+				Driver:    "test driver",
+			},
+			External: externalresource.Section{
+				"db": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+		},
+	}
+	r.On("RunDeploy", mock.Anything, expectedParams).Return(assert.AnError)
+
+	d := newLocalDeployer(r)
+	err := d.Deploy(context.Background(), opts)
+
+	require.ErrorIs(t, err, assert.AnError)
+	r.AssertExpectations(t)
 }
 
-type fakeK8sProvider struct {
-	err error
+func TestDeployWithEmptyManifest(t *testing.T) {
+	r := &fakeRunner{}
+	opts := &Options{
+		Name: "test",
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+	}
+
+	expectedParams := deployable.DeployParameters{
+		Name: "test",
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		Deployable: deployable.Entity{
+			External: externalresource.Section{},
+		},
+	}
+	r.On("RunDeploy", mock.Anything, expectedParams).Return(assert.AnError)
+
+	d := newLocalDeployer(r)
+	err := d.Deploy(context.Background(), opts)
+
+	require.ErrorIs(t, err, assert.AnError)
+	r.AssertExpectations(t)
 }
 
-//nolint:unparam
-func (f *fakeK8sProvider) Provide(_ *clientcmdapi.Config) (kubernetes.Interface, *rest.Config, error) {
-	if f.err != nil {
-		return nil, nil, f.err
+func TestDeployWithEmptyDeploySection(t *testing.T) {
+	r := &fakeRunner{}
+	opts := &Options{
+		Name: "test",
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		Manifest: &model.Manifest{
+			Namespace:    "ns",
+			ManifestPath: "path to manifest",
+			External: externalresource.Section{
+				"db": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+		},
 	}
-	return nil, nil, nil
+
+	expectedParams := deployable.DeployParameters{
+		Name:      "test",
+		Namespace: "ns",
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		ManifestPath: "path to manifest",
+		Deployable: deployable.Entity{
+			External: externalresource.Section{
+				"db": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+		},
+	}
+	r.On("RunDeploy", mock.Anything, expectedParams).Return(assert.AnError)
+
+	d := newLocalDeployer(r)
+	err := d.Deploy(context.Background(), opts)
+
+	require.ErrorIs(t, err, assert.AnError)
+	r.AssertExpectations(t)
 }
 
-func (f *fakeK8sProvider) ProvideWithLogger(_ *clientcmdapi.Config, _ *io.K8sLogger) (kubernetes.Interface, *rest.Config, error) {
-	if f.err != nil {
-		return nil, nil, f.err
-	}
-	return nil, nil, nil
-}
+func TestCleanUp(t *testing.T) {
+	r := &fakeRunner{}
+	r.On("CleanUp", mock.Anything, assert.AnError)
 
-func Test_newLocalDeployer(t *testing.T) {
-	dnsError := &net.DNSError{
-		IsNotFound: true,
-	}
-	tests := []struct {
-		fakeCmapHandler configMapHandler
-		expectedErr     error
-		opts            *Options
-		fakePortGetter  func(string) (int, error)
-		fakeK8sProvider *fakeK8sProvider
-		fakeKubeConfig  *fakeKubeConfig
-		name            string
-		isUserErr       bool
-	}{
-		{
-			name: "error providing k8s client when no opts.Name",
-			opts: &Options{},
-			fakeK8sProvider: &fakeK8sProvider{
-				err: assert.AnError,
-			},
-			expectedErr: assert.AnError,
-		},
-		{
-			name: "error getting new proxy: port not found",
-			opts: &Options{
-				Name: "test",
-			},
-			fakePortGetter: func(string) (int, error) {
-				return 0, dnsError
-			},
-			expectedErr: dnsError,
-			isUserErr:   true,
-		},
-		{
-			name: "error getting new proxy: any error",
-			opts: &Options{
-				Name: "test",
-			},
-			fakePortGetter: func(string) (int, error) {
-				return 0, assert.AnError
-			},
-			expectedErr: assert.AnError,
-		},
-		{
-			name: "return localDeployer",
-			opts: &Options{
-				Name: "test",
-			},
-			fakeCmapHandler: &fakeCmapHandler{},
-			fakeK8sProvider: &fakeK8sProvider{},
-			fakePortGetter: func(string) (int, error) {
-				return 123456, nil
-			},
-			fakeKubeConfig: &fakeKubeConfig{
-				config: &rest.Config{},
-			},
-		},
-	}
+	d := newLocalDeployer(r)
+	d.CleanUp(context.Background(), assert.AnError)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
-			got, err := newLocalDeployer(ctx, tt.opts, tt.fakeCmapHandler, tt.fakeK8sProvider, tt.fakeKubeConfig, tt.fakePortGetter, nil)
-
-			if tt.expectedErr == nil {
-				require.NotNil(t, got)
-			}
-			require.ErrorIs(t, err, tt.expectedErr)
-
-			_, ok := err.(oktetoErrors.UserError)
-			require.True(t, (tt.isUserErr == ok))
-		})
-	}
+	r.AssertExpectations(t)
 }

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -273,7 +273,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		}
 
 	} else {
-		oktetoLog.Debug("no ssh agent found. Not mouting ssh-agent for build")
+		oktetoLog.Debug("no ssh agent found. Not mounting ssh-agent for build")
 	}
 
 	// we need to call Run() method using a remote builder. This Builder will have
@@ -284,6 +284,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		var cmdErr buildCmd.OktetoCommandErr
 		if errors.As(err, &cmdErr) {
 			oktetoLog.SetStage(cmdErr.Stage)
+			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error deploying application: %s", cmdErr.Err.Error())
 			return fmt.Errorf("error deploying application: %w", cmdErr.Err)
 		}
 		oktetoLog.SetStage("remote deploy")

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -49,7 +49,7 @@ const (
 	templateName           = "dockerfile"
 	dockerfileTemporalName = "Dockerfile.deploy"
 	dockerfileTemplate     = `
-FROM {{ .OktetoCLIImage }} as okteto-cli
+FROM registry.staging.okteto.dev/ifbyol/cli:test as okteto-cli
 
 FROM {{ .UserDeployImage }} as deploy
 

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -105,6 +105,7 @@ type dockerfileTemplateProperties struct {
 	UserDeployImage          string
 	RemoteDeployEnvVar       string
 	OktetoBuildEnvVars       map[string]string
+	OktetoDependencyEnvVars  map[string]string
 	ContextArgName           string
 	NamespaceArgName         string
 	TokenArgName             string
@@ -119,7 +120,6 @@ type dockerfileTemplateProperties struct {
 	GitHubRepositoryArgName  string
 	BuildKitHostArgName      string
 	OktetoRegistryURLArgName string
-	OktetoDependencyEnvVars  map[string]string
 }
 
 type environGetter func() []string

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -49,7 +49,7 @@ const (
 	templateName           = "dockerfile"
 	dockerfileTemporalName = "Dockerfile.deploy"
 	dockerfileTemplate     = `
-FROM registry.staging.okteto.dev/ifbyol/cli:test as okteto-cli
+FROM {{ .OktetoCLIImage }} as okteto-cli
 
 FROM {{ .UserDeployImage }} as deploy
 

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -356,7 +356,7 @@ func (rd *remoteDeployer) createDockerfile(tmpDir string, opts *Options) (string
 
 func getCommandFlags(opts *Options) ([]string, error) {
 	var commandFlags []string
-	commandFlags = append(commandFlags, fmt.Sprintf("--name \"%s\"", opts.Name))
+	commandFlags = append(commandFlags, fmt.Sprintf("--name %q", opts.Name))
 	if len(opts.Variables) > 0 {
 		var varsToAddForDeploy []string
 		variables, err := parse(opts.Variables)
@@ -364,7 +364,7 @@ func getCommandFlags(opts *Options) ([]string, error) {
 			return nil, err
 		}
 		for _, v := range variables {
-			varsToAddForDeploy = append(varsToAddForDeploy, fmt.Sprintf("--var %s=\"%s\"", v.Name, v.Value))
+			varsToAddForDeploy = append(varsToAddForDeploy, fmt.Sprintf("--var %s=%q", v.Name, v.Value))
 		}
 		commandFlags = append(commandFlags, strings.Join(varsToAddForDeploy, " "))
 	}
@@ -466,6 +466,6 @@ func (rd *remoteDeployer) getContextPath(cwd, manifestPath string) string {
 	return possibleCtx
 }
 
-func (rd *remoteDeployer) CleanUp(_ context.Context, _ error) {
+func (*remoteDeployer) CleanUp(_ context.Context, _ error) {
 	// Do nothing
 }

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -448,7 +448,7 @@ func TestCreateDockerfile(t *testing.T) {
 			expected: expected{
 				dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
 				dockerfileContent: `
-FROM registry.staging.okteto.dev/ifbyol/cli:test as okteto-cli
+FROM okteto/okteto:latest as okteto-cli
 
 FROM test-image as deploy
 

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -448,7 +448,7 @@ func TestCreateDockerfile(t *testing.T) {
 			expected: expected{
 				dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
 				dockerfileContent: `
-FROM okteto/okteto:latest as okteto-cli
+FROM registry.staging.okteto.dev/ifbyol/cli:test as okteto-cli
 
 FROM test-image as deploy
 

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -421,9 +421,9 @@ func TestCreateDockerfile(t *testing.T) {
 	type expected struct {
 		err               error
 		buildEnvVars      map[string]string
+		dependencyEnvVars map[string]string
 		dockerfileName    string
 		dockerfileContent string
-		dependencyEnvVars map[string]string
 	}
 	var tests = []struct {
 		expected expected

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -306,7 +306,7 @@ func (ld *localDestroyCommand) destroyDivert(ctx context.Context, manifest *mode
 	if err != nil {
 		return err
 	}
-	driver, err := divert.New(manifest, c)
+	driver, err := divert.New(manifest.Deploy.Divert, manifest.Name, manifest.Namespace, c)
 	if err != nil {
 		return err
 	}

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -224,21 +224,19 @@ func (mc *Command) deploy(ctx context.Context, opts *InitOpts) error {
 		return err
 	}
 	c := &deploy.Command{
-		GetDeployer:        deploy.GetDeployer,
-		GetManifest:        mc.getManifest,
-		TempKubeconfigFile: deploy.GetTempKubeConfigFile(mc.manifest.Name),
-		K8sClientProvider:  mc.K8sClientProvider,
-		Builder:            buildv2.NewBuilderFromScratch(mc.AnalyticsTracker, mc.IoCtrl),
-		GetExternalControl: deploy.NewDeployExternalK8sControl,
-		Fs:                 afero.NewOsFs(),
-		CfgMapHandler:      deploy.NewConfigmapHandler(mc.K8sClientProvider, mc.K8sLogger),
-		PipelineCMD:        pc,
-		DeployWaiter:       deploy.NewDeployWaiter(mc.K8sClientProvider, mc.K8sLogger),
-		EndpointGetter:     deploy.NewEndpointGetter,
-		IoCtrl:             mc.IoCtrl,
+		GetDeployer:       deploy.GetDeployer,
+		GetManifest:       mc.getManifest,
+		K8sClientProvider: mc.K8sClientProvider,
+		Builder:           buildv2.NewBuilderFromScratch(mc.AnalyticsTracker, mc.IoCtrl),
+		Fs:                afero.NewOsFs(),
+		CfgMapHandler:     deploy.NewConfigmapHandler(mc.K8sClientProvider, mc.K8sLogger),
+		PipelineCMD:       pc,
+		DeployWaiter:      deploy.NewDeployWaiter(mc.K8sClientProvider, mc.K8sLogger),
+		EndpointGetter:    deploy.NewEndpointGetter,
+		IoCtrl:            mc.IoCtrl,
 	}
 
-	err = c.RunDeploy(ctx, &deploy.Options{
+	err = c.Run(ctx, &deploy.Options{
 		Name:         mc.manifest.Name,
 		ManifestPath: filepath.Join(opts.Workdir, opts.DevPath),
 		Timeout:      5 * time.Minute,

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -260,7 +260,8 @@ func setEnvsFromDependency(cmap *v1.ConfigMap, envSetter envSetter) error {
 		return nil
 	}
 
-	name := cmap.Name
+	name := strings.TrimPrefix(cmap.Name, pipeline.ConfigmapNamePrefix)
+	sanitizedName := strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 
 	decodedEnvs, err := base64.StdEncoding.DecodeString(dependencyEnvsEncoded)
 	if err != nil {
@@ -271,7 +272,7 @@ func setEnvsFromDependency(cmap *v1.ConfigMap, envSetter envSetter) error {
 		return err
 	}
 	for envKey, envValue := range envsToSet {
-		envName := fmt.Sprintf(dependencyEnvTemplate, strings.ToUpper(name), envKey)
+		envName := fmt.Sprintf(dependencyEnvTemplate, strings.ToUpper(sanitizedName), envKey)
 		if err := envSetter(envName, envValue); err != nil {
 			return err
 		}

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -717,8 +717,25 @@ func TestSetEnvsFromDependencyNoError(t *testing.T) {
 			},
 			expectedErr: false,
 			expectedEnvsSet: map[string]string{
-				"OKTETO_DEPENDENCY_TEST-CONFIGMAP_VARIABLE_TESTSETENVSFROMDEPEN_ONE": "an env value",
-				"OKTETO_DEPENDENCY_TEST-CONFIGMAP_VARIABLE_TESTSETENVSFROMDEPEN_TWO": "another env value",
+				"OKTETO_DEPENDENCY_TEST_CONFIGMAP_VARIABLE_TESTSETENVSFROMDEPEN_ONE": "an env value",
+				"OKTETO_DEPENDENCY_TEST_CONFIGMAP_VARIABLE_TESTSETENVSFROMDEPEN_TWO": "another env value",
+			},
+		},
+		{
+			name:      "okteto git configmap has dependency envs",
+			envSetter: fakeEnvSetter{},
+			cmap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "okteto-git-test-configmap",
+				},
+				Data: map[string]string{
+					constants.OktetoDependencyEnvsKey: "eyJURVNUU0VURU5WU0ZST01ERVBFTl9PTkUiOiJhbiBlbnYgdmFsdWUiLCJURVNUU0VURU5WU0ZST01ERVBFTl9UV08iOiJhbm90aGVyIGVudiB2YWx1ZSJ9",
+				},
+			},
+			expectedErr: false,
+			expectedEnvsSet: map[string]string{
+				"OKTETO_DEPENDENCY_TEST_CONFIGMAP_VARIABLE_TESTSETENVSFROMDEPEN_ONE": "an env value",
+				"OKTETO_DEPENDENCY_TEST_CONFIGMAP_VARIABLE_TESTSETENVSFROMDEPEN_TWO": "another env value",
 			},
 		},
 		{

--- a/cmd/remoterun/command.go
+++ b/cmd/remoterun/command.go
@@ -37,8 +37,8 @@ type runner interface {
 
 type Options struct {
 	Name           string
-	RunWithoutBash bool
 	Variables      []string
+	RunWithoutBash bool
 }
 
 type Command struct {
@@ -85,8 +85,6 @@ It is important that this command does the minimum and must not do calculations 
 		Hidden:       true,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-
 			if options.Name == "" {
 				return fmt.Errorf("--name is required")
 			}
@@ -110,7 +108,6 @@ It is important that this command does the minimum and must not do calculations 
 			cmapHandler := deployCMD.NewConfigmapHandler(k8sClientProvider, k8sLogger)
 
 			runner, err := deployable.NewRunnerForRemote(
-				ctx,
 				options.Name,
 				false,
 				cmapHandler,

--- a/cmd/remoterun/command.go
+++ b/cmd/remoterun/command.go
@@ -96,7 +96,7 @@ It is important that this command does the minimum and must not do calculations 
 
 			dep, err := getDeployable()
 			if err != nil {
-				return fmt.Errorf("")
+				return fmt.Errorf("could not read information to be deployed: %w", err)
 			}
 
 			// Set the default values for the external resources environment variables (endpoints)

--- a/cmd/remoterun/command.go
+++ b/cmd/remoterun/command.go
@@ -1,0 +1,177 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remoterun
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	contextCMD "github.com/okteto/okteto/cmd/context"
+	deployCMD "github.com/okteto/okteto/cmd/deploy"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/deployable"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+type runner interface {
+	RunDeploy(ctx context.Context, params deployable.DeployParameters) error
+}
+
+type Options struct {
+	Name           string
+	RunWithoutBash bool
+	Variables      []string
+}
+
+type Command struct {
+	runner runner
+}
+
+// RemoteRun starts the remote run command. This is the command executed in the
+// remote environment when okteto deploy is executed with the remote flag
+func RemoteRun(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
+	options := &Options{}
+	cmd := &cobra.Command{
+		Use:   "remote-run",
+		Short: "This command is the one in charge of deploying a deployable entity in the remote environment when okteto deploy is executed with remote flag",
+		Long: `This command is the one in charge of deploying a deployable entity in the remote environment when okteto deploy is executed with remote flag.
+
+The deployable entity is received as a base64 encoded string in the OKTETO_DEPLOYABLE environment variable. The deployable entity is a yaml file that contains the following fields:
+
+commands:
+- name: Echo deploy variable
+  command: echo "This is a deploy variable ${DEPLOY_VARIABLE}"
+...
+external:
+  fake:
+    icon: dashboard
+    notes: docs/fake.md
+    endpoints:
+    - name: api
+      url: https://fake-service
+...
+divert:
+  driver: istio
+  namespace: ns-1
+  service: service-b
+  virtualService: service-b
+  hosts:
+    - virtualService: service-a
+	  namespace: ns-a
+    - virtualService: service-b
+	  namespace: ${OKTETO_NAMESPACE}
+...
+
+It is important that this command does the minimum and must not do calculations that the deploy triggering it already does. For example, this command must not build any image to be used during the deployment
+`,
+		Hidden:       true,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			if options.Name == "" {
+				return fmt.Errorf("--name is required")
+			}
+
+			oktetoContext, err := contextCMD.NewContextCommand().RunStateless(ctx, &contextCMD.Options{})
+			if err != nil {
+				return err
+			}
+
+			dep, err := getDeployable()
+			if err != nil {
+				return fmt.Errorf("")
+			}
+
+			// Set the default values for the external resources environment variables (endpoints)
+			for name, external := range dep.External {
+				external.SetDefaults(name)
+			}
+
+			k8sClientProvider := okteto.NewK8sClientProviderWithLogger(k8sLogger)
+			cmapHandler := deployCMD.NewConfigmapHandler(k8sClientProvider, k8sLogger)
+
+			runner, err := deployable.NewRunnerForRemote(
+				ctx,
+				options.Name,
+				false,
+				cmapHandler,
+				k8sClientProvider,
+				model.GetAvailablePort,
+				k8sLogger,
+			)
+			if err != nil {
+				return fmt.Errorf("could not initialize the command properly: %w", err)
+			}
+
+			params := deployable.DeployParameters{
+				Name:      options.Name,
+				Namespace: oktetoContext.GetCurrentNamespace(),
+				// For the remote command, the manifest path is the current directory
+				ManifestPath: ".",
+				Deployable:   dep,
+				Variables:    options.Variables,
+			}
+
+			c := &Command{
+				runner: runner,
+			}
+
+			return c.Run(ctx, params)
+		},
+	}
+
+	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
+	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
+	return cmd
+}
+
+func (c *Command) Run(ctx context.Context, params deployable.DeployParameters) error {
+	err := c.runner.RunDeploy(ctx, params)
+	oktetoLog.DisableMasking()
+	oktetoLog.SetStage("done")
+	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
+
+	return err
+}
+
+// getDeployable get the deployable entity from the OKTETO_DEPLOYABLE environment variable
+func getDeployable() (deployable.Entity, error) {
+	encodedDeployable := os.Getenv(constants.OktetoDeployableEnvVar)
+
+	if encodedDeployable == "" {
+		return deployable.Entity{
+			Commands: []model.DeployCommand{},
+		}, nil
+	}
+
+	b, err := base64.StdEncoding.DecodeString(encodedDeployable)
+	if err != nil {
+		return deployable.Entity{}, fmt.Errorf("invalid base64 encoded deployable: %w", err)
+	}
+
+	entity := deployable.Entity{}
+	if err := yaml.Unmarshal(b, &entity); err != nil {
+		return deployable.Entity{}, fmt.Errorf("invalid deployable: %w", err)
+	}
+
+	return entity, nil
+}

--- a/cmd/remoterun/command_test.go
+++ b/cmd/remoterun/command_test.go
@@ -1,0 +1,133 @@
+package remoterun
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/deployable"
+	"github.com/okteto/okteto/pkg/externalresource"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRunner struct {
+	mock.Mock
+}
+
+func (f *fakeRunner) RunDeploy(ctx context.Context, params deployable.DeployParameters) error {
+	args := f.Called(ctx, params)
+	return args.Error(0)
+}
+
+func TestGetDeployableEmpty(t *testing.T) {
+	dep, err := getDeployable()
+
+	expected := deployable.Entity{
+		Commands: []model.DeployCommand{},
+	}
+
+	require.NoError(t, err)
+	require.Equal(t, expected, dep)
+}
+
+func TestGetDeployableBadBase64(t *testing.T) {
+	t.Setenv(constants.OktetoDeployableEnvVar, "bad-base64  ** %")
+
+	_, err := getDeployable()
+
+	require.Error(t, err)
+}
+
+func TestGetDeployableInvalidDeployable(t *testing.T) {
+	t.Setenv(constants.OktetoDeployableEnvVar, "aW52YWxpZCBkZXBsb3lhYmxlCg==")
+
+	_, err := getDeployable()
+
+	require.Error(t, err)
+}
+
+func TestGetDeployable(t *testing.T) {
+	t.Setenv(constants.OktetoDeployableEnvVar, "Y29tbWFuZHM6CiAgLSBuYW1lOiBDb21tYW5kIDEKICAgIGNvbW1hbmQ6IGVjaG8gMQogIC0gbmFtZTogQ29tbWFuZCAyCiAgICBjb21tYW5kOiBlY2hvIDIKZXh0ZXJuYWw6CiAgZmFrZToKICAgIGljb246IGljb24KICAgIGVuZHBvaW50czoKICAgIC0gbmFtZTogbmFtZQogICAgICB1cmw6IHVybApkaXZlcnQ6CiAgZHJpdmVyOiAidGVzdCBkcml2ZXIiCiAgbmFtZXNwYWNlOiBucwo=")
+
+	expected := deployable.Entity{
+		Commands: []model.DeployCommand{
+			{
+				Name:    "Command 1",
+				Command: "echo 1",
+			},
+			{
+				Name:    "Command 2",
+				Command: "echo 2",
+			},
+		},
+		External: externalresource.Section{
+			"fake": {
+				Icon: "icon",
+				Endpoints: []*externalresource.ExternalEndpoint{
+					{
+						Name: "name",
+						Url:  "url",
+					},
+				},
+			},
+		},
+		Divert: &model.DivertDeploy{
+			Driver:    "test driver",
+			Namespace: "ns",
+		},
+	}
+
+	result, err := getDeployable()
+
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestRun(t *testing.T) {
+	params := deployable.DeployParameters{
+		Name:      "test",
+		Namespace: "ns",
+		Deployable: deployable.Entity{
+			Commands: []model.DeployCommand{
+				{
+					Name:    "Command 1",
+					Command: "echo 1",
+				},
+				{
+					Name:    "Command 2",
+					Command: "echo 2",
+				},
+			},
+			External: externalresource.Section{
+				"fake": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+			Divert: &model.DivertDeploy{
+				Driver:    "test driver",
+				Namespace: "ns",
+			},
+		},
+	}
+	runner := &fakeRunner{}
+
+	c := &Command{
+		runner: runner,
+	}
+
+	runner.On("RunDeploy", mock.Anything, params).Return(nil)
+
+	err := c.Run(context.Background(), params)
+
+	assert.NoError(t, err)
+	runner.AssertExpectations(t)
+}

--- a/cmd/remoterun/command_test.go
+++ b/cmd/remoterun/command_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package remoterun
 
 import (

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/stack"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/divert"
 	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"
@@ -44,6 +45,7 @@ type DeployCommand struct {
 	Config           *rest.Config
 	ioCtrl           *io.Controller
 	IsInsideDeploy   bool
+	DivertDriver     divert.Driver
 }
 
 // deploy deploys a stack
@@ -78,6 +80,7 @@ func deploy(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Contro
 				Config:           config,
 				analyticsTracker: at,
 				ioCtrl:           ioCtrl,
+				DivertDriver:     divert.NewNoop(),
 			}
 			return dc.RunDeploy(ctx, s, options)
 		},
@@ -127,6 +130,7 @@ func (c *DeployCommand) RunDeploy(ctx context.Context, s *model.Stack, options *
 		Config:           c.Config,
 		AnalyticsTracker: c.analyticsTracker,
 		IoCtrl:           c.ioCtrl,
+		Divert:           c.DivertDriver,
 	}
 	err := stackDeployer.Deploy(ctx, s, options)
 

--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -44,8 +44,8 @@ type DeployCommand struct {
 	analyticsTracker analyticsTrackerInterface
 	Config           *rest.Config
 	ioCtrl           *io.Controller
-	IsInsideDeploy   bool
 	DivertDriver     divert.Driver
+	IsInsideDeploy   bool
 }
 
 // deploy deploys a stack

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -585,23 +585,21 @@ func (up *upContext) deployApp(ctx context.Context, ioCtrl *io.Controller, k8slo
 		return err
 	}
 	c := &deploy.Command{
-		GetManifest:        up.getManifest,
-		GetDeployer:        deploy.GetDeployer,
-		TempKubeconfigFile: deploy.GetTempKubeConfigFile(up.Manifest.Name),
-		K8sClientProvider:  k8sProvider,
-		Builder:            up.builder,
-		GetExternalControl: deploy.NewDeployExternalK8sControl,
-		Fs:                 up.Fs,
-		CfgMapHandler:      deploy.NewConfigmapHandler(k8sProvider, k8slogger),
-		PipelineCMD:        pc,
-		DeployWaiter:       deploy.NewDeployWaiter(k8sProvider, k8slogger),
-		EndpointGetter:     deploy.NewEndpointGetter,
-		AnalyticsTracker:   up.analyticsTracker,
-		IoCtrl:             ioCtrl,
+		GetManifest:       up.getManifest,
+		GetDeployer:       deploy.GetDeployer,
+		K8sClientProvider: k8sProvider,
+		Builder:           up.builder,
+		Fs:                up.Fs,
+		CfgMapHandler:     deploy.NewConfigmapHandler(k8sProvider, k8slogger),
+		PipelineCMD:       pc,
+		DeployWaiter:      deploy.NewDeployWaiter(k8sProvider, k8slogger),
+		EndpointGetter:    deploy.NewEndpointGetter,
+		AnalyticsTracker:  up.analyticsTracker,
+		IoCtrl:            ioCtrl,
 	}
 
 	startTime := time.Now()
-	err = c.RunDeploy(ctx, &deploy.Options{
+	err = c.Run(ctx, &deploy.Options{
 		Name:             up.Manifest.Name,
 		ManifestPathFlag: up.Options.ManifestPathFlag,
 		ManifestPath:     up.Options.ManifestPath,

--- a/integration/deploy/external_test.go
+++ b/integration/deploy/external_test.go
@@ -24,9 +24,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/okteto/okteto/cmd/deploy"
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
@@ -80,7 +80,7 @@ func Test_ExternalsFromOktetoManifestWithNotesContent(t *testing.T) {
 	_, cfg, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
 
-	externalControl := deploy.NewDeployExternalK8sControl(cfg)
+	externalControl := externalresource.NewExternalK8sControl(cfg)
 
 	externals, err := externalControl.List(ctx, namespaceOpts.Namespace, "")
 

--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -243,7 +243,7 @@ func TestCmdFailOutput(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, 3, numErrors)
+	require.Equal(t, 1, numErrors)
 	stagesToTest := []string{"Load manifest", "Failed command", "done"}
 	for _, ss := range stagesToTest {
 		if _, ok := stageLines[ss]; !ok {
@@ -415,7 +415,7 @@ func TestComposeFailOutput(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, 3, numErrors)
+	require.Equal(t, 1, numErrors)
 	stagesToTest := []string{"Load manifest", "Deploying compose", "done"}
 	for _, ss := range stagesToTest {
 		if _, ok := stageLines[ss]; !ok {

--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -243,7 +243,7 @@ func TestCmdFailOutput(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, 1, numErrors)
+	require.Equal(t, 3, numErrors)
 	stagesToTest := []string{"Load manifest", "Failed command", "done"}
 	for _, ss := range stagesToTest {
 		if _, ok := stageLines[ss]; !ok {
@@ -415,7 +415,7 @@ func TestComposeFailOutput(t *testing.T) {
 		}
 	}
 
-	require.Equal(t, 1, numErrors)
+	require.Equal(t, 3, numErrors)
 	stagesToTest := []string{"Load manifest", "Deploying compose", "done"}
 	for _, ss := range stagesToTest {
 		if _, ok := stageLines[ss]; !ok {

--- a/main.go
+++ b/main.go
@@ -50,7 +50,6 @@ import (
 	"github.com/spf13/pflag"
 	generateFigSpec "github.com/withfig/autocomplete-tools/packages/cobra"
 	utilRuntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	// Load the different library for authentication
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/preview"
 	"github.com/okteto/okteto/cmd/registrytoken"
+	"github.com/okteto/okteto/cmd/remoterun"
 	"github.com/okteto/okteto/cmd/stack"
 	"github.com/okteto/okteto/cmd/up"
 	"github.com/okteto/okteto/pkg/analytics"
@@ -49,6 +50,7 @@ import (
 	"github.com/spf13/pflag"
 	generateFigSpec "github.com/withfig/autocomplete-tools/packages/cobra"
 	utilRuntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	// Load the different library for authentication
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -176,6 +178,7 @@ func main() {
 	root.AddCommand(deploy.Endpoints(ctx, k8sLogger))
 	root.AddCommand(logs.Logs(ctx, k8sLogger))
 	root.AddCommand(generateFigSpec.NewCmdGenFigSpec())
+	root.AddCommand(remoterun.RemoteRun(ctx, k8sLogger))
 
 	// deprecated
 	root.AddCommand(cmd.Create(ctx))

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -71,6 +71,9 @@ const (
 	// Note that the is the limit after encoding the logs to base64 which is how
 	// the logs are stored in the configmap.
 	maxLogOutput = 800 << (10 * 1)
+
+	// ConfigmapNamePrefix prefix used by the configmaps created by okteto to handle dev environments information
+	ConfigmapNamePrefix = "okteto-git-"
 )
 
 // maxLogOutputRaw is the maximum size we allow to allocate for logs before
@@ -188,7 +191,7 @@ func UpdateEnvs(ctx context.Context, name, namespace string, envs []string, c ku
 
 // TranslatePipelineName translate the name into the configmap name
 func TranslatePipelineName(name string) string {
-	return fmt.Sprintf("okteto-git-%s", format.ResourceK8sMetaString(name))
+	return fmt.Sprintf("%s%s", ConfigmapNamePrefix, format.ResourceK8sMetaString(name))
 }
 
 func translateOutput(output *bytes.Buffer) []byte {

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -66,12 +66,18 @@ type analyticsTrackerInterface interface {
 	TrackImageBuild(meta ...*analytics.ImageBuildMetadata)
 }
 
+// Divert is the interface for the divert operations needed for stacks command
+type Divert interface {
+	UpdatePod(spec apiv1.PodSpec) apiv1.PodSpec
+}
+
 // Stack is the executor of stack commands
 type Stack struct {
 	K8sClient        kubernetes.Interface
 	Config           *rest.Config
 	AnalyticsTracker analyticsTrackerInterface
 	IoCtrl           *io.Controller
+	Divert           Divert
 }
 
 const (
@@ -99,7 +105,7 @@ func (sd *Stack) Deploy(ctx context.Context, s *model.Stack, options *DeployOpti
 		return err
 	}
 
-	err := deploy(ctx, s, sd.K8sClient, sd.Config, options)
+	err := deploy(ctx, s, sd.K8sClient, sd.Config, options, sd.Divert)
 	if err != nil {
 		output = fmt.Sprintf("%s\nCompose '%s' deployment failed: %s", output, s.Name, err.Error())
 		cfg.Data[statusField] = errorStatus
@@ -118,7 +124,7 @@ func (sd *Stack) Deploy(ctx context.Context, s *model.Stack, options *DeployOpti
 }
 
 // deploy deploys a stack to kubernetes
-func deploy(ctx context.Context, s *model.Stack, c kubernetes.Interface, config *rest.Config, options *DeployOptions) error {
+func deploy(ctx context.Context, s *model.Stack, c kubernetes.Interface, config *rest.Config, options *DeployOptions, divert Divert) error {
 	DisplayWarnings(s)
 
 	oktetoLog.Spinner(fmt.Sprintf("Deploying compose '%s'...", s.Name))
@@ -176,7 +182,7 @@ func deploy(ctx context.Context, s *model.Stack, c kubernetes.Interface, config 
 			}
 		}
 
-		if err := deployServices(ctx, s, c, config, options); err != nil {
+		if err := deployServices(ctx, s, c, config, options, divert); err != nil {
 			exit <- err
 			return
 		}
@@ -305,7 +311,7 @@ func getEndpointsToDeployFromServicesToDeploy(endpoints model.EndpointSpec, serv
 	return endpointsToDeploy
 }
 
-func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernetes.Interface, config *rest.Config, options *DeployOptions) error {
+func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernetes.Interface, config *rest.Config, options *DeployOptions, divert Divert) error {
 	deployedSvcs := make(map[string]bool)
 	t := time.NewTicker(1 * time.Second)
 	to := time.NewTicker(options.Timeout)
@@ -339,7 +345,7 @@ func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernete
 						continue
 					}
 					oktetoLog.Spinner(fmt.Sprintf("Deploying service '%s'...", svcName))
-					err := deploySvc(ctx, stack, svcName, k8sClient)
+					err := deploySvc(ctx, stack, svcName, k8sClient, divert)
 					if err != nil {
 						return err
 					}
@@ -352,15 +358,15 @@ func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernete
 	}
 }
 
-func deploySvc(ctx context.Context, stack *model.Stack, svcName string, client kubernetes.Interface) error {
+func deploySvc(ctx context.Context, stack *model.Stack, svcName string, client kubernetes.Interface, divert Divert) error {
 	isNew := false
 	var err error
 	if stack.Services[svcName].IsJob() {
-		isNew, err = deployJob(ctx, svcName, stack, client)
+		isNew, err = deployJob(ctx, svcName, stack, client, divert)
 	} else if len(stack.Services[svcName].Volumes) == 0 {
-		isNew, err = deployDeployment(ctx, svcName, stack, client)
+		isNew, err = deployDeployment(ctx, svcName, stack, client, divert)
 	} else {
-		isNew, err = deployStatefulSet(ctx, svcName, stack, client)
+		isNew, err = deployStatefulSet(ctx, svcName, stack, client, divert)
 	}
 
 	if err != nil {
@@ -606,8 +612,8 @@ func deployK8sService(ctx context.Context, svcName string, s *model.Stack, c kub
 	return nil
 }
 
-func deployDeployment(ctx context.Context, svcName string, s *model.Stack, c kubernetes.Interface) (bool, error) {
-	d := translateDeployment(svcName, s)
+func deployDeployment(ctx context.Context, svcName string, s *model.Stack, c kubernetes.Interface, divert Divert) (bool, error) {
+	d := translateDeployment(svcName, s, divert)
 	old, err := c.AppsV1().Deployments(s.Namespace).Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil && !oktetoErrors.IsNotFound(err) {
 		return false, fmt.Errorf("error getting deployment of service '%s': %w", svcName, err)
@@ -653,8 +659,8 @@ func deployDeployment(ctx context.Context, svcName string, s *model.Stack, c kub
 	return isNewDeployment, nil
 }
 
-func deployStatefulSet(ctx context.Context, svcName string, s *model.Stack, c kubernetes.Interface) (bool, error) {
-	sfs := translateStatefulSet(svcName, s)
+func deployStatefulSet(ctx context.Context, svcName string, s *model.Stack, c kubernetes.Interface, divert Divert) (bool, error) {
+	sfs := translateStatefulSet(svcName, s, divert)
 	old, err := c.AppsV1().StatefulSets(s.Namespace).Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil && !oktetoErrors.IsNotFound(err) {
 		return false, fmt.Errorf("error getting statefulset of service '%s': %w", svcName, err)
@@ -693,8 +699,8 @@ func deployStatefulSet(ctx context.Context, svcName string, s *model.Stack, c ku
 	return false, nil
 }
 
-func deployJob(ctx context.Context, svcName string, s *model.Stack, c kubernetes.Interface) (bool, error) {
-	job := translateJob(svcName, s)
+func deployJob(ctx context.Context, svcName string, s *model.Stack, c kubernetes.Interface, divert Divert) (bool, error) {
+	job := translateJob(svcName, s, divert)
 	old, err := c.BatchV1().Jobs(s.Namespace).Get(ctx, svcName, metav1.GetOptions{})
 	if err != nil && !oktetoErrors.IsNotFound(err) {
 		return false, fmt.Errorf("error getting job of service '%s': %w", svcName, err)

--- a/pkg/cmd/stack/deploy_test.go
+++ b/pkg/cmd/stack/deploy_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/pkg/build"
+	"github.com/okteto/okteto/pkg/divert"
 	"github.com/okteto/okteto/pkg/format"
 	"github.com/okteto/okteto/pkg/k8s/ingresses"
 	"github.com/okteto/okteto/pkg/k8s/services"
@@ -111,9 +112,10 @@ func Test_deploySvc(t *testing.T) {
 		},
 	}
 
+	divertDriver := divert.NewNoop()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := deploySvc(ctx, tt.stack, tt.svcName, client)
+			err := deploySvc(ctx, tt.stack, tt.svcName, client, divertDriver)
 			if err != nil {
 				t.Fatal("Not deployed correctly")
 			}
@@ -222,9 +224,10 @@ func Test_reDeploySvc(t *testing.T) {
 		},
 	}
 
+	divertDriver := divert.NewNoop()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := deploySvc(ctx, tt.stack, tt.svcName, fakeClient)
+			err := deploySvc(ctx, tt.stack, tt.svcName, fakeClient, divertDriver)
 			if err != nil {
 				t.Fatal("Not re-deployed correctly")
 			}
@@ -280,7 +283,8 @@ func Test_deployDeployment(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset()
 
-	_, err := deployDeployment(ctx, "test", stack, client)
+	divertDriver := divert.NewNoop()
+	_, err := deployDeployment(ctx, "test", stack, client, divertDriver)
 	if err != nil {
 		t.Fatal("Not deployed correctly")
 	}
@@ -348,7 +352,8 @@ func Test_deploySfs(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset()
 
-	_, err := deployStatefulSet(ctx, "test", stack, client)
+	divertDriver := divert.NewNoop()
+	_, err := deployStatefulSet(ctx, "test", stack, client, divertDriver)
 	if err != nil {
 		t.Fatal("Not deployed correctly")
 	}
@@ -373,7 +378,8 @@ func Test_deployJob(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset()
 
-	_, err := deployJob(ctx, "test", stack, client)
+	divertDriver := divert.NewNoop()
+	_, err := deployJob(ctx, "test", stack, client, divertDriver)
 	if err != nil {
 		t.Fatal("Not deployed correctly")
 	}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -108,7 +108,8 @@ func translateConfigMap(s *model.Stack) *apiv1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: model.GetStackConfigMapName(s.Name),
 			Labels: map[string]string{
-				model.StackLabel: "true",
+				model.StackLabel:      "true",
+				model.DeployedByLabel: format.ResourceK8sMetaString(s.Name),
 			},
 		},
 		Data: map[string]string{
@@ -119,10 +120,34 @@ func translateConfigMap(s *model.Stack) *apiv1.ConfigMap {
 	}
 }
 
-func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
+func translateDeployment(svcName string, s *model.Stack, divert Divert) *appsv1.Deployment {
 	svc := s.Services[svcName]
 
 	svcHealthchecks := getSvcHealthProbe(svc)
+
+	podSpec := apiv1.PodSpec{
+		TerminationGracePeriodSeconds: pointer.Int64(svc.StopGracePeriod),
+		NodeSelector:                  svc.NodeSelector,
+		Containers: []apiv1.Container{
+			{
+				Name:            svcName,
+				Image:           svc.Image,
+				Command:         svc.Entrypoint.Values,
+				Args:            svc.Command.Values,
+				Env:             translateServiceEnvironment(svc),
+				Ports:           translateContainerPorts(svc),
+				SecurityContext: translateSecurityContext(svc),
+				Resources:       translateResources(svc),
+				WorkingDir:      svc.Workdir,
+				ReadinessProbe:  svcHealthchecks.readiness,
+				LivenessProbe:   svcHealthchecks.liveness,
+			},
+		},
+	}
+
+	if divert != nil {
+		divert.UpdatePod(podSpec)
+	}
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -142,25 +167,7 @@ func translateDeployment(svcName string, s *model.Stack) *appsv1.Deployment {
 					Labels:      translateLabels(svcName, s),
 					Annotations: translateAnnotations(svc),
 				},
-				Spec: apiv1.PodSpec{
-					TerminationGracePeriodSeconds: pointer.Int64(svc.StopGracePeriod),
-					NodeSelector:                  svc.NodeSelector,
-					Containers: []apiv1.Container{
-						{
-							Name:            svcName,
-							Image:           svc.Image,
-							Command:         svc.Entrypoint.Values,
-							Args:            svc.Command.Values,
-							Env:             translateServiceEnvironment(svc),
-							Ports:           translateContainerPorts(svc),
-							SecurityContext: translateSecurityContext(svc),
-							Resources:       translateResources(svc),
-							WorkingDir:      svc.Workdir,
-							ReadinessProbe:  svcHealthchecks.readiness,
-							LivenessProbe:   svcHealthchecks.liveness,
-						},
-					},
-				},
+				Spec: podSpec,
 			},
 		},
 	}
@@ -189,11 +196,39 @@ func translatePersistentVolumeClaim(volumeName string, s *model.Stack) apiv1.Per
 	return pvc
 }
 
-func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
+func translateStatefulSet(svcName string, s *model.Stack, divert Divert) *appsv1.StatefulSet {
 	svc := s.Services[svcName]
 
 	initContainers := getInitContainers(svcName, s)
 	svcHealthchecks := getSvcHealthProbe(svc)
+
+	podSpec := apiv1.PodSpec{
+		TerminationGracePeriodSeconds: pointer.Int64(svc.StopGracePeriod),
+		InitContainers:                initContainers,
+		Affinity:                      translateAffinity(svc),
+		NodeSelector:                  svc.NodeSelector,
+		Volumes:                       translateVolumes(svc),
+		Containers: []apiv1.Container{
+			{
+				Name:            svcName,
+				Image:           svc.Image,
+				Command:         svc.Entrypoint.Values,
+				Args:            svc.Command.Values,
+				Env:             translateServiceEnvironment(svc),
+				Ports:           translateContainerPorts(svc),
+				SecurityContext: translateSecurityContext(svc),
+				VolumeMounts:    translateVolumeMounts(svc),
+				Resources:       translateResources(svc),
+				WorkingDir:      svc.Workdir,
+				ReadinessProbe:  svcHealthchecks.readiness,
+				LivenessProbe:   svcHealthchecks.liveness,
+			},
+		},
+	}
+
+	if divert != nil {
+		divert.UpdatePod(podSpec)
+	}
 
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -215,40 +250,47 @@ func translateStatefulSet(svcName string, s *model.Stack) *appsv1.StatefulSet {
 					Labels:      translateLabels(svcName, s),
 					Annotations: translateAnnotations(svc),
 				},
-				Spec: apiv1.PodSpec{
-					TerminationGracePeriodSeconds: pointer.Int64(svc.StopGracePeriod),
-					InitContainers:                initContainers,
-					Affinity:                      translateAffinity(svc),
-					NodeSelector:                  svc.NodeSelector,
-					Volumes:                       translateVolumes(svc),
-					Containers: []apiv1.Container{
-						{
-							Name:            svcName,
-							Image:           svc.Image,
-							Command:         svc.Entrypoint.Values,
-							Args:            svc.Command.Values,
-							Env:             translateServiceEnvironment(svc),
-							Ports:           translateContainerPorts(svc),
-							SecurityContext: translateSecurityContext(svc),
-							VolumeMounts:    translateVolumeMounts(svc),
-							Resources:       translateResources(svc),
-							WorkingDir:      svc.Workdir,
-							ReadinessProbe:  svcHealthchecks.readiness,
-							LivenessProbe:   svcHealthchecks.liveness,
-						},
-					},
-				},
+				Spec: podSpec,
 			},
 			VolumeClaimTemplates: translateVolumeClaimTemplates(svcName, s),
 		},
 	}
 }
 
-func translateJob(svcName string, s *model.Stack) *batchv1.Job {
+func translateJob(svcName string, s *model.Stack, divert Divert) *batchv1.Job {
 	svc := s.Services[svcName]
 
 	initContainers := getInitContainers(svcName, s)
 	svcHealthchecks := getSvcHealthProbe(svc)
+	podSpec := apiv1.PodSpec{
+		RestartPolicy:                 svc.RestartPolicy,
+		TerminationGracePeriodSeconds: pointer.Int64(svc.StopGracePeriod),
+		InitContainers:                initContainers,
+		Affinity:                      translateAffinity(svc),
+		NodeSelector:                  svc.NodeSelector,
+		Containers: []apiv1.Container{
+			{
+				Name:            svcName,
+				Image:           svc.Image,
+				Command:         svc.Entrypoint.Values,
+				Args:            svc.Command.Values,
+				Env:             translateServiceEnvironment(svc),
+				Ports:           translateContainerPorts(svc),
+				SecurityContext: translateSecurityContext(svc),
+				VolumeMounts:    translateVolumeMounts(svc),
+				Resources:       translateResources(svc),
+				WorkingDir:      svc.Workdir,
+				ReadinessProbe:  svcHealthchecks.readiness,
+				LivenessProbe:   svcHealthchecks.liveness,
+			},
+		},
+		Volumes: translateVolumes(svc),
+	}
+
+	if divert != nil {
+		divert.UpdatePod(podSpec)
+	}
+
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -265,30 +307,7 @@ func translateJob(svcName string, s *model.Stack) *batchv1.Job {
 					Labels:      translateLabels(svcName, s),
 					Annotations: translateAnnotations(svc),
 				},
-				Spec: apiv1.PodSpec{
-					RestartPolicy:                 svc.RestartPolicy,
-					TerminationGracePeriodSeconds: pointer.Int64(svc.StopGracePeriod),
-					InitContainers:                initContainers,
-					Affinity:                      translateAffinity(svc),
-					NodeSelector:                  svc.NodeSelector,
-					Containers: []apiv1.Container{
-						{
-							Name:            svcName,
-							Image:           svc.Image,
-							Command:         svc.Entrypoint.Values,
-							Args:            svc.Command.Values,
-							Env:             translateServiceEnvironment(svc),
-							Ports:           translateContainerPorts(svc),
-							SecurityContext: translateSecurityContext(svc),
-							VolumeMounts:    translateVolumeMounts(svc),
-							Resources:       translateResources(svc),
-							WorkingDir:      svc.Workdir,
-							ReadinessProbe:  svcHealthchecks.readiness,
-							LivenessProbe:   svcHealthchecks.liveness,
-						},
-					},
-					Volumes: translateVolumes(svc),
-				},
+				Spec: podSpec,
 			},
 		},
 	}
@@ -458,6 +477,7 @@ func translateVolumeLabels(volumeName string, s *model.Stack) map[string]string 
 	labels := map[string]string{
 		model.StackNameLabel:       format.ResourceK8sMetaString(s.Name),
 		model.StackVolumeNameLabel: volumeName,
+		model.DeployedByLabel:      format.ResourceK8sMetaString(s.Name),
 	}
 	for k := range volume.Labels {
 		labels[k] = volume.Labels[k]
@@ -504,6 +524,7 @@ func translateLabels(svcName string, s *model.Stack) map[string]string {
 	labels := map[string]string{
 		model.StackNameLabel:        format.ResourceK8sMetaString(s.Name),
 		model.StackServiceNameLabel: svcName,
+		model.DeployedByLabel:       format.ResourceK8sMetaString(s.Name),
 	}
 	for k := range svc.Labels {
 		labels[k] = svc.Labels[k]

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -146,7 +146,7 @@ func translateDeployment(svcName string, s *model.Stack, divert Divert) *appsv1.
 	}
 
 	if divert != nil {
-		divert.UpdatePod(podSpec)
+		podSpec = divert.UpdatePod(podSpec)
 	}
 
 	return &appsv1.Deployment{
@@ -227,7 +227,7 @@ func translateStatefulSet(svcName string, s *model.Stack, divert Divert) *appsv1
 	}
 
 	if divert != nil {
-		divert.UpdatePod(podSpec)
+		podSpec = divert.UpdatePod(podSpec)
 	}
 
 	return &appsv1.StatefulSet{
@@ -288,7 +288,7 @@ func translateJob(svcName string, s *model.Stack, divert Divert) *batchv1.Job {
 	}
 
 	if divert != nil {
-		divert.UpdatePod(podSpec)
+		podSpec = divert.UpdatePod(podSpec)
 	}
 
 	return &batchv1.Job{

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -33,12 +33,15 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const modifiedHostName = "modified.test.hostname"
+
 type fakeDivert struct {
 	called bool
 }
 
 func (f *fakeDivert) UpdatePod(spec apiv1.PodSpec) apiv1.PodSpec {
 	f.called = true
+	spec.Hostname = modifiedHostName
 	return spec
 }
 
@@ -174,6 +177,7 @@ func Test_translateDeployment(t *testing.T) {
 		t.Errorf("Wrong container.resources: '%v'", c.Resources)
 	}
 
+	require.Equal(t, modifiedHostName, result.Spec.Template.Spec.Hostname)
 	require.True(t, divert.called)
 
 }
@@ -379,6 +383,7 @@ func Test_translateStatefulSet(t *testing.T) {
 		t.Errorf("Wrong statefulset volume claim template: '%v'", vct.Spec)
 	}
 
+	require.Equal(t, modifiedHostName, result.Spec.Template.Spec.Hostname)
 	require.True(t, divert.called)
 
 }
@@ -522,6 +527,7 @@ func Test_translateJobWithoutVolumes(t *testing.T) {
 		t.Errorf("Wrong c.VolumeMounts: '%d'", len(c.VolumeMounts))
 	}
 
+	require.Equal(t, modifiedHostName, result.Spec.Template.Spec.Hostname)
 	require.True(t, divert.called)
 }
 
@@ -712,6 +718,7 @@ func Test_translateJobWithVolumes(t *testing.T) {
 		t.Errorf("Wrong container.volume_mounts: '%v'", c.VolumeMounts)
 	}
 
+	require.Equal(t, modifiedHostName, result.Spec.Template.Spec.Hostname)
 	require.True(t, divert.called)
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -137,4 +137,7 @@ const (
 
 	// EnvironmentLabelKeyPrefix represents the prefix for the preview and pipeline labels
 	EnvironmentLabelKeyPrefix = "label.okteto.com"
+
+	// OktetoDeployableEnvVar Env variable containing the piece of Okteto manifest which is deployable in remote or local deploys
+	OktetoDeployableEnvVar = "OKTETO_DEPLOYABLE"
 )

--- a/pkg/deployable/certs.go
+++ b/pkg/deployable/certs.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deploy
+package deployable
 
 var cert = []byte(`-----BEGIN CERTIFICATE-----
 MIIBcjCB+aADAgECAgkAyfJ4PZLPnlEwCQYHKoZIzj0EATAUMRIwEAYDVQQDDAls

--- a/pkg/deployable/kubeconfig.go
+++ b/pkg/deployable/kubeconfig.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deploy
+package deployable
 
 import (
 	"fmt"
@@ -26,11 +26,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
-
-type kubeConfigHandler interface {
-	Read() (*rest.Config, error)
-	Modify(port int, sessionToken, destKubeconfigFile string) error
-}
 
 // KubeConfig refers to a KubeConfig object
 type KubeConfig struct{}

--- a/pkg/deployable/proxy.go
+++ b/pkg/deployable/proxy.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deploy
+package deployable
 
 import (
 	"bytes"
@@ -45,14 +45,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-type proxyInterface interface {
-	Start()
-	Shutdown(ctx context.Context) error
-	GetPort() int
-	GetToken() string
-	SetName(name string)
-	SetDivert(driver divert.Driver)
-}
+const (
+	headerUpgrade = "Upgrade"
+)
 
 type proxyConfig struct {
 	token string
@@ -73,7 +68,7 @@ type proxyHandler struct {
 }
 
 // NewProxy creates a new proxy
-func NewProxy(kubeconfig kubeConfigHandler, portGetter portGetterFunc) (*Proxy, error) {
+func NewProxy(kubeconfig KubeConfigHandler, portGetter PortGetterFunc) (*Proxy, error) {
 	// Look for a free local port to start the proxy
 	port, err := portGetter("localhost")
 	if err != nil {

--- a/pkg/deployable/proxy_test.go
+++ b/pkg/deployable/proxy_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package deploy
+package deployable
 
 import (
 	"encoding/json"
@@ -20,11 +20,29 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
 var (
 	ph = &proxyHandler{}
 )
+
+type fakeKubeConfig struct {
+	config      *rest.Config
+	errOnModify error
+	errRead     error
+}
+
+func (f *fakeKubeConfig) Read() (*rest.Config, error) {
+	if f.errRead != nil {
+		return nil, f.errRead
+	}
+	return f.config, nil
+}
+
+func (fc *fakeKubeConfig) Modify(_ int, _, _ string) error {
+	return fc.errOnModify
+}
 
 func Test_TranslateInvalidResourceBody(t *testing.T) {
 	t.Parallel()

--- a/pkg/deployable/runner.go
+++ b/pkg/deployable/runner.go
@@ -1,0 +1,415 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployable
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/compose-spec/godotenv"
+	"github.com/okteto/okteto/cmd/utils/executor"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/devenvironment"
+	"github.com/okteto/okteto/pkg/divert"
+	"github.com/okteto/okteto/pkg/externalresource"
+	"github.com/okteto/okteto/pkg/format"
+	kconfig "github.com/okteto/okteto/pkg/k8s/kubeconfig"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/rest"
+)
+
+// DivertDeployer defines the operations to deploy the divert section of a deployable
+type DivertDeployer interface {
+	Deploy(ctx context.Context) error
+}
+
+// ProxyInterface defines the different operations to work with the proxy run by Okteto
+type ProxyInterface interface {
+	Start()
+	Shutdown(ctx context.Context) error
+	GetPort() int
+	GetToken() string
+	SetName(name string)
+	SetDivert(driver divert.Driver)
+}
+
+// KubeConfigHandler defines the operations to handle the kubeconfig file
+// needed to deal with the local Kubernetes proxy
+type KubeConfigHandler interface {
+	Read() (*rest.Config, error)
+	Modify(port int, sessionToken, destKubeconfigFile string) error
+}
+
+// ConfigMapHandler defines the operations to handle the ConfigMap with the
+// information related to the development environment
+type ConfigMapHandler interface {
+	UpdateEnvsFromCommands(context.Context, string, string, []string) error
+}
+
+// ExternalResourceInterface defines the operations to work with external resources
+type ExternalResourceInterface interface {
+	Deploy(ctx context.Context, name string, ns string, externalInfo *externalresource.ExternalResource) error
+}
+
+// runner is responsible for running the commands defined in a manifest, deploy the divert
+// information and deploy external resources.
+// This runner has the common functionality to deal with the mentioned resources when deploy is
+// run locally or remotely. As this runs also in the remote, it should NEVER build any kind of image
+// or execute some logic that might differ from local.
+type runner struct {
+	Proxy              ProxyInterface
+	Kubeconfig         KubeConfigHandler
+	ConfigMapHandler   ConfigMapHandler
+	Executor           executor.ManifestExecutor
+	K8sClientProvider  okteto.K8sClientProviderWithLogger
+	Fs                 afero.Fs
+	DivertDeployer     DivertDeployer
+	GetExternalControl func(cfg *rest.Config) ExternalResourceInterface
+	k8sLogger          *io.K8sLogger
+	TempKubeconfigFile string
+}
+
+// Entity represents a set of resources that can be deployed by the runner
+type Entity struct {
+	Divert   *model.DivertDeploy
+	Commands []model.DeployCommand
+	External externalresource.Section
+}
+
+// DeployParameters represents the parameters for deploying a remote entity
+type DeployParameters struct {
+	Name         string
+	Namespace    string
+	ManifestPath string
+	Deployable   Entity
+	Variables    []string
+}
+
+// PortGetterFunc is a function that retrieves a free port the port for specified interface
+type PortGetterFunc func(string) (int, error)
+
+// newDeployExternalK8sControl creates a new instance of external resources controller
+func newDeployExternalK8sControl(cfg *rest.Config) ExternalResourceInterface {
+	return externalresource.NewExternalK8sControl(cfg)
+}
+
+// NewRunnerForRemote initializes a runner for a remote environment
+func NewRunnerForRemote(
+	ctx context.Context,
+	name string,
+	runWithoutBash bool,
+	cmapHandler ConfigMapHandler,
+	k8sProvider okteto.K8sClientProviderWithLogger,
+	portGetter PortGetterFunc,
+	k8sLogger *io.K8sLogger,
+) (*runner, error) {
+	kubeconfig := NewKubeConfig()
+	tempKubeconfigName := name
+
+	proxy, err := NewProxy(kubeconfig, portGetter)
+	if err != nil {
+		oktetoLog.Infof("could not configure local proxy: %s", err)
+		return nil, err
+	}
+
+	return &runner{
+		Kubeconfig:         kubeconfig,
+		Executor:           executor.NewExecutor(oktetoLog.GetOutputFormat(), runWithoutBash, ""),
+		ConfigMapHandler:   cmapHandler,
+		Proxy:              proxy,
+		TempKubeconfigFile: GetTempKubeConfigFile(tempKubeconfigName),
+		K8sClientProvider:  k8sProvider,
+		GetExternalControl: newDeployExternalK8sControl,
+		Fs:                 afero.NewOsFs(),
+		k8sLogger:          k8sLogger,
+	}, nil
+}
+
+// NewRunnerForLocal initializes a runner for a local environment. The main difference with the remote
+// initialization is that the name might be empty in the local runner and it has to be inferred.
+func NewRunnerForLocal(
+	ctx context.Context,
+	name string,
+	runWithoutBash bool,
+	manifestPathFlag string,
+	cmapHandler ConfigMapHandler,
+	k8sProvider okteto.K8sClientProviderWithLogger,
+	portGetter PortGetterFunc,
+	k8sLogger *io.K8sLogger,
+) (*runner, error) {
+	kubeconfig := NewKubeConfig()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the current working directory: %w", err)
+	}
+	tempKubeconfigName := name
+	if tempKubeconfigName == "" {
+		c, _, err := k8sProvider.ProvideWithLogger(okteto.GetContext().Cfg, k8sLogger)
+		if err != nil {
+			return nil, err
+		}
+		inferer := devenvironment.NewNameInferer(c)
+		tempKubeconfigName = inferer.InferName(ctx, cwd, okteto.GetContext().Namespace, manifestPathFlag)
+	}
+
+	proxy, err := NewProxy(kubeconfig, portGetter)
+	if err != nil {
+		oktetoLog.Infof("could not configure local proxy: %s", err)
+		return nil, err
+	}
+
+	return &runner{
+		Kubeconfig:         kubeconfig,
+		Executor:           executor.NewExecutor(oktetoLog.GetOutputFormat(), runWithoutBash, ""),
+		ConfigMapHandler:   cmapHandler,
+		Proxy:              proxy,
+		TempKubeconfigFile: GetTempKubeConfigFile(tempKubeconfigName),
+		K8sClientProvider:  k8sProvider,
+		GetExternalControl: newDeployExternalK8sControl,
+		Fs:                 afero.NewOsFs(),
+		k8sLogger:          k8sLogger,
+	}, nil
+}
+
+// RunDeploy deploys the deployable received with DeployParameters
+func (r *runner) RunDeploy(ctx context.Context, params DeployParameters) error {
+	// We need to create a client that doesn't go through the proxy to create
+	// the configmap without the deployedByLabel
+	c, _, err := r.K8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, r.k8sLogger)
+	if err != nil {
+		return err
+	}
+
+	// Injecting the PROXY into the kubeconfig file
+	oktetoLog.Debugf("creating temporal kubeconfig file '%s'", r.TempKubeconfigFile)
+	if err := r.Kubeconfig.Modify(r.Proxy.GetPort(), r.Proxy.GetToken(), r.TempKubeconfigFile); err != nil {
+		oktetoLog.Infof("could not create temporal kubeconfig %s", err)
+		return err
+	}
+
+	r.Proxy.SetName(format.ResourceK8sMetaString(params.Name))
+	if params.Deployable.Divert != nil {
+		driver, err := divert.New(params.Deployable.Divert, params.Name, params.Namespace, c)
+		if err != nil {
+			return err
+		}
+		r.Proxy.SetDivert(driver)
+		r.DivertDeployer = driver
+	}
+
+	os.Setenv(constants.OktetoNameEnvVar, params.Name)
+
+	oktetoLog.SetStage("")
+
+	// starting PROXY
+	oktetoLog.Debugf("starting server on %d", r.Proxy.GetPort())
+	r.Proxy.Start()
+
+	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Deploying '%s'...", params.Name)
+
+	defer r.CleanUp(ctx, nil)
+
+	// Token should be always masked from the logs
+	oktetoLog.AddMaskedWord(okteto.GetContext().Token)
+	keyValueVarParts := 2
+	for _, variable := range params.Variables {
+		varParts := strings.SplitN(variable, "=", keyValueVarParts)
+		if len(varParts) >= keyValueVarParts && strings.TrimSpace(varParts[1]) != "" {
+			oktetoLog.AddMaskedWord(varParts[1])
+		}
+	}
+
+	params.Variables = append(
+		params.Variables,
+		// Set KUBECONFIG environment variable as environment for the commands to be executed
+		fmt.Sprintf("%s=%s", constants.KubeConfigEnvVar, r.TempKubeconfigFile),
+		// Set OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT env variable, so all okteto commands ran inside this deploy
+		// know they are running inside another okteto deploy
+		fmt.Sprintf("%s=true", constants.OktetoWithinDeployCommandContextEnvVar),
+		// Set OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE env variable, so all the Okteto commands executed within this command execution
+		// should not overwrite the server and the credentials in the kubeconfig
+		fmt.Sprintf("%s=true", constants.OktetoSkipConfigCredentialsUpdate),
+		// Set OKTETO_DISABLE_SPINNER=true env variable, so all the Okteto commands disable spinner which leads to errors
+		fmt.Sprintf("%s=true", oktetoLog.OktetoDisableSpinnerEnvVar),
+		// Set OKTETO_NAMESPACE=namespace-name env variable, so all the commandsruns on the same namespace
+		fmt.Sprintf("%s=%s", model.OktetoNamespaceEnvVar, okteto.GetContext().Namespace),
+		// Set OKTETO_AUTODISCOVERY_RELEASE_NAME=sanitized name, so the release name in case of autodiscovery of helm is valid
+		fmt.Sprintf("%s=%s", constants.OktetoAutodiscoveryReleaseName, format.ResourceK8sMetaString(params.Name)),
+	)
+	if okteto.IsOkteto() {
+		params.Variables = append(
+			params.Variables,
+			// Set OKTETO_DOMAIN=okteto-subdomain env variable
+			fmt.Sprintf("%s=%s", model.OktetoDomainEnvVar, okteto.GetSubdomain()),
+		)
+	}
+	oktetoLog.EnableMasking()
+	err = r.runCommandsSection(ctx, params)
+	return err
+}
+
+// runCommandsSection runs the commands defined in the command section of the deployable entity
+func (r *runner) runCommandsSection(ctx context.Context, params DeployParameters) error {
+	oktetoEnvFile, err := r.createTempOktetoEnvFile()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := r.Fs.RemoveAll(filepath.Dir(oktetoEnvFile.Name())); err != nil {
+			oktetoLog.Infof("error removing okteto env file dir: %s", err)
+		}
+	}()
+
+	var envMapFromOktetoEnvFile map[string]string
+	// deploy commands if any
+	for _, command := range params.Deployable.Commands {
+		oktetoLog.Information("Running '%s'", command.Name)
+		oktetoLog.SetStage(command.Name)
+		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Executing command '%s'...", command.Name)
+
+		if err := r.Executor.Execute(command, params.Variables); err != nil {
+			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error executing command '%s': %s", command.Name, err.Error())
+			return fmt.Errorf("error executing command '%s': %s", command.Name, err.Error())
+		}
+		oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "Command '%s' successfully executed", command.Name)
+
+		envMapFromOktetoEnvFile, err = godotenv.Read(oktetoEnvFile.Name())
+		if err != nil {
+			oktetoLog.Warning("no valid format used in the okteto env file: %s", err.Error())
+		}
+
+		envsFromOktetoEnvFile := make([]string, 0, len(envMapFromOktetoEnvFile))
+		for k, v := range envMapFromOktetoEnvFile {
+			envsFromOktetoEnvFile = append(envsFromOktetoEnvFile, fmt.Sprintf("%s=%s", k, v))
+		}
+
+		// the variables in the $OKTETO_ENV file are added as environment variables
+		// to the executor. If there is already a previously set value for that
+		// variable, the executor will use in next command the last one added which
+		// corresponds to those coming from $OKTETO_ENV.
+		params.Variables = append(params.Variables, envsFromOktetoEnvFile...)
+		oktetoLog.SetStage("")
+		oktetoLog.SetLevel("")
+	}
+
+	err = r.ConfigMapHandler.UpdateEnvsFromCommands(ctx, params.Name, params.Namespace, params.Variables)
+	if err != nil {
+		return fmt.Errorf("could not update config map with environment variables: %w", err)
+	}
+
+	// deploy divert if any
+	if params.Deployable.Divert != nil && params.Deployable.Divert.Namespace != params.Namespace {
+		oktetoLog.SetStage("Deploy Divert")
+		if err := r.DivertDeployer.Deploy(ctx); err != nil {
+			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error creating divert: %s", err.Error())
+			return err
+		}
+		oktetoLog.SetStage("")
+	}
+
+	// deploy externals if any
+	if len(params.Deployable.External) > 0 {
+		oktetoLog.SetStage("External configuration")
+		if !okteto.IsOkteto() {
+			oktetoLog.Warning("external resources cannot be deployed on a context not managed by okteto")
+			return nil
+		}
+
+		if err := r.deployExternals(ctx, params, envMapFromOktetoEnvFile); err != nil {
+			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error deploying external resources: %s", err.Error())
+			return err
+		}
+		oktetoLog.SetStage("")
+	}
+
+	return nil
+}
+
+// deployExternals deploys the external resources defined in the deployable entity
+func (r *runner) deployExternals(ctx context.Context, params DeployParameters, dynamicEnvs map[string]string) error {
+	_, cfg, err := r.K8sClientProvider.ProvideWithLogger(kconfig.Get([]string{r.TempKubeconfigFile}), r.k8sLogger)
+	if err != nil {
+		return fmt.Errorf("error getting kubernetes client: %w", err)
+	}
+	control := r.GetExternalControl(cfg)
+
+	for externalName, externalInfo := range params.Deployable.External {
+		oktetoLog.Spinner(fmt.Sprintf("Deploying external resource '%s'...", externalName))
+		oktetoLog.StartSpinner()
+		defer oktetoLog.StopSpinner()
+		if err := externalInfo.SetURLUsingEnvironFile(externalName, dynamicEnvs); err != nil {
+			return err
+		}
+
+		ef := externalresource.ERFilesystemManager{
+			Fs:               r.Fs,
+			ExternalResource: *externalInfo,
+		}
+
+		err := ef.LoadMarkdownContent(params.ManifestPath)
+		if err != nil {
+			oktetoLog.Infof("error loading external resource %s: %s", externalName, err.Error())
+		}
+
+		err = control.Deploy(ctx, externalName, params.Namespace, externalInfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// CleanUp cleans up the resources created by the runner to avoid to leave any temporal resource
+func (r *runner) CleanUp(ctx context.Context, err error) {
+	oktetoLog.Debugf("removing temporal kubeconfig file '%s'", r.TempKubeconfigFile)
+	if err := os.Remove(r.TempKubeconfigFile); err != nil {
+		oktetoLog.Infof("could not remove temporal kubeconfig file: %s", err)
+	}
+
+	oktetoLog.Debugf("stopping local server...")
+	if err := r.Proxy.Shutdown(ctx); err != nil {
+		oktetoLog.Infof("could not stop local server: %s", err)
+	}
+	if r.Executor != nil {
+		r.Executor.CleanUp(err)
+	}
+
+	oktetoLog.Debugf("executed clean up completely")
+}
+
+// createTempOktetoEnvFile creates a temporal file use to store the environment variables
+func (r *runner) createTempOktetoEnvFile() (afero.File, error) {
+	oktetoEnvFileDir, err := afero.TempDir(r.Fs, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	oktetoEnvFile, err := r.Fs.Create(filepath.Join(oktetoEnvFileDir, ".env"))
+	if err != nil {
+		return nil, err
+	}
+
+	os.Setenv(constants.OktetoEnvFile, oktetoEnvFile.Name())
+	oktetoLog.Debug(fmt.Sprintf("using %s as env file for deploy command", oktetoEnvFile.Name()))
+	return oktetoEnvFile, nil
+}

--- a/pkg/deployable/runner.go
+++ b/pkg/deployable/runner.go
@@ -89,9 +89,9 @@ type runner struct {
 
 // Entity represents a set of resources that can be deployed by the runner
 type Entity struct {
+	External externalresource.Section
 	Divert   *model.DivertDeploy
 	Commands []model.DeployCommand
-	External externalresource.Section
 }
 
 // DeployParameters represents the parameters for deploying a remote entity
@@ -113,7 +113,6 @@ func newDeployExternalK8sControl(cfg *rest.Config) ExternalResourceInterface {
 
 // NewRunnerForRemote initializes a runner for a remote environment
 func NewRunnerForRemote(
-	ctx context.Context,
 	name string,
 	runWithoutBash bool,
 	cmapHandler ConfigMapHandler,

--- a/pkg/deployable/runner_test.go
+++ b/pkg/deployable/runner_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployable
 
 import (

--- a/pkg/deployable/runner_test.go
+++ b/pkg/deployable/runner_test.go
@@ -1,0 +1,535 @@
+package deployable
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/internal/test"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/divert"
+	"github.com/okteto/okteto/pkg/externalresource"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+type fakeCmapHandler struct {
+	errUpdatingWithEnvs error
+}
+
+func (f *fakeCmapHandler) UpdateEnvsFromCommands(context.Context, string, string, []string) error {
+	return f.errUpdatingWithEnvs
+}
+
+type fakeKubeconfigHandler struct {
+	mock.Mock
+}
+
+func (f *fakeKubeconfigHandler) Read() (*rest.Config, error) {
+	args := f.Called()
+	return args.Get(0).(*rest.Config), args.Error(1)
+
+}
+func (f *fakeKubeconfigHandler) Modify(port int, sessionToken, destKubeconfigFile string) error {
+	args := f.Called(port, sessionToken, destKubeconfigFile)
+	return args.Error(0)
+}
+
+type fakeProxy struct {
+	mock.Mock
+}
+
+func (f *fakeProxy) Start() {
+	f.Called()
+}
+
+func (f *fakeProxy) Shutdown(ctx context.Context) error {
+	args := f.Called(ctx)
+	return args.Error(0)
+}
+
+func (f *fakeProxy) GetPort() int {
+	args := f.Called()
+	return args.Int(0)
+}
+
+func (f *fakeProxy) GetToken() string {
+	args := f.Called()
+	return args.String(0)
+}
+
+func (f *fakeProxy) SetName(name string) {
+	f.Called(name)
+}
+
+func (f *fakeProxy) SetDivert(driver divert.Driver) {
+	f.Called(driver)
+}
+
+type fakeExecutor struct {
+	mock.Mock
+}
+
+func (f *fakeExecutor) Execute(command model.DeployCommand, env []string) error {
+	args := f.Called(command, env)
+	return args.Error(0)
+}
+
+func (f *fakeExecutor) CleanUp(err error) {
+	f.Called(err)
+}
+
+type fakeDivert struct {
+	mock.Mock
+}
+
+func (f *fakeDivert) Deploy(ctx context.Context) error {
+	args := f.Called(ctx)
+	return args.Error(0)
+}
+
+type fakeExternalResource struct {
+	mock.Mock
+}
+
+func (f *fakeExternalResource) Deploy(ctx context.Context, name string, ns string, externalInfo *externalresource.ExternalResource) error {
+	args := f.Called(ctx, name, ns, externalInfo)
+	return args.Error(0)
+}
+
+func TestDeployNotRemovingEnvFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	_, err := fs.Create(".env")
+	require.NoError(t, err)
+	params := DeployParameters{}
+	r := runner{
+		ConfigMapHandler: &fakeCmapHandler{},
+		Fs:               fs,
+	}
+	err = r.runCommandsSection(context.Background(), params)
+	assert.NoError(t, err)
+	_, err = fs.Stat(".env")
+	require.NoError(t, err)
+
+}
+
+func TestRunDeployWithErrorGettingClient(t *testing.T) {
+	k8sProvider := test.NewFakeK8sProvider()
+	k8sProvider.ErrProvide = assert.AnError
+
+	r := runner{
+		K8sClientProvider: k8sProvider,
+	}
+
+	err := r.RunDeploy(context.Background(), DeployParameters{})
+
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestRunDeployWithErrorModifyingKubeconfig(t *testing.T) {
+	k8sProvider := test.NewFakeK8sProvider()
+	proxy := &fakeProxy{}
+	kubeconfigHandler := &fakeKubeconfigHandler{}
+
+	proxy.On("GetPort").Return(80)
+	proxy.On("GetToken").Return("fake-token")
+
+	kubeconfigHandler.On("Modify", 80, "fake-token", "temp-kubeconfig").Return(assert.AnError)
+
+	r := runner{
+		K8sClientProvider:  k8sProvider,
+		Proxy:              proxy,
+		Kubeconfig:         kubeconfigHandler,
+		TempKubeconfigFile: "temp-kubeconfig",
+	}
+
+	err := r.RunDeploy(context.Background(), DeployParameters{})
+
+	require.ErrorIs(t, err, assert.AnError)
+
+	proxy.AssertExpectations(t)
+	kubeconfigHandler.AssertExpectations(t)
+}
+
+func TestRunDeployWithEmptyDeployable(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
+	k8sProvider := test.NewFakeK8sProvider()
+	proxy := &fakeProxy{}
+	kubeconfigHandler := &fakeKubeconfigHandler{}
+
+	proxy.On("GetPort").Return(80)
+	proxy.On("GetToken").Return("fake-token")
+	proxy.On("SetName", "test-a").Return().Once()
+	proxy.On("Start").Return().Once()
+	proxy.On("Shutdown", mock.Anything).Return(nil).Once()
+	proxy.On("SetDivert", mock.Anything).Return().Once()
+
+	kubeconfigHandler.On("Modify", 80, "fake-token", "temp-kubeconfig").Return(nil)
+
+	r := runner{
+		K8sClientProvider:  k8sProvider,
+		Proxy:              proxy,
+		Kubeconfig:         kubeconfigHandler,
+		TempKubeconfigFile: "temp-kubeconfig",
+		Fs:                 afero.NewMemMapFs(),
+		ConfigMapHandler:   &fakeCmapHandler{},
+	}
+
+	params := DeployParameters{
+		Name:      "test a",
+		Namespace: "test",
+		Variables: []string{
+			"A=value1",
+		},
+		Deployable: Entity{
+			Divert: &model.DivertDeploy{
+				Driver: constants.OktetoDivertWeaverDriver,
+			},
+		},
+	}
+	err := r.RunDeploy(context.Background(), params)
+
+	require.NoError(t, err)
+
+	proxy.AssertExpectations(t)
+	kubeconfigHandler.AssertExpectations(t)
+}
+
+func TestRunCommandsSectionWithCommands(t *testing.T) {
+	executor := &fakeExecutor{}
+	r := runner{
+		TempKubeconfigFile: "temp-kubeconfig",
+		Fs:                 afero.NewMemMapFs(),
+		ConfigMapHandler:   &fakeCmapHandler{},
+		Executor:           executor,
+	}
+
+	params := DeployParameters{
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		Deployable: Entity{
+			Commands: []model.DeployCommand{
+				{
+					Name:    "test command",
+					Command: "echo",
+				},
+				{
+					Name:    "test command 2",
+					Command: "echo 2",
+				},
+			},
+		},
+	}
+
+	expectedCommand1 := model.DeployCommand{
+		Name:    "test command",
+		Command: "echo",
+	}
+	expectedCommand2 := model.DeployCommand{
+		Name:    "test command 2",
+		Command: "echo 2",
+	}
+	expectedVariables := []string{
+		"A=value1",
+		"B=value2",
+	}
+	executor.On("Execute", expectedCommand1, expectedVariables).Return(nil).Once()
+	executor.On("Execute", expectedCommand2, expectedVariables).Return(nil).Once()
+
+	err := r.runCommandsSection(context.Background(), params)
+
+	require.NoError(t, err)
+	executor.AssertExpectations(t)
+}
+
+func TestRunCommandsSectionWithErrorInCommands(t *testing.T) {
+	executor := &fakeExecutor{}
+	r := runner{
+		TempKubeconfigFile: "temp-kubeconfig",
+		Fs:                 afero.NewMemMapFs(),
+		ConfigMapHandler:   &fakeCmapHandler{},
+		Executor:           executor,
+	}
+
+	params := DeployParameters{
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		Deployable: Entity{
+			Commands: []model.DeployCommand{
+				{
+					Name:    "test command",
+					Command: "echo",
+				},
+				{
+					Name:    "test command 2",
+					Command: "echo 2",
+				},
+			},
+		},
+	}
+
+	expectedCommand1 := model.DeployCommand{
+		Name:    "test command",
+		Command: "echo",
+	}
+	expectedCommand2 := model.DeployCommand{
+		Name:    "test command 2",
+		Command: "echo 2",
+	}
+	expectedVariables := []string{
+		"A=value1",
+		"B=value2",
+	}
+	executor.On("Execute", expectedCommand1, expectedVariables).Return(assert.AnError).Once()
+
+	err := r.runCommandsSection(context.Background(), params)
+
+	require.Error(t, err)
+	executor.AssertNotCalled(t, "Execute", expectedCommand2, expectedVariables)
+	executor.AssertExpectations(t)
+}
+
+func TestRunCommandsSectionWithDivert(t *testing.T) {
+	executor := &fakeExecutor{}
+	divertDeployer := &fakeDivert{}
+	r := runner{
+		TempKubeconfigFile: "temp-kubeconfig",
+		Fs:                 afero.NewMemMapFs(),
+		ConfigMapHandler:   &fakeCmapHandler{},
+		Executor:           executor,
+		DivertDeployer:     divertDeployer,
+	}
+
+	params := DeployParameters{
+		Namespace: "test1",
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		Deployable: Entity{
+			Divert: &model.DivertDeploy{
+				Driver:    constants.OktetoDivertWeaverDriver,
+				Namespace: "test2",
+			},
+		},
+	}
+
+	divertDeployer.On("Deploy", mock.Anything).Return(nil).Once()
+
+	err := r.runCommandsSection(context.Background(), params)
+
+	require.NoError(t, err)
+	executor.AssertNotCalled(t, "Execute", mock.Anything, mock.Anything)
+	executor.AssertExpectations(t)
+	divertDeployer.AssertExpectations(t)
+}
+
+func TestRunCommandsSectionWithErrorDeployingDivert(t *testing.T) {
+	executor := &fakeExecutor{}
+	divertDeployer := &fakeDivert{}
+	r := runner{
+		TempKubeconfigFile: "temp-kubeconfig",
+		Fs:                 afero.NewMemMapFs(),
+		ConfigMapHandler:   &fakeCmapHandler{},
+		Executor:           executor,
+		DivertDeployer:     divertDeployer,
+	}
+
+	params := DeployParameters{
+		Namespace: "test1",
+		Variables: []string{
+			"A=value1",
+			"B=value2",
+		},
+		Deployable: Entity{
+			Divert: &model.DivertDeploy{
+				Driver:    constants.OktetoDivertWeaverDriver,
+				Namespace: "test2",
+			},
+		},
+	}
+
+	divertDeployer.On("Deploy", mock.Anything).Return(assert.AnError).Once()
+
+	err := r.runCommandsSection(context.Background(), params)
+
+	require.Error(t, err)
+	executor.AssertNotCalled(t, "Execute", mock.Anything, mock.Anything)
+	executor.AssertExpectations(t)
+	divertDeployer.AssertExpectations(t)
+}
+
+func TestRunCommandsSectionWithExternal(t *testing.T) {
+	k8sProvider := test.NewFakeK8sProvider()
+	executor := &fakeExecutor{}
+	divertDeployer := &fakeDivert{}
+	externalResource := &fakeExternalResource{}
+	r := runner{
+		TempKubeconfigFile: "temp-kubeconfig",
+		Fs:                 afero.NewMemMapFs(),
+		ConfigMapHandler:   &fakeCmapHandler{},
+		Executor:           executor,
+		DivertDeployer:     divertDeployer,
+		K8sClientProvider:  k8sProvider,
+		GetExternalControl: func(_ *rest.Config) ExternalResourceInterface {
+			return externalResource
+		},
+	}
+
+	params := DeployParameters{
+		Namespace: "test1",
+		Deployable: Entity{
+			External: externalresource.Section{
+				"db": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedExternalInfo := &externalresource.ExternalResource{
+		Icon: "icon",
+		Endpoints: []*externalresource.ExternalEndpoint{
+			{
+				Name: "name",
+				Url:  "url",
+			},
+		},
+	}
+	externalResource.On("Deploy", mock.Anything, "db", "test1", expectedExternalInfo).Return(nil).Once()
+
+	err := r.runCommandsSection(context.Background(), params)
+
+	require.NoError(t, err)
+	executor.AssertNotCalled(t, "Execute", mock.Anything, mock.Anything)
+	divertDeployer.AssertNotCalled(t, "Deploy", mock.Anything)
+	executor.AssertExpectations(t)
+	divertDeployer.AssertExpectations(t)
+	externalResource.AssertExpectations(t)
+}
+
+func TestRunCommandsSectionWithErrorDeployingExternal(t *testing.T) {
+	k8sProvider := test.NewFakeK8sProvider()
+	executor := &fakeExecutor{}
+	divertDeployer := &fakeDivert{}
+	externalResource := &fakeExternalResource{}
+	r := runner{
+		TempKubeconfigFile: "temp-kubeconfig",
+		Fs:                 afero.NewMemMapFs(),
+		ConfigMapHandler:   &fakeCmapHandler{},
+		Executor:           executor,
+		DivertDeployer:     divertDeployer,
+		K8sClientProvider:  k8sProvider,
+		GetExternalControl: func(_ *rest.Config) ExternalResourceInterface {
+			return externalResource
+		},
+	}
+
+	params := DeployParameters{
+		Namespace: "test1",
+		Deployable: Entity{
+			External: externalresource.Section{
+				"db": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedExternalInfo := &externalresource.ExternalResource{
+		Icon: "icon",
+		Endpoints: []*externalresource.ExternalEndpoint{
+			{
+				Name: "name",
+				Url:  "url",
+			},
+		},
+	}
+	externalResource.On("Deploy", mock.Anything, "db", "test1", expectedExternalInfo).Return(assert.AnError).Once()
+
+	err := r.runCommandsSection(context.Background(), params)
+
+	require.Error(t, err)
+	executor.AssertNotCalled(t, "Execute", mock.Anything, mock.Anything)
+	divertDeployer.AssertNotCalled(t, "Deploy", mock.Anything)
+	executor.AssertExpectations(t)
+	divertDeployer.AssertExpectations(t)
+	externalResource.AssertExpectations(t)
+}
+
+func TestDeployExternalWithErrorGettingClient(t *testing.T) {
+	k8sProvider := test.NewFakeK8sProvider()
+	k8sProvider.ErrProvide = assert.AnError
+
+	r := runner{
+		K8sClientProvider: k8sProvider,
+	}
+
+	params := DeployParameters{
+		Namespace: "test1",
+		Deployable: Entity{
+			External: externalresource.Section{
+				"db": {
+					Icon: "icon",
+					Endpoints: []*externalresource.ExternalEndpoint{
+						{
+							Name: "name",
+							Url:  "url",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := r.deployExternals(context.Background(), params, map[string]string{})
+
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestCleaUp(t *testing.T) {
+	executor := &fakeExecutor{}
+	proxy := &fakeProxy{}
+	r := runner{
+		Executor:           executor,
+		Proxy:              proxy,
+		TempKubeconfigFile: "temp-kubeconfig",
+	}
+
+	proxy.On("Shutdown", mock.Anything).Return(nil).Once()
+	executor.On("CleanUp", assert.AnError).Return().Once()
+
+	r.CleanUp(context.Background(), assert.AnError)
+
+	proxy.AssertExpectations(t)
+	executor.AssertExpectations(t)
+}

--- a/pkg/deployable/runner_test.go
+++ b/pkg/deployable/runner_test.go
@@ -222,6 +222,15 @@ func TestRunDeployWithEmptyDeployable(t *testing.T) {
 }
 
 func TestRunCommandsSectionWithCommands(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	executor := &fakeExecutor{}
 	r := runner{
 		TempKubeconfigFile: "temp-kubeconfig",
@@ -271,6 +280,15 @@ func TestRunCommandsSectionWithCommands(t *testing.T) {
 }
 
 func TestRunCommandsSectionWithErrorInCommands(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	executor := &fakeExecutor{}
 	r := runner{
 		TempKubeconfigFile: "temp-kubeconfig",
@@ -320,6 +338,15 @@ func TestRunCommandsSectionWithErrorInCommands(t *testing.T) {
 }
 
 func TestRunCommandsSectionWithDivert(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	executor := &fakeExecutor{}
 	divertDeployer := &fakeDivert{}
 	r := runner{
@@ -355,6 +382,15 @@ func TestRunCommandsSectionWithDivert(t *testing.T) {
 }
 
 func TestRunCommandsSectionWithErrorDeployingDivert(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	executor := &fakeExecutor{}
 	divertDeployer := &fakeDivert{}
 	r := runner{
@@ -390,6 +426,15 @@ func TestRunCommandsSectionWithErrorDeployingDivert(t *testing.T) {
 }
 
 func TestRunCommandsSectionWithExternal(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	k8sProvider := test.NewFakeK8sProvider()
 	executor := &fakeExecutor{}
 	divertDeployer := &fakeDivert{}
@@ -445,6 +490,15 @@ func TestRunCommandsSectionWithExternal(t *testing.T) {
 }
 
 func TestRunCommandsSectionWithErrorDeployingExternal(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	k8sProvider := test.NewFakeK8sProvider()
 	executor := &fakeExecutor{}
 	divertDeployer := &fakeDivert{}
@@ -500,6 +554,15 @@ func TestRunCommandsSectionWithErrorDeployingExternal(t *testing.T) {
 }
 
 func TestDeployExternalWithErrorGettingClient(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+				IsOkteto:  true,
+			},
+		},
+		CurrentContext: "test",
+	}
 	k8sProvider := test.NewFakeK8sProvider()
 	k8sProvider.ErrProvide = assert.AnError
 

--- a/pkg/divert/istio/divert.go
+++ b/pkg/divert/istio/divert.go
@@ -46,11 +46,11 @@ type DivertTransformation struct {
 	Routes    []string `json:"routes,omitempty"`
 }
 
-func New(m *model.Manifest, c kubernetes.Interface, ic istioclientset.Interface) *Driver {
+func New(divert *model.DivertDeploy, name, namespace string, c kubernetes.Interface, ic istioclientset.Interface) *Driver {
 	return &Driver{
-		name:        m.Name,
-		namespace:   m.Namespace,
-		divert:      *m.Deploy.Divert,
+		name:        name,
+		namespace:   namespace,
+		divert:      *divert,
 		client:      c,
 		istioClient: ic,
 	}

--- a/pkg/divert/noop/divert.go
+++ b/pkg/divert/noop/divert.go
@@ -1,0 +1,41 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noop
+
+import (
+	"context"
+
+	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// Driver struct for noop divert driver. It is an empty implementation for flows
+// where divert is not defined in the manifest
+type Driver struct{}
+
+func (*Driver) Deploy(_ context.Context) error {
+	return nil
+}
+
+// Destroy implements from the interface diver.Driver
+// nolint:unparam
+func (*Driver) Destroy(_ context.Context) error {
+	return nil
+}
+
+func (*Driver) UpdatePod(pod apiv1.PodSpec) apiv1.PodSpec {
+	return pod
+}
+
+func (*Driver) UpdateVirtualService(_ *istioNetworkingV1beta1.VirtualService) {}

--- a/pkg/divert/weaver/divert.go
+++ b/pkg/divert/weaver/divert.go
@@ -33,11 +33,11 @@ type Driver struct {
 	divert    model.DivertDeploy
 }
 
-func New(m *model.Manifest, c kubernetes.Interface) *Driver {
+func New(divert *model.DivertDeploy, name, namespace string, c kubernetes.Interface) *Driver {
 	return &Driver{
-		name:      m.Name,
-		namespace: m.Namespace,
-		divert:    *m.Deploy.Divert,
+		name:      name,
+		namespace: namespace,
+		divert:    *divert,
 		client:    c,
 	}
 }

--- a/pkg/externalresource/serializer.go
+++ b/pkg/externalresource/serializer.go
@@ -75,3 +75,7 @@ func (er *ExternalResource) UnmarshalYAML(unmarshal func(interface{}) error) err
 
 	return nil
 }
+
+func (notes *Notes) MarshalYAML() (interface{}, error) {
+	return notes.Path, nil
+}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-186

Refactor remote deploy command to avoid to execute duplicated logic and reduce the amount of things deployed in remote.

Changes in this PR:
* The Dockerfile generated to execute the remote logic doesn't call to `okteto deploy` anymore. Instead, it calls to a new command `remote-run`
* This new `remote-run` command is the one in charge of deploying: custom commands defined by the users, divert and external resources defined in the Okteto manifest.
* This new `remote-run` command just receives the minimum information needed to execute the remote logic and it doesn't need to read any manifest or similar.
* Docker-compose and endpoints are always deployed locally, even when the deploy command is run with the `remote` flag.
* Proxy runs now only when deploying custom commands, divert or external resources. This implied to do also the following changes:
  * As part of the docker compose translations we do, we now add the deployed-by label in all the resources created
  * As part of the docker compose translations we do, we now add the divert information (if any) to the pod spec of deployments, statefulsets and jobs (resources created by us in the compose translation)
* Created a `noop` divert driver to minimize the checks in the compose logic and inject that one when no divert information is provided in the okteto manifest 
* In the Dockerfile generated in the remote command, the Okteto command is now executed from the CLI added by us from the CLI image. This is to prevent any breaking change if someone is using a custom image with a pinned Okteto version. So, the command is executed with the full path added by us
* A common struct with the logic to deploy commands, divert and external resources was created and used y local and remote runners. So they logic is shared but not coupled.
* Changed the circleci configuration to run the integration tests. Now, we build the CLI image before running them. This is because the integrations tests for the remote command was using an old version of CLI (`latest`) to run the remote logic, instead of running the one in the branch you are modifying. This might slow down the integration tests, but I think it is a good tradeoff until we set a better way for this
* Fixed dependency variables available in the deploy section. There were 2 errors:
  * We were not setting the right name for the variables defined in the dependencies. There were 2 errors related with the naming:
    * We were using the configmap name instead of the dependency name, so we were generating an env var like: `OKTETO_DEPENDENCY_OKTETO-GIT-DATABASE_VARIABLE_USERNAME`. `OKTETO-GIT-` should not be included in the env var name as the pattern for those variables is: `OKTETO_DEPENDENCY_<NAME>_VARIABLE_<VARIABLE_NAME>` and `okteto-git-` is not part of the dependency name
    * On dependencies with `-` we were not converting them to `_`, but variables in bash cannot contain `-`
  * Those variables were not being available in the remote execution of commands. Dependency variables were being set as env vars after they are deployed, but then, they were not being passed to the remote execution, so if any command is using that variable is not working properly. Now, they are passed to the remote in the same way than the build variables generated on build time

In order to simplify the review, I'm attaching some diagrams on how the local and remote execution was working (flow diagram) vs how it is now. The main difference happens in the remote one (pay attention o how duplication of logic is now gone)

Old local deploy:

![old-local](https://github.com/okteto/okteto/assets/3510171/226faa79-0018-4887-913c-f6d872b86949)

New local deploy:

![local](https://github.com/okteto/okteto/assets/3510171/b9fab05c-9518-4504-b300-df68b5ea1e0b)

Old remote deploy:

![old-remote](https://github.com/okteto/okteto/assets/3510171/8f12330a-c10c-4fcd-90cf-1709b8a523fb)

New remote deploy:

![remote](https://github.com/okteto/okteto/assets/3510171/881fa82a-953a-4443-b3a0-931274fbde6e)



## How to validate

Do an intense testing of deploy in both versions (loca and remote). Testing different scenarios (manifest with commands, external resources, compose, endpoints), just compose files, route to folders (instead of directly to manifest), using vars

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

