### PR TITLE
[Compose] Allow setting K8S labels from `docker-compose.yml`

### DIFF
--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -35,7 +35,9 @@ const (
 	secondStack = `services:
   app:
     labels:
-      a: b
+      label-a: value-label-a
+    annotations:
+      annotation-a: value-annotation-a
     image: ${OKTETO_BUILD_APP_IMAGE}
 `
 )
@@ -68,7 +70,10 @@ func Test_multipleStack(t *testing.T) {
 			},
 		},
 		Labels: model.Labels{
-			"a": "b",
+			"label-a": "value-label-a",
+		},
+		Annotations: model.Annotations{
+			"annotation-a": "value-annotation-a",
 		},
 		Image: "",
 	}
@@ -79,6 +84,9 @@ func Test_multipleStack(t *testing.T) {
 	}
 	if !reflect.DeepEqual(svc.Labels, svcResult.Labels) {
 		t.Fatalf("Expected %v but got %v", svcResult.Labels, svc.Labels)
+	}
+	if !reflect.DeepEqual(svc.Annotations, svcResult.Annotations) {
+		t.Fatalf("Expected %v but got %v", svcResult.Annotations, svc.Annotations)
 	}
 	if svc.Image != svcResult.Image {
 		t.Fatalf("Expected %v but got %v", svcResult.Image, svc.Image)
@@ -134,8 +142,11 @@ func Test_overrideFileStack(t *testing.T) {
 				Value: "b",
 			},
 		},
+		Labels: model.Labels{
+			"label-a": "value-label-a",
+		},
 		Annotations: model.Annotations{
-			"a": "b",
+			"annotation-a": "value-annotation-a",
 		},
 		Image: "test",
 	}
@@ -145,8 +156,11 @@ func Test_overrideFileStack(t *testing.T) {
 	if !reflect.DeepEqual(svc.Environment, svcResult.Environment) {
 		t.Fatalf("Expected %v but got %v", svcResult.Environment, svc.Environment)
 	}
-	if !reflect.DeepEqual(svc.Annotations, svcResult.Annotations) {
+	if !reflect.DeepEqual(svc.Labels, svcResult.Labels) {
 		t.Fatalf("Expected %v but got %v", svcResult.Labels, svc.Labels)
+	}
+	if !reflect.DeepEqual(svc.Annotations, svcResult.Annotations) {
+		t.Fatalf("Expected %v but got %v", svcResult.Annotations, svc.Annotations)
 	}
 	if svc.Image != svcResult.Image {
 		t.Fatalf("Expected %v but got %v", svcResult.Image, svc.Image)

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -181,7 +181,7 @@ func translatePersistentVolumeClaim(volumeName string, s *model.Stack) apiv1.Per
 			Name:        volumeName,
 			Namespace:   s.Namespace,
 			Labels:      labels,
-			Annotations: volumeSpec.Annotations,
+			Annotations: volumeSpec.Labels,
 		},
 		Spec: apiv1.PersistentVolumeClaimSpec{
 			AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOnce},
@@ -479,8 +479,8 @@ func translateVolumeLabels(volumeName string, s *model.Stack) map[string]string 
 		model.StackVolumeNameLabel: volumeName,
 		model.DeployedByLabel:      format.ResourceK8sMetaString(s.Name),
 	}
-	for k := range volume.Labels {
-		labels[k] = volume.Labels[k]
+	for k := range volume.Annotations {
+		labels[k] = volume.Annotations[k]
 	}
 	return labels
 }
@@ -526,8 +526,8 @@ func translateLabels(svcName string, s *model.Stack) map[string]string {
 		model.StackServiceNameLabel: svcName,
 		model.DeployedByLabel:       format.ResourceK8sMetaString(s.Name),
 	}
-	for k := range svc.Labels {
-		labels[k] = svc.Labels[k]
+	for k, v := range svc.Annotations {
+		labels[k] = v
 	}
 
 	for _, volume := range svc.Volumes {
@@ -547,15 +547,15 @@ func translateLabelSelector(svcName string, s *model.Stack) map[string]string {
 }
 
 func translateAnnotations(svc *model.Service) map[string]string {
+	result := getOktetoAnnotations()
 
-	result := getAnnotations()
-	for k, v := range svc.Annotations {
+	for k, v := range svc.Labels {
 		result[k] = v
 	}
 	return result
 }
 
-func getAnnotations() map[string]string {
+func getOktetoAnnotations() map[string]string {
 	annotations := map[string]string{}
 	if utils.IsOktetoRepo() {
 		annotations[model.OktetoSampleAnnotation] = "true"

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -112,16 +112,16 @@ func Test_translateDeployment(t *testing.T) {
 		t.Errorf("Wrong deployment name: '%s'", result.Name)
 	}
 	labels := map[string]string{
-		"label1":                    "value1",
-		"label2":                    "value2",
+		"annotation1":               "value1",
+		"annotation2":               "value2",
 		model.StackNameLabel:        "stackname",
 		model.StackServiceNameLabel: "svcName",
 		model.DeployedByLabel:       "stackname",
 	}
 	assert.Equal(t, result.Labels, labels)
 	annotations := map[string]string{
-		"annotation1": "value1",
-		"annotation2": "value2",
+		"label1": "value1",
+		"label2": "value2",
 	}
 	assert.Equal(t, result.Annotations, annotations)
 	nodeSelector := map[string]string{
@@ -240,16 +240,16 @@ func Test_translateStatefulSet(t *testing.T) {
 		t.Errorf("Wrong statefulset name: '%s'", result.Name)
 	}
 	labels := map[string]string{
-		"label1":                    "value1",
-		"label2":                    "value2",
+		"annotation1":               "value1",
+		"annotation2":               "value2",
 		model.StackNameLabel:        "stackname",
 		model.StackServiceNameLabel: "svcName",
 		model.DeployedByLabel:       "stackname",
 	}
 	assert.Equal(t, labels, result.Labels)
 	annotations := map[string]string{
-		"annotation1": "value1",
-		"annotation2": "value2",
+		"label1": "value1",
+		"label2": "value2",
 	}
 	assert.Equal(t, result.Annotations, annotations)
 	nodeSelector := map[string]string{
@@ -446,16 +446,16 @@ func Test_translateJobWithoutVolumes(t *testing.T) {
 		t.Errorf("Wrong job name: '%s'", result.Name)
 	}
 	labels := map[string]string{
-		"label1":                    "value1",
-		"label2":                    "value2",
+		"annotation1":               "value1",
+		"annotation2":               "value2",
 		model.StackNameLabel:        "stackname",
 		model.StackServiceNameLabel: "svcName",
 		model.DeployedByLabel:       "stackname",
 	}
 	assert.Equal(t, labels, result.Labels)
 	annotations := map[string]string{
-		"annotation1": "value1",
-		"annotation2": "value2",
+		"label1": "value1",
+		"label2": "value2",
 	}
 	assert.Equal(t, result.Annotations, annotations)
 	nodeSelector := map[string]string{
@@ -590,16 +590,16 @@ func Test_translateJobWithVolumes(t *testing.T) {
 		t.Errorf("Wrong job name: '%s'", result.Name)
 	}
 	labels := map[string]string{
-		"label1":                    "value1",
-		"label2":                    "value2",
+		"annotation1":               "value1",
+		"annotation2":               "value2",
 		model.StackNameLabel:        "stackname",
 		model.StackServiceNameLabel: "svcName",
 		model.DeployedByLabel:       "stackname",
 	}
 	assert.Equal(t, labels, result.Labels)
 	annotations := map[string]string{
-		"annotation1": "value1",
-		"annotation2": "value2",
+		"label1": "value1",
+		"label2": "value2",
 	}
 	assert.Equal(t, result.Annotations, annotations)
 	nodeSelector := map[string]string{
@@ -761,15 +761,15 @@ func Test_translateService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svcName",
 					Labels: map[string]string{
-						"label1":                    "value1",
-						"label2":                    "value2",
+						"annotation1":               "value1",
+						"annotation2":               "value2",
 						model.StackNameLabel:        "stackname",
 						model.StackServiceNameLabel: "svcName",
 						model.DeployedByLabel:       "stackname",
 					},
 					Annotations: map[string]string{
-						"annotation1": "value1",
-						"annotation2": "value2",
+						"label1": "value1",
+						"label2": "value2",
 					},
 				},
 				Spec: apiv1.ServiceSpec{
@@ -808,15 +808,14 @@ func Test_translateService(t *testing.T) {
 				Services: map[string]*model.Service{
 					"svcName": {
 						Labels: model.Labels{
-							"label1": "value1",
-							"label2": "value2",
+							"label1":                          "value1",
+							"label2":                          "value2",
+							model.OktetoAutoIngressAnnotation: "true",
 						},
-
 						Public: true,
 						Annotations: model.Annotations{
-							"annotation1":                     "value1",
-							"annotation2":                     "value2",
-							model.OktetoAutoIngressAnnotation: "true",
+							"annotation1": "value1",
+							"annotation2": "value2",
 						},
 						Ports: []model.Port{
 							{
@@ -836,15 +835,15 @@ func Test_translateService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svcName",
 					Labels: map[string]string{
-						"label1":                    "value1",
-						"label2":                    "value2",
+						"annotation1":               "value1",
+						"annotation2":               "value2",
 						model.StackNameLabel:        "stackname",
 						model.StackServiceNameLabel: "svcName",
 						model.DeployedByLabel:       "stackname",
 					},
 					Annotations: map[string]string{
-						"annotation1":                     "value1",
-						"annotation2":                     "value2",
+						"label1":                          "value1",
+						"label2":                          "value2",
 						model.OktetoAutoIngressAnnotation: "true",
 					},
 				},
@@ -884,13 +883,13 @@ func Test_translateService(t *testing.T) {
 				Services: map[string]*model.Service{
 					"svcName": {
 						Labels: model.Labels{
-							"label1": "value1",
-							"label2": "value2",
+							"label1":                          "value1",
+							"label2":                          "value2",
+							model.OktetoAutoIngressAnnotation: "private",
 						},
 						Annotations: model.Annotations{
-							"annotation1":                     "value1",
-							"annotation2":                     "value2",
-							model.OktetoAutoIngressAnnotation: "private",
+							"annotation1": "value1",
+							"annotation2": "value2",
 						},
 						Public: true,
 						Ports: []model.Port{
@@ -910,15 +909,15 @@ func Test_translateService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svcName",
 					Labels: map[string]string{
-						"label1":                    "value1",
-						"label2":                    "value2",
+						"annotation1":               "value1",
+						"annotation2":               "value2",
 						model.StackNameLabel:        "stackname",
 						model.StackServiceNameLabel: "svcName",
 						model.DeployedByLabel:       "stackname",
 					},
 					Annotations: map[string]string{
-						"annotation1":                     "value1",
-						"annotation2":                     "value2",
+						"label1":                          "value1",
+						"label2":                          "value2",
 						model.OktetoAutoIngressAnnotation: "private",
 					},
 				},
@@ -958,13 +957,13 @@ func Test_translateService(t *testing.T) {
 				Services: map[string]*model.Service{
 					"svcName": {
 						Labels: model.Labels{
-							"label1": "value1",
-							"label2": "value2",
+							"label1":                         "value1",
+							"label2":                         "value2",
+							model.OktetoPrivateSvcAnnotation: "true",
 						},
 						Annotations: model.Annotations{
-							"annotation1":                    "value1",
-							"annotation2":                    "value2",
-							model.OktetoPrivateSvcAnnotation: "true",
+							"annotation1": "value1",
+							"annotation2": "value2",
 						},
 						Public: true,
 						Ports: []model.Port{
@@ -984,15 +983,15 @@ func Test_translateService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svcName",
 					Labels: map[string]string{
-						"label1":                    "value1",
-						"label2":                    "value2",
+						"annotation1":               "value1",
+						"annotation2":               "value2",
 						model.StackNameLabel:        "stackname",
 						model.StackServiceNameLabel: "svcName",
 						model.DeployedByLabel:       "stackname",
 					},
 					Annotations: map[string]string{
-						"annotation1":                    "value1",
-						"annotation2":                    "value2",
+						"label1":                         "value1",
+						"label2":                         "value2",
 						model.OktetoPrivateSvcAnnotation: "true",
 					},
 				},
@@ -1053,15 +1052,15 @@ func Test_translateService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svcName",
 					Labels: map[string]string{
-						"label1":                    "value1",
-						"label2":                    "value2",
+						"annotation1":               "value1",
+						"annotation2":               "value2",
 						model.StackNameLabel:        "stackname",
 						model.StackServiceNameLabel: "svcName",
 						model.DeployedByLabel:       "stackname",
 					},
 					Annotations: map[string]string{
-						"annotation1": "value1",
-						"annotation2": "value2",
+						"label1": "value1",
+						"label2": "value2",
 					},
 				},
 				Spec: apiv1.ServiceSpec{

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -298,15 +298,15 @@ services:
 	if storage.Cmp(resource.MustParse("1Gi")) != 0 {
 		t.Errorf("'vote.resources.storage' was not parsed: %+v", s)
 	}
-	for key, value := range s.Services["vote"].Annotations {
+	for key, value := range s.Services["vote"].Labels {
 		if key == "traeffick.routes" && value == `Path("/")` {
 			continue
 		}
 		t.Errorf("'vote.annotations' was not parsed correctly: %+v", s.Services["vote"].Annotations)
 	}
 
-	if len(s.Services["vote"].Labels) > 0 {
-		t.Errorf("'vote.labels' has labels inside")
+	if len(s.Services["vote"].Annotations) > 0 {
+		t.Errorf("'vote.annotations' should be empty")
 	}
 	if _, ok := s.Services["db"]; !ok {
 		t.Errorf("'db' was not parsed: %+v", s)


### PR DESCRIPTION
# Proposed changes

Fixes DEV-215

This PR changes enables users to set k8s labels when using docker compose manifests.

At the moment both `labels` and `annotations` are translated into k8s annotations, with this change compose annotations will be k8s labels, and viceversa.

|         | `master` | `af/compose-annotations-dev-215` |
|---------|--------|-----|
| `service` |    <img width="965" alt="Screenshot 2024-03-18 at 10 32 16" src="https://github.com/okteto/okteto/assets/2318450/50c7f36e-a2e1-4a42-a029-332d5be916a3">    |   <img width="927" alt="Screenshot 2024-03-18 at 10 34 26" src="https://github.com/okteto/okteto/assets/2318450/6538a004-bb6c-4baa-a853-85fc581469d4">  |
| `volume`  |    <img width="1141" alt="Screenshot 2024-03-18 at 10 30 53" src="https://github.com/okteto/okteto/assets/2318450/ed753927-251b-44b7-92e6-a3a94ae72509">    |    <img width="1220" alt="Screenshot 2024-03-18 at 10 23 24" src="https://github.com/okteto/okteto/assets/2318450/94828485-7d68-4c85-9110-e9e38784ced5"> |

## How to validate

1. Clone https://github.com/okteto/movies-with-compose
2. Override the `docker-compose.yml` with [this one](https://gist.github.com/andreafalzetti/30311d9dba40b46422e65671bdbf3550)
Highlight of changes from my test `docker-compose.yml` are:
a. Adding `services.api.labels` and `services.api.annotations`
b. Adding `volumes.data.labels`

3. Run `okteto deploy` and observe annotations and labels for the api service and the volume. Compose annotations should become k8s labels, and vice versa

Additional checks:
1. Try making a very long label/annotation and observe the CLI failing with:
```
 x  Error updating kubernetes service: Service "api" is invalid: [metadata.labels: Invalid value: "dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.": name part must be no more than 63 characters, metadata.labels: Invalid value: "dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]
```


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
