### PR TITLE
[New Feature] Manifest Variables

### DIFF
--- a/cmd/context/cmd_test.go
+++ b/cmd/context/cmd_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func Test_NoArgsAcceptedCtx(t *testing.T) {
-	cmd := Show()
+	cmd := Show(nil)
 	cmd.SetArgs([]string{"args"})
 	err := cmd.Execute()
 	if err == nil {
@@ -27,7 +27,7 @@ func Test_NoArgsAcceptedCtx(t *testing.T) {
 }
 
 func Test_NoArgsAcceptedShow(t *testing.T) {
-	cmd := Context(nil)
+	cmd := Context(nil, nil)
 	cmd.SetArgs([]string{"args"})
 	err := cmd.Execute()
 	if err == nil {
@@ -36,7 +36,7 @@ func Test_NoArgsAcceptedShow(t *testing.T) {
 }
 
 func Test_NoArgsAcceptedList(t *testing.T) {
-	cmd := List()
+	cmd := List(nil)
 	cmd.SetArgs([]string{"args"})
 	err := cmd.Execute()
 	if err == nil {
@@ -45,7 +45,7 @@ func Test_NoArgsAcceptedList(t *testing.T) {
 }
 
 func Test_NoArgsAcceptedUpdateKubeConfig(t *testing.T) {
-	cmd := UpdateKubeconfigCMD(nil)
+	cmd := UpdateKubeconfigCMD(nil, nil)
 	cmd.SetArgs([]string{"args"})
 	err := cmd.Execute()
 	if err == nil {
@@ -54,7 +54,7 @@ func Test_NoArgsAcceptedUpdateKubeConfig(t *testing.T) {
 }
 
 func Test_MaxArgsCreate(t *testing.T) {
-	cmd := CreateCMD()
+	cmd := CreateCMD(nil)
 	cmd.SetArgs([]string{"args", "args"})
 	err := cmd.Execute()
 	if err == nil {
@@ -63,7 +63,7 @@ func Test_MaxArgsCreate(t *testing.T) {
 }
 
 func Test_MaxArgsUse(t *testing.T) {
-	cmd := Use()
+	cmd := Use(nil)
 	cmd.SetArgs([]string{"args", "args"})
 	err := cmd.Execute()
 	if err == nil {

--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -15,13 +15,14 @@ package context
 
 import (
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
 
 // Context points okteto to a cluster.
-func Context(okClientProvider oktetoClientProvider) *cobra.Command {
+func Context(okClientProvider oktetoClientProvider, envManager *env.Manager) *cobra.Command {
 	ctxOptions := &Options{}
 	cmd := &cobra.Command{
 		Use:     "context",
@@ -42,17 +43,17 @@ This will prompt you to select one of your existing contexts or to create a new 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			okteto.SetInsecureSkipTLSVerifyPolicy(ctxOptions.InsecureSkipTlsVerify)
 		},
-		RunE: Use().RunE,
+		RunE: Use(envManager).RunE,
 	}
-	cmd.AddCommand(Show())
-	cmd.AddCommand(Use())
-	cmd.AddCommand(List())
+	cmd.AddCommand(Show(envManager))
+	cmd.AddCommand(Use(envManager))
+	cmd.AddCommand(List(envManager))
 	cmd.AddCommand(DeleteCMD())
 
 	// deprecated
-	cmd.AddCommand(CreateCMD())
-	cmd.AddCommand(UpdateKubeconfigCMD(okClientProvider))
-	cmd.AddCommand(UseNamespace())
+	cmd.AddCommand(CreateCMD(envManager))
+	cmd.AddCommand(UpdateKubeconfigCMD(okClientProvider, envManager))
+	cmd.AddCommand(UseNamespace(envManager))
 
 	cmd.PersistentFlags().BoolVarP(&ctxOptions.InsecureSkipTlsVerify, "insecure-skip-tls-verify", "", false, " If enabled, the server's certificate will not be checked for validity. This will make your connections insecure")
 	cmd.Flags().StringVarP(&ctxOptions.Token, "token", "t", "", "API token for authentication")

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/internal/test/client"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
@@ -35,6 +36,22 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+type fakeEnvManager struct{}
+
+func (*fakeEnvManager) LookupEnv(string) (string, bool) {
+	return "", false
+}
+func (*fakeEnvManager) SetEnv(string, string) error {
+	return nil
+}
+func (*fakeEnvManager) MaskVar(string) {}
+func (*fakeEnvManager) WarningLogf(string, ...interface{}) {
+}
+
+func newFakeEnvManager() *fakeEnvManager {
+	return &fakeEnvManager{}
+}
+
 func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User, fakeObjects []runtime.Object) *Command {
 	return &Command{
 		K8sClientProvider:    test.NewFakeK8sProvider(fakeObjects...),
@@ -42,6 +59,7 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User, fakeObj
 		OktetoClientProvider: client.NewFakeOktetoClientProvider(c),
 		OktetoContextWriter:  test.NewFakeOktetoContextWriter(),
 		kubetokenController:  newStaticKubetokenController(),
+		EnvManager:           env.NewEnvManager(newFakeEnvManager()),
 	}
 }
 

--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -21,6 +21,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -29,7 +30,7 @@ import (
 var output string
 
 // List returns all contexts managed by okteto
-func List() *cobra.Command {
+func List(envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -37,7 +38,7 @@ func List() *cobra.Command {
 		Short:   "List available contexts",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if err := NewContextCommand().Run(ctx, &Options{raiseNotCtxError: true}); err != nil {
+			if err := NewContextCommand(WithEnvManger(envManager)).Run(ctx, &Options{raiseNotCtxError: true}); err != nil {
 				return err
 			}
 			return executeListContext()

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ import (
 )
 
 // Show current context
-func Show() *cobra.Command {
+func Show(envManager *env.Manager) *cobra.Command {
 	var output string
 	var includeToken bool
 	cmd := &cobra.Command{
@@ -36,7 +37,7 @@ func Show() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
-			if err := NewContextCommand().Run(ctx, &Options{raiseNotCtxError: true}); err != nil {
+			if err := NewContextCommand(WithEnvManger(envManager)).Run(ctx, &Options{raiseNotCtxError: true}); err != nil {
 				return err
 			}
 			ctxStore := okteto.GetContextStore()

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -54,7 +54,7 @@ func newKubeconfigController(okClientProvider oktetoClientProvider) *KubeconfigC
 }
 
 // UpdateKubeconfigCMD all contexts managed by okteto
-func UpdateKubeconfigCMD(okClientProvider oktetoClientProvider) *cobra.Command {
+func UpdateKubeconfigCMD(okClientProvider oktetoClientProvider, envManager *env.Manager) *cobra.Command {
 	kc := newKubeconfigController(okClientProvider)
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -65,7 +65,7 @@ func UpdateKubeconfigCMD(okClientProvider oktetoClientProvider) *cobra.Command {
 			ctx := context.Background()
 
 			// Run context command to get the Cfg into Okteto GetContext
-			if err := NewContextCommand(withKubeTokenController(kc.kubetokenController)).Run(ctx, &Options{}); err != nil {
+			if err := NewContextCommand(WithEnvManger(envManager), withKubeTokenController(kc.kubetokenController)).Run(ctx, &Options{}); err != nil {
 				return err
 			}
 

--- a/cmd/context/use-namespace.go
+++ b/cmd/context/use-namespace.go
@@ -18,13 +18,14 @@ import (
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
 
 // UseNamespace changes your current context namespace.
-func UseNamespace() *cobra.Command {
+func UseNamespace(envManager *env.Manager) *cobra.Command {
 	ctxOptions := &Options{}
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -40,7 +41,7 @@ func UseNamespace() *cobra.Command {
 			ctxOptions.Save = true
 			ctxOptions.IsCtxCommand = true
 
-			err := NewContextCommand().Run(ctx, ctxOptions)
+			err := NewContextCommand(WithEnvManger(envManager)).Run(ctx, ctxOptions)
 			analytics.TrackContextUseNamespace(err == nil)
 			if err != nil {
 				return err

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/discovery"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -141,7 +142,7 @@ func getCtxResource(path string) (*model.ContextResource, error) {
 }
 
 // LoadManifestWithContext loads context and then loads a manifest
-func LoadManifestWithContext(ctx context.Context, opts ManifestOptions, fs afero.Fs) (*model.Manifest, error) {
+func LoadManifestWithContext(ctx context.Context, opts ManifestOptions, fs afero.Fs, envManager *env.Manager) (*model.Manifest, error) {
 	ctxResource, err := model.GetContextResource(opts.Filename)
 	if err != nil {
 		return nil, err
@@ -160,16 +161,17 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions, fs afero
 		Show:      true,
 	}
 
-	if err := NewContextCommand().Run(ctx, ctxOptions); err != nil {
+	if err := NewContextCommand(WithEnvManger(envManager)).Run(ctx, ctxOptions); err != nil {
 		return nil, err
 	}
 
 	manifest, err := model.GetManifestV1(opts.Filename, fs)
 	if err != nil {
-		if !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
+		if !errors.Is(err, discovery.ErrOktetoManifestNotFound) && !errors.Is(err, discovery.ErrOktetoManifestNotV1) {
 			return nil, err
 		}
-		manifest, err = model.GetManifestV2(opts.Filename, fs)
+
+		manifest, err = model.GetManifestV2(opts.Filename, fs, envManager)
 		if err != nil {
 			return nil, err
 		}
@@ -190,7 +192,7 @@ func LoadManifestWithContext(ctx context.Context, opts ManifestOptions, fs afero
 	return manifest, nil
 }
 
-func LoadStackWithContext(ctx context.Context, name, namespace string, stackPaths []string, fs afero.Fs) (*model.Stack, error) {
+func LoadStackWithContext(ctx context.Context, name, namespace string, stackPaths []string, fs afero.Fs, envManager *env.Manager) (*model.Stack, error) {
 	ctxResource, err := utils.LoadStackContext(stackPaths)
 	if err != nil {
 		if name == "" {
@@ -209,7 +211,7 @@ func LoadStackWithContext(ctx context.Context, name, namespace string, stackPath
 		Show:      true,
 	}
 
-	if err := NewContextCommand().Run(ctx, ctxOptions); err != nil {
+	if err := NewContextCommand(WithEnvManger(envManager)).Run(ctx, ctxOptions); err != nil {
 		return nil, err
 	}
 
@@ -225,7 +227,7 @@ func LoadStackWithContext(ctx context.Context, name, namespace string, stackPath
 }
 
 // LoadContextFromPath initializes the okteto context taking into account command flags and manifest namespace/context fields
-func LoadContextFromPath(ctx context.Context, namespace, k8sContext, path string, defaultCtxOpts Options) error {
+func LoadContextFromPath(ctx context.Context, namespace, k8sContext, path string, defaultCtxOpts Options, envManager *env.Manager) error {
 	ctxResource, err := getCtxResource(path)
 	if err != nil {
 		return err
@@ -243,5 +245,5 @@ func LoadContextFromPath(ctx context.Context, namespace, k8sContext, path string
 	ctxOptions.Context = ctxResource.Context
 	ctxOptions.Namespace = ctxResource.Namespace
 
-	return NewContextCommand().Run(ctx, &ctxOptions)
+	return NewContextCommand(WithEnvManger(envManager)).Run(ctx, &ctxOptions)
 }

--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/vars"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -186,8 +187,9 @@ dependencies:
 						Repository: "https://repo.url",
 					},
 				},
-				External: externalresource.Section{},
-				Fs:       afero.NewOsFs(),
+				External:  externalresource.Section{},
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 		},
 		{
@@ -213,7 +215,7 @@ dependencies:
 				filename = ""
 			}
 
-			m, err := model.GetManifestV2(filename, afero.NewMemMapFs())
+			m, err := model.GetManifestV2(filename, afero.NewMemMapFs(), nil)
 			if tt.expectedErr {
 				assert.NotNil(t, err)
 			} else {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -20,6 +20,7 @@ import (
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -27,24 +28,24 @@ import (
 )
 
 // Create creates resources
-func Create(ctx context.Context) *cobra.Command {
+func Create(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "create",
 		Short:  "Create resources",
 		Args:   utils.NoArgsAccepted(""),
 	}
-	cmd.AddCommand(deprecatedCreateNamespace(ctx))
+	cmd.AddCommand(deprecatedCreateNamespace(ctx, envManager))
 	return cmd
 }
 
-func deprecatedCreateNamespace(ctx context.Context) *cobra.Command {
+func deprecatedCreateNamespace(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace <name>",
 		Short: "Create a namespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto create namespace' is deprecated in favor of 'okteto namespace create', and will be removed in a future version")
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 
@@ -53,7 +54,7 @@ func deprecatedCreateNamespace(ctx context.Context) *cobra.Command {
 				return errors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := namespace.NewCommand()
+			nsCmd, err := namespace.NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -20,6 +20,7 @@ import (
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -27,24 +28,24 @@ import (
 )
 
 // Delete creates resources
-func Delete(ctx context.Context) *cobra.Command {
+func Delete(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "delete",
 		Short:  "Delete resources",
 		Args:   utils.NoArgsAccepted(""),
 	}
-	cmd.AddCommand(deprecatedDeleteNamespace(ctx))
+	cmd.AddCommand(deprecatedDeleteNamespace(ctx, envManager))
 	return cmd
 }
 
-func deprecatedDeleteNamespace(ctx context.Context) *cobra.Command {
+func deprecatedDeleteNamespace(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace <name>",
 		Short: "Delete a namespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto delete namespace' is deprecated in favor of 'okteto namespace delete', and will be removed in a future version")
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 
@@ -52,7 +53,7 @@ func deprecatedDeleteNamespace(ctx context.Context) *cobra.Command {
 				return errors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := namespace.NewCommand()
+			nsCmd, err := namespace.NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/deps"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/format"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
@@ -275,7 +276,9 @@ func TestDeployWithErrorReadingManifestFile(t *testing.T) {
 		Variables:    []string{},
 	}
 
-	err := c.Run(ctx, opts)
+	envManager := env.NewEnvManager(newFakeEnvManager(make(map[string]string)))
+
+	err := c.Run(ctx, opts, envManager)
 
 	// Verify the deploy phase is not even reached
 	fakeDeployer.AssertNotCalled(t, "Get")
@@ -304,7 +307,9 @@ func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
 		Variables:    []string{},
 	}
 
-	err := c.Run(ctx, opts)
+	envManager := env.NewEnvManager(newFakeEnvManager(make(map[string]string)))
+
+	err := c.Run(ctx, opts, envManager)
 
 	assert.ErrorIs(t, err, oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands)
 	// Verify the deploy phase is not even reached
@@ -374,7 +379,9 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := c.Run(ctx, opts)
+	envManager := env.NewEnvManager(newFakeEnvManager(make(map[string]string)))
+
+	err := c.Run(ctx, opts, envManager)
 
 	// we should get a build error because Dockerfile does not exist
 	assert.True(t, strings.Contains(err.Error(), oktetoErrors.InvalidDockerfile))
@@ -469,7 +476,9 @@ func TestDeployWithErrorDeploying(t *testing.T) {
 	}
 	fakeDeployer.On("Deploy", mock.Anything, expectedOpts).Return(assert.AnError)
 
-	err := c.Run(ctx, opts)
+	envManager := env.NewEnvManager(newFakeEnvManager(make(map[string]string)))
+
+	err := c.Run(ctx, opts, envManager)
 
 	assert.Error(t, err)
 
@@ -527,7 +536,9 @@ func TestDeployWithErrorBecauseOtherPipelineRunning(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	err := c.Run(ctx, opts)
+	envManager := env.NewEnvManager(newFakeEnvManager(make(map[string]string)))
+
+	err := c.Run(ctx, opts, envManager)
 
 	assert.Error(t, err)
 
@@ -601,7 +612,9 @@ func TestDeployWithoutErrors(t *testing.T) {
 	}
 	fakeDeployer.On("Deploy", mock.Anything, expectedOpts).Return(nil)
 
-	err := c.Run(ctx, opts)
+	envManager := env.NewEnvManager(newFakeEnvManager(make(map[string]string)))
+
+	err := c.Run(ctx, opts, envManager)
 
 	assert.NoError(t, err)
 
@@ -759,7 +772,9 @@ func TestDeployOnlyDependencies(t *testing.T) {
 				CurrentContext: "test",
 			}
 
-			err := c.Run(ctx, opts)
+			envManager := env.NewEnvManager(newFakeEnvManager(make(map[string]string)))
+
+			err := c.Run(ctx, opts, envManager)
 
 			require.ErrorIs(t, err, tc.expecterErr)
 		})

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -151,7 +151,7 @@ func TestRemoteTest(t *testing.T) {
 				getBuildEnvVars:      func() map[string]string { return nil },
 				getDependencyEnvVars: func(_ environGetter) map[string]string { return nil },
 			}
-			err := rdc.Deploy(ctx, tt.config.options)
+			err := rdc.Deploy(ctx, tt.config.options, nil)
 			if tt.expected != nil {
 				assert.ErrorContains(t, err, tt.expected.Error())
 			} else {
@@ -195,7 +195,7 @@ func TestExtraHosts(t *testing.T) {
 
 	err := rdc.Deploy(ctx, &Options{
 		Manifest: fakeManifest,
-	})
+	}, nil)
 	require.NoError(t, err)
 }
 
@@ -241,7 +241,7 @@ func TestRemoteDeployWithSshAgent(t *testing.T) {
 				Image: "test-image",
 			},
 		},
-	})
+	}, nil)
 	assert.NoError(t, err)
 }
 
@@ -280,7 +280,7 @@ func TestRemoteDeployWithBadSshAgent(t *testing.T) {
 				Image: "test-image",
 			},
 		},
-	})
+	}, nil)
 	assert.NoError(t, err)
 }
 

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -20,12 +20,15 @@ import (
 	"github.com/okteto/okteto/pkg/env"
 )
 
-func validateAndSet(variables []string, setEnv func(key, value string) error) error {
+// validateAndSetVarsFromFlag validates the --var flag of the deploy command by parsing them as KEY=VALUE pairs
+// and sets them as environment variables
+func validateAndSetVarsFromFlag(variables []string, envManager *env.Manager) error {
 	envVars, err := parse(variables)
 	if err != nil {
 		return err
 	}
-	return setOptionVarsAsEnvs(envVars, setEnv)
+	envManager.AddGroup(envVars, env.PriorityVarFromFlag)
+	return envManager.Export()
 }
 
 func parse(variables []string) ([]env.Var, error) {
@@ -39,13 +42,4 @@ func parse(variables []string) ([]env.Var, error) {
 		result = append(result, env.Var{Name: kv[0], Value: kv[1]})
 	}
 	return result, nil
-}
-
-func setOptionVarsAsEnvs(variables []env.Var, setEnv func(key, value string) error) error {
-	for _, v := range variables {
-		if err := setEnv(v.Name, v.Value); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/doctor"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"
@@ -38,7 +39,7 @@ type doctorOptions struct {
 }
 
 // Doctor generates a zip file with all okteto-related log files
-func Doctor(k8sLogger *io.K8sLogger) *cobra.Command {
+func Doctor(k8sLogger *io.K8sLogger, envManager *env.Manager) *cobra.Command {
 	doctorOpts := &doctorOptions{}
 	cmd := &cobra.Command{
 		Use:   "doctor [service]",
@@ -52,7 +53,7 @@ func Doctor(k8sLogger *io.K8sLogger) *cobra.Command {
 				return oktetoErrors.ErrNotInDevContainer
 			}
 
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: doctorOpts.DevPath, Namespace: doctorOpts.Namespace, K8sContext: doctorOpts.K8sContext}, afero.NewOsFs())
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: doctorOpts.DevPath, Namespace: doctorOpts.Namespace, K8sContext: doctorOpts.K8sContext}, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/down"
 	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
@@ -40,7 +41,7 @@ import (
 )
 
 // Down deactivates the development container
-func Down(k8sLogsCtrl *io.K8sLogger) *cobra.Command {
+func Down(k8sLogsCtrl *io.K8sLogger, envManager *env.Manager) *cobra.Command {
 	var devPath string
 	var namespace string
 	var k8sContext string
@@ -62,7 +63,7 @@ func Down(k8sLogsCtrl *io.K8sLogger) *cobra.Command {
 				}
 				devPath = model.GetManifestPathFromWorkdir(devPath, workdir)
 			}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -26,6 +26,7 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/status"
 	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/k8s/exec"
@@ -47,7 +48,7 @@ type execFlags struct {
 }
 
 // Exec executes a command on the CND container
-func Exec(k8sLogger *io.K8sLogger) *cobra.Command {
+func Exec(k8sLogger *io.K8sLogger, envManager *env.Manager) *cobra.Command {
 	execFlags := &execFlags{}
 
 	cmd := &cobra.Command{
@@ -58,7 +59,7 @@ func Exec(k8sLogger *io.K8sLogger) *cobra.Command {
 			defer cancel()
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: execFlags.manifestPath, Namespace: execFlags.namespace, K8sContext: execFlags.k8sContext}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,7 @@ import (
 	"github.com/okteto/okteto/cmd/manifest"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
@@ -33,7 +34,7 @@ type analyticsTrackerInterface interface {
 }
 
 // Init creates okteto manifest
-func Init(at analyticsTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
+func Init(at analyticsTrackerInterface, ioCtrl *io.Controller, envManager *env.Manager) *cobra.Command {
 	opts := &manifest.InitOpts{}
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -55,7 +56,7 @@ func Init(at analyticsTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
 				Namespace: ctxResource.Namespace,
 				Show:      true,
 			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, ctxOptions); err != nil {
 				return err
 			}
 
@@ -76,7 +77,7 @@ func Init(at analyticsTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
 					return err
 				}
 			} else {
-				_, err := mc.RunInitV2(ctx, opts)
+				_, err := mc.RunInitV2(ctx, opts, envManager)
 				return err
 			}
 			return nil

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -16,6 +16,7 @@ package cmd
 import (
 	"github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
@@ -27,7 +28,7 @@ type oktetoClientProvider interface {
 }
 
 // Kubeconfig fetch credentials for a cluster namespace
-func Kubeconfig(okClientProvider oktetoClientProvider) *cobra.Command {
+func Kubeconfig(okClientProvider oktetoClientProvider, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubeconfig",
 		Short: "Download credentials for the Kubernetes cluster selected via 'okteto context'",
@@ -37,7 +38,7 @@ Generated kubeconfig file uses a credential plugin to get the cluster credential
 `,
 		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#kubeconfig"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return context.UpdateKubeconfigCMD(okClientProvider).RunE(cmd, args)
+			return context.UpdateKubeconfigCMD(okClientProvider, envManager).RunE(cmd, args)
 		},
 	}
 	return cmd

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
@@ -81,26 +82,21 @@ type Options struct {
 	getCtxResource       initCtxOptsFunc
 }
 
-func defaultKubetokenOptions() *Options {
+func defaultKubetokenOptions(envManager *env.Manager) *Options {
 	ctxStore := okteto.GetContextStore()
 	return &Options{
 		oktetoClientProvider: okteto.NewOktetoClientProvider(),
 		k8sClientProvider:    okteto.NewK8sClientProvider(),
-		oktetoCtxCmdRunner:   contextCMD.NewContextCommand(),
+		oktetoCtxCmdRunner:   contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)),
 		ctxStore:             ctxStore,
 		serializer:           &Serializer{},
 		getCtxResource:       getCtxResource,
 	}
 }
 
-type kubetokenOption func(*Options)
-
 // NewKubetokenCmd returns a new cobra command
-func NewKubetokenCmd(optFunc ...kubetokenOption) *Cmd {
-	opts := defaultKubetokenOptions()
-	for _, o := range optFunc {
-		o(opts)
-	}
+func NewKubetokenCmd(envManager *env.Manager) *Cmd {
+	opts := defaultKubetokenOptions(envManager)
 	return &Cmd{
 		oktetoClientProvider: opts.oktetoClientProvider,
 		serializer:           opts.serializer,

--- a/cmd/kubetoken/kubetoken_test.go
+++ b/cmd/kubetoken/kubetoken_test.go
@@ -147,7 +147,7 @@ func TestKubetoken(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewKubetokenCmd()
+			cmd := NewKubetokenCmd(nil)
 			cmd.ctxStore = tc.input.contextStore
 			cmd.oktetoClientProvider = tc.input.fakeOktetoClientProvider
 			cmd.oktetoCtxCmdRunner = tc.input.fakeCtxCmdRunner

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,29 +18,30 @@ import (
 
 	"github.com/okteto/okteto/cmd/namespace"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/spf13/cobra"
 )
 
 // List lists resources
-func List(ctx context.Context) *cobra.Command {
+func List(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "list",
 		Short:  "List resources",
 		Args:   utils.NoArgsAccepted(""),
 	}
-	cmd.AddCommand(deprecatedListNamespace(ctx))
+	cmd.AddCommand(deprecatedListNamespace(ctx, envManager))
 	return cmd
 }
 
-func deprecatedListNamespace(ctx context.Context) *cobra.Command {
+func deprecatedListNamespace(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "namespace <name>",
 		Short: "List namespaces",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto list namespace' is deprecated in favor of 'okteto namespace list', and will be removed in a future version")
-			return cmd.RunE(namespace.List(ctx), args)
+			return cmd.RunE(namespace.List(ctx, envManager), args)
 		},
 		Args: utils.NoArgsAccepted(""),
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,13 +20,14 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
 
 // Login starts the login handshake with GitHub and okteto
-func Login() *cobra.Command {
+func Login(envManager *env.Manager) *cobra.Command {
 	token := ""
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -63,7 +64,7 @@ to log in to a Okteto Enterprise instance running at okteto.example.com.
 			}
 
 			ctx := context.Background()
-			err := contextCMD.NewContextCommand().Run(ctx, &ctxOptions)
+			err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &ctxOptions)
 			if err != nil {
 				analytics.TrackLogin(false)
 			} else {

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/devenvironment"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/log/io"
@@ -55,7 +56,7 @@ type Options struct {
 	All          bool
 }
 
-func Logs(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
+func Logs(ctx context.Context, k8sLogger *io.K8sLogger, envManager *env.Manager) *cobra.Command {
 	options := &Options{}
 
 	cmd := &cobra.Command{
@@ -65,7 +66,7 @@ func Logs(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: options.ManifestPath, Namespace: options.Namespace, K8sContext: options.Context}, afero.NewOsFs())
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, contextCMD.ManifestOptions{Filename: options.ManifestPath, Namespace: options.Namespace, K8sContext: options.Context}, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -33,6 +33,7 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	"github.com/okteto/okteto/pkg/discovery"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/linguist"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -74,7 +75,7 @@ type InitOpts struct {
 }
 
 // RunInitV2 initializes a new okteto manifest
-func (mc *Command) RunInitV2(ctx context.Context, opts *InitOpts) (*model.Manifest, error) {
+func (mc *Command) RunInitV2(ctx context.Context, opts *InitOpts, envManager *env.Manager) (*model.Manifest, error) {
 	c, _, er := mc.K8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, mc.K8sLogger)
 	if er != nil {
 		return nil, er
@@ -85,14 +86,14 @@ func (mc *Command) RunInitV2(ctx context.Context, opts *InitOpts) (*model.Manife
 	manifest := model.NewManifest()
 	var err error
 	if !opts.Overwrite {
-		manifest, err = model.GetManifestV2(opts.DevPath, afero.NewOsFs())
+		manifest, err = model.GetManifestV2(opts.DevPath, afero.NewOsFs(), envManager)
 		if err != nil && !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
 			return nil, err
 		}
 	}
 
 	if manifest == nil || len(manifest.Build) == 0 || manifest.Deploy == nil {
-		manifest, err = mc.configureManifestDeployAndBuild(opts.Workdir)
+		manifest, err = mc.configureManifestDeployAndBuild(opts.Workdir, envManager)
 		if err != nil {
 			return nil, err
 		}
@@ -145,7 +146,7 @@ func (mc *Command) RunInitV2(ctx context.Context, opts *InitOpts) (*model.Manife
 			}
 		}
 		if deployAnswer || (!isDeployed && opts.AutoDeploy) {
-			if err := mc.deploy(ctx, opts); err != nil {
+			if err := mc.deploy(ctx, opts, envManager); err != nil {
 				return nil, err
 			}
 			isDeployed = true
@@ -181,7 +182,7 @@ func (mc *Command) RunInitV2(ctx context.Context, opts *InitOpts) (*model.Manife
 	return manifest, nil
 }
 
-func (*Command) configureManifestDeployAndBuild(cwd string) (*model.Manifest, error) {
+func (*Command) configureManifestDeployAndBuild(cwd string, envManager *env.Manager) (*model.Manifest, error) {
 
 	composeFiles := utils.GetStackFiles(cwd)
 	if len(composeFiles) > 0 {
@@ -203,14 +204,14 @@ func (*Command) configureManifestDeployAndBuild(cwd string) (*model.Manifest, er
 			}
 			return manifest, nil
 		}
-		manifest, err := createFromKubernetes(cwd)
+		manifest, err := createFromKubernetes(cwd, envManager)
 		if err != nil {
 			return nil, err
 		}
 		return manifest, nil
 
 	}
-	manifest, err := createFromKubernetes(cwd)
+	manifest, err := createFromKubernetes(cwd, envManager)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (*Command) configureManifestDeployAndBuild(cwd string) (*model.Manifest, er
 
 }
 
-func (mc *Command) deploy(ctx context.Context, opts *InitOpts) error {
+func (mc *Command) deploy(ctx context.Context, opts *InitOpts, envManager *env.Manager) error {
 	pc, err := pipelineCMD.NewCommand()
 	if err != nil {
 		return err
@@ -242,7 +243,8 @@ func (mc *Command) deploy(ctx context.Context, opts *InitOpts) error {
 		Timeout:      5 * time.Minute,
 		Build:        false,
 		Wait:         true,
-	})
+	},
+		envManager)
 	if err != nil {
 		return err
 	}
@@ -404,7 +406,7 @@ func createFromCompose(composePath string) (*model.Manifest, error) {
 	return manifest, err
 }
 
-func createFromKubernetes(cwd string) (*model.Manifest, error) {
+func createFromKubernetes(cwd string, envManager *env.Manager) (*model.Manifest, error) {
 	manifest := model.NewManifest()
 	dockerfiles, err := selectDockerfiles(cwd)
 	if err != nil {
@@ -414,11 +416,11 @@ func createFromKubernetes(cwd string) (*model.Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
-	manifest.Deploy, err = inferDeploySection(cwd)
+	manifest.Deploy, err = inferDeploySection(cwd, envManager)
 	if err != nil {
 		return nil, err
 	}
-	manifest.Dev, err = inferDevsSection(cwd)
+	manifest.Dev, err = inferDevsSection(cwd, envManager)
 	if err != nil {
 		return nil, err
 	}
@@ -462,8 +464,8 @@ func inferBuildSectionFromDockerfiles(cwd string, dockerfiles []string) (build.M
 	return manifestBuild, nil
 }
 
-func inferDeploySection(cwd string) (*model.DeployInfo, error) {
-	m, err := model.GetInferredManifest(cwd, afero.NewOsFs())
+func inferDeploySection(cwd string, envManager *env.Manager) (*model.DeployInfo, error) {
+	m, err := model.GetInferredManifest(cwd, afero.NewOsFs(), envManager)
 	if err != nil {
 		return nil, err
 	}
@@ -480,7 +482,7 @@ func inferDeploySection(cwd string) (*model.DeployInfo, error) {
 	}, nil
 }
 
-func inferDevsSection(cwd string) (model.ManifestDevs, error) {
+func inferDevsSection(cwd string, envManager *env.Manager) (model.ManifestDevs, error) {
 	files, err := os.ReadDir(cwd)
 	if err != nil {
 		return nil, err
@@ -491,7 +493,7 @@ func inferDevsSection(cwd string) (model.ManifestDevs, error) {
 		if !f.IsDir() {
 			continue
 		}
-		dev, err := model.GetManifestV2(f.Name(), afero.NewOsFs())
+		dev, err := model.GetManifestV2(f.Name(), afero.NewOsFs(), envManager)
 		if err != nil {
 			oktetoLog.Debugf("could not detect any okteto manifest on %s", f.Name())
 			continue
@@ -505,7 +507,7 @@ func inferDevsSection(cwd string) (model.ManifestDevs, error) {
 	return devs, nil
 }
 
-func (mc *Command) getManifest(path string, fs afero.Fs) (*model.Manifest, error) {
+func (mc *Command) getManifest(path string, fs afero.Fs, envManager *env.Manager) (*model.Manifest, error) {
 	if mc.manifest != nil {
 		// Deepcopy so it does not get overwritten these changes
 		manifest := *mc.manifest
@@ -525,7 +527,7 @@ func (mc *Command) getManifest(path string, fs afero.Fs) (*model.Manifest, error
 		manifest.Deploy = d
 		return &manifest, nil
 	}
-	return model.GetManifestV2(path, fs)
+	return model.GetManifestV2(path, fs, envManager)
 }
 
 func configureAutoCreateDev(manifest *model.Manifest) error {

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -21,6 +21,7 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -36,7 +37,7 @@ type CreateOptions struct {
 }
 
 // Create creates a namespace
-func Create(ctx context.Context) *cobra.Command {
+func Create(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	options := &CreateOptions{
 		Show: false,
 	}
@@ -44,14 +45,14 @@ func Create(ctx context.Context) *cobra.Command {
 		Use:   "create <name>",
 		Short: "Create a namespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 			options.Namespace = args[0]
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"
@@ -35,13 +36,13 @@ import (
 )
 
 // Delete deletes a namespace
-func Delete(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
+func Delete(ctx context.Context, k8sLogger *io.K8sLogger, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <name>",
 		Short: "Delete a namespace",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 
@@ -54,7 +55,7 @@ func Delete(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -21,20 +21,21 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
 
 // List all namespace in current context
-func List(ctx context.Context) *cobra.Command {
+func List(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
 		Short:   "List namespaces managed by Okteto in your current context",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 
@@ -42,7 +43,7 @@ func List(ctx context.Context) *cobra.Command {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/namespace/sleep.go
+++ b/cmd/namespace/sleep.go
@@ -19,6 +19,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -26,13 +27,13 @@ import (
 )
 
 // Sleep sleeps a namespace
-func Sleep(ctx context.Context) *cobra.Command {
+func Sleep(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sleep <name>",
 		Short: "Sleeps a namespace",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 
@@ -45,7 +46,7 @@ func Sleep(ctx context.Context) *cobra.Command {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -20,6 +20,7 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -36,7 +37,7 @@ type UseOptions struct {
 }
 
 // Use sets the namespace of current context
-func Use(ctx context.Context) *cobra.Command {
+func Use(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	options := &UseOptions{}
 	cmd := &cobra.Command{
 		Use:     "use [namespace]",
@@ -57,7 +58,7 @@ func Use(ctx context.Context) *cobra.Command {
 				namespace = okteto.GetContext().PersonalNamespace
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/namespace/wake.go
+++ b/cmd/namespace/wake.go
@@ -19,13 +19,14 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
 )
 
-func Wake(ctx context.Context) *cobra.Command {
+func Wake(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wake <name>",
 		Short: "Wakes a namespace",
@@ -35,14 +36,14 @@ func Wake(ctx context.Context) *cobra.Command {
 			if len(args) > 0 {
 				nsToWake = args[0]
 			}
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: nsToWake, Show: true}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{Namespace: nsToWake, Show: true}); err != nil {
 				return err
 			}
 
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -81,7 +82,7 @@ type DeployOptions struct {
 	ReuseParams  bool
 }
 
-func deploy(ctx context.Context) *cobra.Command {
+func deploy(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	flags := &deployFlags{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
@@ -97,7 +98,7 @@ func deploy(ctx context.Context) *cobra.Command {
 				Namespace: ctxResource.Namespace,
 				Show:      true,
 			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, ctxOptions); err != nil {
 				return err
 			}
 

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -24,6 +24,7 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/devenvironment"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -51,7 +52,7 @@ type DestroyOptions struct {
 	Timeout        time.Duration
 }
 
-func destroy(ctx context.Context) *cobra.Command {
+func destroy(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	flags := &destroyFlags{}
 
 	cmd := &cobra.Command{
@@ -68,7 +69,7 @@ func destroy(ctx context.Context) *cobra.Command {
 				Namespace: ctxResource.Namespace,
 				Show:      true,
 			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, ctxOptions); err != nil {
 				return err
 			}
 

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -26,6 +26,7 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
 	"github.com/okteto/okteto/pkg/model"
@@ -54,7 +55,7 @@ type pipelineListItem struct {
 	Labels     []string `json:"labels" yaml:"labels"`
 }
 
-func list(ctx context.Context) *cobra.Command {
+func list(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	flags := &listFlags{}
 
 	cmd := &cobra.Command{
@@ -62,7 +63,7 @@ func list(ctx context.Context) *cobra.Command {
 		Short: "List all okteto pipelines",
 		Args:  utils.NoArgsAccepted(""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return pipelineListCommandHandler(ctx, flags, contextCMD.NewContextCommand().Run)
+			return pipelineListCommandHandler(ctx, flags, contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run)
 		},
 	}
 

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
@@ -52,14 +53,14 @@ func NewCommand() (*Command, error) {
 }
 
 // Pipeline pipeline management commands
-func Pipeline(ctx context.Context) *cobra.Command {
+func Pipeline(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
 		Short: "Pipeline management commands",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#pipeline"),
 	}
-	cmd.AddCommand(deploy(ctx))
-	cmd.AddCommand(destroy(ctx))
-	cmd.AddCommand(list(ctx))
+	cmd.AddCommand(deploy(ctx, envManager))
+	cmd.AddCommand(destroy(ctx, envManager))
+	cmd.AddCommand(list(ctx, envManager))
 	return cmd
 }

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -53,7 +54,7 @@ type DeployOptions struct {
 }
 
 // Deploy Deploy a preview environment
-func Deploy(ctx context.Context) *cobra.Command {
+func Deploy(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	opts := &DeployOptions{}
 	cmd := &cobra.Command{
 		Use:   "deploy <name>",
@@ -69,7 +70,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 			oktetoLog.Information("Using %s @ %s as context", opts.name, okteto.RemoveSchema(okteto.GetContext().Name))

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -54,7 +55,7 @@ type DestroyOptions struct {
 }
 
 // Destroy destroy a preview
-func Destroy(ctx context.Context) *cobra.Command {
+func Destroy(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	opts := &DestroyOptions{}
 	cmd := &cobra.Command{
 		Use:   "destroy <name>",
@@ -68,7 +69,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 			oktetoLog.Information("Using %s @ %s as context", opts.name, okteto.RemoveSchema(okteto.GetContext().Name))

--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -24,6 +24,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -32,7 +33,7 @@ import (
 )
 
 // Endpoints show all the endpoints of a preview environment
-func Endpoints(ctx context.Context) *cobra.Command {
+func Endpoints(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	var output string
 
 	cmd := &cobra.Command{
@@ -53,7 +54,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 				oktetoLog.SetOutput(jsonContextBuffer)
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 			if output != "json" {

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -22,6 +22,7 @@ import (
 	"text/tabwriter"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
@@ -59,7 +60,7 @@ func newListPreviewCommand(okClient types.OktetoInterface, flags *listFlags) *li
 }
 
 // List lists all the previews
-func List(ctx context.Context) *cobra.Command {
+func List(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	flags := &listFlags{}
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -71,7 +72,7 @@ func List(ctx context.Context) *cobra.Command {
 				ctxOptions.Show = true
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, ctxOptions); err != nil {
 				return err
 			}
 

--- a/cmd/preview/preview.go
+++ b/cmd/preview/preview.go
@@ -16,6 +16,7 @@ package preview
 import (
 	"context"
 
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
@@ -37,17 +38,17 @@ func NewCommand() (*Command, error) {
 }
 
 // Preview preview management commands
-func Preview(ctx context.Context) *cobra.Command {
+func Preview(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "preview",
 		Short: "Preview environment management commands",
 	}
 
-	cmd.AddCommand(Deploy(ctx))
-	cmd.AddCommand(Destroy(ctx))
-	cmd.AddCommand(List(ctx))
-	cmd.AddCommand(Endpoints(ctx))
-	cmd.AddCommand(Sleep(ctx))
-	cmd.AddCommand(Wake(ctx))
+	cmd.AddCommand(Deploy(ctx, envManager))
+	cmd.AddCommand(Destroy(ctx, envManager))
+	cmd.AddCommand(List(ctx, envManager))
+	cmd.AddCommand(Endpoints(ctx, envManager))
+	cmd.AddCommand(Sleep(ctx, envManager))
+	cmd.AddCommand(Wake(ctx, envManager))
 	return cmd
 }

--- a/cmd/preview/sleep.go
+++ b/cmd/preview/sleep.go
@@ -19,6 +19,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -26,14 +27,14 @@ import (
 )
 
 // Sleep sleeps a preview environment
-func Sleep(ctx context.Context) *cobra.Command {
+func Sleep(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sleep <name>",
 		Short: "Sleeps a preview environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prToSleep := args[0]
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 

--- a/cmd/preview/wake.go
+++ b/cmd/preview/wake.go
@@ -19,6 +19,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -26,14 +27,14 @@ import (
 )
 
 // Wake wakes a preview environment
-func Wake(ctx context.Context) *cobra.Command {
+func Wake(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wake <name>",
 		Short: "Wakes a preview environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prToWake := args[0]
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -56,7 +56,7 @@ type pushOptions struct {
 }
 
 // Push builds, pushes and redeploys the target app
-func Push(ctx context.Context) *cobra.Command {
+func Push(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	pushOpts := &pushOptions{}
 	cmd := &cobra.Command{
 		Hidden: true,
@@ -89,7 +89,7 @@ func Push(ctx context.Context) *cobra.Command {
 				Namespace: ctxResource.Namespace,
 				Show:      true,
 			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+			if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, ctxOptions); err != nil {
 				return err
 			}
 

--- a/cmd/registrytoken/registrytoken.go
+++ b/cmd/registrytoken/registrytoken.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-credential-helpers/credentials"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/pkg/auth/dockercredentials"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/cobra"
@@ -46,7 +47,7 @@ func (r regCreds) GetRegistryCredentials(host string) (string, string, error) {
 	return r.GetExternalRegistryCredentials(host)
 }
 
-func RegistryToken(ctx context.Context) *cobra.Command {
+func RegistryToken(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "registrytoken",
 		Short: "docker credentials helper for private registries registered in okteto",
@@ -66,7 +67,7 @@ More info about docker credentials helpers here: https://github.com/docker/docke
 	}
 
 	cmd.Run = func(_ *cobra.Command, args []string) {
-		if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
+		if err := contextCMD.NewContextCommand(contextCMD.WithEnvManger(envManager)).Run(ctx, &contextCMD.Options{}); err != nil {
 			_, _ = fmt.Fprintln(os.Stdout, err)
 			os.Exit(1) // skipcq: RVV-A0003
 		}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -23,6 +23,7 @@ import (
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/pods"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -33,7 +34,7 @@ import (
 )
 
 // Restart restarts the pods of a given dev mode deployment
-func Restart() *cobra.Command {
+func Restart(envManager *env.Manager) *cobra.Command {
 	var namespace string
 	var k8sContext string
 	var devPath string
@@ -47,7 +48,7 @@ func Restart() *cobra.Command {
 			ctx := context.Background()
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: devPath, Namespace: namespace, K8sContext: k8sContext}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack/destroy.go
+++ b/cmd/stack/destroy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/stack"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/spf13/afero"
@@ -28,7 +29,7 @@ import (
 )
 
 // Destroy destroys a stack
-func Destroy(ctx context.Context) *cobra.Command {
+func Destroy(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	var stackPath []string
 	var name string
 	var namespace string
@@ -46,7 +47,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 				}
 				stackPath[0] = model.GetManifestPathFromWorkdir(stackPath[0], workdir)
 			}
-			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath, afero.NewOsFs())
+			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack/endpoints.go
+++ b/cmd/stack/endpoints.go
@@ -19,6 +19,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/pkg/cmd/stack"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -27,7 +28,7 @@ import (
 )
 
 // Endpoints show all the endpoints of a stack
-func Endpoints(ctx context.Context) *cobra.Command {
+func Endpoints(ctx context.Context, envManager *env.Manager) *cobra.Command {
 	var (
 		output    string
 		name      string
@@ -39,7 +40,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 		Short: "Show endpoints for a stack",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Warning("'okteto stack endpoints' is deprecated and will be removed in a future version")
-			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath, afero.NewOsFs())
+			s, err := contextCMD.LoadStackWithContext(ctx, name, namespace, stackPath, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/spf13/cobra"
 )
@@ -27,15 +28,15 @@ type analyticsTrackerInterface interface {
 }
 
 // Stack stack management commands
-func Stack(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
+func Stack(ctx context.Context, at analyticsTrackerInterface, ioCtrl *io.Controller, envManager *env.Manager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "stack",
 		Short:  "Stack management commands",
 		Args:   utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy"),
 		Hidden: true,
 	}
-	cmd.AddCommand(deploy(ctx, at, ioCtrl))
-	cmd.AddCommand(Destroy(ctx))
-	cmd.AddCommand(Endpoints(ctx))
+	cmd.AddCommand(deploy(ctx, at, ioCtrl, envManager))
+	cmd.AddCommand(Destroy(ctx, envManager))
+	cmd.AddCommand(Endpoints(ctx, envManager))
 	return cmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/status"
 	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -38,7 +39,7 @@ const (
 )
 
 // Status returns the status of the synchronization process
-func Status() *cobra.Command {
+func Status(envManager *env.Manager) *cobra.Command {
 	var devPath string
 	var namespace string
 	var k8sContext string
@@ -57,7 +58,7 @@ func Status() *cobra.Command {
 			ctx := context.Background()
 
 			manifestOpts := contextCMD.ManifestOptions{Filename: devPath, Namespace: namespace, K8sContext: k8sContext}
-			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs())
+			manifest, err := contextCMD.LoadManifestWithContext(ctx, manifestOpts, afero.NewOsFs(), envManager)
 			if err != nil {
 				return err
 			}

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -29,6 +29,7 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
@@ -40,7 +41,6 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/ssh"
-	"github.com/okteto/okteto/pkg/types"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -160,7 +160,7 @@ type imageGetterInterface interface {
 }
 
 type secretsGetterInterface interface {
-	GetUserSecrets(context.Context) ([]types.Secret, error)
+	GetUserSecrets(context.Context) ([]env.Var, error)
 }
 
 type devContainerEnvGetter struct{}
@@ -220,6 +220,7 @@ func (eg *envsGetter) getEnvs(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 
+	fmt.Println("DEBUG!!! GET ENV")
 	svcImage := apps.GetDevContainer(app.PodSpec(), "").Image
 	imageEnvs, err := eg.imageEnvsGetter.getEnvsFromImage(svcImage)
 	if err != nil {

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
-	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -828,10 +827,10 @@ func TestGetEnvsFromDevContainer(t *testing.T) {
 
 type fakeUserSecretsGetter struct {
 	err     error
-	secrets []types.Secret
+	secrets []env.Var
 }
 
-func (fusg fakeUserSecretsGetter) GetUserSecrets(context.Context) ([]types.Secret, error) {
+func (fusg fakeUserSecretsGetter) GetUserSecrets(context.Context) ([]env.Var, error) {
 	return fusg.secrets, fusg.err
 }
 
@@ -857,7 +856,7 @@ func TestGetEnvsFromSecrets(t *testing.T) {
 			name:     "with user secrets",
 			isOkteto: true,
 			fakeSecretsGetter: fakeUserSecretsGetter{
-				secrets: []types.Secret{
+				secrets: []env.Var{
 					{
 						Name:  "FROMSECRETSTORE",
 						Value: "AVALUE",

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -343,7 +343,7 @@ func TestCommandAddedToUpOptionsWhenPassedAsFlag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			cmd := Up(nil, io.NewIOController(), nil)
+			cmd := Up(nil, io.NewIOController(), nil, nil)
 			for _, val := range tt.command {
 				err := cmd.Flags().Set("command", val)
 				if err != nil {

--- a/integration/commands/build.go
+++ b/integration/commands/build.go
@@ -41,6 +41,13 @@ func RunOktetoBuild(oktetoPath string, buildOptions *BuildOptions) error {
 	return ExecOktetoBuildCmd(cmd)
 }
 
+// RunOktetoBuildWithOutput runs an okteto build command and returns the output of the command
+func RunOktetoBuildWithOutput(oktetoPath string, buildOptions *BuildOptions) (string, error) {
+	cmd := GetOktetoBuildCmd(oktetoPath, buildOptions)
+	o, err := cmd.CombinedOutput()
+	return string(o), err
+}
+
 // GetOktetoBuildCmd returns an exec.Cmd with the needed values given buildOpts
 func GetOktetoBuildCmd(oktetoPath string, buildOptions *BuildOptions) *exec.Cmd {
 	cmd := exec.Command(oktetoPath)

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -40,35 +40,9 @@ type DeployOptions struct {
 	IsRemote         bool
 }
 
-// DestroyOptions defines the options that can be added to a deploy command
-type DestroyOptions struct {
-	Workdir      string
-	ManifestPath string
-	Namespace    string
-	OktetoHome   string
-	Token        string
-	Name         string
-	IsRemote     bool
-}
-
-// GetOktetoDeployCmdOutput runs an okteto deploy command
-func GetOktetoDeployCmdOutput(oktetoPath string, deployOptions *DeployOptions) ([]byte, error) {
-	cmd := getDeployCmd(oktetoPath, deployOptions)
-	log.Printf("Running '%s'", cmd.String())
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return output, err
-	}
-	log.Printf("okteto deploy success")
-	return output, nil
-}
-
 // RunOktetoDeploy runs an okteto deploy command
 func RunOktetoDeploy(oktetoPath string, deployOptions *DeployOptions) error {
-	output, err := GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
-	if err != nil {
-		return fmt.Errorf("okteto deploy failed: %s - %w", string(output), err)
-	}
+	_, err := RunOktetoDeployAndGetOutput(oktetoPath, deployOptions)
 	return err
 }
 
@@ -82,75 +56,6 @@ func RunOktetoDeployAndGetOutput(oktetoPath string, deployOptions *DeployOptions
 	}
 	log.Printf("okteto deploy success")
 	return string(o), nil
-}
-
-// RunOktetoDestroy runs an okteto destroy command
-func RunOktetoDestroy(oktetoPath string, destroyOptions *DestroyOptions) error {
-	log.Printf("okteto destroy %s", oktetoPath)
-	cmd := getDestroyCmd(oktetoPath, destroyOptions)
-	o, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
-	}
-	log.Printf("okteto destroy success")
-	return nil
-}
-
-// RunOktetoDestroyAndGetOutput runs an okteto destroy command and returns the output
-func RunOktetoDestroyAndGetOutput(oktetoPath string, destroyOptions *DestroyOptions) (string, error) {
-	cmd := getDestroyCmd(oktetoPath, destroyOptions)
-	log.Printf("Running '%s'", cmd.String())
-	o, err := cmd.CombinedOutput()
-	if err != nil {
-		return string(o), fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
-	}
-	log.Printf("okteto deploy success")
-	return string(o), nil
-}
-
-// RunOktetoDestroyRemote runs an okteto destroy command in remote
-func RunOktetoDestroyRemote(oktetoPath string, destroyOptions *DestroyOptions) error {
-	log.Printf("okteto destroy %s", oktetoPath)
-	cmd := getDestroyCmd(oktetoPath, destroyOptions)
-	cmd.Args = append(cmd.Args, "--remote")
-
-	o, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("okteto deploy --remote failed: %s - %w", string(o), err)
-	}
-	log.Printf("okteto destroy success")
-	return nil
-}
-
-func getDestroyCmd(oktetoPath string, destroyOptions *DestroyOptions) *exec.Cmd {
-	cmd := exec.Command(oktetoPath, "destroy")
-	if destroyOptions.Workdir != "" {
-		cmd.Dir = destroyOptions.Workdir
-	}
-	if destroyOptions.Name != "" {
-		cmd.Args = append(cmd.Args, "--name", destroyOptions.Name)
-	}
-	if destroyOptions.ManifestPath != "" {
-		cmd.Args = append(cmd.Args, "-f", destroyOptions.ManifestPath)
-	}
-	if destroyOptions.Namespace != "" {
-		cmd.Args = append(cmd.Args, "--namespace", destroyOptions.Namespace)
-	}
-	if destroyOptions.IsRemote {
-		cmd.Args = append(cmd.Args, "--remote")
-	}
-	cmd.Env = os.Environ()
-	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))
-	}
-
-	if destroyOptions.OktetoHome != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, destroyOptions.OktetoHome))
-	}
-	if destroyOptions.Token != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, destroyOptions.Token))
-	}
-	return cmd
 }
 
 func getDeployCmd(oktetoPath string, deployOptions *DeployOptions) *exec.Cmd {

--- a/integration/commands/destroy.go
+++ b/integration/commands/destroy.go
@@ -1,0 +1,104 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/model"
+)
+
+// DestroyOptions defines the options that can be added to a deploy command
+type DestroyOptions struct {
+	Workdir      string
+	ManifestPath string
+	Namespace    string
+	OktetoHome   string
+	Token        string
+	Name         string
+	IsRemote     bool
+}
+
+// RunOktetoDestroy runs an okteto destroy command
+func RunOktetoDestroy(oktetoPath string, destroyOptions *DestroyOptions) error {
+	log.Printf("okteto destroy %s", oktetoPath)
+	cmd := getDestroyCmd(oktetoPath, destroyOptions)
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("okteto deploy failed: %s - %w", string(o), err)
+	}
+	log.Printf("okteto destroy success")
+	return nil
+}
+
+// RunOktetoDestroyAndGetOutput runs an okteto destroy command and returns the output
+func RunOktetoDestroyAndGetOutput(oktetoPath string, destroyOptions *DestroyOptions) (string, error) {
+	cmd := getDestroyCmd(oktetoPath, destroyOptions)
+	log.Printf("Running '%s'", cmd.String())
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(o), fmt.Errorf("okteto destroy failed: %s - %w", string(o), err)
+	}
+	log.Printf("okteto destroy success")
+	return string(o), nil
+}
+
+// RunOktetoDestroyRemote runs an okteto destroy command in remote
+func RunOktetoDestroyRemote(oktetoPath string, destroyOptions *DestroyOptions) error {
+	log.Printf("okteto destroy %s", oktetoPath)
+	cmd := getDestroyCmd(oktetoPath, destroyOptions)
+	cmd.Args = append(cmd.Args, "--remote")
+
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("okteto deploy --remote failed: %s - %w", string(o), err)
+	}
+	log.Printf("okteto destroy success")
+	return nil
+}
+
+func getDestroyCmd(oktetoPath string, destroyOptions *DestroyOptions) *exec.Cmd {
+	cmd := exec.Command(oktetoPath, "destroy")
+	if destroyOptions.Workdir != "" {
+		cmd.Dir = destroyOptions.Workdir
+	}
+	if destroyOptions.Name != "" {
+		cmd.Args = append(cmd.Args, "--name", destroyOptions.Name)
+	}
+	if destroyOptions.ManifestPath != "" {
+		cmd.Args = append(cmd.Args, "-f", destroyOptions.ManifestPath)
+	}
+	if destroyOptions.Namespace != "" {
+		cmd.Args = append(cmd.Args, "--namespace", destroyOptions.Namespace)
+	}
+	if destroyOptions.IsRemote {
+		cmd.Args = append(cmd.Args, "--remote")
+	}
+	cmd.Env = os.Environ()
+	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))
+	}
+
+	if destroyOptions.OktetoHome != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, destroyOptions.OktetoHome))
+	}
+	if destroyOptions.Token != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, destroyOptions.Token))
+	}
+	return cmd
+}

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -534,7 +534,7 @@ services:
 		OktetoHome: dir,
 		Token:      token,
 	}
-	output, err := commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
+	output, err := commands.RunOktetoDeployAndGetOutput(oktetoPath, deployOptions)
 	require.Error(t, err)
 	require.Contains(t, strings.ToLower(string(output)), "invalid depends_on: service 'app' depends on service 'nginx' which is undefined")
 
@@ -545,7 +545,7 @@ services:
 		Token:        token,
 		ManifestPath: "docker-compose.yml",
 	}
-	output, err = commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptionsWithFile)
+	output, err = commands.RunOktetoDeployAndGetOutput(oktetoPath, deployOptionsWithFile)
 	require.Error(t, err)
 	require.Contains(t, strings.ToLower(string(output)), "invalid depends_on: service 'app' depends on service 'nginx' which is undefined")
 }

--- a/integration/deploy/variables_test.go
+++ b/integration/deploy/variables_test.go
@@ -47,8 +47,8 @@ const (
 )
 
 // TestDeployAndDestroyOktetoManifestWithEnv tests the following scenario:
-// - Deploying a okteto manifest locally with masked variables
-// - Destroying a okteto manifest locally with masked variables
+// - Deploying an okteto manifest locally with masked variables
+// - Destroying an okteto manifest locally with masked variables
 func TestDeployAndDestroyOktetoManifestWithEnv(t *testing.T) {
 	t.Parallel()
 	oktetoPath, err := integration.GetOktetoPath()

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	dockertypes "github.com/docker/cli/cli/config/types"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/types"
 )
 
@@ -24,7 +25,7 @@ import (
 type FakeUserClient struct {
 	errGetUserSecrets error
 	userCtx           *types.UserContext
-	userSecrets       []types.Secret
+	userSecrets       []env.Var
 	err               []error
 }
 
@@ -48,7 +49,7 @@ func (c *FakeUserClient) GetContext(_ context.Context, _ string) (*types.UserCon
 	return c.userCtx, nil
 }
 
-func (c *FakeUserClient) GetUserSecrets(_ context.Context) ([]types.Secret, error) {
+func (c *FakeUserClient) GetUserSecrets(_ context.Context) ([]env.Var, error) {
 	if c.errGetUserSecrets != nil {
 		return nil, c.errGetUserSecrets
 	}

--- a/pkg/discovery/errors.go
+++ b/pkg/discovery/errors.go
@@ -30,6 +30,8 @@ var (
 		E:    errors.New("could not detect any okteto manifest"),
 		Hint: "If you have an okteto manifest file, use the flag '--file' to point to your okteto manifest file",
 	}
+	// ErrOktetoManifestNotV1 is returned by GetManiestV1 when the manifest is not a v1 manifest
+	ErrOktetoManifestNotV1 = errors.New("okteto manifest is not a v1 manifest")
 	// ErrOktetoPipelineManifestNotFound is raised when discovery package could not found any okteto pipeline manifest
 	ErrOktetoPipelineManifestNotFound = errors.New("could not detect any okteto pipeline manifest")
 	// ErrHelmChartNotFound is raised when discovery package could not found any helm chart

--- a/pkg/env/manager.go
+++ b/pkg/env/manager.go
@@ -1,0 +1,153 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Vars in groups with higher priority override those with lower priority
+const (
+	PriorityVarFromFlag     = 1
+	PriorityVarFromLocal    = 2
+	PriorityVarFromManifest = 3
+	PriorityVarFromPlatform = 4
+)
+
+type ConfigItem struct {
+	Name   string
+	Masked bool
+}
+
+type Priority int
+
+var config = map[Priority]ConfigItem{
+	PriorityVarFromFlag:     {Name: "as --var", Masked: true},
+	PriorityVarFromLocal:    {Name: "locally or in the catalog", Masked: false},
+	PriorityVarFromManifest: {Name: "in the manifest", Masked: true},
+	PriorityVarFromPlatform: {Name: "in the Okteto Platform", Masked: true},
+}
+
+type LookupEnvFunc func(key string) (string, bool)
+type SetEnvFunc func(key, value string) error
+type MaskVarFunc func(name string)
+type WarningLogFunc func(format string, args ...interface{})
+
+type group struct {
+	Vars     []Var
+	Priority Priority
+}
+
+type ManagerInterface interface {
+	LookupEnv(key string) (string, bool)
+	SetEnv(key, value string) error
+	MaskVar(value string)
+	WarningLogf(format string, args ...interface{})
+}
+
+type Manager struct {
+	envManager ManagerInterface
+	groups     []group
+	mu         sync.Mutex
+}
+
+// NewEnvManager creates a new environment variables manager
+func NewEnvManager(m ManagerInterface) *Manager {
+	return &Manager{
+		envManager: m,
+	}
+}
+
+func (m *Manager) AddGroup(vars []Var, priority Priority) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	g := group{
+		Vars:     vars,
+		Priority: priority,
+	}
+	m.groups = append(m.groups, g)
+
+	if config[g.Priority].Masked {
+		for _, v := range vars {
+			m.envManager.MaskVar(v.Value)
+		}
+	}
+
+	m.sortGroupsByPriorityDesc()
+}
+
+// sortGroupsByPriorityDesc sorts the groups by priority descending, so higher priority variables override lower priority ones.
+func (m *Manager) sortGroupsByPriorityDesc() {
+	sort.Slice(m.groups, func(i, j int) bool {
+		return m.groups[i].Priority > m.groups[j].Priority
+	})
+}
+
+// Export exports the environment variables to the current process
+func (m *Manager) Export() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, g := range m.groups {
+		for _, v := range g.Vars {
+			err := m.envManager.SetEnv(v.Name, v.Value)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// WarnVarsPrecedence prints out a warning message clarifying which variables take precedence over others in case a variables has been defined in multiple groups
+func (m *Manager) WarnVarsPrecedence() {
+	warnings := make(map[string]string)
+	exportedVars := make(map[string]Priority)
+
+	for _, g := range m.groups {
+		for _, v := range g.Vars {
+			if priority, exported := exportedVars[v.Name]; exported {
+				if priority > g.Priority {
+					prevGroupName := config[priority].Name
+					currentGroupName := config[g.Priority].Name
+					warnings[v.Name] = fmt.Sprintf("Variable '%s' defined %s takes precedence over the same variable defined %s, which will be ignored", v.Name, currentGroupName, prevGroupName)
+				}
+			}
+			exportedVars[v.Name] = g.Priority
+		}
+	}
+
+	for _, w := range warnings {
+		m.envManager.WarningLogf(w)
+	}
+}
+
+func CreateGroupFromLocalVars(environ func() []string) []Var {
+	envVars := environ()
+	vars := make([]Var, 0, len(envVars))
+
+	for _, envVar := range envVars {
+		variableFormatParts := 2
+		parts := strings.SplitN(envVar, "=", variableFormatParts)
+		if len(parts) == variableFormatParts {
+			vars = append(vars, Var{Name: parts[0], Value: parts[1]})
+		}
+	}
+
+	return vars
+}

--- a/pkg/env/manager_test.go
+++ b/pkg/env/manager_test.go
@@ -1,0 +1,162 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeEnvManager struct {
+	t           *testing.T
+	maskedWords []string
+	logs        []string
+}
+
+func (*fakeEnvManager) LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+func (e *fakeEnvManager) SetEnv(key, value string) error {
+	e.t.Setenv(key, value)
+	return nil
+}
+func (e *fakeEnvManager) MaskVar(value string) {
+	e.maskedWords = append(e.maskedWords, value)
+}
+func (e *fakeEnvManager) WarningLogf(msg string, _ ...interface{}) {
+	e.logs = append(e.logs, msg)
+}
+func (*fakeEnvManager) WarnVarsPrecedence() {}
+
+func newFakeEnvManager(t *testing.T) *fakeEnvManager {
+	return &fakeEnvManager{
+		t: t,
+	}
+}
+
+func varExists(key string) bool {
+	_, exists := os.LookupEnv(key)
+	return exists
+}
+
+func Test_EnvManager(t *testing.T) {
+	fakeEnvManager := newFakeEnvManager(t)
+
+	t.Run("empty env manager", func(t *testing.T) {
+		envManager := NewEnvManager(fakeEnvManager)
+		err := envManager.Export()
+		assert.NoError(t, err)
+
+		var emptyGroup []Var
+
+		envManager.AddGroup(emptyGroup, PriorityVarFromLocal)
+		err = envManager.Export()
+		assert.NoError(t, err)
+	})
+
+	t.Run("add multiple groups and lookup var with higher priority successfully", func(t *testing.T) {
+		fakeGroupVarsFromPlatform := []Var{
+			{
+				Name:  "TEST_VAR_1",
+				Value: "platform-value1",
+			},
+			{
+				Name:  "TEST_VAR_2",
+				Value: "platform-value2",
+			},
+		}
+
+		fakeGroupVarsFromManifest := []Var{
+			{
+				Name:  "TEST_VAR_1",
+				Value: "manifest-value1",
+			},
+		}
+
+		fakeGroupVarsFromLoal := []Var{
+			{
+				Name:  "TEST_VAR_1",
+				Value: "local-value1",
+			},
+		}
+
+		fakeGroupVarsFromFlag := []Var{
+			{
+				Name:  "TEST_VAR_1",
+				Value: "flag-value1",
+			},
+		}
+
+		// making sure these vars are not set
+		assert.Equal(t, false, varExists("TEST_VAR_1"))
+		assert.Equal(t, false, varExists("TEST_VAR_2"))
+		assert.Equal(t, false, varExists("TEST_VAR_3"))
+
+		envManager := NewEnvManager(fakeEnvManager)
+		envManager.AddGroup(fakeGroupVarsFromPlatform, PriorityVarFromPlatform)
+		assert.NoError(t, envManager.Export())
+		assert.Equal(t, "platform-value1", os.Getenv("TEST_VAR_1"))
+
+		envManager.AddGroup(fakeGroupVarsFromManifest, PriorityVarFromManifest)
+
+		// until we export, the value stays the same
+		assert.Equal(t, "platform-value1", os.Getenv("TEST_VAR_1"))
+
+		assert.NoError(t, envManager.Export())
+		assert.Equal(t, "manifest-value1", os.Getenv("TEST_VAR_1"))
+
+		envManager.AddGroup(fakeGroupVarsFromLoal, PriorityVarFromLocal)
+		assert.NoError(t, envManager.Export())
+		assert.Equal(t, "local-value1", os.Getenv("TEST_VAR_1"))
+
+		envManager.AddGroup(fakeGroupVarsFromFlag, PriorityVarFromFlag)
+		assert.NoError(t, envManager.Export())
+		assert.Equal(t, "flag-value1", os.Getenv("TEST_VAR_1"))
+
+		// no other groups override the value
+		assert.Equal(t, "platform-value2", os.Getenv("TEST_VAR_2"))
+
+		// make sure values are obfuscated
+		// note: currently local vars are not obsucated so "local-value1" should not be in the list
+		expectedMaskedValues := []string{"platform-value1", "platform-value2", "manifest-value1", "flag-value1"}
+		assert.ElementsMatch(t, expectedMaskedValues, fakeEnvManager.maskedWords, "Masked words should match expected values")
+	})
+}
+
+func Test_CreateGroupFromLocalVars(t *testing.T) {
+	t.Run("create group from local vars", func(t *testing.T) {
+		fakeLocalVars := []string{
+			"TEST_VAR_1=local-value1",
+			"TEST_VAR_2=local-value2",
+		}
+
+		fakeLocalGroup := CreateGroupFromLocalVars(func() []string {
+			return fakeLocalVars
+		})
+
+		assert.Equal(t, 2, len(fakeLocalGroup))
+		assert.ElementsMatch(t, []Var{
+			{
+				Name:  "TEST_VAR_1",
+				Value: "local-value1",
+			},
+			{
+				Name:  "TEST_VAR_2",
+				Value: "local-value2",
+			},
+		}, fakeLocalGroup)
+	})
+}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -28,6 +28,7 @@ import (
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/okteto/okteto/pkg/vars"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1284,7 +1285,7 @@ func Test_getInferredManifestFromK8sManifestFile(t *testing.T) {
 			t.Fatalf("Error closing file %s: %s", fullpath, err)
 		}
 	}()
-	_, err = GetInferredManifest(wd, afero.NewMemMapFs())
+	_, err = GetInferredManifest(wd, afero.NewMemMapFs(), nil)
 	assert.NoError(t, err)
 }
 
@@ -1300,7 +1301,7 @@ func Test_getInferredManifestFromK8sManifestFolder(t *testing.T) {
 		}
 	}()
 
-	_, err = GetInferredManifest(wd, afero.NewMemMapFs())
+	_, err = GetInferredManifest(wd, afero.NewMemMapFs(), nil)
 	assert.NoError(t, err)
 }
 
@@ -1336,7 +1337,7 @@ func Test_getInferredManifestFromHelmPath(t *testing.T) {
 					}
 				}()
 			}
-			_, err := GetInferredManifest(wd, afero.NewMemMapFs())
+			_, err := GetInferredManifest(wd, afero.NewMemMapFs(), nil)
 			assert.NoError(t, err)
 		})
 	}
@@ -1344,7 +1345,7 @@ func Test_getInferredManifestFromHelmPath(t *testing.T) {
 
 func Test_getInferredManifestWhenNoManifestExist(t *testing.T) {
 	wd := t.TempDir()
-	result, err := GetInferredManifest(wd, afero.NewMemMapFs())
+	result, err := GetInferredManifest(wd, afero.NewMemMapFs(), nil)
 	assert.Empty(t, result)
 	assert.ErrorIs(t, err, oktetoErrors.ErrCouldNotInferAnyManifest)
 }
@@ -1433,6 +1434,7 @@ func TestRead(t *testing.T) {
 				Manifest:      nil,
 				IsV2:          false,
 				Fs:            afero.NewOsFs(),
+				Variables:     vars.Vars{},
 			},
 		},
 		{
@@ -1464,6 +1466,7 @@ func TestRead(t *testing.T) {
 				Manifest:      []uint8{},
 				IsV2:          false,
 				Fs:            afero.NewOsFs(),
+				Variables:     vars.Vars{},
 			},
 		},
 		{
@@ -1570,8 +1573,9 @@ func TestRead(t *testing.T) {
   test:
     image: test-image
     context: ./test`),
-				IsV2: true,
-				Fs:   afero.NewOsFs(),
+				IsV2:      true,
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 			expectedErr: false,
 		},
@@ -1628,6 +1632,7 @@ func TestRead(t *testing.T) {
 				Type:          OktetoManifestType,
 				IsV2:          true,
 				Fs:            afero.NewOsFs(),
+				Variables:     vars.Vars{},
 				Manifest: []byte(`deploy:
   divert:
     namespace: staging

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/okteto/okteto/pkg/externalresource"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/okteto/okteto/pkg/vars"
 	apiv1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -758,6 +759,7 @@ type manifestRaw struct {
 	Dependencies  deps.ManifestSection     `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 	GlobalForward []forward.GlobalForward  `json:"forward,omitempty" yaml:"forward,omitempty"`
 	External      externalresource.Section `json:"external,omitempty" yaml:"external,omitempty"`
+	Variables     vars.Vars                `json:"variables,omitempty" yaml:"variables,omitempty"`
 
 	DeprecatedDevs []string `yaml:"devs"`
 }
@@ -778,6 +780,7 @@ func (m *Manifest) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Build:        map[string]*build.Info{},
 		Dependencies: deps.ManifestSection{},
 		External:     externalresource.Section{},
+		Variables:    vars.Vars{},
 	}
 	err = unmarshal(&manifest)
 	if err != nil {
@@ -795,6 +798,7 @@ func (m *Manifest) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	m.Name = manifest.Name
 	m.GlobalForward = manifest.GlobalForward
 	m.External = manifest.External
+	m.Variables = manifest.Variables
 
 	err = m.SanitizeSvcNames()
 	if err != nil {

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/externalresource"
 	"github.com/okteto/okteto/pkg/model/forward"
+	"github.com/okteto/okteto/pkg/vars"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1071,6 +1072,7 @@ deploy:
 				IsV2:         true,
 				Type:         OktetoManifestType,
 				Fs:           afero.NewOsFs(),
+				Variables:    vars.Vars{},
 			},
 			isErrorExpected: false,
 		},
@@ -1236,7 +1238,8 @@ dev:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
-				Fs: afero.NewOsFs(),
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 
 			isErrorExpected: false,
@@ -1322,7 +1325,8 @@ sync:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
-				Fs: afero.NewOsFs(),
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 			isErrorExpected: false,
 		},
@@ -1446,7 +1450,8 @@ services:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
-				Fs: afero.NewOsFs(),
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 			isErrorExpected: false,
 		},
@@ -1544,7 +1549,8 @@ dev:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
-				Fs: afero.NewOsFs(),
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 			isErrorExpected: false,
 		},
@@ -1700,7 +1706,8 @@ dev:
 						Mode:        constants.OktetoSyncModeFieldValue,
 					},
 				},
-				Fs: afero.NewOsFs(),
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 			isErrorExpected: false,
 		},
@@ -1746,7 +1753,8 @@ deploy:
 						},
 					},
 				},
-				Fs: afero.NewOsFs(),
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 			isErrorExpected: false,
 		},
@@ -1775,7 +1783,8 @@ devs:
 						},
 					},
 				},
-				Fs: afero.NewOsFs(),
+				Fs:        afero.NewOsFs(),
+				Variables: vars.Vars{},
 			},
 			isErrorExpected: false,
 		},

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -22,6 +22,7 @@ import (
 	dockertypes "github.com/docker/cli/cli/config/types"
 	dockercredentials "github.com/docker/docker-credential-helpers/credentials"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/shurcooL/graphql"
@@ -125,7 +126,7 @@ type contextFileJSON struct {
 	} `yaml:"contexts"`
 }
 
-// GetSecrets returns the secrets from Okteto API
+// GetContext returns the user context, credentials and secrets from Okteto API
 func (c *userClient) GetContext(ctx context.Context, ns string) (*types.UserContext, error) {
 	var queryStruct getContextQuery
 	variables := map[string]interface{}{
@@ -142,10 +143,10 @@ func (c *userClient) GetContext(ctx context.Context, ns string) (*types.UserCont
 		return nil, err
 	}
 
-	secrets := make([]types.Secret, 0)
+	secrets := make([]env.Var, 0)
 	for _, secret := range queryStruct.Secrets {
 		if !strings.Contains(string(secret.Name), ".") {
-			secrets = append(secrets, types.Secret{
+			secrets = append(secrets, env.Var{
 				Name:  string(secret.Name),
 				Value: string(secret.Value),
 			})
@@ -181,18 +182,18 @@ func (c *userClient) GetContext(ctx context.Context, ns string) (*types.UserCont
 	return result, nil
 }
 
-// GetSecrets returns the secrets from Okteto API
-func (c *userClient) GetUserSecrets(ctx context.Context) ([]types.Secret, error) {
+// GetUserSecrets returns the secrets from Okteto API
+func (c *userClient) GetUserSecrets(ctx context.Context) ([]env.Var, error) {
 	var queryStruct getSecretsQuery
 	err := query(ctx, &queryStruct, nil, c.client)
 	if err != nil {
 		return nil, err
 	}
 
-	secrets := make([]types.Secret, 0)
+	secrets := make([]env.Var, 0)
 	for _, secret := range queryStruct.Secrets {
 		if !strings.Contains(string(secret.Name), ".") {
-			secrets = append(secrets, types.Secret{
+			secrets = append(secrets, env.Var{
 				Name:  string(secret.Name),
 				Value: string(secret.Value),
 			})
@@ -213,10 +214,10 @@ func (c *userClient) deprecatedGetUserContext(ctx context.Context) (*types.UserC
 		return nil, err
 	}
 
-	secrets := make([]types.Secret, 0)
+	secrets := make([]env.Var, 0)
 	for _, secret := range queryStruct.Secrets {
 		if !strings.Contains(string(secret.Name), ".") {
-			secrets = append(secrets, types.Secret{
+			secrets = append(secrets, env.Var{
 				Name:  string(secret.Name),
 				Value: string(secret.Value),
 			})

--- a/pkg/okteto/secrets_test.go
+++ b/pkg/okteto/secrets_test.go
@@ -23,6 +23,7 @@ import (
 	dockertypes "github.com/docker/cli/cli/config/types"
 	dockercredentials "github.com/docker/docker-credential-helpers/credentials"
 	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/shurcooL/graphql"
@@ -107,7 +108,7 @@ func TestGetContext(t *testing.T) {
 						GlobalNamespace: "globalNs",
 						Analytics:       false,
 					},
-					Secrets: []types.Secret{
+					Secrets: []env.Var{
 						{
 							Name:  "name",
 							Value: "value",
@@ -173,7 +174,7 @@ func TestGetContext(t *testing.T) {
 						GlobalNamespace: constants.DefaultGlobalNamespace,
 						Analytics:       false,
 					},
-					Secrets: []types.Secret{
+					Secrets: []env.Var{
 						{
 							Name:  "name",
 							Value: "value",
@@ -247,7 +248,7 @@ func TestGetUserSecrets(t *testing.T) {
 	}
 	type expected struct {
 		err         error
-		userSecrets []types.Secret
+		userSecrets []env.Var
 	}
 	testCases := []struct {
 		cfg      input
@@ -285,7 +286,7 @@ func TestGetUserSecrets(t *testing.T) {
 				},
 			},
 			expected: expected{
-				userSecrets: []types.Secret{
+				userSecrets: []env.Var{
 					{
 						Name:  "password",
 						Value: "test",
@@ -381,7 +382,7 @@ func TestGetDeprecatedContext(t *testing.T) {
 						GlobalNamespace: constants.DefaultGlobalNamespace,
 						Analytics:       true,
 					},
-					Secrets: []types.Secret{
+					Secrets: []env.Var{
 						{
 							Name:  "name",
 							Value: "value",

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	dockertypes "github.com/docker/cli/cli/config/types"
+	"github.com/okteto/okteto/pkg/env"
 )
 
 // OktetoInterface represents the client that connects to the backend to create API calls
@@ -32,7 +33,7 @@ type OktetoInterface interface {
 
 // UserInterface represents the client that connects to the user functions
 type UserInterface interface {
-	GetUserSecrets(ctx context.Context) ([]Secret, error)
+	GetUserSecrets(ctx context.Context) ([]env.Var, error)
 	GetContext(ctx context.Context, ns string) (*UserContext, error)
 	GetClusterCertificate(ctx context.Context, cluster, ns string) ([]byte, error)
 	GetClusterMetadata(ctx context.Context, ns string) (ClusterMetadata, error)

--- a/pkg/types/user_context.go
+++ b/pkg/types/user_context.go
@@ -13,8 +13,10 @@
 
 package types
 
+import "github.com/okteto/okteto/pkg/env"
+
 type UserContext struct {
 	Credentials Credential `json:"credentials,omitempty"`
 	User        User       `json:"user,omitempty"`
-	Secrets     []Secret   `json:"secrets,omitempty"`
+	Secrets     []env.Var  `json:"secrets,omitempty"`
 }

--- a/pkg/vars/var.go
+++ b/pkg/vars/var.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Okteto Authors
+// Copyright 2024 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,10 +11,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package vars
 
-// Secret represents a secret
-type Secret struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+import "fmt"
+
+// Var represents a manifest variable
+type Var struct {
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
+}
+
+func (v Var) String() string {
+	return fmt.Sprintf("%s: %s", v.Name, v.Value)
+}
+
+// MarshalYAML Implements the marshaler interface of the yaml pkg.
+func (v Var) MarshalYAML() (interface{}, error) {
+	return v.String(), nil
 }

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -1,0 +1,74 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vars
+
+import (
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v2"
+)
+
+type ManifestVars struct {
+	Variables Vars `json:"variables,omitempty" yaml:"variables,omitempty"`
+}
+
+type Vars []Var
+
+func GetManifestVars(manifestPath string, fs afero.Fs) (Vars, error) {
+	b, err := afero.ReadFile(fs, manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var vars ManifestVars
+	err = yaml.Unmarshal(b, &vars)
+	if err != nil {
+		return nil, err
+	}
+
+	return vars.Variables, nil
+}
+
+// MarshalYAML Implements the marshaler interface of the yaml pkg.
+func (vars Vars) MarshalYAML() (interface{}, error) {
+	vMap := make(map[string]string)
+	for _, v := range vars {
+		vMap[v.Name] = v.Value
+	}
+	return vMap, nil
+}
+
+// UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.
+func (vars *Vars) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var rawVars map[string]string
+	if err := unmarshal(&rawVars); err != nil {
+		return err
+	}
+
+	for key, val := range rawVars {
+		*vars = append(*vars, Var{Name: key, Value: val})
+	}
+
+	return nil
+}
+
+func (vars *Vars) Expand(expandEnv func(string) (string, error)) error {
+	for i := range *vars {
+		expanded, err := expandEnv((*vars)[i].Value)
+		if err != nil {
+			return err
+		}
+		(*vars)[i].Value = expanded
+	}
+	return nil
+}

--- a/pkg/vars/vars_test.go
+++ b/pkg/vars/vars_test.go
@@ -1,0 +1,200 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vars
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/pkg/env"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func Test_Vars_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		expected    Vars
+		name        string
+		yaml        []byte
+		expectedErr bool
+	}{
+		{
+			name: "failed to deserialize",
+			yaml: []byte(`
+UNIT_TEST_VAR_1=value1
+`),
+			expectedErr: true,
+		},
+		{
+			name: "deserialized single var successfully",
+			yaml: []byte(`
+UNIT_TEST_VAR_1: value1
+`),
+			expected: Vars{
+				{
+					Name:  "UNIT_TEST_VAR_1",
+					Value: "value1",
+				},
+			},
+		},
+		{
+			name: "deserialized multiple vars successfully",
+			yaml: []byte(`
+UNIT_TEST_VAR_1: value1
+UNIT_TEST_VAR_2: value2
+UNIT_TEST_VAR_3: value3
+`),
+			expected: Vars{
+				{
+					Name:  "UNIT_TEST_VAR_1",
+					Value: "value1",
+				},
+				{
+					Name:  "UNIT_TEST_VAR_2",
+					Value: "value2",
+				},
+				{
+					Name:  "UNIT_TEST_VAR_3",
+					Value: "value3",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var vars Vars
+			err := yaml.Unmarshal(tt.yaml, &vars)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				require.ElementsMatch(t, tt.expected, vars)
+			}
+		})
+	}
+}
+
+func Test_Vars_MarshalYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		expected    string
+		vars        Vars
+		expectedErr bool
+	}{
+		{
+			name: "serialized successfully",
+			vars: Vars{
+				{
+					Name:  "foo1",
+					Value: "bar1",
+				},
+				{
+					Name:  "foo2",
+					Value: "bar2",
+				},
+				{
+					Name:  "foo3",
+					Value: "bar3",
+				},
+			},
+			expected: "foo1: bar1\nfoo2: bar2\nfoo3: bar3\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := yaml.Marshal(tt.vars)
+			if tt.expectedErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, string(b))
+			}
+		})
+	}
+}
+
+func Test_ExpandSuccess(t *testing.T) {
+	t.Setenv("UNIT_TEST_VALUE1", "value-1")
+
+	vars := Vars{
+		Var{Name: "UNIT_TEST_VAR1", Value: "$UNIT_TEST_VALUE1"},
+		Var{Name: "UNIT_TEST_VAR2", Value: "value-2"},
+		Var{Name: "UNIT_TEST_VAR3", Value: "$UNIT_TEST_VALUE3"},
+	}
+
+	err := vars.Expand(env.ExpandEnvIfNotEmpty)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "value-1", vars[0].Value)
+	assert.Equal(t, "value-2", vars[1].Value)
+	assert.Equal(t, "$UNIT_TEST_VALUE3", vars[2].Value)
+}
+
+func Test_GetManifestVarsSuccess(t *testing.T) {
+	manifest := `variables:
+  UNIT_TEST_VAR1: value-1
+  UNIT_TEST_VAR2: value-2
+  UNIT_TEST_VAR3: value-3`
+
+	fs := afero.NewMemMapFs()
+	manifestPath := "/okteto.yml"
+	err := afero.WriteFile(fs, manifestPath, []byte(manifest), 0644)
+	assert.NoError(t, err)
+
+	vars, err := GetManifestVars(manifestPath, fs)
+	assert.NoError(t, err)
+
+	// helper func to find a var by name
+	findVar := func(name string) Var {
+		for _, v := range vars {
+			if v.Name == name {
+				return v
+			}
+		}
+		return Var{}
+	}
+
+	assert.Equal(t, "value-1", findVar("UNIT_TEST_VAR1").Value)
+	assert.Equal(t, "value-2", findVar("UNIT_TEST_VAR2").Value)
+	assert.Equal(t, "value-3", findVar("UNIT_TEST_VAR3").Value)
+	assert.Equal(t, "", findVar("NON_EXISTING_VAR").Value)
+}
+
+func Test_GetManifestVarsUnmarshallingFail(t *testing.T) {
+	manifest := `variables:
+  - UNIT_TEST_VAR1: value-1
+  - UNIT_TEST_VAR2: value-2
+  - UNIT_TEST_VAR3: value-3`
+
+	fs := afero.NewMemMapFs()
+	manifestPath := "/okteto.yml"
+	err := afero.WriteFile(fs, manifestPath, []byte(manifest), 0644)
+	assert.NoError(t, err)
+
+	vars, err := GetManifestVars(manifestPath, fs)
+	assert.Error(t, err)
+	assert.Nil(t, vars)
+}
+
+func Test_GetManifestVarsReadFileFail(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	manifestPath := "/okteto.yml"
+
+	vars, err := GetManifestVars(manifestPath, fs)
+	assert.ErrorIs(t, err, afero.ErrFileNotFound)
+	assert.Nil(t, vars)
+}


### PR DESCRIPTION
# Proposed changes

DEV-56

## Description

⚠️ WORK IN PROGRESS
- [ ] Confirm product requirements (ie. shall we expand manifest variables?)
- [ ] Make it compatible with the new remote deploy cmd
- [ ] Review linter / tests

With this change we introduce a new way to configure the Okteto CLI, in particular to provide the CLI with variables defined within the manifest.

Note: the original PR was https://github.com/okteto/okteto/pull/4190 but there was a refactor in master so it was much easier to rebase and create a new PR. It's still useful to link to https://github.com/okteto/okteto/pull/4190 for the initial comments/feedback received.

## How it's implemented

Currently, we already allow users to pass variables to the Okteto CLI via a number of methods. The more sources of variables we introduce, the harder it gets to keep track of them, and make sure the order is respected. The challenge to introduce a new way of providing vars is mainly about making sure the order is predictable and always honored. 

Becuase the order in which we have access to the different sources of vars may depend on several factors, for example the UI variables are fetched at the very beginning of the execution, when we get the user context, however we want to give those a lower priority. The vars from the flag `--var` are defined as second but those should have high priority. To decouple the order in which we have access to them, to the order in which they should be used, I've introduced a new component called `envManager`. I've tried to represent the idea with this diagram below:

![env-manager drawio](https://github.com/okteto/okteto/assets/2318450/b9d302fc-c6d6-4a78-a262-15c218180ed7)

The EnvManager allows us to add groups of vars, define a priority for each group, then internally sort by priority, and exposing the vars in the order in which they should be placed, rather then the order in which they were added. Enabling us to predict which var comes first.

This also allow us to easily change priority for a group, in view of CLI 3.0, where we could very easily make env vars 1st group, and also filter by prefix `OKTETO_` if we decide so.

## How to validate

The order that should be respected is defined as follows:

1️⃣ = Higher Priority (it overrides the vars with the same name, with lower priority: 1️⃣ > 3️⃣)

1. `--var` from `deploy` command
2. local environment variables
3. vars defined in the catalog (deploy modal)
4. Vars defined in the `variables` section of the manifest
5. User Variables defined in the UI (Settings → Variables)
6. Cluster Variables defined in the UI (Admin → Variables)

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
