### PR TITLE
Smart Build fixes and improvements

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -71,7 +71,7 @@ type registryInterface interface {
 
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
-	CloneGlobalImageToDev(imageWithDigest, tag string) (string, error)
+	CloneGlobalImageToDev(imageWithDigest string) (string, error)
 }
 
 // NewBuildCommand creates a struct to run all build methods

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -71,7 +71,7 @@ type registryInterface interface {
 
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
-	CloneGlobalImageToDev(imageWithDigest string) (string, error)
+	CloneGlobalImageToDev(imageWithDigest, defaultTag string) (string, error)
 }
 
 // NewBuildCommand creates a struct to run all build methods

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -71,7 +71,7 @@ type registryInterface interface {
 
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
-	CloneGlobalImageToDev(imageWithDigest, defaultTag string) (string, error)
+	CloneGlobalImageToDev(imageWithDigest string) (string, error)
 }
 
 // NewBuildCommand creates a struct to run all build methods

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -100,7 +100,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_, _ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -100,7 +100,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -100,7 +100,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(_, _ string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -262,7 +262,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				meta.CacheHitDuration = time.Since(cacheHitDurationStart)
 
 				if isBuilt {
-					ob.ioCtrl.Out().Infof("Okteto Smart Builds is skipping build of '%s' because it's already built from cache. To force a rebuild use okteto build --no-cache", svcToBuild)
+					ob.ioCtrl.Out().Infof("Okteto Smart Builds is skipping build of '%s' because it's already built from cache.", svcToBuild)
 
 					imageWithDigest, err = ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest)
 					if err != nil {

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -51,7 +51,7 @@ type oktetoRegistryInterface interface {
 
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
-	CloneGlobalImageToDev(imageWithDigest string) (string, error)
+	CloneGlobalImageToDev(imageWithDigest, defaultTag string) (string, error)
 }
 
 // oktetoBuilderConfigInterface returns the configuration that the builder has for the registry and project
@@ -267,7 +267,11 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				if isBuilt {
 					ob.ioCtrl.Out().Infof("Skipping build of '%s' image because it's already built for commit %s", svcToBuild, ob.smartBuildCtrl.GetBuildCommit(svcToBuild))
 
-					imageWithDigest, err = ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest)
+					defaultTag := model.OktetoDefaultImageTag
+					if serviceHasVolumesToInclude(buildSvcInfo) {
+						defaultTag = model.OktetoImageTagWithVolumes
+					}
+					imageWithDigest, err = ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest, defaultTag)
 					if err != nil {
 						return err
 					}

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -264,7 +264,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				meta.CacheHitDuration = time.Since(cacheHitDurationStart)
 
 				if isBuilt {
-					ob.ioCtrl.Out().Infof("Skipping build of '%s' image because it's already built for commit %s", svcToBuild, ob.smartBuildCtrl.GetBuildCommit(buildSvcInfo))
+					ob.ioCtrl.Out().Infof("Skipping build of '%s' image because it's already built for commit %s", svcToBuild, ob.smartBuildCtrl.GetBuildCommit(svcToBuild))
 
 					imageWithDigest, err = ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest, buildHash)
 					if err != nil {

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -49,7 +49,7 @@ type oktetoRegistryInterface interface {
 
 	GetRegistryAndRepo(image string) (string, string)
 	GetRepoNameAndTag(repo string) (string, string)
-	CloneGlobalImageToDev(imageWithDigest, tag string) (string, error)
+	CloneGlobalImageToDev(imageWithDigest string) (string, error)
 }
 
 // oktetoBuilderConfigInterface returns the configuration that the builder has for the registry and project
@@ -266,7 +266,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				if isBuilt {
 					ob.ioCtrl.Out().Infof("Skipping build of '%s' image because it's already built for commit %s", svcToBuild, ob.smartBuildCtrl.GetBuildCommit(svcToBuild))
 
-					imageWithDigest, err = ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest, buildHash)
+					imageWithDigest, err = ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest)
 					if err != nil {
 						return err
 					}

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -262,7 +262,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				meta.CacheHitDuration = time.Since(cacheHitDurationStart)
 
 				if isBuilt {
-					ob.ioCtrl.Out().Infof("Skipping build of '%s' image because it's already built for commit %s", svcToBuild, ob.smartBuildCtrl.GetBuildCommit(svcToBuild))
+					ob.ioCtrl.Out().Infof("Okteto Smart Builds is skipping build of '%s' because it's already built from cache. To force a rebuild use okteto build --no-cache", svcToBuild)
 
 					imageWithDigest, err = ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest)
 					if err != nil {

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -255,10 +255,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				imageChecker := getImageChecker(ob.Config, ob.Registry, ob.smartBuildCtrl, ob.ioCtrl.Logger())
 				cacheHitDurationStart := time.Now()
 
-				buildHash, err := ob.smartBuildCtrl.GetBuildHash(buildSvcInfo, svcToBuild)
-				if err != nil {
-					ob.ioCtrl.Logger().Infof("error getting build hash: %s", err)
-				}
+				buildHash := ob.smartBuildCtrl.GetBuildHash(buildSvcInfo, svcToBuild)
 				imageWithDigest, isBuilt := imageChecker.checkIfBuildHashIsBuilt(options.Manifest.Name, svcToBuild, buildHash)
 
 				meta.CacheHit = isBuilt
@@ -338,10 +335,7 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 	var err error
 	var buildHash string
 	if bc.smartBuildCtrl.IsEnabled() {
-		buildHash, err = bc.smartBuildCtrl.GetBuildHash(buildSvcInfo, svcName)
-		if err != nil {
-			bc.ioCtrl.Logger().Infof("error getting build hash: %s", err)
-		}
+		buildHash = bc.smartBuildCtrl.GetBuildHash(buildSvcInfo, svcName)
 	}
 	tagToBuild := newImageTagger(bc.Config, bc.smartBuildCtrl).getServiceImageReference(manifest.Name, svcName, buildSvcInfo, buildHash)
 	buildSvcInfo.Image = tagToBuild

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -28,7 +28,9 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/build"
 	buildCmd "github.com/okteto/okteto/pkg/cmd/build"
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/log/io"
@@ -161,11 +163,11 @@ func (*OktetoBuilder) IsV1() bool {
 // TODO: Function with cyclomatic complexity higher than threshold. Refactor function in order to reduce its complexity
 // skipcq: GO-R1005
 func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions) error {
-	/*if env.LoadBoolean(constants.OktetoDeployRemote) {
+	if env.LoadBoolean(constants.OktetoDeployRemote) {
 		// Since the local build has already been built,
 		// we have the environment variables set and we can skip this code
 		return nil
-	}*/
+	}
 	if options.File != "" {
 		workdir := model.GetWorkdirFromManifestPath(options.File)
 		if err := os.Chdir(workdir); err != nil {
@@ -216,7 +218,6 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				ob.ioCtrl.Logger().Infof("skipping image '%s' due to being already built", svcToBuild)
 				continue
 			}
-			// How do we build the image when all the dependencies are built?
 			if !areAllServicesBuilt(buildManifest[svcToBuild].DependsOn, builtImagesControl) {
 				ob.ioCtrl.Logger().Infof("image '%s' can't be deployed because at least one of its dependent images(%s) are not built", svcToBuild, strings.Join(buildManifest[svcToBuild].DependsOn, ", "))
 				continue

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -284,10 +284,10 @@ func TestTwoStepsBuild(t *testing.T) {
 	}
 	image, err := bc.buildServiceImages(ctx, manifest, "test", &types.BuildOptions{})
 
-	// error from the build
-	assert.NoError(t, err)
-	// assert that the name of the image is the dev one
-	image, err = bc.Registry.GetImageTagWithDigest("okteto.dev/test-test:okteto")
+	require.NoError(t, err)
+	require.Equal(t, "okteto.dev/test-test:okteto", image)
+	// the image is at the fake registry
+	image, err = bc.Registry.GetImageTagWithDigest(image)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, image)
 }

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -147,7 +147,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -147,7 +147,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_, _ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/build/v2/environment_test.go
+++ b/cmd/build/v2/environment_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_SetServiceEnvVars(t *testing.T) {
@@ -124,6 +125,8 @@ func TestExpandStackVariables(t *testing.T) {
 		isOkteto: true,
 	}
 
+	err := registry.AddImageByName("okteto.global/test-test:5f2d51f7ce48b2d3396d2a38c8e7f2010234d3e6c2c17566f93f9c27532037d5")
+	require.NoError(t, err)
 	bc := NewFakeBuilder(builder, registry, fakeConfig, &fakeAnalyticsTracker{})
 	stack := &model.Stack{
 		Services: map[string]*model.Service{
@@ -137,7 +140,6 @@ func TestExpandStackVariables(t *testing.T) {
 		Name: "test",
 		Build: build.ManifestBuild{
 			"test": &build.Info{
-				Image: "nginx",
 				VolumesToInclude: []build.VolumeMounts{
 					{
 						LocalPath:  "test",
@@ -154,7 +156,7 @@ func TestExpandStackVariables(t *testing.T) {
 		Type: model.StackType,
 		IsV2: true,
 	}
-	err := bc.Build(ctx, &types.BuildOptions{
+	err = bc.Build(ctx, &types.BuildOptions{
 		Manifest: manifest,
 	})
 

--- a/cmd/build/v2/imagechecker.go
+++ b/cmd/build/v2/imagechecker.go
@@ -84,11 +84,7 @@ func (ic imageChecker) getImageDigestReferenceForServiceDeploy(manifestName, svc
 
 	// get all possible references
 	var possibleReferences []string
-	if !ic.cfg.IsOkteto() && serviceHasVolumesToInclude(buildInfo) {
-		possibleReferences = []string{buildInfo.Image}
-	} else if serviceHasVolumesToInclude(buildInfo) {
-		possibleReferences = ic.tagger.getImageReferencesForDeploy(manifestName, svcToBuild)
-	} else if serviceHasDockerfile(buildInfo) && buildInfo.Image == "" {
+	if serviceHasDockerfile(buildInfo) && buildInfo.Image == "" {
 		possibleReferences = ic.tagger.getImageReferencesForDeploy(manifestName, svcToBuild)
 	} else if buildInfo.Image != "" {
 		possibleReferences = []string{buildInfo.Image}

--- a/cmd/build/v2/imagechecker.go
+++ b/cmd/build/v2/imagechecker.go
@@ -51,7 +51,7 @@ func newImageChecker(cfg oktetoBuilderConfigInterface, registry registryImageChe
 	}
 }
 
-// checkIfBuildHashIsBuilt returns if the buildhash is already built
+// checkIfBuildHashIsBuilt returns if the buildHash is already built
 // in case is built, the image with digest ([name]@sha256:[sha]) is returned
 // if not, empty reference is returned
 func (ic imageChecker) checkIfBuildHashIsBuilt(manifestName, svcToBuild string, buildHash string) (string, bool) {
@@ -68,7 +68,8 @@ func (ic imageChecker) checkIfBuildHashIsBuilt(manifestName, svcToBuild string, 
 				continue
 			}
 			ic.logger.Infof("could not check image %s: %s", ref, err)
-			return "", false
+			// If trying to get access to the image, it fails unexpectedly, we try with any other image (if any)
+			continue
 		}
 		ic.logger.Infof("image %s found", ref)
 		return imageWithDigest, true

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -103,7 +103,7 @@ func (bc *OktetoBuilder) checkServiceToBuildDuringDeploy(service string, manifes
 		buildCh <- service
 		return nil
 	} else if err != nil {
-		bc.ioCtrl.Out().Warning("could not verify if image for service %s is already in the registry. Building image...", service)
+		bc.ioCtrl.Out().Warning("could not verify if image for service %q is already in the registry. Building image...", service)
 		// If there is an error trying to get the image from the registry, we just rebuild that image
 		bc.ioCtrl.Logger().Debugf("unexpected error checking if the images exist: %s", err)
 		buildCh <- service

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -96,7 +96,7 @@ func (bc *OktetoBuilder) checkServiceToBuildDuringDeploy(service string, manifes
 		buildInfo.Image = ""
 	}
 
-	imageChecker := getImageChecker(buildInfo, bc.Config, bc.Registry, bc.smartBuildCtrl, bc.ioCtrl.Logger())
+	imageChecker := getImageChecker(bc.Config, bc.Registry, bc.smartBuildCtrl, bc.ioCtrl.Logger())
 	imageWithDigest, err := imageChecker.getImageDigestReferenceForServiceDeploy(manifest.Name, service, buildInfo)
 	if oktetoErrors.IsNotFound(err) {
 		bc.ioCtrl.Logger().Debug("image not found, building image")

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"golang.org/x/sync/errgroup"
 )
@@ -103,6 +104,7 @@ func (bc *OktetoBuilder) checkServiceToBuildDuringDeploy(service string, manifes
 		buildCh <- service
 		return nil
 	} else if err != nil {
+		oktetoLog.Warning("could not verify if image for service %s is already in the registry. Building image...", service)
 		// If there is an error trying to get the image from the registry, we just rebuild that image
 		bc.ioCtrl.Logger().Debugf("unexpected error checking if the images exist: %s", err)
 		buildCh <- service

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -103,6 +103,7 @@ func (bc *OktetoBuilder) checkServiceToBuildDuringDeploy(service string, manifes
 		buildCh <- service
 		return nil
 	} else if err != nil {
+		// If there is an error trying to get the image from the registry, we just rebuild that image
 		bc.ioCtrl.Logger().Debugf("unexpected error checking if the images exist: %s", err)
 		buildCh <- service
 		return nil

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"golang.org/x/sync/errgroup"
 )
@@ -104,7 +103,7 @@ func (bc *OktetoBuilder) checkServiceToBuildDuringDeploy(service string, manifes
 		buildCh <- service
 		return nil
 	} else if err != nil {
-		oktetoLog.Warning("could not verify if image for service %s is already in the registry. Building image...", service)
+		bc.ioCtrl.Out().Warning("could not verify if image for service %s is already in the registry. Building image...", service)
 		// If there is an error trying to get the image from the registry, we just rebuild that image
 		bc.ioCtrl.Logger().Debugf("unexpected error checking if the images exist: %s", err)
 		buildCh <- service

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -97,7 +97,7 @@ func (bc *OktetoBuilder) checkServiceToBuild(service string, manifest *model.Man
 	var err error
 	var buildHash string
 	if bc.smartBuildCtrl.IsEnabled() {
-		buildHash, err = bc.smartBuildCtrl.GetBuildHash(buildInfo)
+		buildHash, err = bc.smartBuildCtrl.GetBuildHash(buildInfo, service)
 		if err != nil {
 			bc.ioCtrl.Logger().Infof("error getting build hash: %s", err)
 		}
@@ -110,7 +110,9 @@ func (bc *OktetoBuilder) checkServiceToBuild(service string, manifest *model.Man
 		buildCh <- service
 		return nil
 	} else if err != nil {
-		return err
+		bc.ioCtrl.Logger().Debugf("unexpected error checking if the images exist: %s", err)
+		buildCh <- service
+		return nil
 	}
 	bc.ioCtrl.Logger().Debugf("Skipping build for image for service: %s", service)
 

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -23,9 +23,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// GetServicesToBuild returns the services it has to build if they are not already built
-// this function is called from outside the build cmd
-func (bc *OktetoBuilder) GetServicesToBuild(ctx context.Context, manifest *model.Manifest, svcsToDeploy []string) ([]string, error) {
+// GetServicesToBuildDuringDeploy returns the services it has to build if they are not already built
+// this function is called from outside the build cmd and during a "deploy operation" (up, deploy, destroy, compose).
+func (bc *OktetoBuilder) GetServicesToBuildDuringDeploy(ctx context.Context, manifest *model.Manifest, svcsToDeploy []string) ([]string, error) {
 	buildManifest := manifest.Build
 
 	if len(buildManifest) == 0 {
@@ -59,7 +59,7 @@ func (bc *OktetoBuilder) GetServicesToBuild(ctx context.Context, manifest *model
 		svc := service
 
 		g.Go(func() error {
-			return bc.checkServiceToBuild(svc, manifest, toBuildCh)
+			return bc.checkServiceToBuildDuringDeploy(svc, manifest, toBuildCh)
 		})
 	}
 
@@ -86,25 +86,18 @@ func (bc *OktetoBuilder) GetServicesToBuild(ctx context.Context, manifest *model
 	return svcsToBuildList, nil
 }
 
-// checkServiceToBuild looks for the service image reference at the registry and adds it to the buildCh if is not found
-func (bc *OktetoBuilder) checkServiceToBuild(service string, manifest *model.Manifest, buildCh chan string) error {
+// checkServiceToBuildDuringDeploy looks for the service image reference at the registry and adds it to the buildCh
+// if is not found. This function is called during deploy operations (up, deploy, destroy and compose) to check if
+// images have to be built or not. In that case, we only check the existence of "okteto" tag in the dev registry
+func (bc *OktetoBuilder) checkServiceToBuildDuringDeploy(service string, manifest *model.Manifest, buildCh chan string) error {
 	buildInfo := manifest.Build[service].Copy()
 	isStack := manifest.Type == model.StackType
 	if isStack && bc.oktetoContext.IsOkteto() && !bc.Registry.IsOktetoRegistry(buildInfo.Image) {
 		buildInfo.Image = ""
 	}
 
-	var err error
-	var buildHash string
-	if bc.smartBuildCtrl.IsEnabled() {
-		buildHash, err = bc.smartBuildCtrl.GetBuildHash(buildInfo, service)
-		if err != nil {
-			bc.ioCtrl.Logger().Infof("error getting build hash: %s", err)
-		}
-	}
-
 	imageChecker := getImageChecker(buildInfo, bc.Config, bc.Registry, bc.smartBuildCtrl, bc.ioCtrl.Logger())
-	imageWithDigest, err := imageChecker.getImageDigestReferenceForService(manifest.Name, service, buildInfo, buildHash)
+	imageWithDigest, err := imageChecker.getImageDigestReferenceForServiceDeploy(manifest.Name, service, buildInfo)
 	if oktetoErrors.IsNotFound(err) {
 		bc.ioCtrl.Logger().Debug("image not found, building image")
 		buildCh <- service

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -31,7 +31,7 @@ func TestNoneOfTheServicesBuilt(t *testing.T) {
 	alreadyBuilt := []string{}
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{})
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, []string{})
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, len(fakeManifest.Build)-len(alreadyBuilt), len(toBuild))
@@ -46,7 +46,7 @@ func TestAllServicesAlreadyBuilt(t *testing.T) {
 	alreadyBuilt := []string{"test/test-1", "okteto.dev/test-test-2:okteto-with-volume-mounts", "okteto.dev/test-test-3:okteto", "okteto.dev/test-test-4:okteto-with-volume-mounts"}
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{})
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, []string{})
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, len(fakeManifest.Build)-len(alreadyBuilt), len(toBuild))
@@ -62,7 +62,7 @@ func TestServicesNotAreAlreadyBuilt(t *testing.T) {
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
 	toBuildSvcsInput := []string{"test-1", "test-2"}
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, toBuildSvcsInput)
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, toBuildSvcsInput)
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, len(toBuildSvcsInput)-len(alreadyBuilt), len(toBuild))
@@ -78,7 +78,7 @@ func TestNoServiceBuilt(t *testing.T) {
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
 	toBuildSvcsInput := []string{"test-1"}
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, toBuildSvcsInput)
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, toBuildSvcsInput)
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, len(toBuildSvcsInput)-len(alreadyBuilt), len(toBuild))
@@ -122,7 +122,7 @@ func TestServicesNotInStack(t *testing.T) {
 	}
 	toBuildSvcsInput := []string{}
 
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, toBuildSvcsInput)
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, toBuildSvcsInput)
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, 0, len(toBuild))
@@ -148,7 +148,7 @@ func TestServicesNotOktetoWithStack(t *testing.T) {
 	}}
 	toBuildSvcsInput := []string{"test-1"}
 
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, toBuildSvcsInput)
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, toBuildSvcsInput)
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, len(toBuildSvcsInput)-len(alreadyBuilt), len(toBuild))
@@ -163,7 +163,7 @@ func TestAllServicesAlreadyBuiltWithSubset(t *testing.T) {
 	alreadyBuilt := []string{}
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1"})
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, []string{"test-1"})
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, 1, len(toBuild))
@@ -178,7 +178,7 @@ func TestServicesNotAreAlreadyBuiltWithSubset(t *testing.T) {
 	alreadyBuilt := []string{"test/test-1"}
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1"})
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, []string{"test-1"})
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, 0, len(toBuild))
@@ -194,7 +194,7 @@ func TestServicesBuildSection(t *testing.T) {
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
 	fakeManifest.Build = map[string]*build.Info{}
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{})
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, []string{})
 	// should not throw error
 	require.NoError(t, err)
 	require.Empty(t, toBuild)
@@ -209,7 +209,7 @@ func TestNoServiceBuiltWithSubset(t *testing.T) {
 	alreadyBuilt := []string{"test/test-1", "test/test-2"}
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
-	toBuild, err := bc.GetServicesToBuild(ctx, fakeManifest, []string{"test-1"})
+	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, []string{"test-1"})
 	// should not throw error
 	require.NoError(t, err)
 	require.Equal(t, 0, len(toBuild))

--- a/cmd/build/v2/services_test.go
+++ b/cmd/build/v2/services_test.go
@@ -43,7 +43,7 @@ func TestAllServicesAlreadyBuilt(t *testing.T) {
 		isOkteto: true,
 	}
 	bc := NewFakeBuilder(nil, fakeReg, fakeConfig, &fakeAnalyticsTracker{})
-	alreadyBuilt := []string{"test/test-1", "okteto.dev/test-test-2:okteto-with-volume-mounts", "okteto.dev/test-test-3:okteto", "okteto.dev/test-test-4:okteto-with-volume-mounts"}
+	alreadyBuilt := []string{"test/test-1", "test/test-2", "okteto.dev/test-test-3:okteto", "okteto.dev/test-test-4:okteto"}
 	require.NoError(t, fakeReg.AddImageByName(alreadyBuilt...))
 	ctx := context.Background()
 	toBuild, err := bc.GetServicesToBuildDuringDeploy(ctx, fakeManifest, []string{})

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/okteto/okteto/pkg/build"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -38,18 +39,21 @@ type serviceHasher struct {
 	gitRepoCtrl repositoryCommitRetriever
 	fs          afero.Fs
 
-	buildContextCache map[string]string
-	projectCommit     string
+	serviceShaCache map[string]string
+	projectCommit   string
 
 	// lock is a mutex to provide thread safety
 	lock sync.RWMutex
+
+	getCurrentTimestampNano func() int64
 }
 
 func newServiceHasher(gitRepoCtrl repositoryCommitRetriever, fs afero.Fs) *serviceHasher {
 	return &serviceHasher{
-		gitRepoCtrl:       gitRepoCtrl,
-		buildContextCache: map[string]string{},
-		fs:                fs,
+		gitRepoCtrl:             gitRepoCtrl,
+		serviceShaCache:         map[string]string{},
+		fs:                      fs,
+		getCurrentTimestampNano: time.Now().UnixNano,
 	}
 }
 
@@ -72,28 +76,48 @@ func (sh *serviceHasher) hashProjectCommit(buildInfo *build.Info) (string, error
 }
 
 // hashBuildContext returns the hash of the service using its context tree hash
-func (sh *serviceHasher) hashBuildContext(buildInfo *build.Info) (string, error) {
+func (sh *serviceHasher) hashWithBuildContext(buildInfo *build.Info, service string) string {
 	buildContext := buildInfo.Context
 	if buildContext == "" {
 		buildContext = "."
 	}
-	if _, ok := sh.buildContextCache[buildContext]; !ok {
+	if _, ok := sh.serviceShaCache[service]; !ok {
 		dirCommit, err := sh.gitRepoCtrl.GetLatestDirCommit(buildContext)
 		if err != nil {
-			return "", fmt.Errorf("could not get build context sha: %w", err)
+			oktetoLog.Infof("could not get build context sha: %s, generating a random one", err)
+			// In case of error getting the dir commit, we just generate a random one, and it will rebuild the image
+			dirCommit = sh.calculateRandomShaForService(service)
 		}
+		oktetoLog.Debugf("############ Dir commit %q", dirCommit)
 
 		diffHash, err := sh.gitRepoCtrl.GetDiffHash(buildContext)
 		if err != nil {
-			return "", fmt.Errorf("could not get build context diff sha: %w", err)
+			oktetoLog.Infof("could not get build context diff sha: %s, generating a random one", err)
+			// In case of error getting the diff hash, we just generate a random one, and it will rebuild the image
+			diffHash = sh.calculateRandomShaForService(service)
 		}
 
+		oktetoLog.Debugf("############## Diff hash %q", diffHash)
+
 		sh.lock.Lock()
-		sh.buildContextCache[buildContext] = sh.hash(buildInfo, dirCommit, diffHash)
+		hash := sh.hash(buildInfo, dirCommit, diffHash)
+		oktetoLog.Debugf("############## Image hash %q", hash)
+		sh.serviceShaCache[service] = hash
 		sh.lock.Unlock()
+	} else {
+		oktetoLog.Debugf("############ getting the build context for service %q from the cache: %q", buildInfo.Name, sh.serviceShaCache[service])
 	}
 
-	return sh.buildContextCache[buildContext], nil
+	return sh.serviceShaCache[service]
+}
+
+// calculateRandomShaForService generates a random sha for the given service taking into account current timestamp
+// in nanoseconds
+func (sh *serviceHasher) calculateRandomShaForService(service string) string {
+	key := fmt.Sprintf("%s-%d", service, sh.getCurrentTimestampNano())
+
+	sha := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(sha[:])
 }
 
 func (sh *serviceHasher) hash(buildInfo *build.Info, commitHash string, diff string) string {
@@ -122,7 +146,9 @@ func (sh *serviceHasher) hash(buildInfo *build.Info, commitHash string, diff str
 	fmt.Fprintf(&b, "diff:%s;", diff)
 	fmt.Fprintf(&b, "image:%s;", buildInfo.Image)
 
-	oktetoBuildHash := sha256.Sum256([]byte(b.String()))
+	hashFrom := b.String()
+	oktetoLog.Infof("hashing build info: %s", hashFrom)
+	oktetoBuildHash := sha256.Sum256([]byte(hashFrom))
 	return hex.EncodeToString(oktetoBuildHash[:])
 }
 
@@ -144,10 +170,10 @@ func (sh *serviceHasher) getDockerfileContent(dockerfileContext, dockerfilePath 
 	return hex.EncodeToString(encodedFile[:])
 }
 
-func (sh *serviceHasher) getBuildContextHashInCache(buildContext string) string {
+func (sh *serviceHasher) getServiceShaInCache(service string) string {
 	sh.lock.RLock()
 	defer sh.lock.RUnlock()
-	v, ok := sh.buildContextCache[buildContext]
+	v, ok := sh.serviceShaCache[service]
 	if !ok {
 		return ""
 	}

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -37,15 +37,16 @@ type repositoryCommitRetriever interface {
 
 type serviceHasher struct {
 	gitRepoCtrl repositoryCommitRetriever
-	fs          afero.Fs
+
+	fs afero.Fs
 
 	serviceShaCache map[string]string
-	projectCommit   string
+
+	getCurrentTimestampNano func() int64
+	projectCommit           string
 
 	// lock is a mutex to provide thread safety
 	lock sync.RWMutex
-
-	getCurrentTimestampNano func() int64
 }
 
 func newServiceHasher(gitRepoCtrl repositoryCommitRetriever, fs afero.Fs) *serviceHasher {

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -104,7 +104,7 @@ func (sh *serviceHasher) hashWithBuildContext(buildInfo *build.Info, service str
 		// This is to display just one single warning if any of the git operation fails. As we generate random sha
 		// it will imply a new build of image, and we want to warn users
 		if errorGettingGitInfo {
-			oktetoLog.Warning("smart builds cannot access git metadata, building image for service %s...", service)
+			oktetoLog.Warning("smart builds cannot access git metadata, building image %q...", service)
 		}
 
 		sh.lock.Lock()

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -89,7 +89,6 @@ func (sh *serviceHasher) hashWithBuildContext(buildInfo *build.Info, service str
 			// In case of error getting the dir commit, we just generate a random one, and it will rebuild the image
 			dirCommit = sh.calculateRandomShaForService(service)
 		}
-		oktetoLog.Debugf("############ Dir commit %q", dirCommit)
 
 		diffHash, err := sh.gitRepoCtrl.GetDiffHash(buildContext)
 		if err != nil {
@@ -98,15 +97,10 @@ func (sh *serviceHasher) hashWithBuildContext(buildInfo *build.Info, service str
 			diffHash = sh.calculateRandomShaForService(service)
 		}
 
-		oktetoLog.Debugf("############## Diff hash %q", diffHash)
-
 		sh.lock.Lock()
 		hash := sh.hash(buildInfo, dirCommit, diffHash)
-		oktetoLog.Debugf("############## Image hash %q", hash)
 		sh.serviceShaCache[service] = hash
 		sh.lock.Unlock()
-	} else {
-		oktetoLog.Debugf("############ getting the build context for service %q from the cache: %q", buildInfo.Name, sh.serviceShaCache[service])
 	}
 
 	return sh.serviceShaCache[service]

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -104,7 +104,7 @@ func (sh *serviceHasher) hashWithBuildContext(buildInfo *build.Info, service str
 		// This is to display just one single warning if any of the git operation fails. As we generate random sha
 		// it will imply a new build of image, and we want to warn users
 		if errorGettingGitInfo {
-			oktetoLog.Warning("smart builds cannot access git metadata, building image %q...", service)
+			oktetoLog.Warning("Smart builds cannot access git metadata, building image %q...", service)
 		}
 
 		sh.lock.Lock()

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -174,9 +174,3 @@ func (sh *serviceHasher) getServiceShaInCache(service string) string {
 	}
 	return v
 }
-
-func (sh *serviceHasher) getProjectCommitHashInCache() string {
-	sh.lock.RLock()
-	defer sh.lock.RUnlock()
-	return sh.projectCommit
-}

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -104,7 +104,7 @@ func (sh *serviceHasher) hashWithBuildContext(buildInfo *build.Info, service str
 		// This is to display just one single warning if any of the git operation fails. As we generate random sha
 		// it will imply a new build of image, and we want to warn users
 		if errorGettingGitInfo {
-			oktetoLog.Warning("smart builds cannot access git metadata, building image...", service)
+			oktetoLog.Warning("smart builds cannot access git metadata, building image for service %s...", service)
 		}
 
 		sh.lock.Lock()

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -129,12 +129,3 @@ func TestGetBuildContextHashInCache(t *testing.T) {
 		})
 	}
 }
-
-func TestGetProjectCommitHashInCache(t *testing.T) {
-	sh := newServiceHasher(nil, afero.NewMemMapFs())
-	result := sh.getProjectCommitHashInCache()
-	assert.Equal(t, "", result)
-	sh.projectCommit = "hash123"
-	result = sh.getProjectCommitHashInCache()
-	assert.Equal(t, "hash123", result)
-}

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -32,7 +32,7 @@ const (
 
 // registryController is the interface to interact with registries
 type registryController interface {
-	CloneGlobalImageToDev(string, string) (string, error)
+	CloneGlobalImageToDev(string) (string, error)
 	IsGlobalRegistry(string) bool
 }
 
@@ -127,10 +127,10 @@ func (s *Ctrl) GetBuildCommit(serviceName string) string {
 // CloneGlobalImageToDev clones the image from the global registry to the dev registry if needed
 // if the built image belongs to global registry we clone it to the dev registry
 // so that in can be used in dev containers (i.e. okteto up)
-func (s *Ctrl) CloneGlobalImageToDev(image, buildHash string) (string, error) {
+func (s *Ctrl) CloneGlobalImageToDev(image string) (string, error) {
 	if s.registryController.IsGlobalRegistry(image) {
 		s.ioCtrl.Logger().Debugf("Copying image '%s' from global to personal registry", image)
-		devImage, err := s.registryController.CloneGlobalImageToDev(image, buildHash)
+		devImage, err := s.registryController.CloneGlobalImageToDev(image)
 		if err != nil {
 			return "", fmt.Errorf("error cloning image '%s': %w", image, err)
 		}

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -65,7 +65,8 @@ type Ctrl struct {
 // NewSmartBuildCtrl creates a new smart build controller
 func NewSmartBuildCtrl(repo repositoryInterface, registry registryController, fs afero.Fs, ioCtrl *io.Controller) *Ctrl {
 	isEnabled := env.LoadBooleanOrDefault(OktetoEnableSmartBuildEnvVar, true)
-	isUsingBuildCtx := env.LoadBoolean(OktetoSmartBuildUsingContextEnvVar)
+	// If using build context is not explicitly set, we use the value of smart builds
+	isUsingBuildCtx := env.LoadBooleanOrDefault(OktetoSmartBuildUsingContextEnvVar, isEnabled)
 
 	return &Ctrl{
 		gitRepo:             repo,

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -45,8 +45,8 @@ type repositoryInterface interface {
 
 type hasherController interface {
 	hashProjectCommit(*build.Info) (string, error)
-	hashBuildContext(*build.Info) (string, error)
-	getBuildContextHashInCache(string) string
+	hashWithBuildContext(*build.Info, string) string
+	getServiceShaInCache(string) string
 	getProjectCommitHashInCache() string
 }
 
@@ -89,17 +89,17 @@ func (s *Ctrl) GetProjectHash(buildInfo *build.Info) (string, error) {
 }
 
 // GetServiceHash returns the hash of the service
-func (s *Ctrl) GetServiceHash(buildInfo *build.Info) (string, error) {
+func (s *Ctrl) GetServiceHash(buildInfo *build.Info, service string) string {
 	s.ioCtrl.Logger().Debugf("getting service hash")
-	return s.hasher.hashBuildContext(buildInfo)
+	return s.hasher.hashWithBuildContext(buildInfo, service)
 }
 
 // GetBuildHash returns the hash of the build based on the env vars
-func (s *Ctrl) GetBuildHash(buildInfo *build.Info) (string, error) {
+func (s *Ctrl) GetBuildHash(buildInfo *build.Info, service string) (string, error) {
 	s.ioCtrl.Logger().Debugf("getting hash based on the buildContext env var")
 	if s.isUsingBuildContext {
 		s.ioCtrl.Logger().Info("getting hash using build context due to env var")
-		return s.hasher.hashBuildContext(buildInfo)
+		return s.hasher.hashWithBuildContext(buildInfo, service), nil
 	}
 	s.ioCtrl.Logger().Info("getting hash using project commit")
 	return s.hasher.hashProjectCommit(buildInfo)
@@ -112,7 +112,7 @@ func (s *Ctrl) GetBuildCommit(buildInfo *build.Info) string {
 		if buildContext == "" {
 			buildContext = "."
 		}
-		commit := s.hasher.getBuildContextHashInCache(buildContext)
+		commit := s.hasher.getServiceShaInCache(buildContext)
 		if commit == "" {
 			s.ioCtrl.Logger().Debugf("build context '%s' not found in cache", buildContext)
 		}

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -94,15 +94,6 @@ func (s *Ctrl) GetBuildHash(buildInfo *build.Info, service string) string {
 	return s.hasher.hashWithBuildContext(buildInfo, service)
 }
 
-// GetBuildCommit returns the commit that generated the smart build
-func (s *Ctrl) GetBuildCommit(serviceName string) string {
-	commit := s.hasher.getServiceShaInCache(serviceName)
-	if commit == "" {
-		s.ioCtrl.Logger().Debugf("image sha for service '%s' not found in cache", serviceName)
-	}
-	return commit
-}
-
 // CloneGlobalImageToDev clones the image from the global registry to the dev registry if needed
 // if the built image belongs to global registry we clone it to the dev registry
 // so that in can be used in dev containers (i.e. okteto up)

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -32,7 +32,7 @@ const (
 
 // registryController is the interface to interact with registries
 type registryController interface {
-	CloneGlobalImageToDev(string, string) (string, error)
+	CloneGlobalImageToDev(string) (string, error)
 	IsGlobalRegistry(string) bool
 }
 
@@ -127,10 +127,10 @@ func (s *Ctrl) GetBuildCommit(serviceName string) string {
 // CloneGlobalImageToDev clones the image from the global registry to the dev registry if needed
 // if the built image belongs to global registry we clone it to the dev registry
 // so that in can be used in dev containers (i.e. okteto up)
-func (s *Ctrl) CloneGlobalImageToDev(image, defaultTag string) (string, error) {
+func (s *Ctrl) CloneGlobalImageToDev(image string) (string, error) {
 	if s.registryController.IsGlobalRegistry(image) {
 		s.ioCtrl.Logger().Debugf("Copying image '%s' from global to personal registry", image)
-		devImage, err := s.registryController.CloneGlobalImageToDev(image, defaultTag)
+		devImage, err := s.registryController.CloneGlobalImageToDev(image)
 		if err != nil {
 			return "", fmt.Errorf("error cloning image '%s': %w", image, err)
 		}

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -82,6 +82,12 @@ func (s *Ctrl) IsEnabled() bool {
 	return s.isEnabled
 }
 
+// IsBuildContextEnabled returns true if the build context implementation of smart builds is enabled.
+// This could be temporal until we remove the project commit implementation
+func (s *Ctrl) IsBuildContextEnabled() bool {
+	return s.isUsingBuildContext
+}
+
 // GetProjectHash returns the commit hash of the project
 func (s *Ctrl) GetProjectHash(buildInfo *build.Info) (string, error) {
 	s.ioCtrl.Logger().Debugf("getting project hash")
@@ -106,15 +112,11 @@ func (s *Ctrl) GetBuildHash(buildInfo *build.Info, service string) (string, erro
 }
 
 // GetBuildCommit returns the commit that generated the smart build
-func (s *Ctrl) GetBuildCommit(buildInfo *build.Info) string {
+func (s *Ctrl) GetBuildCommit(serviceName string) string {
 	if s.isUsingBuildContext {
-		buildContext := buildInfo.Context
-		if buildContext == "" {
-			buildContext = "."
-		}
-		commit := s.hasher.getServiceShaInCache(buildContext)
+		commit := s.hasher.getServiceShaInCache(serviceName)
 		if commit == "" {
-			s.ioCtrl.Logger().Debugf("build context '%s' not found in cache", buildContext)
+			s.ioCtrl.Logger().Debugf("image sha for service '%s' not found in cache", serviceName)
 		}
 		return commit
 	}

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -32,7 +32,7 @@ const (
 
 // registryController is the interface to interact with registries
 type registryController interface {
-	CloneGlobalImageToDev(string) (string, error)
+	CloneGlobalImageToDev(string, string) (string, error)
 	IsGlobalRegistry(string) bool
 }
 
@@ -127,10 +127,10 @@ func (s *Ctrl) GetBuildCommit(serviceName string) string {
 // CloneGlobalImageToDev clones the image from the global registry to the dev registry if needed
 // if the built image belongs to global registry we clone it to the dev registry
 // so that in can be used in dev containers (i.e. okteto up)
-func (s *Ctrl) CloneGlobalImageToDev(image string) (string, error) {
+func (s *Ctrl) CloneGlobalImageToDev(image, defaultTag string) (string, error) {
 	if s.registryController.IsGlobalRegistry(image) {
 		s.ioCtrl.Logger().Debugf("Copying image '%s' from global to personal registry", image)
-		devImage, err := s.registryController.CloneGlobalImageToDev(image)
+		devImage, err := s.registryController.CloneGlobalImageToDev(image, defaultTag)
 		if err != nil {
 			return "", fmt.Errorf("error cloning image '%s': %w", image, err)
 		}

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -186,37 +186,6 @@ func TestGetBuildHash(t *testing.T) {
 	assert.Equal(t, "hash", out)
 }
 
-func TestGetBuildCommit(t *testing.T) {
-	tests := []struct {
-		name     string
-		hash     string
-		expected string
-	}{
-		{
-			name:     "correct hash",
-			hash:     "hash",
-			expected: "hash",
-		},
-		{
-			name:     "empty",
-			hash:     "",
-			expected: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sbc := Ctrl{
-				ioCtrl: io.NewIOController(),
-				hasher: fakeHasher{
-					hash: tt.hash,
-				},
-			}
-			out := sbc.GetBuildCommit("service-test")
-			assert.Equal(t, tt.expected, out)
-		})
-	}
-}
-
 func TestCloneGlobalImageToDev(t *testing.T) {
 	type input struct {
 		err      error

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -39,7 +39,7 @@ type fakeRegistryController struct {
 	isGlobalRegistry bool
 }
 
-func (frc fakeRegistryController) CloneGlobalImageToDev(image string) (string, error) {
+func (frc fakeRegistryController) CloneGlobalImageToDev(image, _ string) (string, error) {
 	return image, frc.err
 }
 func (frc fakeRegistryController) IsGlobalRegistry(string) bool { return frc.isGlobalRegistry }
@@ -375,7 +375,7 @@ func TestCloneGlobalImageToDev(t *testing.T) {
 					isGlobalRegistry: tt.input.isGlobal,
 				},
 			}
-			out, err := sbc.CloneGlobalImageToDev("test")
+			out, err := sbc.CloneGlobalImageToDev("test", "default-tag")
 			assert.Equal(t, tt.output.hash, out)
 			assert.ErrorIs(t, err, tt.output.err)
 		})

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -238,18 +238,6 @@ func TestGetBuildHash(t *testing.T) {
 				err:  nil,
 			},
 		},
-		{
-			name: "build context - error",
-			input: input{
-				hash:                "",
-				err:                 assert.AnError,
-				isUsingBuildContext: true,
-			},
-			output: output{
-				hash: "",
-				err:  assert.AnError,
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -273,15 +261,11 @@ func TestGetBuildCommit(t *testing.T) {
 		hash                string
 		isUsingBuildContext bool
 	}
-	type output struct {
-		err  error
-		hash string
-	}
 
 	tests := []struct {
-		output output
-		name   string
-		input  input
+		name     string
+		input    input
+		expected string
 	}{
 		{
 			name: "project commit - correct hash",
@@ -289,21 +273,7 @@ func TestGetBuildCommit(t *testing.T) {
 				hash:                "hash",
 				isUsingBuildContext: false,
 			},
-			output: output{
-				hash: "hash",
-				err:  nil,
-			},
-		},
-		{
-			name: "project commit - error",
-			input: input{
-				hash:                "",
-				isUsingBuildContext: false,
-			},
-			output: output{
-				hash: "",
-				err:  assert.AnError,
-			},
+			expected: "hash",
 		},
 		{
 			name: "build context - correct hash",
@@ -311,21 +281,15 @@ func TestGetBuildCommit(t *testing.T) {
 				hash:                "hash",
 				isUsingBuildContext: true,
 			},
-			output: output{
-				hash: "hash",
-				err:  nil,
-			},
+			expected: "hash",
 		},
 		{
-			name: "build context - error",
+			name: "build context - empty",
 			input: input{
 				hash:                "",
 				isUsingBuildContext: true,
 			},
-			output: output{
-				hash: "",
-				err:  assert.AnError,
-			},
+			expected: "",
 		},
 	}
 	for _, tt := range tests {
@@ -337,8 +301,8 @@ func TestGetBuildCommit(t *testing.T) {
 				},
 				isUsingBuildContext: tt.input.isUsingBuildContext,
 			}
-			out := sbc.GetBuildCommit(&build.Info{})
-			assert.Equal(t, tt.output.hash, out)
+			out := sbc.GetBuildCommit("service-test")
+			assert.Equal(t, tt.expected, out)
 		})
 	}
 }

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -39,7 +39,7 @@ type fakeRegistryController struct {
 	isGlobalRegistry bool
 }
 
-func (frc fakeRegistryController) CloneGlobalImageToDev(image, _ string) (string, error) {
+func (frc fakeRegistryController) CloneGlobalImageToDev(image string) (string, error) {
 	return image, frc.err
 }
 func (frc fakeRegistryController) IsGlobalRegistry(string) bool { return frc.isGlobalRegistry }
@@ -375,7 +375,7 @@ func TestCloneGlobalImageToDev(t *testing.T) {
 					isGlobalRegistry: tt.input.isGlobal,
 				},
 			}
-			out, err := sbc.CloneGlobalImageToDev("test", "default-tag")
+			out, err := sbc.CloneGlobalImageToDev("test")
 			assert.Equal(t, tt.output.hash, out)
 			assert.ErrorIs(t, err, tt.output.err)
 		})

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -39,7 +39,7 @@ type fakeRegistryController struct {
 	isGlobalRegistry bool
 }
 
-func (frc fakeRegistryController) CloneGlobalImageToDev(image string, _ string) (string, error) {
+func (frc fakeRegistryController) CloneGlobalImageToDev(image string) (string, error) {
 	return image, frc.err
 }
 func (frc fakeRegistryController) IsGlobalRegistry(string) bool { return frc.isGlobalRegistry }
@@ -375,7 +375,7 @@ func TestCloneGlobalImageToDev(t *testing.T) {
 					isGlobalRegistry: tt.input.isGlobal,
 				},
 			}
-			out, err := sbc.CloneGlobalImageToDev("test", "hash")
+			out, err := sbc.CloneGlobalImageToDev("test")
 			assert.Equal(t, tt.output.hash, out)
 			assert.ErrorIs(t, err, tt.output.err)
 		})

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -79,7 +79,7 @@ func TestNewSmartBuildCtrl(t *testing.T) {
 			},
 			output: output{
 				isEnabled:  true,
-				isBuildCtx: false,
+				isBuildCtx: true,
 			},
 		},
 		{
@@ -102,6 +102,17 @@ func TestNewSmartBuildCtrl(t *testing.T) {
 			output: output{
 				isEnabled:  true,
 				isBuildCtx: true,
+			},
+		},
+		{
+			name: "Smart builds enabled but build context disabled",
+			input: input{
+				isEnabledValue:  "true",
+				isBuildCtxValue: "false",
+			},
+			output: output{
+				isEnabled:  true,
+				isBuildCtx: false,
 			},
 		},
 	}

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -264,8 +264,8 @@ func TestGetBuildCommit(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		input    input
 		expected string
+		input    input
 	}{
 		{
 			name: "project commit - correct hash",

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -31,7 +31,6 @@ type imageTaggerInterface interface {
 
 type smartBuildController interface {
 	IsEnabled() bool
-	IsBuildContextEnabled() bool
 }
 
 // imageTagger implements an imageTaggerInterface with no volume mounts
@@ -79,9 +78,7 @@ func (it imageTagger) getServiceImageReference(manifestName, svcName string, b *
 	tag := ""
 	if it.cfg.HasGlobalAccess() && it.smartBuildController.IsEnabled() {
 		// With build context enabled, we should always use global registry
-		if it.smartBuildController.IsBuildContextEnabled() || it.cfg.IsCleanProject() {
-			targetRegistry = constants.GlobalRegistry
-		}
+		targetRegistry = constants.GlobalRegistry
 		tag = buildHash
 	}
 	sanitizedName := format.ResourceK8sMetaString(manifestName)

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -137,78 +137,7 @@ func (imageTagger) getImageReferencesForDeploy(manifestName, svcToBuildName stri
 	return imageReferences
 }
 
-// imageTaggerWithVolumes represent an imageTaggerInterface with a reference tag with volume mounts
-type imagerTaggerWithVolumes struct {
-	cfg                  oktetoBuilderConfigInterface
-	smartBuildController smartBuildController
-}
-
-// newImageWithVolumesTagger returns a new image tagger
-func newImageWithVolumesTagger(cfg oktetoBuilderConfigInterface, sbc smartBuildController) imagerTaggerWithVolumes {
-	return imagerTaggerWithVolumes{
-		cfg:                  cfg,
-		smartBuildController: sbc,
-	}
-}
-
-// getServiceImageReference returns the full image tag for the build
-func (i imagerTaggerWithVolumes) getServiceImageReference(manifestName, svcName string, _ *build.Info, buildHash string) string {
-
-	targetRegistry := constants.DevRegistry
-	tag := ""
-	if i.cfg.HasGlobalAccess() && i.smartBuildController.IsEnabled() {
-		// With build context enabled, we should always use global registry
-		if i.smartBuildController.IsBuildContextEnabled() || i.cfg.IsCleanProject() {
-			targetRegistry = constants.GlobalRegistry
-		}
-		tag = buildHash
-	}
-	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	if tag != "" {
-		return useReferenceTemplateWithVolumes(targetRegistry, sanitizedName, svcName, tag)
-	}
-	return useReferenceTemplate(targetRegistry, sanitizedName, svcName, model.OktetoImageTagWithVolumes)
-}
-
-// getImageReferencesForTag returns all the possible images that can be built from a commit hash
-func (i imagerTaggerWithVolumes) getImageReferencesForTag(manifestName, svcToBuildName, tag string) []string {
-	if tag == "" {
-		return []string{}
-	}
-	// manifestName can be not sanitized when option name is used at deploy
-	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	tagsToCheck := []string{}
-	for _, targetRegistry := range getTargetRegistries(i.cfg.IsOkteto()) {
-		tagsToCheck = append(tagsToCheck, useReferenceTemplateWithVolumes(targetRegistry, sanitizedName, svcToBuildName, tag))
-	}
-	return tagsToCheck
-}
-
-// getImageReferencesForTagWithDefaults returns all the possible images that can be built (with and without hash)
-func (i imagerTaggerWithVolumes) getImageReferencesForTagWithDefaults(manifestName, svcToBuildName, tag string) []string {
-	tags := i.getImageReferencesForTag(manifestName, svcToBuildName, tag)
-	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	for _, targetRegistry := range getTargetRegistries(i.cfg.IsOkteto()) {
-		tags = append(tags, useReferenceTemplate(targetRegistry, sanitizedName, svcToBuildName, model.OktetoImageTagWithVolumes))
-	}
-	return tags
-}
-
-// getImageReferencesForDeploy returns the list of images references for a service when deploying it. In case of deploy,
-// we only have to check if the image is present with the okteto tag. We don't check anything related to the hash
-func (i imagerTaggerWithVolumes) getImageReferencesForDeploy(manifestName, svcToBuildName string) []string {
-	var tags []string
-	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	tags = append(tags, useReferenceTemplate(constants.DevRegistry, sanitizedName, svcToBuildName, model.OktetoImageTagWithVolumes))
-	return tags
-}
-
 // useReferenceTemplate returns the image reference with the given parameters [name]:[tag]
 func useReferenceTemplate(targetRegistry, repoName, svcName, tag string) string {
 	return fmt.Sprintf("%s/%s-%s:%s", targetRegistry, repoName, svcName, tag)
-}
-
-// useReferenceTemplateWithVolumes returns the image reference from the template of image with volume mounts [name]:okteto-with-volume-mounts-[tag]
-func useReferenceTemplateWithVolumes(targetRegistry, repoName, svcName, tag string) string {
-	return fmt.Sprintf("%s/%s-%s:%s-%s", targetRegistry, repoName, svcName, model.OktetoImageTagWithVolumes, tag)
 }

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -127,9 +127,8 @@ func (it imageTagger) getImageReferencesForTagWithDefaults(manifestName, svcToBu
 // getImageReferencesForDeploy returns the list of images references for a service when deploying it. In case of deploy,
 // we only have to check if the image is present with the okteto tag. We don't check anything related to the hash
 func (imageTagger) getImageReferencesForDeploy(manifestName, svcToBuildName string) []string {
-	var imageReferences []string
 	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	imageReferences = append(imageReferences, useReferenceTemplate(constants.DevRegistry, sanitizedName, svcToBuildName, model.OktetoDefaultImageTag))
+	imageReferences := []string{useReferenceTemplate(constants.DevRegistry, sanitizedName, svcToBuildName, model.OktetoDefaultImageTag)}
 
 	return imageReferences
 }

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -30,6 +30,7 @@ type imageTaggerInterface interface {
 
 type smartBuildController interface {
 	IsEnabled() bool
+	IsBuildContextEnabled() bool
 }
 
 // imageTagger implements an imageTaggerInterface with no volume mounts
@@ -76,9 +77,10 @@ func (it imageTagger) getServiceImageReference(manifestName, svcName string, b *
 	targetRegistry := constants.DevRegistry
 	tag := ""
 	if it.cfg.HasGlobalAccess() && it.smartBuildController.IsEnabled() {
-		// if it.cfg.IsCleanProject() {
-		targetRegistry = constants.GlobalRegistry
-		//}
+		// With build context enabled, we should always use global registry
+		if it.smartBuildController.IsBuildContextEnabled() || it.cfg.IsCleanProject() {
+			targetRegistry = constants.GlobalRegistry
+		}
 		tag = buildHash
 	}
 	sanitizedName := format.ResourceK8sMetaString(manifestName)
@@ -144,9 +146,10 @@ func (i imagerTaggerWithVolumes) getServiceImageReference(manifestName, svcName 
 	targetRegistry := constants.DevRegistry
 	tag := ""
 	if i.cfg.HasGlobalAccess() && i.smartBuildController.IsEnabled() {
-		//if i.cfg.IsCleanProject() {
-		targetRegistry = constants.GlobalRegistry
-		//}
+		// With build context enabled, we should always use global registry
+		if i.smartBuildController.IsBuildContextEnabled() || i.cfg.IsCleanProject() {
+			targetRegistry = constants.GlobalRegistry
+		}
 		tag = buildHash
 	}
 	sanitizedName := format.ResourceK8sMetaString(manifestName)

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/build"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeSmartBuildCtrl struct {
@@ -426,4 +427,22 @@ func Test_getTargetRegistries(t *testing.T) {
 			assert.Equal(t, tc.expected, getTargetRegistries(tc.isOkteto))
 		})
 	}
+}
+
+func TestImageTaggerWithoutVolumesGetImageReferenceForDeploy(t *testing.T) {
+	imageTagger := &imageTagger{}
+	expected := []string{"okteto.dev/test-repository-service-a:okteto"}
+
+	result := imageTagger.getImageReferencesForDeploy("test repository", "service-a")
+
+	require.Equal(t, expected, result)
+}
+
+func TestImageTaggerWithVolumesGetImageReferenceForDeploy(t *testing.T) {
+	imageTagger := &imagerTaggerWithVolumes{}
+	expected := []string{"okteto.dev/test-repository-service-a:okteto-with-volume-mounts"}
+
+	result := imageTagger.getImageReferencesForDeploy("test repository", "service-a")
+
+	require.Equal(t, expected, result)
 }

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -21,11 +21,16 @@ import (
 )
 
 type fakeSmartBuildCtrl struct {
-	isEnabled bool
+	isEnabled             bool
+	isBuildContextEnabled bool
 }
 
 func (fsc *fakeSmartBuildCtrl) IsEnabled() bool {
 	return fsc.isEnabled
+}
+
+func (fsc *fakeSmartBuildCtrl) IsBuildContextEnabled() bool {
+	return fsc.isBuildContextEnabled
 }
 
 func TestInitTaggers(t *testing.T) {

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -159,6 +159,20 @@ func Test_ImageTaggerWithoutVolumes_GetServiceImageReference(t *testing.T) {
 			},
 			expectedImage: "okteto.global/test-test:sha",
 		},
+		{
+			name: "image inferred with clean project, has access to global registry, feature flag enabled and empty build hash",
+			cfg: fakeConfig{
+				isClean:             true,
+				hasAccess:           true,
+				sha:                 "",
+				isSmartBuildsEnable: true,
+			},
+			b: &build.Info{
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+			},
+			expectedImage: "okteto.dev/test-test:okteto",
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
@@ -317,7 +331,6 @@ func TestImageTaggerGetPossibleTags(t *testing.T) {
 			sha:  "",
 			expectedImages: []string{
 				"okteto.dev/test-test:okteto",
-				"okteto.global/test-test:okteto",
 			},
 			isSmartBuildsEnabled: true,
 		},
@@ -328,7 +341,6 @@ func TestImageTaggerGetPossibleTags(t *testing.T) {
 				"okteto.dev/test-test:sha",
 				"okteto.global/test-test:sha",
 				"okteto.dev/test-test:okteto",
-				"okteto.global/test-test:okteto",
 			},
 			isSmartBuildsEnabled: true,
 		},
@@ -337,7 +349,6 @@ func TestImageTaggerGetPossibleTags(t *testing.T) {
 			sha:  "sha",
 			expectedImages: []string{
 				"okteto.dev/test-test:okteto",
-				"okteto.global/test-test:okteto",
 			},
 			isSmartBuildsEnabled: false,
 		},

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -158,6 +158,9 @@ func (c *Command) RunStateless(ctx context.Context, ctxOptions *Options) (*oktet
 	}
 
 	cfg := okteto.GetContext().Cfg.DeepCopy()
+	// Storing previous global namespace gotten after executing c.Run as it is memory, but after reading the
+	// context store from path that is lost
+	globalNamespace := okteto.GetContext().GlobalNamespace
 
 	oktetoContextStore := okteto.GetContextStoreFromStorePath()
 
@@ -166,6 +169,8 @@ func (c *Command) RunStateless(ctx context.Context, ctxOptions *Options) (*oktet
 	}
 
 	oktetoContextStateless.SetCurrentCfg(cfg)
+	// Setting the global namespace becuase it is missing after reading again the context from the store path
+	oktetoContextStateless.SetGlobalNamespace(globalNamespace)
 
 	return oktetoContextStateless, nil
 

--- a/cmd/deploy/build.go
+++ b/cmd/deploy/build.go
@@ -48,7 +48,7 @@ func buildImages(ctx context.Context, builder builderInterface, deployOptions *O
 			return errBuild
 		}
 	} else {
-		servicesToBuild, err := builder.GetServicesToBuild(ctx, deployOptions.Manifest, setToSlice(servicesToBuildSet))
+		servicesToBuild, err := builder.GetServicesToBuildDuringDeploy(ctx, deployOptions.Manifest, setToSlice(servicesToBuildSet))
 		if err != nil {
 			return err
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -88,7 +88,7 @@ type Options struct {
 
 type builderInterface interface {
 	Build(ctx context.Context, options *types.BuildOptions) error
-	GetServicesToBuild(ctx context.Context, manifest *model.Manifest, svcsToDeploy []string) ([]string, error)
+	GetServicesToBuildDuringDeploy(ctx context.Context, manifest *model.Manifest, svcsToDeploy []string) ([]string, error)
 	GetBuildEnvVars() map[string]string
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -119,7 +119,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_, _ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -119,7 +119,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(_, _ string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -119,7 +119,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -119,7 +119,7 @@ func (fr fakeRegistry) IsGlobalRegistry(image string) bool { return false }
 
 func (fr fakeRegistry) GetRegistryAndRepo(image string) (string, string) { return "", "" }
 func (fr fakeRegistry) GetRepoNameAndTag(repo string) (string, string)   { return "", "" }
-func (fr fakeRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+func (fr fakeRegistry) CloneGlobalImageToDev(_ string) (string, error) {
 	return "", nil
 }
 
@@ -175,7 +175,7 @@ func (b *fakeV2Builder) Build(_ context.Context, buildOptions *types.BuildOption
 	return nil
 }
 
-func (b *fakeV2Builder) GetServicesToBuild(_ context.Context, manifest *model.Manifest, servicesToDeploy []string) ([]string, error) {
+func (b *fakeV2Builder) GetServicesToBuildDuringDeploy(_ context.Context, manifest *model.Manifest, servicesToDeploy []string) ([]string, error) {
 	toBuild := make(map[string]bool, len(manifest.Build))
 	for service := range manifest.Build {
 		toBuild[service] = true

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -230,7 +230,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		return err
 	}
 
-	buildOptions := buildCmd.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{OutputMode: "deploy"})
+	buildOptions := buildCmd.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{OutputMode: buildCmd.DeployOutputModeOnBuild})
 	buildOptions.Manifest = deployOptions.Manifest
 	buildOptions.BuildArgs = append(
 		buildOptions.BuildArgs,

--- a/cmd/destroy/build_control.go
+++ b/cmd/destroy/build_control.go
@@ -39,7 +39,7 @@ func newBuildCtrl(name string, analyticsTracker analyticsTrackerInterface, ioCtr
 }
 
 type builderInterface interface {
-	GetServicesToBuild(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error)
+	GetServicesToBuildDuringDeploy(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error)
 	Build(ctx context.Context, options *types.BuildOptions) error
 }
 
@@ -67,7 +67,7 @@ func (bc buildCtrl) buildImageIfNecessary(ctx context.Context, manifest *model.M
 			oktetoLog.Infof("image is not defined in build section: %s", imageToBuild)
 			return nil
 		}
-		svcsToBuild, err := bc.builder.GetServicesToBuild(ctx, manifest, []string{svc})
+		svcsToBuild, err := bc.builder.GetServicesToBuildDuringDeploy(ctx, manifest, []string{svc})
 		if err != nil {
 			return fmt.Errorf("error getting services to build: %w", err)
 		}

--- a/cmd/destroy/build_control_test.go
+++ b/cmd/destroy/build_control_test.go
@@ -37,7 +37,7 @@ type fakeGetSvcs struct {
 	svcs []string
 }
 
-func (fb fakeBuilderV2) GetServicesToBuild(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error) {
+func (fb fakeBuilderV2) GetServicesToBuildDuringDeploy(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error) {
 	return fb.getSvcs.svcs, fb.getSvcs.err
 }
 

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -195,7 +195,7 @@ func (rd *remoteDestroyCommand) destroy(ctx context.Context, opts *Options) erro
 		return err
 	}
 
-	buildOptions := buildCmd.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{Path: cwd, OutputMode: "destroy"})
+	buildOptions := buildCmd.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{Path: cwd, OutputMode: buildCmd.DestroyOutputModeOnBuild})
 	buildOptions.Manifest = rd.manifest
 	buildOptions.BuildArgs = append(
 		buildOptions.BuildArgs,

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -36,7 +36,7 @@ type registryInterface interface {
 }
 
 type builderInterface interface {
-	GetServicesToBuild(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error)
+	GetServicesToBuildDuringDeploy(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error)
 	Build(ctx context.Context, options *types.BuildOptions) error
 	GetBuildEnvVars() map[string]string
 }

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -1068,7 +1068,7 @@ func printDisplayContext(up *upContext) {
 
 // buildServicesAndSetBuildEnvs get services to build and run build to set build envs
 func buildServicesAndSetBuildEnvs(ctx context.Context, m *model.Manifest, builder builderInterface) error {
-	svcsToBuild, err := builder.GetServicesToBuild(ctx, m, []string{})
+	svcsToBuild, err := builder.GetServicesToBuildDuringDeploy(ctx, m, []string{})
 	if err != nil {
 		return err
 	}

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -652,7 +652,7 @@ type fakeBuilder struct {
 	services         []string
 }
 
-func (b *fakeBuilder) GetServicesToBuild(_ context.Context, _ *model.Manifest, _ []string) ([]string, error) {
+func (b *fakeBuilder) GetServicesToBuildDuringDeploy(_ context.Context, _ *model.Manifest, _ []string) ([]string, error) {
 	if b.getServicesErr != nil {
 		return nil, b.getServicesErr
 	}
@@ -680,20 +680,20 @@ func Test_buildServicesAndSetBuildEnvs(t *testing.T) {
 		name              string
 	}{
 		{
-			name: "builder GetServicesToBuild returns error",
+			name: "builder GetServicesToBuildDuringDeploy returns error",
 			builder: &fakeBuilder{
 				getServicesErr: assert.AnError,
 			},
 			expectedErr: assert.AnError,
 		},
 		{
-			name: "builder GetServicesToBuild returns empty list",
+			name: "builder GetServicesToBuildDuringDeploy returns empty list",
 			builder: &fakeBuilder{
 				services: nil,
 			},
 		},
 		{
-			name: "builder GetServicesToBuild returns list, Build is called with the list and the input manifest",
+			name: "builder GetServicesToBuildDuringDeploy returns list, Build is called with the list and the input manifest",
 			builder: &fakeBuilder{
 				services: []string{"test", "okteto"},
 				usedBuildOptions: &types.BuildOptions{
@@ -714,7 +714,7 @@ func Test_buildServicesAndSetBuildEnvs(t *testing.T) {
 			},
 		},
 		{
-			name: "builder GetServicesToBuild returns list, Build returns error",
+			name: "builder GetServicesToBuildDuringDeploy returns list, Build returns error",
 			builder: &fakeBuilder{
 				services: []string{"test", "okteto"},
 				usedBuildOptions: &types.BuildOptions{

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -336,10 +336,9 @@ func TestBuildCommandV2SpecifyingServices(t *testing.T) {
 	require.True(t, isImageBuilt(expectedApiImage))
 }
 
-// TestBuildCommandV2VolumeMounts tests the following scenario:
+// TestBuildCommandV2FromCompose tests the following scenario:
 // - building having a compose file
-// - building an image that needs to mount local volumes
-func TestBuildCommandV2VolumeMounts(t *testing.T) {
+func TestBuildCommandV2FromCompose(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	require.NoError(t, createDockerfile(dir))
@@ -360,9 +359,6 @@ func TestBuildCommandV2VolumeMounts(t *testing.T) {
 	expectedBuildImage := fmt.Sprintf("%s/%s/%s-vols:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedBuildImage))
 
-	expectedImageWithVolumes := fmt.Sprintf("%s/%s/%s-vols:okteto-with-volume-mounts", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
-	require.False(t, isImageBuilt(expectedImageWithVolumes))
-
 	options := &commands.BuildOptions{
 		Workdir:    dir,
 		Namespace:  testNamespace,
@@ -371,7 +367,6 @@ func TestBuildCommandV2VolumeMounts(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedBuildImage), "%s not found", expectedBuildImage)
-	require.True(t, isImageBuilt(expectedImageWithVolumes), "%s not found", expectedImageWithVolumes)
 }
 
 // TestTestBuildCommandV2Secrets tests the following scenario:

--- a/integration/deploy/endpoints_test.go
+++ b/integration/deploy/endpoints_test.go
@@ -70,7 +70,7 @@ services:
     environment:
     - RABBITMQ_PASS
   nginx:
-    image: nginx
+    build: nginx
     volumes:
     - ./nginx/nginx.conf:/tmp/nginx.conf
     command: /bin/bash -c "envsubst < /tmp/nginx.conf > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
@@ -103,7 +103,7 @@ services:
     environment:
     - RABBITMQ_PASS
   nginx:
-    image: nginx
+    build: nginx
     volumes:
     - ./nginx/nginx.conf:/tmp/nginx.conf
     command: /bin/bash -c "envsubst < /tmp/nginx.conf > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
@@ -309,6 +309,10 @@ func createStackWithEndpointsInferredNameScenario(dir string) error {
 		return err
 	}
 
+	if err := createNginxDockerfile(dir); err != nil {
+		return err
+	}
+
 	if err := createAppDockerfile(dir); err != nil {
 		return err
 	}
@@ -371,6 +375,10 @@ func createStackWithEndpointsNameScenario(dir string) error {
 	nginxPath := filepath.Join(dir, "nginx", "nginx.conf")
 	nginxContent := []byte(nginxConf)
 	if err := os.WriteFile(nginxPath, nginxContent, 0600); err != nil {
+		return err
+	}
+
+	if err := createNginxDockerfile(dir); err != nil {
 		return err
 	}
 

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -270,9 +270,9 @@ func createAppDockerfile(dir string) error {
 }
 
 func createNginxDockerfile(dir string) error {
-	appDockerfilePath := filepath.Join(dir, "nginx", "Dockerfile")
-	appDockerfileContent := []byte(nginxDockerfile)
-	if err := os.WriteFile(appDockerfilePath, appDockerfileContent, 0600); err != nil {
+	nginxDockerfilePath := filepath.Join(dir, "nginx", "Dockerfile")
+	nginxDockerfileContent := []byte(nginxDockerfile)
+	if err := os.WriteFile(nginxDockerfilePath, nginxDockerfileContent, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/integration/okteto/dependencies_test.go
+++ b/integration/okteto/dependencies_test.go
@@ -92,7 +92,7 @@ func TestDependencies(t *testing.T) {
 	}
 
 	output, err := commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
-	require.NoError(t, err)
+	require.NoError(t, err, "there was an error executing the command, output is: %s", string(output))
 
 	expectedOutputCommand := "dependency variable test-value"
 	require.Contains(t, strings.ToLower(string(output)), expectedOutputCommand)
@@ -138,7 +138,7 @@ func TestDependenciesOnRemote(t *testing.T) {
 	}
 
 	output, err := commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptions)
-	require.NoError(t, err)
+	require.NoError(t, err, "there was an error executing the command, output is: %s", string(output))
 
 	expectedOutputCommand := "dependency variable test-value"
 	require.Contains(t, strings.ToLower(string(output)), expectedOutputCommand)

--- a/integration/okteto/dependencies_test.go
+++ b/integration/okteto/dependencies_test.go
@@ -118,7 +118,7 @@ func TestDependenciesOnRemote(t *testing.T) {
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceDeployOpts))
 	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceDeployOpts)
 
-	testNamespace := integration.GetTestNamespace("Dependency", user)
+	testNamespace := integration.GetTestNamespace("RemoteDep", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -43,7 +43,7 @@ const (
     ports:
     - 8080
   nginx:
-    image: nginx
+    build: nginx
     volumes:
     - ./nginx/nginx.conf:/tmp/nginx.conf
     command: /bin/bash -c "envsubst < /tmp/nginx.conf > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
@@ -83,6 +83,9 @@ const (
 destroy:
   - name: Mask command destroy
     command: echo $TOMASK
+`
+	nginxDockerfile = `FROM nginx
+COPY ./nginx.conf /tmp/nginx.conf
 `
 )
 
@@ -461,6 +464,10 @@ func createComposeScenario(dir string) error {
 		return err
 	}
 
+	if err := createNginxDockerfile(dir); err != nil {
+		return err
+	}
+
 	if err := createAppDockerfile(dir); err != nil {
 		return err
 	}
@@ -482,6 +489,15 @@ func createAppDockerfile(dir string) error {
 	appDockerfilePath := filepath.Join(dir, "app", "Dockerfile")
 	appDockerfileContent := []byte(appDockerfile)
 	if err := os.WriteFile(appDockerfilePath, appDockerfileContent, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+func createNginxDockerfile(dir string) error {
+	nginxDockerfilePath := filepath.Join(dir, "nginx", "Dockerfile")
+	nginxDockerfileContent := []byte(nginxDockerfile)
+	if err := os.WriteFile(nginxDockerfilePath, nginxDockerfileContent, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/integration/up/compose_test.go
+++ b/integration/up/compose_test.go
@@ -43,7 +43,7 @@ const (
     volumes:
     - .:/usr/src/app
   nginx:
-    image: nginx
+    build: nginx
     volumes:
       - ./nginx/nginx.conf:/tmp/nginx.conf
     command: /bin/bash -c "envsubst < /tmp/nginx.conf > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
@@ -69,6 +69,10 @@ const (
     proxy_pass http://$SERVER;
   }
 }`
+
+	nginxDockerfile = `FROM nginx
+COPY ./nginx.conf /tmp/nginx.conf
+`
 )
 
 func TestUpCompose(t *testing.T) {
@@ -188,6 +192,12 @@ func createNginxDir(dir string) error {
 	nginxPath := filepath.Join(dir, "nginx", "nginx.conf")
 	nginxContent := []byte(nginxConf)
 	if err := os.WriteFile(nginxPath, nginxContent, 0600); err != nil {
+		return err
+	}
+
+	nginxDockerfilePath := filepath.Join(dir, "nginx", "Dockerfile")
+	nginxDockerfileContent := []byte(nginxDockerfile)
+	if err := os.WriteFile(nginxDockerfilePath, nginxDockerfileContent, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/build/manifest_section.go
+++ b/pkg/build/manifest_section.go
@@ -42,7 +42,7 @@ func (b *ManifestBuild) Validate() error {
 	return nil
 }
 
-// GetSvcsToBuildFromList returns the builds from a list and all its
+// GetSvcsToBuildFromList returns the builds from a list and all its dependencies
 func (b *ManifestBuild) GetSvcsToBuildFromList(toBuild []string) []string {
 	initialSvcsToBuild := toBuild
 	svcsToBuildWithDependencies := getDependentNodes(b.toGraph(), toBuild)

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -85,19 +85,22 @@ func (ob *OktetoBuilder) GetBuilder() string {
 
 // Run runs the build sequence
 func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptions, ioCtrl *io.Controller) error {
+	isDeployOrDestroy := buildOptions.OutputMode == DeployOutputModeOnBuild || buildOptions.OutputMode == DestroyOutputModeOnBuild
 	buildOptions.OutputMode = setOutputMode(buildOptions.OutputMode)
 	depotToken := os.Getenv(DepotTokenEnvVar)
 	depotProject := os.Getenv(DepotProjectEnvVar)
 
-	builder := ob.GetBuilder()
-	buildMsg := fmt.Sprintf("Building '%s'", buildOptions.File)
-	depotEnabled := isDepotEnabled(depotProject, depotToken)
-	if depotEnabled {
-		ioCtrl.Out().Infof("%s on depot's machine...", buildMsg)
-	} else if builder == "" {
-		ioCtrl.Out().Infof("%s using your local docker daemon", buildMsg)
-	} else {
-		ioCtrl.Out().Infof("%s in %s...", buildMsg, builder)
+	if !isDeployOrDestroy {
+		builder := ob.GetBuilder()
+		buildMsg := fmt.Sprintf("Building '%s'", buildOptions.File)
+		depotEnabled := isDepotEnabled(depotProject, depotToken)
+		if depotEnabled {
+			ioCtrl.Out().Infof("%s on depot's machine...", buildMsg)
+		} else if builder == "" {
+			ioCtrl.Out().Infof("%s using your local docker daemon", buildMsg)
+		} else {
+			ioCtrl.Out().Infof("%s in %s...", buildMsg, builder)
+		}
 	}
 
 	switch {

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -261,9 +261,6 @@ func OptsFromBuildInfo(manifestName, svcName string, b *build.Info, o *types.Bui
 			targetRegistry = constants.GlobalRegistry
 		}
 		b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, sanitizedName, svcName, model.OktetoDefaultImageTag)
-		if len(b.VolumesToInclude) > 0 {
-			b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, sanitizedName, svcName, model.OktetoImageTagWithVolumes)
-		}
 	}
 
 	file := b.Dockerfile

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -251,7 +251,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			isOkteto: true,
 			expected: &types.BuildOptions{
 				OutputMode: oktetoLog.TTYFormat,
-				Tag:        "okteto.dev/movies-service:okteto-with-volume-mounts",
+				Tag:        "okteto.dev/movies-service:okteto",
 				File:       filepath.Join(serviceContext, serviceDockerfile),
 				Target:     "build",
 				Path:       "service",

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -427,7 +427,7 @@ func TestOptsFromBuildInfoForRemoteDeploy(t *testing.T) {
 			},
 			expected: &types.BuildOptions{
 				File:       "Dockerfile",
-				OutputMode: "deploy",
+				OutputMode: DeployOutputModeOnBuild,
 				Path:       "service",
 			},
 		},
@@ -444,14 +444,14 @@ func TestOptsFromBuildInfoForRemoteDeploy(t *testing.T) {
 			},
 			expected: &types.BuildOptions{
 				File:       "Dockerfile",
-				OutputMode: "deploy",
+				OutputMode: DeployOutputModeOnBuild,
 				Path:       "service",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := OptsFromBuildInfoForRemoteDeploy(tt.buildInfo, &types.BuildOptions{OutputMode: "deploy"})
+			result := OptsFromBuildInfoForRemoteDeploy(tt.buildInfo, &types.BuildOptions{OutputMode: DeployOutputModeOnBuild})
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -61,7 +61,7 @@ func getSolveOpt(buildOptions *types.BuildOptions, okctx OktetoContextInterface,
 
 	imageCtrl := registry.NewImageCtrl(GetRegistryConfigFromOktetoConfig(okctx))
 	if okctx.IsOkteto() {
-		buildOptions.DevTag = imageCtrl.ExpandOktetoDevRegistry(registry.GetDevTagFromGlobal(buildOptions.Tag))
+		buildOptions.DevTag = imageCtrl.ExpandOktetoDevRegistry(imageCtrl.GetDevTagFromGlobal(buildOptions.Tag))
 		buildOptions.Tag = imageCtrl.ExpandOktetoDevRegistry(buildOptions.Tag)
 		buildOptions.Tag = imageCtrl.ExpandOktetoGlobalRegistry(buildOptions.Tag)
 		for i := range buildOptions.CacheFrom {

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -364,12 +364,8 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 			// We need to wait until the tty channel is closed to avoid writing to stdout while the tty is being used
 			_, err := progressui.DisplaySolveStatus(context.TODO(), c, ioCtrl.Out(), ttyChannel)
 			return err
-		case DeployOutputModeOnBuild:
-			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: DeployOutputModeOnBuild})
-			commandFailChannel <- err
-			return err
-		case DestroyOutputModeOnBuild:
-			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: DestroyOutputModeOnBuild})
+		case DeployOutputModeOnBuild, DestroyOutputModeOnBuild:
+			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: progress})
 			commandFailChannel <- err
 			return err
 		default:

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -364,12 +364,12 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 			// We need to wait until the tty channel is closed to avoid writing to stdout while the tty is being used
 			_, err := progressui.DisplaySolveStatus(context.TODO(), c, ioCtrl.Out(), ttyChannel)
 			return err
-		case "deploy":
-			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: "deploy"})
+		case DeployOutputModeOnBuild:
+			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: DeployOutputModeOnBuild})
 			commandFailChannel <- err
 			return err
-		case "destroy":
-			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: "destroy"})
+		case DestroyOutputModeOnBuild:
+			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: DestroyOutputModeOnBuild})
 			commandFailChannel <- err
 			return err
 		default:

--- a/pkg/cmd/build/constants.go
+++ b/pkg/cmd/build/constants.go
@@ -1,0 +1,21 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+const (
+	// DeployOutputModeOnBuild Defines the output mode set to BuildOptions when running a remote deploy
+	DeployOutputModeOnBuild = "deploy"
+	// DestroyOutputModeOnBuild Defines the output mode set to BuildOptions when running a remote destroy
+	DestroyOutputModeOnBuild = "destroy"
+)

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -45,10 +45,10 @@ func deployDisplayer(ctx context.Context, ch chan *client.SolveStatus, o *types.
 	var done bool
 	var outputMode string
 
-	if o.OutputMode == "destroy" {
-		outputMode = "destroy"
+	if o.OutputMode == DestroyOutputModeOnBuild {
+		outputMode = DeployOutputModeOnBuild
 	} else {
-		outputMode = "deploy"
+		outputMode = DeployOutputModeOnBuild
 	}
 	for {
 		select {
@@ -152,7 +152,7 @@ func (t *trace) display(progress string) {
 			}
 		}
 		if t.hasCommandLogs(v) {
-			if progress == "deploy" {
+			if progress == DeployOutputModeOnBuild {
 				oktetoLog.Spinner("Deploying your development environment...")
 			} else {
 				oktetoLog.Spinner("Destroying your development environment...")

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -46,7 +46,7 @@ func deployDisplayer(ctx context.Context, ch chan *client.SolveStatus, o *types.
 	var outputMode string
 
 	if o.OutputMode == DestroyOutputModeOnBuild {
-		outputMode = DeployOutputModeOnBuild
+		outputMode = DestroyOutputModeOnBuild
 	} else {
 		outputMode = DeployOutputModeOnBuild
 	}

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -84,7 +84,7 @@ func buildStackImages(ctx context.Context, s *model.Stack, options *DeployOption
 			return err
 		}
 	} else {
-		svcsToBuild, err := builder.GetServicesToBuild(ctx, manifest, options.ServicesToDeploy)
+		svcsToBuild, err := builder.GetServicesToBuildDuringDeploy(ctx, manifest, options.ServicesToDeploy)
 		if err != nil {
 			return err
 		}

--- a/pkg/log/io/out.go
+++ b/pkg/log/io/out.go
@@ -59,114 +59,129 @@ func (oc *OutputController) SetOutputFormat(output string) {
 }
 
 // Println prints a line into stdout
-func (l *OutputController) Println(args ...any) {
+func (oc *OutputController) Println(args ...any) {
 	msg := fmt.Sprint(args...)
-	bytes, err := l.formatter.format(msg)
+	bytes, err := oc.formatter.format(msg)
 	if err != nil {
 		return
 	}
-	if l.spinner != nil && l.spinner.isActive() {
-		l.spinner.Stop()
-		defer l.Spinner(l.spinner.getMessage()).Start()
+	if oc.spinner != nil && oc.spinner.isActive() {
+		oc.spinner.Stop()
+		defer oc.Spinner(oc.spinner.getMessage()).Start()
 	}
-	fmt.Fprintln(l.out, string(bytes))
+	fmt.Fprintln(oc.out, string(bytes))
 }
 
 // Print prints a line into stdout without a new line at the end
-func (l *OutputController) Print(args ...any) {
+func (oc *OutputController) Print(args ...any) {
 	msg := fmt.Sprint(args...)
-	bytes, err := l.formatter.format(msg)
+	bytes, err := oc.formatter.format(msg)
 	if err != nil {
 		return
 	}
-	if l.spinner != nil && l.spinner.isActive() {
-		l.spinner.Stop()
-		defer l.Spinner(l.spinner.getMessage()).Start()
+	if oc.spinner != nil && oc.spinner.isActive() {
+		oc.spinner.Stop()
+		defer oc.Spinner(oc.spinner.getMessage()).Start()
 	}
-	fmt.Fprint(l.out, string(bytes))
+	fmt.Fprint(oc.out, string(bytes))
 }
 
 // Printf prints a line into stdout with a format
-func (l *OutputController) Printf(format string, args ...any) {
+func (oc *OutputController) Printf(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	bytes, err := l.formatter.format(msg)
+	bytes, err := oc.formatter.format(msg)
 	if err != nil {
 		return
 	}
-	if l.spinner != nil && l.spinner.isActive() {
-		l.spinner.Stop()
-		defer l.Spinner(l.spinner.getMessage()).Start()
+	if oc.spinner != nil && oc.spinner.isActive() {
+		oc.spinner.Stop()
+		defer oc.Spinner(oc.spinner.getMessage()).Start()
 	}
-	fmt.Fprint(l.out, string(bytes))
+	fmt.Fprint(oc.out, string(bytes))
 }
 
 // Infof prints a information message to the user
-func (l *OutputController) Infof(format string, args ...any) {
+func (oc *OutputController) Infof(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	msg = l.decorator.Information(msg)
-	bytes, err := l.formatter.format(msg)
+	msg = oc.decorator.Information(msg)
+	bytes, err := oc.formatter.format(msg)
 	if err != nil {
 		return
 	}
-	if l.spinner != nil && l.spinner.isActive() {
-		l.spinner.Stop()
-		defer l.Spinner(l.spinner.getMessage()).Start()
+	if oc.spinner != nil && oc.spinner.isActive() {
+		oc.spinner.Stop()
+		defer oc.Spinner(oc.spinner.getMessage()).Start()
 	}
-	fmt.Fprint(l.out, string(bytes))
+	fmt.Fprint(oc.out, string(bytes))
 }
 
 // Success prints a success message to the user
-func (l *OutputController) Success(format string, args ...any) {
+func (oc *OutputController) Success(format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	msg = l.decorator.Success(msg)
-	bytes, err := l.formatter.format(msg)
+	msg = oc.decorator.Success(msg)
+	bytes, err := oc.formatter.format(msg)
 	if err != nil {
 		return
 	}
-	if l.spinner != nil && l.spinner.isActive() {
-		l.spinner.Stop()
-		defer l.Spinner(l.spinner.getMessage()).Start()
+	if oc.spinner != nil && oc.spinner.isActive() {
+		oc.spinner.Stop()
+		defer oc.Spinner(oc.spinner.getMessage()).Start()
 	}
-	fmt.Fprint(l.out, string(bytes))
+	fmt.Fprint(oc.out, string(bytes))
+}
+
+// Warning prints a warning message to the user
+func (oc *OutputController) Warning(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	msg = oc.decorator.Warning(msg)
+	bytes, err := oc.formatter.format(msg)
+	if err != nil {
+		return
+	}
+	if oc.spinner != nil && oc.spinner.isActive() {
+		oc.spinner.Stop()
+		defer oc.Spinner(oc.spinner.getMessage()).Start()
+	}
+	fmt.Fprint(oc.out, string(bytes))
 }
 
 // SetStage sets the stage of the logger if it's json
-func (l *OutputController) SetStage(stage string) {
-	if v, ok := l.formatter.(*jsonFormatter); ok {
+func (oc *OutputController) SetStage(stage string) {
+	if v, ok := oc.formatter.(*jsonFormatter); ok {
 		v.SetStage(stage)
 	}
 }
 
 // Spinner returns a spinner
-func (l *OutputController) Spinner(msg string) OktetoSpinner {
-	if l.spinner != nil {
-		if l.spinner.getMessage() == msg {
-			return l.spinner
+func (oc *OutputController) Spinner(msg string) OktetoSpinner {
+	if oc.spinner != nil {
+		if oc.spinner.getMessage() == msg {
+			return oc.spinner
 		}
-		l.spinner.Stop()
+		oc.spinner.Stop()
 	}
 
 	disableSpinner := env.LoadBoolean(OktetoDisableSpinnerEnvVar)
 
-	_, isTTY := l.formatter.(*ttyFormatter)
+	_, isTTY := oc.formatter.(*ttyFormatter)
 	if isTTY && !disableSpinner {
-		l.spinner = newTTYSpinner(msg)
+		oc.spinner = newTTYSpinner(msg)
 	} else {
-		l.spinner = newNoSpinner(msg, l)
+		oc.spinner = newNoSpinner(msg, oc)
 	}
-	return l.spinner
+	return oc.spinner
 }
 
 // Write logs into the buffer but does not print anything
-func (l *OutputController) Write(p []byte) (n int, err error) {
+func (oc *OutputController) Write(p []byte) (n int, err error) {
 	msg := string(p)
 	if !strings.HasSuffix(msg, "\n") {
 		msg += "\n"
 	}
-	bytes, err := l.formatter.format(msg)
+	bytes, err := oc.formatter.format(msg)
 	if err != nil {
 		return
 	}
 
-	return l.out.Write(bytes)
+	return oc.out.Write(bytes)
 }

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -260,7 +260,4 @@ const (
 
 	// OktetoDefaultImageTag default tag assigned to image to build
 	OktetoDefaultImageTag = "okteto"
-
-	// OktetoImageTagWithVolumes is the tag assigned to an image with volume mounts
-	OktetoImageTagWithVolumes = "okteto-with-volume-mounts"
 )

--- a/pkg/okteto/context_stateless.go
+++ b/pkg/okteto/context_stateless.go
@@ -105,6 +105,10 @@ func (oc *ContextStateless) GetGlobalNamespace() string {
 	return oc.getCurrentOktetoContext().GlobalNamespace
 }
 
+func (oc *ContextStateless) SetGlobalNamespace(globalNamespace string) {
+	oc.getCurrentOktetoContext().GlobalNamespace = globalNamespace
+}
+
 func (oc *ContextStateless) GetTokenByContextName(name string) (string, error) {
 	ctx, ok := oc.Store.Contexts[name]
 	if !ok {

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -153,23 +153,22 @@ func (ImageCtrl) getExposedPortsFromCfg(cfg *containerv1.ConfigFile) []Port {
 	return result
 }
 
-func GetDevTagFromGlobal(image string) string {
-	if !strings.HasPrefix(image, constants.GlobalRegistry) {
+func (ic ImageCtrl) GetDevTagFromGlobal(image string) string {
+	expandedImage := ic.ExpandOktetoGlobalRegistry(image)
+	expandedGlobalRegPrefix := fmt.Sprintf("%s/%s", ic.config.GetRegistryURL(), ic.config.GetGlobalNamespace())
+	if !strings.HasPrefix(expandedImage, expandedGlobalRegPrefix) {
 		return ""
 	}
 
 	// separate image reference and tag eg: okteto.dev/image:tag
-	reference, _, found := strings.Cut(image, "@sha256")
+	reference, _, found := strings.Cut(expandedImage, "@sha256")
 	if !found {
-		reference, _, found = strings.Cut(image, ":")
+		reference, _, found = strings.Cut(expandedImage, ":")
 		if !found {
 			return ""
 		}
 	}
 
-	devReference := strings.Replace(reference, constants.GlobalRegistry, constants.DevRegistry, 1)
-	if devReference == reference {
-		return ""
-	}
+	devReference := strings.Replace(reference, expandedGlobalRegPrefix, constants.DevRegistry, 1)
 	return fmt.Sprintf("%s:%s", devReference, model.OktetoDefaultImageTag)
 }

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -356,11 +356,39 @@ func Test_GetExpandedDevTagFromGlobal(t *testing.T) {
 			input:    "okteto.global/my-image@sha256:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
 			expected: "okteto.dev/my-image:okteto",
 		},
+		{
+			name:     "is expanded global image with sha",
+			input:    "registry.test.dev.okteto.net/okteto/my-image@sha256:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
+			expected: "okteto.dev/my-image:okteto",
+		},
+		{
+			name:     "is expanded global image with tag",
+			input:    "registry.test.dev.okteto.net/okteto/my-image:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
+			expected: "okteto.dev/my-image:okteto",
+		},
+		{
+			name:     "is expanded dev image with tag",
+			input:    "registry.test.dev.okteto.net/my-ns/my-image:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
+			expected: "",
+		},
+		{
+			name:     "is expanded dev image with sha",
+			input:    "registry.test.dev.okteto.net/my-ns/my-image@sha256:ffa944a92b29ea4fa26d53c63054605c4fb7a8b787a673c",
+			expected: "",
+		},
 	}
 
 	for _, tt := range tests {
+		config := fakeImageConfig{
+			registryURL: "registry.test.dev.okteto.net",
+			globalNs:    "okteto",
+		}
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetDevTagFromGlobal(tt.input)
+			imageCtrl := ImageCtrl{
+				config:           config,
+				registryReplacer: NewRegistryReplacer(config),
+			}
+			got := imageCtrl.GetDevTagFromGlobal(tt.input)
 			assert.Equal(t, tt.expected, got)
 		})
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 )
 
 const globalTestImage = "okteto.global/test"
@@ -157,7 +158,7 @@ func (or OktetoRegistry) GetRepoNameAndTag(repo string) (string, string) {
 }
 
 // CloneGlobalImageToDev clones an image from the global registry to the dev registry
-func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest, defaultTag string) (string, error) {
+func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest string) (string, error) {
 	// parse the image URI to extract registry and repository name
 	reg, repositoryWithTag := or.imageCtrl.GetRegistryAndRepo(imageWithDigest)
 	repo, _ := or.imageCtrl.GetRepoNameAndTag(repositoryWithTag)
@@ -173,7 +174,7 @@ func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest, defaultTag strin
 	personalNamespacePrefix := fmt.Sprintf("%s/", or.config.GetNamespace())
 	devRepo := strings.Replace(repo, globalNamespacePrefix, personalNamespacePrefix, 1)
 	// When cloning an image from global to dev, we should do it to the "okteto" tag
-	devImage := fmt.Sprintf("%s/%s:%s", reg, devRepo, defaultTag)
+	devImage := fmt.Sprintf("%s/%s:%s", reg, devRepo, model.OktetoDefaultImageTag)
 
 	newRef, err := name.ParseReference(devImage)
 	if err != nil {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 )
 
 const globalTestImage = "okteto.global/test"
@@ -157,7 +158,7 @@ func (or OktetoRegistry) GetRepoNameAndTag(repo string) (string, string) {
 }
 
 // CloneGlobalImageToDev clones an image from the global registry to the dev registry
-func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (string, error) {
+func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest string) (string, error) {
 	// parse the image URI to extract registry and repository name
 	reg, repositoryWithTag := or.imageCtrl.GetRegistryAndRepo(imageWithDigest)
 	repo, _ := or.imageCtrl.GetRepoNameAndTag(repositoryWithTag)
@@ -172,7 +173,8 @@ func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (str
 	// forging a new image URI in the dev registry, using the same repo name and tag as the global image
 	personalNamespacePrefix := fmt.Sprintf("%s/", or.config.GetNamespace())
 	devRepo := strings.Replace(repo, globalNamespacePrefix, personalNamespacePrefix, 1)
-	devImage := fmt.Sprintf("%s/%s:%s", reg, devRepo, tag)
+	// When cloning an image from global to dev, we should do it to the "okteto" tag
+	devImage := fmt.Sprintf("%s/%s:%s", reg, devRepo, model.OktetoDefaultImageTag)
 
 	newRef, err := name.ParseReference(devImage)
 	if err != nil {
@@ -195,5 +197,13 @@ func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest, tag string) (str
 		return "", err
 	}
 
-	return devImage, nil
+	// TODO: Could we assume that the sha256 of the global image would be the same than the dev registry one?
+	// To return always the sha256 os the dev image
+	r, err := or.GetImageTagWithDigest(devImage)
+	if err != nil {
+		// If there is an error getting the tag with digest we just return the dev image
+		return devImage, nil
+	}
+
+	return r, nil
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -200,6 +200,7 @@ func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest string) (string, 
 	// To return always the sha256 os the dev image
 	r, err := or.GetImageTagWithDigest(devImage)
 	if err != nil {
+		oktetoLog.Debugf("error getting the tag with digest for dev image: %s", err)
 		// If there is an error getting the tag with digest we just return the dev image
 		return devImage, nil
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -14,12 +14,12 @@
 package registry
 
 import (
-    "crypto/x509"
-    "fmt"
-    "strings"
+	"crypto/x509"
+	"fmt"
+	"strings"
 
-    "github.com/google/go-containerregistry/pkg/name"
-    oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/google/go-containerregistry/pkg/name"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
 const globalTestImage = "okteto.global/test"

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -197,7 +197,6 @@ func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest string) (string, 
 		return "", err
 	}
 
-	// TODO: Could we assume that the sha256 of the global image would be the same than the dev registry one?
 	// To return always the sha256 os the dev image
 	r, err := or.GetImageTagWithDigest(devImage)
 	if err != nil {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -14,13 +14,12 @@
 package registry
 
 import (
-	"crypto/x509"
-	"fmt"
-	"strings"
+    "crypto/x509"
+    "fmt"
+    "strings"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/model"
+    "github.com/google/go-containerregistry/pkg/name"
+    oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
 const globalTestImage = "okteto.global/test"
@@ -158,7 +157,7 @@ func (or OktetoRegistry) GetRepoNameAndTag(repo string) (string, string) {
 }
 
 // CloneGlobalImageToDev clones an image from the global registry to the dev registry
-func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest string) (string, error) {
+func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest, defaultTag string) (string, error) {
 	// parse the image URI to extract registry and repository name
 	reg, repositoryWithTag := or.imageCtrl.GetRegistryAndRepo(imageWithDigest)
 	repo, _ := or.imageCtrl.GetRepoNameAndTag(repositoryWithTag)
@@ -174,7 +173,7 @@ func (or OktetoRegistry) CloneGlobalImageToDev(imageWithDigest string) (string, 
 	personalNamespacePrefix := fmt.Sprintf("%s/", or.config.GetNamespace())
 	devRepo := strings.Replace(repo, globalNamespacePrefix, personalNamespacePrefix, 1)
 	// When cloning an image from global to dev, we should do it to the "okteto" tag
-	devImage := fmt.Sprintf("%s/%s:%s", reg, devRepo, model.OktetoDefaultImageTag)
+	devImage := fmt.Sprintf("%s/%s:%s", reg, devRepo, defaultTag)
 
 	newRef, err := name.ParseReference(devImage)
 	if err != nil {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -444,7 +444,7 @@ func Test_OktetoRegistry_CloneGlobalImageToDev(t *testing.T) {
 				},
 			},
 			expected: expected{
-				image: "this.is.my.okteto.registry/test-ns/test-repo:default-tag",
+				image: "this.is.my.okteto.registry/test-ns/test-repo:okteto",
 				err:   nil,
 			},
 		},
@@ -457,7 +457,7 @@ func Test_OktetoRegistry_CloneGlobalImageToDev(t *testing.T) {
 				client:    tt.client,
 			}
 
-			result, err := or.CloneGlobalImageToDev(tt.input.image, "default-tag")
+			result, err := or.CloneGlobalImageToDev(tt.input.image)
 			assert.Equal(t, tt.expected.image, result)
 			if tt.expected.err != nil && err != nil {
 				assert.Equal(t, err.Error(), tt.expected.err.Error())

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -444,7 +444,7 @@ func Test_OktetoRegistry_CloneGlobalImageToDev(t *testing.T) {
 				},
 			},
 			expected: expected{
-				image: "this.is.my.okteto.registry/test-ns/test-repo:okteto",
+				image: "this.is.my.okteto.registry/test-ns/test-repo:default-tag",
 				err:   nil,
 			},
 		},
@@ -457,7 +457,7 @@ func Test_OktetoRegistry_CloneGlobalImageToDev(t *testing.T) {
 				client:    tt.client,
 			}
 
-			result, err := or.CloneGlobalImageToDev(tt.input.image)
+			result, err := or.CloneGlobalImageToDev(tt.input.image, "default-tag")
 			assert.Equal(t, tt.expected.image, result)
 			if tt.expected.err != nil && err != nil {
 				assert.Equal(t, err.Error(), tt.expected.err.Error())

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -31,6 +31,10 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	gitOperationTimeout = 5 * time.Second
+)
+
 var (
 	errNotCleanRepo    = errors.New("repository is not clean")
 	errTimeoutExceeded = errors.New("timeout exceeded")
@@ -143,10 +147,8 @@ func (r gitRepoController) GetLatestDirCommit(contextDir string) (string, error)
 	timeoutCh := make(chan struct{})
 	ch := make(chan commitResponse)
 
-	timeout := 5 * time.Second
-
 	go func() {
-		time.Sleep(timeout)
+		time.Sleep(gitOperationTimeout)
 		close(timeoutCh)
 		cancel()
 		ch <- commitResponse{
@@ -195,8 +197,6 @@ func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
 	diffCh := make(chan diffResponse)
 	untrackedFilesCh := make(chan untrackedFilesResponse)
 
-	timeout := 5 * time.Second
-
 	repo, err := r.repoGetter.get(r.path)
 	if err != nil {
 		return "", fmt.Errorf("failed to analyze git repo: %w", err)
@@ -204,7 +204,7 @@ func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
 
 	// go func that cancels the context after the timeout
 	go func() {
-		time.Sleep(timeout)
+		time.Sleep(gitOperationTimeout)
 		close(timeoutCh)
 		cancel()
 		diffCh <- diffResponse{

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -416,7 +416,7 @@ func TestGetDiffHash(t *testing.T) {
 			},
 			buildContext: "test",
 			expected: expected{
-				sha: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				sha: "3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112",
 				err: nil,
 			},
 		},


### PR DESCRIPTION
# Proposed changes

Fixes DEV-187

## Context

A bit of context on how smart builds have to work. This only applies when the images to build doesn't specify a destination image through the `image` field. If the `image` field is set, we just use that one as destiny.

The idea is to use the dev registry (`okteto.dev`) as the registry where we have the latest build done for any image. And use the global registry (`okteto.global`) as a cache for images already built. 

That latest images stored in the dev registry have the tag `okteto`.

### Build flow

When we build an image (`okteto build` or `okteto deploy --build`), we do the following:
* We get the build context hash, which is mainly:
  * The last commit of the build context (folder) specified for an image
  * A hash of the git diff of the build context (folder) specified for an image
* We calculate a SHA for the service image with the different information like the build context, image targer, build args, etc...
* With that SHA, we see if the image is already built in the global registry:
  * If it is built, we just copy that image to the dev registry using the tag `okteto`
  * If it is not built, we build the image and push it to both global (`okteto.gobal/<image-name>:<calculated-sha>`) and dev (`okteto.dev/<image-name>:okteto`) registries

### Deploy build

When a deploy is executed with a manifest, we do the following operations:
* For every image defined in the manifest, we check if the tag `okteto` exists in the dev registry (`okteto.dev`).
  * If the image exists, we don't build it and use that one
  * If the image doesn't exist in the dev registry, we build it, and the flow mentioned above will start (image might be finally built or not depending on if that variable is present in the global registry with the sha or not)

### Changes

This PR includes several fixes and changes:
* Fixed an issue in which the `globalNamespace` flag for the context wasn't being propagated correctly to build command and the images for the global registry were being pushed to the wrong repository making the smart builds not working in dogfooding environments
* Remove `Building image '/tmp/....` message displayed as part of remote deploy and destroy as it is misleading because the main operation is not a build
* We remove the support of volume mounts as part of compose building our own images with the volumes. This is a breaking change.
* Project commit implementation of smart builds is now deleted and we only have the build context one
* We don't have a different logic if the current repository/context is dirty or not. We always behave in the same way
* When there is an error getting the current commit or getting the git diff, we generate a random commit/diff sha, so we force a rebuild of the image
* If there is an error trying to see if an image is already present or not in the registry, we consider that service to be built instead of failing the operation
* Fixed an issue with the internal cache of the hasher as it was caching the image SHA using the folder name, so 2 images using different targets or different build args were ending up with the same SHA (and they shouldn't)

## How to validate

Do different builds and deploy operations, cases I was testing:
* When the `image` field is set, that registry is used to be pushed.
  * When deploying (without specifically build the image), if the image already exists, we use that one
  * When building (`okteto build` or `okteto deploy --build`), the image is always built as we don't know if it has the latest changes or not
* When the `image` field is not set:
  * For new images, they are built and pushed to both global and dev registry.
    * The global one should use a SHA as tag
    * The dev one should use the `okteto` tag
  * If I change to a new namespace and I build the same images without doing any change on the repo, images are not built but they are copied from the global registry to the dev one
  * If I try to build the images again, it should say they already exists and don't build anything
  * Run `okteto build --no-cache` will rebuild them again even if they exists
  * Now I do changes to my repository and push it
  * If I try to build them, they should be built as a new commit is detected and they have to be pushed to both global and dev registry
  * If I go to the context of an image (folder) and I do any change there without pushing it and I build the images, only the affected image should be built pushing to both registries
  * If I deploy the manifest, images should not be built and the `okteto` tag will be built
  * If I change to a new namespace and I deploy the manifest, it will detect that images are not in the dev registry and it will try to build them. When building the images, it will realize that the images are in the global registry and they will be copied to the dev registry one
  * Then I do any change in the repository and push it to have a new commit. Then, change to a new namespace and deploy the manifest. It will trigger the build of the images

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
