### PR TITLE
[Compose] Allow setting K8S labels from `docker-compose.yml`

### DIFF
--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -204,8 +204,8 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 	// Test that the nginx image has been created correctly
 	appDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "app", c)
 	require.NoError(t, err)
-	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/annotation-1"], "value-annotation-1")
-	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/annotation-2"], "value-annotation-2")
+	require.Equal(t, appDeployment.ObjectMeta.Labels["dev.okteto.com/annotation-1"], "value-annotation-1")
+	require.Equal(t, appDeployment.ObjectMeta.Labels["dev.okteto.com/annotation-2"], "value-annotation-2")
 	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/label-1"], "value-label-1")
 	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/label-2"], "value-label-2")
 

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -214,8 +214,8 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 
 	appVolume, err := integration.GetVolume(context.Background(), testNamespace, "data", c)
 	require.NoError(t, err)
-	require.Equal(t, appVolume.ObjectMeta.Annotations["dev.okteto.com/annotation-1"], "volume-annotation-1")
-	require.Equal(t, appVolume.ObjectMeta.Annotations["dev.okteto.com/annotation-2"], "volume-annotation-2")
+	require.Equal(t, appVolume.ObjectMeta.Labels["dev.okteto.com/annotation-1"], "volume-annotation-1")
+	require.Equal(t, appVolume.ObjectMeta.Labels["dev.okteto.com/annotation-2"], "volume-annotation-2")
 	require.Equal(t, appVolume.ObjectMeta.Annotations["dev.okteto.com/label-1"], "volume-label-1")
 	require.Equal(t, appVolume.ObjectMeta.Annotations["dev.okteto.com/label-2"], "volume-label-2")
 

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -547,7 +547,6 @@ func translateLabelSelector(svcName string, s *model.Stack) map[string]string {
 }
 
 func translateAnnotations(svc *model.Service) map[string]string {
-
 	result := getAnnotations()
 	for k, v := range svc.Annotations {
 		result[k] = v

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -399,11 +399,14 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 		translateHealtcheckCurlToHTTP(svc.Healtcheck)
 	}
 
-	svc.Annotations = serviceRaw.Annotations
+	svc.NodeSelector = serviceRaw.NodeSelector
+
+	if svc.Labels == nil {
+		svc.Labels = make(Labels)
+	}
 	if svc.Annotations == nil {
 		svc.Annotations = make(Annotations)
 	}
-	svc.NodeSelector = serviceRaw.NodeSelector
 
 	if stack.IsCompose {
 		if len(serviceRaw.Args.Values) > 0 {
@@ -415,7 +418,9 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 		for key, value := range unmarshalLabels(serviceRaw.Labels, serviceRaw.Deploy) {
 			svc.Annotations[key] = value
 		}
-
+		for key, value := range serviceRaw.Annotations {
+			svc.Labels[key] = value
+		}
 	} else { // isOktetoStack
 		if len(serviceRaw.Entrypoint.Values) > 0 {
 			return nil, fmt.Errorf("unsupported field for services.%s: 'entrypoint'", svcName)
@@ -428,12 +433,10 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 		}
 		svc.Command.Values = serviceRaw.Args.Values
 
-		if svc.Labels == nil {
-			svc.Labels = make(Labels)
-		}
 		for key, value := range unmarshalLabels(serviceRaw.Labels, serviceRaw.Deploy) {
 			svc.Labels[key] = value
 		}
+		svc.Annotations = serviceRaw.Annotations
 	}
 
 	svc.EnvFiles = serviceRaw.EnvFiles

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -323,43 +323,45 @@ func unmarshalVolume(volume *VolumeTopLevel, isCompose bool) (*VolumeSpec, error
 		Annotations: make(Annotations),
 	}
 
-	if volume != nil {
-		if isCompose {
-			for key, value := range volume.Annotations {
-				result.Labels[key] = value
-			}
-			for key, value := range volume.Labels {
-				result.Annotations[key] = value
-			}
-		} else { // stack
-			for key, value := range volume.Annotations {
-				result.Annotations[key] = value
-			}
-			for key, value := range volume.Labels {
-				result.Annotations[key] = value
-			}
-		}
+	if volume == nil {
+		return result, nil
+	}
 
-		if volume.Size.Value.Cmp(resource.MustParse("0")) > 0 {
-			result.Size = volume.Size
+	if isCompose {
+		for key, value := range volume.Annotations {
+			result.Labels[key] = value
 		}
-		if volume.DriverOpts != nil {
-			for key, value := range volume.DriverOpts {
-				if key == "size" {
-					qK8s, err := resource.ParseQuantity(value)
-					if err != nil {
-						return nil, err
-					}
-					result.Size.Value = qK8s
+		for key, value := range volume.Labels {
+			result.Annotations[key] = value
+		}
+	} else { // stack
+		for key, value := range volume.Annotations {
+			result.Annotations[key] = value
+		}
+		for key, value := range volume.Labels {
+			result.Annotations[key] = value
+		}
+	}
+
+	if volume.Size.Value.Cmp(resource.MustParse("0")) > 0 {
+		result.Size = volume.Size
+	}
+	if volume.DriverOpts != nil {
+		for key, value := range volume.DriverOpts {
+			if key == "size" {
+				qK8s, err := resource.ParseQuantity(value)
+				if err != nil {
+					return nil, err
 				}
-				if key == "class" {
-					result.Class = value
-				}
+				result.Size.Value = qK8s
+			}
+			if key == "class" {
+				result.Class = value
 			}
 		}
-		if result.Class == "" {
-			result.Class = volume.Class
-		}
+	}
+	if result.Class == "" {
+		result.Class = volume.Class
 	}
 
 	return result, nil

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -1439,7 +1439,7 @@ func Test_UnmarshalSvcName(t *testing.T) {
 	}
 }
 
-func Test_DeployLabels(t *testing.T) {
+func Test_DeployLabelsAndAnnotations(t *testing.T) {
 	tests := []struct {
 		annotations Annotations
 		labels      Labels
@@ -1447,48 +1447,158 @@ func Test_DeployLabels(t *testing.T) {
 		manifest    []byte
 		isCompose   bool
 	}{
-
 		{
-			name:        "deploy labels",
-			manifest:    []byte("services:\n  app:\n    deploy:\n      labels:\n        env: production\n    image: okteto/vote:1"),
-			annotations: Annotations{"env": "production"},
-			labels:      Labels{},
-			isCompose:   true,
-		},
-		{
-			name:        "no labels",
-			manifest:    []byte("services:\n  app:\n    image: okteto/vote:1"),
+			name: "compose - no labels or annotations",
+			manifest: []byte(`
+services:
+  app:
+    image: okteto/vote:1
+`),
 			annotations: Annotations{},
 			labels:      Labels{},
 			isCompose:   true,
 		},
 		{
-			name:        "labels on service",
-			manifest:    []byte("services:\n  app:\n    image: okteto/vote:1\n    labels:\n      env: production"),
+			name: "compose - deploy labels",
+			manifest: []byte(`
+services:
+  app:
+    deploy:
+      labels:
+        env: production
+    image: okteto/vote:1
+`),
 			annotations: Annotations{"env": "production"},
 			labels:      Labels{},
 			isCompose:   true,
 		},
 		{
-			name:        "labels on deploy and service",
-			manifest:    []byte("services:\n  app:\n    image: okteto/vote:1\n    labels:\n      app: main\n    deploy:\n      labels:\n        env: production\n"),
-			annotations: Annotations{"env": "production", "app": "main"},
+			name: "compose - labels on service",
+			manifest: []byte(`
+services:
+  app:
+    image: okteto/vote:1
+    labels:
+      env: production
+`),
+			annotations: Annotations{"env": "production"},
 			labels:      Labels{},
 			isCompose:   true,
 		},
-
 		{
-			name:        "labels on deploy and service",
-			manifest:    []byte("services:\n  app:\n    image: okteto/vote:1\n    labels:\n      app: main\n    deploy:\n      labels:\n        env: production\n"),
+			name: "compose - annotations on service",
+			manifest: []byte(`
+services:
+  app:
+    image: okteto/vote:1
+    annotations:
+      env: production
+`),
+			annotations: Annotations{},
+			labels:      Labels{"env": "production"},
+			isCompose:   true,
+		},
+		{
+			name: "compose - labels on deploy and service and annotations",
+			manifest: []byte(`
+services:
+  app:
+    deploy:
+      labels:
+        env: production
+    image: okteto/vote:1
+    labels:
+      app: main
+    annotations:
+      annotation: test
+`),
+			annotations: Annotations{"env": "production", "app": "main"},
+			labels:      Labels{"annotation": "test"},
+			isCompose:   true,
+		},
+		{
+			name: "stack - no labels or annotations",
+			manifest: []byte(`
+services:
+  app:
+    image: okteto/vote:1
+`),
+			annotations: Annotations{},
+			labels:      Labels{},
+			isCompose:   false,
+		},
+		{
+			name: "stack - deploy labels",
+			manifest: []byte(`
+services:
+  app:
+    deploy:
+      labels:
+        env: production
+    image: okteto/vote:1
+`),
+			annotations: Annotations{},
+			labels:      Labels{"env": "production"},
+			isCompose:   false,
+		},
+		{
+			name: "stack - labels on deploy and service",
+			manifest: []byte(`
+services:
+  app:
+    deploy:
+      labels:
+        env: production
+    image: okteto/vote:1
+    labels:
+      app: main
+`),
 			annotations: Annotations{},
 			labels:      Labels{"app": "main", "env": "production"},
 			isCompose:   false,
 		},
 		{
-			name:        "labels on service",
-			manifest:    []byte("services:\n  app:\n    image: okteto/vote:1\n    labels:\n      env: production"),
+			name: "stack - labels on service",
+			manifest: []byte(`
+services:
+  app:
+    image: okteto/vote:1
+    labels:
+      env: production
+`),
 			annotations: Annotations{},
 			labels:      Labels{"env": "production"},
+			isCompose:   false,
+		},
+		{
+			name: "stack - annotations on service",
+			manifest: []byte(`
+services:
+  app:
+    image: okteto/vote:1
+    annotations:
+      env: production
+`),
+			annotations: Annotations{"env": "production"},
+			labels:      Labels{},
+			isCompose:   false,
+		},
+		{
+			name: "stack - labels on deploy and service and annotations",
+			manifest: []byte(`
+services:
+  app:
+    deploy:
+      labels:
+        env: production
+    image: okteto/vote:1
+    labels:
+      app: main
+    annotations:
+      annotation: test
+`),
+			annotations: Annotations{"annotation": "test"},
+			labels:      Labels{"env": "production", "app": "main"},
 			isCompose:   false,
 		},
 	}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-215

Note: this is an alternative PR to https://github.com/okteto/okteto/pull/4199. The original PR approached the problem by changing how the serializer would create the model (labels into labels, annotations into annotations), however it impacted stack too. With this PR we only change compose, as intended, and also used an approach that requires less changes and may be less confusing, which is to keep the serialization as is, and make the requires changes using the current logic.

This PR changes enables users to set k8s labels when using docker compose manifests.

At the moment both `labels` and `annotations` are translated into k8s annotations, with this change compose annotations will be k8s labels, and viceversa.

|         | `master` | `af/compose-annotations-dev-215-2` |
|---------|--------|-----|
| `service` |    <img width="965" alt="Screenshot 2024-03-18 at 10 32 16" src="https://github.com/okteto/okteto/assets/2318450/50c7f36e-a2e1-4a42-a029-332d5be916a3">    |   <img width="927" alt="Screenshot 2024-03-18 at 10 34 26" src="https://github.com/okteto/okteto/assets/2318450/6538a004-bb6c-4baa-a853-85fc581469d4">  |
| `volume`  |    <img width="1141" alt="Screenshot 2024-03-18 at 10 30 53" src="https://github.com/okteto/okteto/assets/2318450/ed753927-251b-44b7-92e6-a3a94ae72509">    |    <img width="1220" alt="Screenshot 2024-03-18 at 10 23 24" src="https://github.com/okteto/okteto/assets/2318450/94828485-7d68-4c85-9110-e9e38784ced5"> |

## How to validate

1. Clone https://github.com/okteto/movies-with-compose
2. Override the `docker-compose.yml` with [this one](https://gist.github.com/andreafalzetti/30311d9dba40b46422e65671bdbf3550)
Highlight of changes from my test `docker-compose.yml` are:
a. Adding `services.api.labels` and `services.api.annotations`
b. Adding `volumes.data.labels`

3. Run `okteto deploy` and observe annotations and labels for the api service and the volume. Compose annotations should become k8s labels, and vice versa

Additional checks:
1. Try making a very long label/annotation and observe the CLI failing with:
```
 x  Error updating kubernetes service: Service "api" is invalid: [metadata.labels: Invalid value: "dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.": name part must be no more than 63 characters, metadata.labels: Invalid value: "dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.dev.okteto.com.": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]
```


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
