### PR TITLE
Don't add extra hosts for remote deploy w/ depot

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -243,6 +243,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		fmt.Sprintf("%s=%s", model.OktetoActionNameEnvVar, os.Getenv(model.OktetoActionNameEnvVar)),
 		fmt.Sprintf("%s=%s", constants.OktetoGitCommitEnvVar, os.Getenv(constants.OktetoGitCommitEnvVar)),
 		fmt.Sprintf("%s=%s", constants.OktetoGitBranchEnvVar, os.Getenv(constants.OktetoGitBranchEnvVar)),
+		fmt.Sprintf("%s=%s", constants.OktetoTlsCertBase64EnvVar, base64.StdEncoding.EncodeToString(sc.Certificate)),
 		fmt.Sprintf("%s=%d", constants.OktetoInvalidateCacheEnvVar, int(randomNumber.Int64())),
 		fmt.Sprintf("%s=%s", constants.OktetoDeployableEnvVar, base64.StdEncoding.EncodeToString(b)),
 		fmt.Sprintf("%s=%s", model.GithubRepositoryEnvVar, os.Getenv(model.GithubRepositoryEnvVar)),
@@ -254,7 +255,6 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		buildOptions.BuildArgs = append(
 			buildOptions.BuildArgs,
 			fmt.Sprintf("%s=%s", constants.OktetoInternalServerNameEnvVar, sc.ServerName),
-			fmt.Sprintf("%s=%s", constants.OktetoTlsCertBase64EnvVar, base64.StdEncoding.EncodeToString(sc.Certificate)),
 		)
 		if sc.ServerName != "" {
 			registryUrl := okteto.GetContext().Registry

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -191,6 +191,7 @@ func TestExtraHosts(t *testing.T) {
 		},
 		getBuildEnvVars:      func() map[string]string { return nil },
 		getDependencyEnvVars: func(_ environGetter) map[string]string { return nil },
+		useInternalNetwork:   true,
 	}
 
 	err := rdc.Deploy(ctx, &Options{

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -91,7 +91,7 @@ func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptio
 
 	builder := ob.GetBuilder()
 	buildMsg := fmt.Sprintf("Building '%s'", buildOptions.File)
-	depotEnabled := isDepotEnabled(depotProject, depotToken)
+	depotEnabled := IsDepotEnabled()
 	if depotEnabled {
 		ioCtrl.Out().Infof("%s on depot's machine...", buildMsg)
 	} else if builder == "" {
@@ -101,7 +101,7 @@ func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptio
 	}
 
 	switch {
-	case isDepotEnabled(depotProject, depotToken):
+	case IsDepotEnabled():
 		depotManager := newDepotBuilder(depotProject, depotToken, ob.OktetoContext, ioCtrl)
 		return depotManager.Run(ctx, buildOptions, runAndHandleBuild)
 	case ob.OktetoContext.GetCurrentBuilder() == "":

--- a/pkg/cmd/build/depot.go
+++ b/pkg/cmd/build/depot.go
@@ -16,6 +16,7 @@ package build
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/depot/depot-go/build"
@@ -52,9 +53,8 @@ type depotBuilder struct {
 	project        string
 }
 
-// isDepotEnabled returns true if depot env vars are set
-func isDepotEnabled(depotProject, depotToken string) bool {
-	return depotToken != "" && depotProject != ""
+func IsDepotEnabled() bool {
+	return os.Getenv(DepotTokenEnvVar) != "" && os.Getenv(DepotProjectEnvVar) != ""
 }
 
 // newDepotBuilder creates a new instance of DepotBuilder.

--- a/pkg/cmd/build/depot_test.go
+++ b/pkg/cmd/build/depot_test.go
@@ -45,41 +45,6 @@ func (m *fakeDepotMachine) Connect(ctx context.Context) (*buildkitClient.Client,
 	return nil, m.err
 }
 
-func Test_isDepotEnabled(t *testing.T) {
-	tests := []struct {
-		depotProject string
-		depotToken   string
-		expected     bool
-	}{
-		{
-			depotProject: "project1",
-			depotToken:   "token1",
-			expected:     true,
-		},
-		{
-			depotProject: "",
-			depotToken:   "token2",
-			expected:     false,
-		},
-		{
-			depotProject: "project3",
-			depotToken:   "",
-			expected:     false,
-		},
-		{
-			depotProject: "",
-			depotToken:   "",
-			expected:     false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("depotProject=%s, depotToken=%s", tt.depotProject, tt.depotToken), func(t *testing.T) {
-			res := isDepotEnabled(tt.depotProject, tt.depotToken)
-			assert.Equal(t, tt.expected, res)
-		})
-	}
-}
 func Test_newDepotBuilder(t *testing.T) {
 	projectId := "test-project"
 	token := "test-token"


### PR DESCRIPTION
If the remote build runs in depot, don't add the extra hosts, the certificate, nor the server-name.

Still needs testing but opening early to get feedback.

cc @jpf-okteto to get another set of eyes since he is the most familiar with the certs parts