### PR TITLE
Remove "Build section is not defined in your okteto manifest" info me…

### DIFF
--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -29,7 +29,6 @@ func (bc *OktetoBuilder) GetServicesToBuild(ctx context.Context, manifest *model
 	buildManifest := manifest.Build
 
 	if len(buildManifest) == 0 {
-		bc.ioCtrl.Out().Infof("Build section is not defined in your okteto manifest")
 		return nil, nil
 	}
 


### PR DESCRIPTION
…ssage

If no `build` section is defined, we show an info message saying "Build section is not defined in your okteto manifest".

The message doesn't help to configure the build section. And there are many users with okteto manifest without build sections, where this message is noisy. Our getting started samples don't have `build` section either.

I would like to write a spec to improve the CLI messages for a better DevX, but I think we can safely remove this one now.