### PR TITLE
fix: add CORS PNA support to browser login

### DIFF
--- a/pkg/cmd/login/browser.go
+++ b/pkg/cmd/login/browser.go
@@ -38,6 +38,19 @@ type Handler struct {
 
 func (h *Handler) handle() http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.Header().Add("Access-Control-Allow-Origin", h.baseURL)
+			w.Header().Add("Access-Control-Allow-Methods", "GET")
+			w.Header().Add("Access-Control-Allow-Private-Network", "true")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
 		code := r.URL.Query().Get("code")
 		s := r.URL.Query().Get("state")
 


### PR DESCRIPTION
Signed-off-by: Javier Provecho Fernández (Okteto) <jpf@okteto.com>

Chrome 123 (1) reintroduced Private Network Access (2), causing the following behavior:

1. By using `okteto context use` with browser login.
2. If the IDP shows a webpage.
3. Upon redirect from the Okteto API to the Okteto CLI webserver.
4. Chrome will send two requests instead of one.
   - The first request is a CORS preflight (HTTP method `OPTIONS`).
   - It sends the following request headers:
     - `Access-Control-Request-Private-Network: true`
   - And expects the following response headers: - `Access-Control-Allow-Origin: https://okteto-instance-hostname` - `Access-Control-Allow-Private-Network: true`

The CORS preflight request in Chrome 123 is in warning mode, and it will be cancelled if the response takes more than 200 milliseconds.

The Okteto CLI webserver didn't differentiate between the preflight and the actual request, so it would start processing the preflight request, but when Chrome cancelled it, the Okteto CLI webserver would mark as done the `context.Context`, and it will propagate the cancellation to their children.

Upon context cancellation, the Okteto CLI webserver would close itself and exit with an error.

Depending on the IDP, some of them such as GitHub only use a webpage for the first interaction, while following interactions are purely HTTP redirects. Other IDPs may use a webpage for every interaction, which resulted in the Okteto CLI unable to complete the login process via a browser.

This PR adds support for the CORS preflight request by returning specific headers if the HTTP method is `OPTIONS`.

(1): https://developer.chrome.com/blog/chrome-123-beta#private_network_access_checks_for_navigation_requests_warning-only_mode

(2): https://developer.chrome.com/blog/private-network-access-preflight/