### PR TITLE
fix: run remote on buildkit

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -104,7 +104,7 @@ func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptio
 	}
 
 	switch {
-	case IsDepotEnabled():
+	case IsDepotEnabled() && !isDeployOrDestroy:
 		depotManager := newDepotBuilder(depotProject, depotToken, ob.OktetoContext, ioCtrl)
 		return depotManager.Run(ctx, buildOptions, runAndHandleBuild)
 	case ob.OktetoContext.GetCurrentBuilder() == "":

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -104,6 +104,9 @@ func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptio
 	}
 
 	switch {
+	// When depot is available we only go to depot if it's not a deploy or a destroy.
+	// On depot the workload id is not working correctly and the users would not be able to
+	// use the internal cluster ip as if they were running their scripts on the k8s cluster
 	case IsDepotEnabled() && !isDeployOrDestroy:
 		depotManager := newDepotBuilder(depotProject, depotToken, ob.OktetoContext, ioCtrl)
 		return depotManager.Run(ctx, buildOptions, runAndHandleBuild)


### PR DESCRIPTION
# Proposed changes

Fixes LAKE-250

This PR modifies the behavior of the Okteto builder in the `pkg/cmd/build/build.go` file. This will ensure that if it's a deploy/destroy and it's running on remote we can't use a depot instance. It'll go to the buildkit instance in the cluster

## How to validate

1. Clone okteto/movies
1. Run `okteto deploy --remote -l info` and check that depot is not mentioned
1. Run `okteto destroy --remote -l info` and check that depot is not mentioned

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
