### PR TITLE
Initialize test command

### DIFF
--- a/cmd/deploy/build.go
+++ b/cmd/deploy/build.go
@@ -30,7 +30,7 @@ func buildImages(ctx context.Context, builder builderInterface, deployOptions *O
 
 	allServicesWithBuildSection := deployOptions.Manifest.GetBuildServices()
 	oktetoManifestServicesWithBuild := setDifference(allServicesWithBuildSection, stackServicesWithBuild) // Warning: this way of getting the oktetoManifestServicesWithBuild is highly dependent on the manifest struct as it is now. We are assuming that: *okteto* manifest build = manifest build - stack build section
-	servicesToDeployWithBuild := setIntersection(allServicesWithBuildSection, sliceToSet(deployOptions.servicesToDeploy))
+	servicesToDeployWithBuild := setIntersection(allServicesWithBuildSection, sliceToSet(deployOptions.ServicesToDeploy))
 	// We need to build:
 	// - All the services that have a build section defined in the *okteto* manifest
 	// - Services from *deployOptions.servicesToDeploy* that have a build section

--- a/cmd/deploy/build_test.go
+++ b/cmd/deploy/build_test.go
@@ -133,7 +133,7 @@ func TestBuildImages(t *testing.T) {
 						},
 					},
 				},
-				servicesToDeploy: testCase.servicesToDeploy,
+				ServicesToDeploy: testCase.servicesToDeploy,
 			}
 
 			for _, service := range testCase.buildServices {

--- a/cmd/deploy/cfghandler.go
+++ b/cmd/deploy/cfghandler.go
@@ -25,13 +25,13 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 )
 
-// configMapHandler defines the different functions to run okteto inside an okteto deploy
+// ConfigMapHandler defines the different functions to run okteto inside an okteto deploy
 // or an okteto destroy directly
-type configMapHandler interface {
-	translateConfigMapAndDeploy(context.Context, *pipeline.CfgData) (*apiv1.ConfigMap, error)
-	updateConfigMap(context.Context, *apiv1.ConfigMap, *pipeline.CfgData, error) error
+type ConfigMapHandler interface {
+	TranslateConfigMapAndDeploy(context.Context, *pipeline.CfgData) (*apiv1.ConfigMap, error)
+	UpdateConfigMap(context.Context, *apiv1.ConfigMap, *pipeline.CfgData, error) error
 	UpdateEnvsFromCommands(context.Context, string, string, []string) error
-	getConfigmapVariablesEncoded(ctx context.Context, name, namespace string) (string, error)
+	GetConfigmapVariablesEncoded(ctx context.Context, name, namespace string) (string, error)
 }
 
 // deployInsideDeployConfigMapHandler is the runner used when the okteto is executed
@@ -62,14 +62,14 @@ func newDefaultConfigMapHandler(provider okteto.K8sClientProviderWithLogger, k8s
 	}
 }
 
-func NewConfigmapHandler(provider okteto.K8sClientProviderWithLogger, k8slogger *io.K8sLogger) configMapHandler {
+func NewConfigmapHandler(provider okteto.K8sClientProviderWithLogger, k8slogger *io.K8sLogger) ConfigMapHandler {
 	if env.LoadBoolean(constants.OktetoDeployRemote) {
 		return newDeployInsideDeployConfigMapHandler(provider, k8slogger)
 	}
 	return newDefaultConfigMapHandler(provider, k8slogger)
 }
 
-func (ch *defaultConfigMapHandler) translateConfigMapAndDeploy(ctx context.Context, data *pipeline.CfgData) (*apiv1.ConfigMap, error) {
+func (ch *defaultConfigMapHandler) TranslateConfigMapAndDeploy(ctx context.Context, data *pipeline.CfgData) (*apiv1.ConfigMap, error) {
 	c, _, err := ch.k8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ch.k8slogger)
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func (ch *defaultConfigMapHandler) translateConfigMapAndDeploy(ctx context.Conte
 	return pipeline.TranslateConfigMapAndDeploy(ctx, data, c)
 }
 
-func (ch *defaultConfigMapHandler) getConfigmapVariablesEncoded(ctx context.Context, name, namespace string) (string, error) {
+func (ch *defaultConfigMapHandler) GetConfigmapVariablesEncoded(ctx context.Context, name, namespace string) (string, error) {
 	c, _, err := ch.k8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ch.k8slogger)
 	if err != nil {
 		return "", err
@@ -85,7 +85,7 @@ func (ch *defaultConfigMapHandler) getConfigmapVariablesEncoded(ctx context.Cont
 	return pipeline.GetConfigmapVariablesEncoded(ctx, name, namespace, c)
 }
 
-func (ch *defaultConfigMapHandler) updateConfigMap(ctx context.Context, cfg *apiv1.ConfigMap, data *pipeline.CfgData, errMain error) error {
+func (ch *defaultConfigMapHandler) UpdateConfigMap(ctx context.Context, cfg *apiv1.ConfigMap, data *pipeline.CfgData, errMain error) error {
 	c, _, err := ch.k8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ch.k8slogger)
 	if err != nil {
 		return err
@@ -113,14 +113,14 @@ func (ch *defaultConfigMapHandler) UpdateEnvsFromCommands(ctx context.Context, n
 	return nil
 }
 
-// translateConfigMapAndDeploy with the receiver deployInsideDeployConfigMapHandler doesn't do anything
+// TranslateConfigMapAndDeploy with the receiver deployInsideDeployConfigMapHandler doesn't do anything
 // because we have to  control the cfmap in the main execution. If both handled the configmap we will be
 // overwritten the cfmap and leave it in a inconsistent status
-func (*deployInsideDeployConfigMapHandler) translateConfigMapAndDeploy(_ context.Context, _ *pipeline.CfgData) (*apiv1.ConfigMap, error) {
+func (*deployInsideDeployConfigMapHandler) TranslateConfigMapAndDeploy(_ context.Context, _ *pipeline.CfgData) (*apiv1.ConfigMap, error) {
 	return nil, nil
 }
 
-func (ch *deployInsideDeployConfigMapHandler) getConfigmapVariablesEncoded(ctx context.Context, name, namespace string) (string, error) {
+func (ch *deployInsideDeployConfigMapHandler) GetConfigmapVariablesEncoded(ctx context.Context, name, namespace string) (string, error) {
 	c, _, err := ch.k8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ch.k8slogger)
 	if err != nil {
 		return "", err
@@ -128,10 +128,10 @@ func (ch *deployInsideDeployConfigMapHandler) getConfigmapVariablesEncoded(ctx c
 	return pipeline.GetConfigmapVariablesEncoded(ctx, name, namespace, c)
 }
 
-// updateConfigMap with the receiver deployInsideDeployConfigMapHandler doesn't do anything
+// UpdateConfigMap with the receiver deployInsideDeployConfigMapHandler doesn't do anything
 // because we have to  control the cfmap in the main execution. If both handled the configmap we will be
 // overwritten the cfmap and leave it in a inconsistent status
-func (*deployInsideDeployConfigMapHandler) updateConfigMap(_ context.Context, _ *apiv1.ConfigMap, _ *pipeline.CfgData, err error) error {
+func (*deployInsideDeployConfigMapHandler) UpdateConfigMap(_ context.Context, _ *apiv1.ConfigMap, _ *pipeline.CfgData, err error) error {
 	return nil
 }
 

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -75,18 +75,18 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 	if deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection != nil && deployOptions.Manifest.Deploy.ComposeSection.Stack != nil {
 
 		mergeServicesToDeployFromOptionsAndManifest(deployOptions)
-		if len(deployOptions.servicesToDeploy) == 0 {
-			deployOptions.servicesToDeploy = []string{}
+		if len(deployOptions.ServicesToDeploy) == 0 {
+			deployOptions.ServicesToDeploy = []string{}
 			for service := range deployOptions.Manifest.Deploy.ComposeSection.Stack.Services {
-				deployOptions.servicesToDeploy = append(deployOptions.servicesToDeploy, service)
+				deployOptions.ServicesToDeploy = append(deployOptions.ServicesToDeploy, service)
 			}
 		}
 		if len(deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo) > 0 {
-			if err := stack.ValidateDefinedServices(deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.servicesToDeploy); err != nil {
+			if err := stack.ValidateDefinedServices(deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.ServicesToDeploy); err != nil {
 				return err
 			}
-			deployOptions.servicesToDeploy = stack.AddDependentServicesIfNotPresent(ctx, deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.servicesToDeploy, c)
-			deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo[0].ServicesToDeploy = deployOptions.servicesToDeploy
+			deployOptions.ServicesToDeploy = stack.AddDependentServicesIfNotPresent(ctx, deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.ServicesToDeploy, c)
+			deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo[0].ServicesToDeploy = deployOptions.ServicesToDeploy
 		}
 	}
 	return nil
@@ -104,7 +104,7 @@ func mergeServicesToDeployFromOptionsAndManifest(deployOptions *Options) {
 	}
 
 	commandDeclaredServicesToDeploy := map[string]bool{}
-	for _, service := range deployOptions.servicesToDeploy {
+	for _, service := range deployOptions.ServicesToDeploy {
 		commandDeclaredServicesToDeploy[service] = true
 	}
 
@@ -112,11 +112,11 @@ func mergeServicesToDeployFromOptionsAndManifest(deployOptions *Options) {
 		return
 	}
 
-	if len(deployOptions.servicesToDeploy) > 0 && len(manifestDeclaredServicesToDeploy) > 0 {
+	if len(deployOptions.ServicesToDeploy) > 0 && len(manifestDeclaredServicesToDeploy) > 0 {
 		oktetoLog.Warning("overwriting manifest's `services to deploy` with command line arguments")
 	}
-	if len(deployOptions.servicesToDeploy) == 0 && len(manifestDeclaredServicesToDeploy) > 0 {
-		deployOptions.servicesToDeploy = manifestDeclaredServicesToDeploy
+	if len(deployOptions.ServicesToDeploy) == 0 && len(manifestDeclaredServicesToDeploy) > 0 {
+		deployOptions.ServicesToDeploy = manifestDeclaredServicesToDeploy
 	}
 }
 
@@ -153,7 +153,7 @@ func (dc *Command) addEnvVars(cwd string) {
 			oktetoLog.Infof("could not retrieve sha: %s", err)
 		}
 		isClean := true
-		if !dc.isRemote {
+		if !dc.IsRemote {
 			isClean, err = repository.NewRepository(cwd).IsClean()
 			if err != nil {
 				oktetoLog.Infof("could not status: %s", err)

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -85,7 +85,7 @@ devs:
 		},
 	}
 
-	currentCfg, err := dc.CfgMapHandler.translateConfigMapAndDeploy(ctx, data)
+	currentCfg, err := dc.CfgMapHandler.TranslateConfigMapAndDeploy(ctx, data)
 	if err != nil {
 		t.Fatal("error trying to get configmap from data object")
 	}
@@ -106,7 +106,7 @@ func Test_mergeServicesToDeployFromOptionsAndManifest(t *testing.T) {
 		{
 			name: "no manifest services to deploy",
 			options: &Options{
-				servicesToDeploy: []string{"a", "b"},
+				ServicesToDeploy: []string{"a", "b"},
 				Manifest: &model.Manifest{
 					Deploy: &model.DeployInfo{
 						ComposeSection: &model.ComposeSectionInfo{
@@ -136,7 +136,7 @@ func Test_mergeServicesToDeployFromOptionsAndManifest(t *testing.T) {
 		{
 			name: "both",
 			options: &Options{
-				servicesToDeploy: []string{"from command a", "from command b"},
+				ServicesToDeploy: []string{"from command a", "from command b"},
 				Manifest: &model.Manifest{
 					Deploy: &model.DeployInfo{
 						ComposeSection: &model.ComposeSectionInfo{
@@ -161,7 +161,7 @@ func Test_mergeServicesToDeployFromOptionsAndManifest(t *testing.T) {
 			}
 
 			got := map[string]bool{}
-			for _, service := range test.options.servicesToDeploy {
+			for _, service := range test.options.ServicesToDeploy {
 				got[service] = true
 			}
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -73,10 +73,8 @@ type Options struct {
 	Name             string
 	Namespace        string
 	K8sContext       string
-	Repository       string
-	Branch           string
 	Variables        []string
-	servicesToDeploy []string
+	ServicesToDeploy []string
 	Timeout          time.Duration
 	Build            bool
 	Dependencies     bool
@@ -95,7 +93,7 @@ type builderInterface interface {
 type getDeployerFunc func(
 	context.Context, *Options,
 	buildEnvVarsGetter,
-	configMapHandler,
+	ConfigMapHandler,
 	okteto.K8sClientProviderWithLogger,
 	*io.Controller,
 	*io.K8sLogger,
@@ -112,10 +110,10 @@ type Command struct {
 	GetDeployer       getDeployerFunc
 	EndpointGetter    func(k8sLogger *io.K8sLogger) (EndpointGetter, error)
 	DeployWaiter      Waiter
-	CfgMapHandler     configMapHandler
+	CfgMapHandler     ConfigMapHandler
 	Fs                afero.Fs
 	PipelineCMD       pipelineCMD.DeployerInterface
-	AnalyticsTracker  analyticsTrackerInterface
+	AnalyticsTracker  AnalyticsTrackerInterface
 	IoCtrl            *io.Controller
 	K8sLogger         *io.K8sLogger
 
@@ -125,11 +123,11 @@ type Command struct {
 	// This can probably be improved using context cancellation
 	onCleanUp []cleanUpFunc
 
-	isRemote           bool
-	runningInInstaller bool
+	IsRemote           bool
+	RunningInInstaller bool
 }
 
-type analyticsTrackerInterface interface {
+type AnalyticsTrackerInterface interface {
 	TrackDeploy(dm analytics.DeployMetadata)
 	buildTrackerInterface
 }
@@ -146,7 +144,7 @@ type Deployer interface {
 }
 
 // Deploy deploys the okteto manifest
-func Deploy(ctx context.Context, at analyticsTrackerInterface, insightsTracker buildTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLogger) *cobra.Command {
+func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker buildTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLogger) *cobra.Command {
 	options := &Options{}
 	cmd := &cobra.Command{
 		Use:   "deploy [service...]",
@@ -197,7 +195,7 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface, insightsTracker b
 			}
 
 			options.ShowCTA = oktetoLog.IsInteractive()
-			options.servicesToDeploy = args
+			options.ServicesToDeploy = args
 
 			k8sClientProvider := okteto.NewK8sClientProviderWithLogger(k8sLogger)
 			pc, err := pipelineCMD.NewCommand()
@@ -218,11 +216,11 @@ func Deploy(ctx context.Context, at analyticsTrackerInterface, insightsTracker b
 				Builder:            buildv2.NewBuilderFromScratch(ioCtrl, onBuildFinish),
 				DeployWaiter:       NewDeployWaiter(k8sClientProvider, k8sLogger),
 				EndpointGetter:     NewEndpointGetter,
-				isRemote:           env.LoadBoolean(constants.OktetoDeployRemote),
+				IsRemote:           env.LoadBoolean(constants.OktetoDeployRemote),
 				CfgMapHandler:      NewConfigmapHandler(k8sClientProvider, k8sLogger),
 				Fs:                 afero.NewOsFs(),
 				PipelineCMD:        pc,
-				runningInInstaller: config.RunningInInstaller(),
+				RunningInInstaller: config.RunningInInstaller(),
 				AnalyticsTracker:   at,
 				IoCtrl:             ioCtrl,
 				K8sLogger:          k8sLogger,
@@ -288,7 +286,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		return oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands
 	}
 
-	if len(deployOptions.servicesToDeploy) > 0 && deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection == nil {
+	if len(deployOptions.ServicesToDeploy) > 0 && deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection == nil {
 		return oktetoErrors.ErrDeployCantDeploySvcsIfNotCompose
 	}
 
@@ -319,8 +317,8 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		return err
 	}
 
-	if dc.isRemote || dc.runningInInstaller {
-		currentVars, err := dc.CfgMapHandler.getConfigmapVariablesEncoded(ctx, deployOptions.Name, deployOptions.Manifest.Namespace)
+	if dc.IsRemote || dc.RunningInInstaller {
+		currentVars, err := dc.CfgMapHandler.GetConfigmapVariablesEncoded(ctx, deployOptions.Name, deployOptions.Manifest.Namespace)
 		if err != nil {
 			return err
 		}
@@ -348,7 +346,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		data.Manifest = deployOptions.Manifest.Deploy.ComposeSection.Stack.Manifest
 	}
 
-	cfg, err := dc.CfgMapHandler.translateConfigMapAndDeploy(ctx, data)
+	cfg, err := dc.CfgMapHandler.TranslateConfigMapAndDeploy(ctx, data)
 	if err != nil {
 		return err
 	}
@@ -356,7 +354,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	os.Setenv(constants.OktetoNameEnvVar, deployOptions.Name)
 
 	if err := dc.deployDependencies(ctx, deployOptions); err != nil {
-		if errStatus := dc.CfgMapHandler.updateConfigMap(ctx, cfg, data, err); errStatus != nil {
+		if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); errStatus != nil {
 			return errStatus
 		}
 		return err
@@ -367,7 +365,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	}
 
 	if err := buildImages(ctx, dc.Builder, deployOptions); err != nil {
-		if errStatus := dc.CfgMapHandler.updateConfigMap(ctx, cfg, data, err); errStatus != nil {
+		if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); errStatus != nil {
 			return errStatus
 		}
 		return err
@@ -422,7 +420,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		data.Status = pipeline.DeployedStatus
 	}
 
-	if errStatus := dc.CfgMapHandler.updateConfigMap(ctx, cfg, data, err); errStatus != nil {
+	if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); errStatus != nil {
 		return errStatus
 	}
 
@@ -431,7 +429,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 
 func (dc *Command) deploy(ctx context.Context, deployOptions *Options, cwd string, c kubernetes.Interface) error {
 	// If the command is configured to execute things remotely (--remote, deploy.image or deploy.remote) it should be executed in the remote. If not, it should be executed locally
-	deployer, err := dc.GetDeployer(ctx, deployOptions, dc.Builder.GetBuildEnvVars, dc.CfgMapHandler, dc.K8sClientProvider, dc.IoCtrl, dc.K8sLogger, dc.getDependencyEnvVars)
+	deployer, err := dc.GetDeployer(ctx, deployOptions, dc.Builder.GetBuildEnvVars, dc.CfgMapHandler, dc.K8sClientProvider, dc.IoCtrl, dc.K8sLogger, GetDependencyEnvVars)
 	if err != nil {
 		return err
 	}
@@ -525,7 +523,7 @@ func shouldRunInRemote(opts *Options) bool {
 func GetDeployer(ctx context.Context,
 	opts *Options,
 	buildEnvVarsGetter buildEnvVarsGetter,
-	cmapHandler configMapHandler,
+	cmapHandler ConfigMapHandler,
 	k8sProvider okteto.K8sClientProviderWithLogger,
 	ioCtrl *io.Controller,
 	k8Logger *io.K8sLogger,
@@ -683,7 +681,7 @@ func (dc *Command) deployStack(ctx context.Context, opts *Options) error {
 		ForceBuild:       false,
 		Wait:             opts.Wait,
 		Timeout:          opts.Timeout,
-		ServicesToDeploy: opts.servicesToDeploy,
+		ServicesToDeploy: opts.ServicesToDeploy,
 		InsidePipeline:   true,
 	}
 
@@ -737,10 +735,10 @@ func (dc *Command) deployEndpoints(ctx context.Context, opts *Options) error {
 	return nil
 }
 
-// getDependencyEnvVars This function gets the variables defined by the dependencies (OKTETO_DEPENDENCY_XXXX)
+// GetDependencyEnvVars This function gets the variables defined by the dependencies (OKTETO_DEPENDENCY_XXXX)
 // deployed before the deploy phase from the environment. This function is here as the command is the one in charge
 // of deploying dependencies and trigger the rest of the deploy phase.
-func (*Command) getDependencyEnvVars(environGetter environGetter) map[string]string {
+func GetDependencyEnvVars(environGetter environGetter) map[string]string {
 	varsParts := 2
 	result := map[string]string{}
 	for _, e := range environGetter() {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -231,7 +231,7 @@ func getFakeEndpoint(_ *io.K8sLogger) (EndpointGetter, error) {
 func (f *fakeDeployer) Get(ctx context.Context,
 	opts *Options,
 	buildEnvVarsGetter buildEnvVarsGetter,
-	cmapHandler configMapHandler,
+	cmapHandler ConfigMapHandler,
 	k8sProvider okteto.K8sClientProviderWithLogger,
 	ioCtrl *io.Controller,
 	k8Logger *io.K8sLogger,
@@ -331,7 +331,7 @@ func TestDeployWithServicesToBuildWithoutComposeSection(t *testing.T) {
 		Name:             "movies",
 		ManifestPath:     "",
 		Variables:        []string{},
-		servicesToDeploy: []string{"service1"},
+		ServicesToDeploy: []string{"service1"},
 	}
 
 	err := c.Run(ctx, opts)
@@ -1029,9 +1029,7 @@ func TestGetDependencyEnvVars(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			dc := &Command{}
-
-			result := dc.getDependencyEnvVars(tc.environGetter)
+			result := GetDependencyEnvVars(tc.environGetter)
 
 			require.Equal(t, tc.expected, result)
 		})

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -89,7 +89,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		External: deployOptions.Manifest.External,
 	}
 
-	commandsFlags, err := getCommandFlags(deployOptions)
+	commandsFlags, err := GetCommandFlags(deployOptions.Name, deployOptions.Variables)
 	if err != nil {
 		return err
 	}
@@ -127,12 +127,12 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 	return nil
 }
 
-func getCommandFlags(opts *Options) ([]string, error) {
+func GetCommandFlags(name string, vars []string) ([]string, error) {
 	var commandFlags []string
-	commandFlags = append(commandFlags, fmt.Sprintf("--name %q", opts.Name))
-	if len(opts.Variables) > 0 {
+	commandFlags = append(commandFlags, fmt.Sprintf("--name %q", name))
+	if len(vars) > 0 {
 		var varsToAddForDeploy []string
-		variables, err := env.Parse(opts.Variables)
+		variables, err := env.Parse(vars)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -153,7 +153,7 @@ func TestGetCommandFlags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			flags, err := getCommandFlags(tt.config.opts)
+			flags, err := GetCommandFlags(tt.config.opts.Name, tt.config.opts.Variables)
 			if tt.expectErr {
 				require.Error(t, err)
 			}

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -139,7 +139,6 @@ func deploy(ctx context.Context) *cobra.Command {
 
 // ExecuteDeployPipeline executes deploy pipeline given a set of options
 func (pc *Command) ExecuteDeployPipeline(ctx context.Context, opts *DeployOptions) error {
-
 	if err := opts.setDefaults(); err != nil {
 		return fmt.Errorf("could not set default values for options: %w", err)
 	}

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -1,0 +1,252 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+
+	buildv2 "github.com/okteto/okteto/cmd/build/v2"
+	contextCMD "github.com/okteto/okteto/cmd/context"
+	deployCMD "github.com/okteto/okteto/cmd/deploy"
+	"github.com/okteto/okteto/cmd/namespace"
+	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
+	"github.com/okteto/okteto/cmd/utils"
+	buildCMD "github.com/okteto/okteto/pkg/cmd/build"
+	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/dag"
+	"github.com/okteto/okteto/pkg/deployable"
+	"github.com/okteto/okteto/pkg/env"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	oktetoPath "github.com/okteto/okteto/pkg/path"
+	"github.com/okteto/okteto/pkg/remote"
+)
+
+type Options struct {
+	ManifestPath     string
+	ManifestPathFlag string
+	Namespace        string
+	K8sContext       string
+	Variables        []string
+	Timeout          time.Duration
+
+	Name string
+}
+
+func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at deployCMD.AnalyticsTrackerInterface) *cobra.Command {
+	options := &Options{}
+	cmd := &cobra.Command{
+		Use:          "test",
+		Short:        "Run tests",
+		Hidden:       true,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			stop := make(chan os.Signal, 1)
+			signal.Notify(stop, os.Interrupt)
+			exit := make(chan error, 1)
+
+			go func() {
+				exit <- doRun(ctx, options, ioCtrl, k8sLogger, at)
+			}()
+			select {
+			case <-stop:
+				oktetoLog.Infof("CTRL+C received, starting shutdown sequence")
+				oktetoLog.Spinner("Shutting down...")
+				oktetoLog.StartSpinner()
+				defer oktetoLog.StopSpinner()
+				return oktetoErrors.ErrIntSig
+			case err := <-exit:
+				return err
+			}
+
+		},
+	}
+
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the okteto manifest file")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
+	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
+	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
+	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
+	cmd.Flags().StringVar(&options.Name, "name", "", "name of the development environment name to be deployed")
+
+	return cmd
+}
+
+func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at deployCMD.AnalyticsTrackerInterface) error {
+	fs := afero.NewOsFs()
+
+	// Loads, updates and uses the context from path. If not found, it creates and uses a new context
+	if err := contextCMD.LoadContextFromPath(ctx, options.Namespace, options.K8sContext, options.ManifestPath, contextCMD.Options{Show: true}); err != nil {
+		if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: options.Namespace}); err != nil {
+			return err
+		}
+	}
+
+	if !okteto.IsOkteto() {
+		return fmt.Errorf("'okteto test' is only supported in contexts that have Okteto installed")
+	}
+
+	create, err := utils.ShouldCreateNamespace(ctx, okteto.GetContext().Namespace)
+	if err != nil {
+		return err
+	}
+	if create {
+		nsCmd, err := namespace.NewCommand()
+		if err != nil {
+			return err
+		}
+		if err := nsCmd.Create(ctx, &namespace.CreateOptions{Namespace: okteto.GetContext().Namespace}); err != nil {
+			return err
+		}
+	}
+
+	if options.ManifestPath != "" {
+		// if path is absolute, its transformed to rel from root
+		initialCWD, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get the current working directory: %w", err)
+		}
+		manifestPathFlag, err := oktetoPath.GetRelativePathFromCWD(initialCWD, options.ManifestPath)
+		if err != nil {
+			return err
+		}
+		// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
+		options.ManifestPathFlag = manifestPathFlag
+
+		// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir
+		uptManifestPath, err := model.UpdateCWDtoManifestPath(options.ManifestPath)
+		if err != nil {
+			return err
+		}
+		options.ManifestPath = uptManifestPath
+	}
+
+	manifest, err := model.GetManifestV2(options.ManifestPath, fs)
+	if err != nil {
+		return err
+	}
+
+	k8sClientProvider := okteto.NewK8sClientProviderWithLogger(k8sLogger)
+
+	pc, err := pipelineCMD.NewCommand()
+	if err != nil {
+		return fmt.Errorf("could not create pipeline command: %w", err)
+	}
+
+	configmapHandler := deployCMD.NewConfigmapHandler(k8sClientProvider, k8sLogger)
+
+	builder := buildv2.NewBuilderFromScratch(ioCtrl, nil)
+
+	c := deployCMD.Command{
+		GetManifest: func(path string, fs afero.Fs) (*model.Manifest, error) {
+			return manifest, nil
+		},
+		K8sClientProvider:  k8sClientProvider,
+		Builder:            builder,
+		GetDeployer:        deployCMD.GetDeployer,
+		EndpointGetter:     deployCMD.NewEndpointGetter,
+		DeployWaiter:       deployCMD.NewDeployWaiter(k8sClientProvider, k8sLogger),
+		CfgMapHandler:      configmapHandler,
+		Fs:                 fs,
+		PipelineCMD:        pc,
+		AnalyticsTracker:   at,
+		IoCtrl:             ioCtrl,
+		K8sLogger:          k8sLogger,
+		IsRemote:           env.LoadBoolean(constants.OktetoDeployRemote),
+		RunningInInstaller: config.RunningInInstaller(),
+	}
+	if err = c.Run(ctx, &deployCMD.Options{
+		Manifest:         manifest,
+		ManifestPathFlag: options.ManifestPathFlag,
+		ManifestPath:     options.ManifestPath,
+		Name:             options.Name,
+		Namespace:        options.Namespace,
+		K8sContext:       options.K8sContext,
+		Variables:        options.Variables,
+		Build:            false,
+		Dependencies:     false,
+		Timeout:          options.Timeout,
+		RunWithoutBash:   false,
+		RunInRemote:      manifest.Deploy.Remote,
+		Wait:             true,
+		ShowCTA:          false,
+	}); err != nil {
+		oktetoLog.Error("deploy failed: %s", err.Error())
+		return err
+	}
+
+	var nodes []dag.Node
+
+	for name, test := range manifest.Test {
+		nodes = append(nodes, Node{name, test})
+	}
+
+	tree, err := dag.From(nodes...)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range tree.Ordered() {
+		test := manifest.Test[name]
+
+		commandsFlags, err := deployCMD.GetCommandFlags(name, options.Variables)
+		if err != nil {
+			return err
+		}
+
+		runner := remote.NewRunner(ioCtrl, buildCMD.NewOktetoBuilder(
+			&okteto.ContextStateless{
+				Store: okteto.GetContextStore(),
+			},
+			fs,
+		))
+		commands := make([]model.DeployCommand, len(test.Commands))
+
+		for i, cmd := range test.Commands {
+			commands[i] = model.DeployCommand(cmd)
+		}
+
+		params := &remote.Params{
+			BaseImage:           test.Image,
+			ManifestPathFlag:    options.ManifestPathFlag,
+			TemplateName:        "dockerfile",
+			CommandFlags:        commandsFlags,
+			BuildEnvVars:        builder.GetBuildEnvVars(),
+			DependenciesEnvVars: deployCMD.GetDependencyEnvVars(os.Environ),
+			DockerfileName:      "Dockerfile.test",
+			Deployable: deployable.Entity{
+				Commands: commands,
+			},
+			Manifest: manifest,
+			Command:  remote.DeployCommand, // TODO: use test?
+		}
+
+		ioCtrl.Logger().Infof("Executing test for: %s", name)
+		if err := runner.Run(ctx, params); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -19,9 +19,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/spf13/afero"
-	"github.com/spf13/cobra"
-
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	deployCMD "github.com/okteto/okteto/cmd/deploy"
@@ -41,6 +38,8 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	oktetoPath "github.com/okteto/okteto/pkg/path"
 	"github.com/okteto/okteto/pkg/remote"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
 )
 
 type Options struct {
@@ -48,10 +47,9 @@ type Options struct {
 	ManifestPathFlag string
 	Namespace        string
 	K8sContext       string
+	Name             string
 	Variables        []string
 	Timeout          time.Duration
-
-	Name string
 }
 
 func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at deployCMD.AnalyticsTrackerInterface) *cobra.Command {
@@ -199,7 +197,7 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 	var nodes []dag.Node
 
 	for name, test := range manifest.Test {
-		nodes = append(nodes, Node{name, test})
+		nodes = append(nodes, Node{test, name})
 	}
 
 	tree, err := dag.From(nodes...)

--- a/cmd/test/dag.go
+++ b/cmd/test/dag.go
@@ -15,8 +15,8 @@ package test
 import "github.com/okteto/okteto/pkg/model"
 
 type Node struct {
-	Name string
 	Test *model.Test
+	Name string
 }
 
 func (n Node) ID() string          { return n.Name }

--- a/cmd/test/dag.go
+++ b/cmd/test/dag.go
@@ -1,0 +1,23 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package test
+
+import "github.com/okteto/okteto/pkg/model"
+
+type Node struct {
+	Name string
+	Test *model.Test
+}
+
+func (n Node) ID() string          { return n.Name }
+func (n Node) DependsOn() []string { return n.Test.DependsOn }

--- a/cmd/test/lib.go
+++ b/cmd/test/lib.go
@@ -1,0 +1,38 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package test
+
+import (
+	"os"
+	"time"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+)
+
+func getDefaultTimeout() time.Duration {
+	defaultTimeout := 5 * time.Minute
+	t := os.Getenv(model.OktetoTimeoutEnvVar)
+	if t == "" {
+		return defaultTimeout
+	}
+
+	parsed, err := time.ParseDuration(t)
+	if err != nil {
+		oktetoLog.Infof("OKTETO_TIMEOUT value is not a valid duration: %s", t)
+		oktetoLog.Infof("timeout fallback to defaultTimeout")
+		return defaultTimeout
+	}
+
+	return parsed
+}

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/okteto/okteto/cmd/registrytoken"
 	"github.com/okteto/okteto/cmd/remoterun"
 	"github.com/okteto/okteto/cmd/stack"
+	"github.com/okteto/okteto/cmd/test"
 	"github.com/okteto/okteto/cmd/up"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/config"
@@ -181,6 +182,7 @@ func main() {
 	root.AddCommand(logs.Logs(ctx, k8sLogger))
 	root.AddCommand(generateFigSpec.NewCmdGenFigSpec())
 	root.AddCommand(remoterun.RemoteRun(ctx, k8sLogger))
+	root.AddCommand(test.Test(ctx, ioController, k8sLogger, at))
 
 	// deprecated
 	root.AddCommand(cmd.Create(ctx))

--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -55,3 +55,12 @@ func From(nodes ...Node) (*Tree, error) {
 	}
 	return tree, nil
 }
+
+// Ordered returns a list of node ids ordered by dependsOn starting by the root
+// (nodes with no dependencies) and traversing the whole tree
+func (tree *Tree) Ordered() (s []string) {
+	tree.Traverse(func(n Node) {
+		s = append(s, n.ID())
+	})
+	return
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -106,6 +106,7 @@ type Manifest struct {
 	Icon         string                   `json:"icon,omitempty" yaml:"icon,omitempty"`
 	ManifestPath string                   `json:"-" yaml:"-"`
 	Destroy      *DestroyInfo             `json:"destroy,omitempty" yaml:"destroy,omitempty"`
+	Test         ManifestTests            `json:"test,omitempty" yaml:"test,omitempty"`
 
 	Type          Archetype               `json:"-" yaml:"-"`
 	GlobalForward []forward.GlobalForward `json:"forward,omitempty" yaml:"forward,omitempty"`
@@ -116,10 +117,14 @@ type Manifest struct {
 // ManifestDevs defines all the dev section
 type ManifestDevs map[string]*Dev
 
+// ManifestTests defines all the test sections
+type ManifestTests map[string]*Test
+
 // NewManifest creates a new empty manifest
 func NewManifest() *Manifest {
 	return &Manifest{
 		Dev:           map[string]*Dev{},
+		Test:          map[string]*Test{},
 		Build:         map[string]*build.Info{},
 		Dependencies:  deps.ManifestSection{},
 		Deploy:        &DeployInfo{},
@@ -412,6 +417,7 @@ func getManifestFromFile(cwd, manifestPath string, fs afero.Fs) (*Manifest, erro
 				},
 			},
 			Dev:   ManifestDevs{},
+			Test:  ManifestTests{},
 			Build: build.ManifestBuild{},
 			IsV2:  true,
 			Fs:    fs,
@@ -513,6 +519,7 @@ func GetInferredManifest(cwd string, fs afero.Fs) (*Manifest, error) {
 				},
 			},
 			Dev:   ManifestDevs{},
+			Test:  ManifestTests{},
 			Build: build.ManifestBuild{},
 			IsV2:  true,
 			Fs:    fs,
@@ -554,6 +561,7 @@ func GetInferredManifest(cwd string, fs afero.Fs) (*Manifest, error) {
 				},
 			},
 			Dev:   ManifestDevs{},
+			Test:  ManifestTests{},
 			Build: build.ManifestBuild{},
 			Fs:    fs,
 		}
@@ -579,6 +587,7 @@ func GetInferredManifest(cwd string, fs afero.Fs) (*Manifest, error) {
 				},
 			},
 			Dev:   ManifestDevs{},
+			Test:  ManifestTests{},
 			Build: build.ManifestBuild{},
 			Fs:    fs,
 		}
@@ -969,6 +978,12 @@ func (manifest *Manifest) ExpandEnvVars() error {
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	for _, mf := range manifest.Test {
+		if mf.expandEnvVars() != nil {
+			return err
 		}
 	}
 

--- a/pkg/model/manifest_friendly_err_test.go
+++ b/pkg/model/manifest_friendly_err_test.go
@@ -71,9 +71,9 @@ yaml: some random error
 		},
 		{
 			name:  "yaml errors with heading and link to docs",
-			input: errors.New("yaml: unmarshal errors:\n  line 4: field contest not found in type model.manifestRaw"),
+			input: errors.New("yaml: unmarshal errors:\n  line 4: field kontext not found in type model.manifestRaw"),
 			expected: `your okteto manifest is not valid, please check the following errors:
-     - line 4: field 'contest' is not a property of the okteto manifest. Did you mean "context"?
+     - line 4: field 'kontext' is not a property of the okteto manifest. Did you mean "context"?
     Check out the okteto manifest docs at: https://www.okteto.com/docs/reference/okteto-manifest`,
 		},
 	}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1413,6 +1413,7 @@ func TestRead(t *testing.T) {
 				Context:      "",
 				Icon:         "",
 				ManifestPath: "",
+				Test:         ManifestTests{},
 				Deploy: &DeployInfo{
 					Endpoints: nil,
 					Image:     "",
@@ -1444,6 +1445,7 @@ func TestRead(t *testing.T) {
 				Context:      "",
 				Icon:         "",
 				ManifestPath: "",
+				Test:         ManifestTests{},
 				Deploy: &DeployInfo{
 					Endpoints: nil,
 					Image:     "",

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -201,7 +201,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.HealthCheck":          {"test", "interval", "timeout", "retries", "start_period", "disable", "x-okteto-liveness", "x-okteto-readiness"},
 				"model.InitContainer":        {"image"},
 				"model.Lifecycle":            {"postStart", "postStop"},
-				"model.Manifest":             {"name", "namespace", "context", "icon", "dev", "build", "dependencies", "external"},
+				"model.Manifest":             {"name", "namespace", "context", "icon", "dev", "build", "dependencies", "external", "test"},
 				"model.Metadata":             {"labels", "annotations"},
 				"model.PersistentVolumeInfo": {"storageClass", "size", "enabled"},
 				"model.Probes":               {"liveness", "readiness", "startup"},
@@ -214,6 +214,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.Sync":                 {"rescanInterval", "compression", "verbose"},
 				"model.Timeout":              {"default", "resources"},
 				"model.VolumeSpec":           {"labels", "annotations", "class"},
+				"model.Test":                 {"image", "depends_on"},
 			},
 		},
 	}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -753,6 +753,7 @@ type manifestRaw struct {
 	Icon          string                   `json:"icon,omitempty" yaml:"icon,omitempty"`
 	Deploy        *DeployInfo              `json:"deploy,omitempty" yaml:"deploy,omitempty"`
 	Dev           ManifestDevs             `json:"dev,omitempty" yaml:"dev,omitempty"`
+	Test          ManifestTests            `json:"test,omitempty" yaml:"test,omitempty"`
 	Destroy       *DestroyInfo             `json:"destroy,omitempty" yaml:"destroy,omitempty"`
 	Build         build.ManifestBuild      `json:"build,omitempty" yaml:"build,omitempty"`
 	Dependencies  deps.ManifestSection     `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
@@ -795,6 +796,7 @@ func (m *Manifest) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	m.Name = manifest.Name
 	m.GlobalForward = manifest.GlobalForward
 	m.External = manifest.External
+	m.Test = manifest.Test
 
 	err = m.SanitizeSvcNames()
 	if err != nil {

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1254,6 +1254,7 @@ sync:
 				Dependencies:  map[string]*deps.Dependency{},
 				External:      externalresource.Section{},
 				GlobalForward: []forward.GlobalForward{},
+				Test:          ManifestTests{},
 				Dev: map[string]*Dev{
 					"test": {
 						Name: "test",
@@ -1341,6 +1342,7 @@ services:
 				Dependencies:  map[string]*deps.Dependency{},
 				GlobalForward: []forward.GlobalForward{},
 				External:      externalresource.Section{},
+				Test:          ManifestTests{},
 				Dev: map[string]*Dev{
 					"test": {
 						Name: "test",

--- a/pkg/model/test.go
+++ b/pkg/model/test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package model
+
+import "github.com/okteto/okteto/pkg/env"
+
+type Test struct {
+	Image     string        `yaml:"image,omitempty"`
+	Commands  []TestCommand `yaml:"commands,omitempty"`
+	DependsOn []string      `yaml:"depends_on,omitempty"`
+}
+
+func (test *Test) expandEnvVars() error {
+	var err error
+	if len(test.Image) > 0 {
+		test.Image, err = env.ExpandEnv(test.Image)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type TestCommand struct {
+	Name    string `yaml:"name,omitempty"`
+	Command string `yaml:"command,omitempty"`
+}
+
+func (t *TestCommand) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var command string
+	err := unmarshal(&command)
+	if err == nil {
+		t.Command = command
+		t.Name = command
+		return nil
+	}
+
+	// prevent recursion
+	type alias TestCommand
+	var extendedCommand alias
+	err = unmarshal(&extendedCommand)
+	if err != nil {
+		return err
+	}
+	*t = TestCommand(extendedCommand)
+	return nil
+}


### PR DESCRIPTION
Initializes `okteto test` command following current conventions and existing building blocks. There are some fundamental changes I think we need to do but I kept it out of this PR. Examples of this are:

- catching kill signals in every command and not cancelling root context
- cross importing from `cmd/:package`

# How it works

Before running `okteto test` we potentially run an `okteto build` and an `okteto deploy`. We then do a remote run of okteto test.

### Included in this PR

- pre building
- pre deploying
- command initialization
- manifest `test` entry
- variable interpolation in manifest
- remote execution
- Dependency resolution based on depends_on

### Still pending

- It runs remotely as a deploy action and not a test (assuming we want a remote test command?)
- testing



