### PR TITLE
feat: add variable expansion in manifest.build.dockerfile

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -130,8 +130,14 @@ func (i *Info) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	i.Name = rawBuildInfo.Name
-	i.Context = rawBuildInfo.Context
-	i.Dockerfile = rawBuildInfo.Dockerfile
+	i.Context, err = env.ExpandEnvIfNotEmpty(rawBuildInfo.Context)
+	if err != nil {
+		return err
+	}
+	i.Dockerfile, err = env.ExpandEnvIfNotEmpty(rawBuildInfo.Dockerfile)
+	if err != nil {
+		return err
+	}
 	i.Target = rawBuildInfo.Target
 	i.Args = rawBuildInfo.Args
 	i.Image = rawBuildInfo.Image

--- a/pkg/build/info_test.go
+++ b/pkg/build/info_test.go
@@ -286,6 +286,8 @@ func TestSetBuildDefaults(t *testing.T) {
 }
 
 func TestUnmarshalInfo(t *testing.T) {
+	t.Setenv("CONTEXT", "testContext")
+	t.Setenv("DOCKERFILE", "dockerfile")
 	tests := []struct {
 		input       string
 		expected    *Info
@@ -335,7 +337,42 @@ secrets:
 				},
 			},
 		},
-
+		{
+			name: "unmarshal struct with expansion",
+			input: `
+name: default
+context: $CONTEXT
+dockerfile: $DOCKERFILE
+target: testTarget
+image: testImage
+cache_from:
+  - test_cache_from
+export_cache:
+  - test_export_cache
+depends_on:
+  - test_depends_on
+secrets:
+  secretName: secretValue`,
+			expected: &Info{
+				Name:       "default",
+				Context:    "testContext",
+				Dockerfile: "dockerfile",
+				Target:     "testTarget",
+				Image:      "testImage",
+				CacheFrom: cache.From{
+					"test_cache_from",
+				},
+				ExportCache: cache.ExportCache{
+					"test_export_cache",
+				},
+				DependsOn: DependsOn{
+					"test_depends_on",
+				},
+				Secrets: Secrets{
+					"secretName": "secretValue",
+				},
+			},
+		},
 		{
 			name:        "error unmarshal string nor struct",
 			input:       "- an string value as list",


### PR DESCRIPTION
# Proposed changes

This PR adds support for variable expansion on the expanded syntax of build.Dockerfile and build.Context

## How to validate

1. Create the following manifest:
```yaml
build:
  app:
    context: .
    dockerfile: $DOCKERFILEPATH
```
1. Run the command `export DOCKERFILEPATH=Dockerfile`
1. Run `okteto build`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
