### PR TITLE
DEV-258: Changed command used to get the latest commit for a folder

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -237,6 +237,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 
 			repoHashDurationStart := time.Now()
 
+			ob.ioCtrl.Logger().Debugf("getting project hash for analytics")
 			repoHash, err := ob.smartBuildCtrl.GetProjectHash(buildSvcInfo)
 			if err != nil {
 				ob.ioCtrl.Logger().Infof("error getting project commit hash: %s", err)

--- a/cmd/build/v2/config.go
+++ b/cmd/build/v2/config.go
@@ -31,7 +31,7 @@ type configRepositoryInterface interface {
 	GetSHA() (string, error)
 	IsClean() (bool, error)
 	GetAnonymizedRepo() string
-	GetLatestDirCommit(string) (string, error)
+	GetLatestDirSHA(string) (string, error)
 }
 
 type configRegistryInterface interface {

--- a/cmd/build/v2/config_test.go
+++ b/cmd/build/v2/config_test.go
@@ -37,11 +37,11 @@ type fakeConfigRepo struct {
 	isClean bool
 }
 
-func (fcr fakeConfigRepo) GetSHA() (string, error)                   { return fcr.sha, fcr.err }
-func (fcr fakeConfigRepo) IsClean() (bool, error)                    { return fcr.isClean, fcr.err }
-func (fcr fakeConfigRepo) GetAnonymizedRepo() string                 { return fcr.url }
-func (fcr fakeConfigRepo) GetLatestDirCommit(string) (string, error) { return fcr.sha, fcr.err }
-func (fcr fakeConfigRepo) GetDiffHash(string) (string, error)        { return fcr.diff, fcr.err }
+func (fcr fakeConfigRepo) GetSHA() (string, error)                { return fcr.sha, fcr.err }
+func (fcr fakeConfigRepo) IsClean() (bool, error)                 { return fcr.isClean, fcr.err }
+func (fcr fakeConfigRepo) GetAnonymizedRepo() string              { return fcr.url }
+func (fcr fakeConfigRepo) GetLatestDirSHA(string) (string, error) { return fcr.sha, fcr.err }
+func (fcr fakeConfigRepo) GetDiffHash(string) (string, error)     { return fcr.diff, fcr.err }
 
 type fakeLogger struct{}
 

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -31,7 +31,7 @@ import (
 
 type repositoryCommitRetriever interface {
 	GetSHA() (string, error)
-	GetLatestDirCommit(string) (string, error)
+	GetLatestDirSHA(string) (string, error)
 	GetDiffHash(string) (string, error)
 }
 
@@ -84,7 +84,7 @@ func (sh *serviceHasher) hashWithBuildContext(buildInfo *build.Info, service str
 	}
 	if _, ok := sh.serviceShaCache[service]; !ok {
 		errorGettingGitInfo := false
-		dirCommit, err := sh.gitRepoCtrl.GetLatestDirCommit(buildContext)
+		dirCommit, err := sh.gitRepoCtrl.GetLatestDirSHA(buildContext)
 		if err != nil {
 			errorGettingGitInfo = true
 

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -36,7 +36,7 @@ type registryController interface {
 // repositoryInterface is the interface to interact with git repositories
 type repositoryInterface interface {
 	GetSHA() (string, error)
-	GetLatestDirCommit(string) (string, error)
+	GetLatestDirSHA(string) (string, error)
 	GetDiffHash(string) (string, error)
 }
 

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -30,9 +30,9 @@ type fakeConfigRepo struct {
 	diff string
 }
 
-func (fcr fakeConfigRepo) GetSHA() (string, error)                   { return fcr.sha, fcr.err }
-func (fcr fakeConfigRepo) GetLatestDirCommit(string) (string, error) { return fcr.sha, fcr.err }
-func (fcr fakeConfigRepo) GetDiffHash(string) (string, error)        { return fcr.diff, fcr.err }
+func (fcr fakeConfigRepo) GetSHA() (string, error)                { return fcr.sha, fcr.err }
+func (fcr fakeConfigRepo) GetLatestDirSHA(string) (string, error) { return fcr.sha, fcr.err }
+func (fcr fakeConfigRepo) GetDiffHash(string) (string, error)     { return fcr.diff, fcr.err }
 
 type fakeRegistryController struct {
 	err              error

--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -300,7 +300,7 @@ func TestGetSHA(t *testing.T) {
 	}
 }
 
-func TestGetLatestDirCommit(t *testing.T) {
+func TestGetLatestDirSHA(t *testing.T) {
 	type config struct {
 		repositoryGetter *fakeRepositoryGetter
 	}
@@ -371,7 +371,7 @@ func TestGetLatestDirCommit(t *testing.T) {
 					repoGetter: tt.config.repositoryGetter,
 				},
 			}
-			commit, err := repo.GetLatestDirCommit(tt.buildContext)
+			commit, err := repo.GetLatestDirSHA(tt.buildContext)
 			assert.ErrorIs(t, err, tt.expected.err)
 			assert.Equal(t, tt.expected.sha, commit)
 		})

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -229,7 +229,7 @@ func (lg *LocalGit) GetDirContentSHA(ctx context.Context, gitPath, dirPath strin
 	}
 
 	lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
-	hashObjectCmdArgs := []string{"--no-optional-locks", "hash-objectasd", "--stdin"}
+	hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
 
 	output, err := lg.exec.RunPipeCommands(ctx, gitPath, lg.gitPath, lsFilesCmdArgs, lg.gitPath, hashObjectCmdArgs)
 	if err != nil {

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -14,265 +14,265 @@
 package repository
 
 import (
-    "bytes"
-    "context"
-    "errors"
-    "io"
-    "os"
-    "os/exec"
-    "runtime"
-    "strings"
-    "syscall"
-    "time"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
 
-    "github.com/go-git/go-git/v5"
-    oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/go-git/go-git/v5"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
 var (
-    errLocalGitCannotGetStatusTooManyAttempts = errors.New("failed to get status: too many attempts")
-    errLocalGitCannotGetStatusCannotRecover   = errors.New("failed to get status: cannot recover")
-    errLocalGitInvalidStatusOutput            = errors.New("failed to get git status: unexpected status line")
-    errLocalGitCannotGetCommitTooManyAttempts = errors.New("failed to get latest dir commit: too many attempts")
+	errLocalGitCannotGetStatusTooManyAttempts = errors.New("failed to get status: too many attempts")
+	errLocalGitCannotGetStatusCannotRecover   = errors.New("failed to get status: cannot recover")
+	errLocalGitInvalidStatusOutput            = errors.New("failed to get git status: unexpected status line")
+	errLocalGitCannotGetCommitTooManyAttempts = errors.New("failed to get latest dir commit: too many attempts")
 )
 
 type CommandExecutor interface {
-    RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
-    RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
-    LookPath(file string) (string, error)
+	RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
+	RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
+	LookPath(file string) (string, error)
 }
 
 type LocalExec struct{}
 
 func (le *LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-    c := le.createCommand(ctx, dir, name, arg...)
+	c := le.createCommand(ctx, dir, name, arg...)
 
-    return c.Output()
+	return c.Output()
 }
 
 func (*LocalExec) LookPath(file string) (string, error) {
-    return exec.LookPath(file)
+	return exec.LookPath(file)
 }
 
 // RunPipeCommands runs two commands in a pipeline. cmd1 | cmd2. Example:
 // /usr/bin/git --no-optional-locks ls-files -s . | /usr/bin/git --no-optional-locks hash-object --stdin
 func (le *LocalExec) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-    c1 := le.createCommand(ctx, dir, cmd1, cmd1Args...)
-    c2 := le.createCommand(ctx, dir, cmd2, cmd2Args...)
+	c1 := le.createCommand(ctx, dir, cmd1, cmd1Args...)
+	c2 := le.createCommand(ctx, dir, cmd2, cmd2Args...)
 
-    var errOut bytes.Buffer
-    var errOut2 bytes.Buffer
+	var errOut bytes.Buffer
+	var errOut2 bytes.Buffer
 
-    // Create a pipe to connect the stdout of c1 to the stdin of c2
-    pipeReader, pipeWriter := io.Pipe()
-    c1.Stdout = pipeWriter
-    c1.Stderr = &errOut
-    c2.Stdin = pipeReader
-    c2.Stderr = &errOut2
+	// Create a pipe to connect the stdout of c1 to the stdin of c2
+	pipeReader, pipeWriter := io.Pipe()
+	c1.Stdout = pipeWriter
+	c1.Stderr = &errOut
+	c2.Stdin = pipeReader
+	c2.Stderr = &errOut2
 
-    // Start both commands
-    if err := c1.Start(); err != nil {
-        return []byte{}, err
-    }
+	// Start both commands
+	if err := c1.Start(); err != nil {
+		return []byte{}, err
+	}
 
-    var b2 bytes.Buffer
-    c2.Stdout = &b2
-    if err := c2.Start(); err != nil {
-        return []byte{}, err
-    }
+	var b2 bytes.Buffer
+	c2.Stdout = &b2
+	if err := c2.Start(); err != nil {
+		return []byte{}, err
+	}
 
-    err := c1.Wait()
-    pipeWriter.Close()
-    if err != nil {
-        oktetoLog.Infof("error executing command %q: %s", strings.Join(c1.Args, " "), errOut.String())
-        return []byte{}, err
-    }
+	err := c1.Wait()
+	pipeWriter.Close()
+	if err != nil {
+		oktetoLog.Infof("error executing command %q: %s", strings.Join(c1.Args, " "), errOut.String())
+		return []byte{}, err
+	}
 
-    if err := c2.Wait(); err != nil {
-        oktetoLog.Infof("error executing command %q: %s", strings.Join(c2.Args, " "), errOut2.String())
-        return []byte{}, err
-    }
+	if err := c2.Wait(); err != nil {
+		oktetoLog.Infof("error executing command %q: %s", strings.Join(c2.Args, " "), errOut2.String())
+		return []byte{}, err
+	}
 
-    output := strings.TrimSuffix(b2.String(), "\n")
-    return []byte(output), nil
+	output := strings.TrimSuffix(b2.String(), "\n")
+	return []byte(output), nil
 }
 
 func (*LocalExec) createCommand(ctx context.Context, dir, cmd string, args ...string) *exec.Cmd {
-    c := exec.CommandContext(ctx, cmd, args...)
-    c.Cancel = func() error {
-        // windows: https://pkg.go.dev/os#Signal
-        // Terminating the process with Signal is not implemented for windows.
-        // Windows platform will only be able to kill the process
-        if runtime.GOOS == "windows" {
-            return c.Process.Kill()
-        }
+	c := exec.CommandContext(ctx, cmd, args...)
+	c.Cancel = func() error {
+		// windows: https://pkg.go.dev/os#Signal
+		// Terminating the process with Signal is not implemented for windows.
+		// Windows platform will only be able to kill the process
+		if runtime.GOOS == "windows" {
+			return c.Process.Kill()
+		}
 
-        oktetoLog.Debugf("terminating %s - %s/%s", c.String(), dir, cmd)
-        if err := c.Process.Signal(syscall.SIGTERM); err != nil {
-            oktetoLog.Debugf("err at signal SIGTERM: %v", err)
-        }
+		oktetoLog.Debugf("terminating %s - %s/%s", c.String(), dir, cmd)
+		if err := c.Process.Signal(syscall.SIGTERM); err != nil {
+			oktetoLog.Debugf("err at signal SIGTERM: %v", err)
+		}
 
-        time.Sleep(3 * time.Second)
-        if err := c.Process.Signal(syscall.Signal(0)); err != nil {
-            if errors.Is(err, os.ErrProcessDone) {
-                return nil
-            }
-            oktetoLog.Debugf("reading signal with error %v", err)
-        }
-        oktetoLog.Debugf("killing %s - %s/%s", c.String(), dir, cmd)
-        return c.Process.Signal(syscall.SIGKILL)
-    }
+		time.Sleep(3 * time.Second)
+		if err := c.Process.Signal(syscall.Signal(0)); err != nil {
+			if errors.Is(err, os.ErrProcessDone) {
+				return nil
+			}
+			oktetoLog.Debugf("reading signal with error %v", err)
+		}
+		oktetoLog.Debugf("killing %s - %s/%s", c.String(), dir, cmd)
+		return c.Process.Signal(syscall.SIGKILL)
+	}
 
-    c.Env = os.Environ()
-    c.Dir = dir
-    return c
+	c.Env = os.Environ()
+	c.Dir = dir
+	return c
 }
 
 type LocalGitInterface interface {
-    Status(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (git.Status, error)
-    Exists() (string, error)
-    FixDubiousOwnershipConfig(path string) error
-    parseGitStatus(string) (git.Status, error)
-    GetDirContentSHA(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
-    Diff(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
+	Status(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (git.Status, error)
+	Exists() (string, error)
+	FixDubiousOwnershipConfig(path string) error
+	parseGitStatus(string) (git.Status, error)
+	GetDirContentSHA(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
+	Diff(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
 }
 
 type LocalGit struct {
-    exec    CommandExecutor
-    gitPath string
+	exec    CommandExecutor
+	gitPath string
 }
 
 func NewLocalGit(gitPath string, exec CommandExecutor) *LocalGit {
-    return &LocalGit{
-        gitPath: gitPath,
-        exec:    exec,
-    }
+	return &LocalGit{
+		gitPath: gitPath,
+		exec:    exec,
+	}
 }
 
 // Status returns the status of the repository at the given path
 func (lg *LocalGit) Status(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (git.Status, error) {
-    if fixAttempt > 1 {
-        return git.Status{}, errLocalGitCannotGetStatusTooManyAttempts
-    }
+	if fixAttempt > 1 {
+		return git.Status{}, errLocalGitCannotGetStatusTooManyAttempts
+	}
 
-    args := []string{"--no-optional-locks", "status", "--porcelain"}
-    if dirPath != "" {
-        args = append(args, dirPath)
-    }
-    output, err := lg.exec.RunCommand(ctx, repoRoot, lg.gitPath, args...)
-    if err != nil {
-        var exitError *exec.ExitError
-        errors.As(err, &exitError)
-        if exitError != nil {
-            exitErr := string(exitError.Stderr)
-            if strings.Contains(exitErr, "detected dubious ownership in repository") {
-                err = lg.FixDubiousOwnershipConfig(repoRoot)
-                if err != nil {
-                    return git.Status{}, errLocalGitCannotGetStatusCannotRecover
-                }
-                fixAttempt++
-                return lg.Status(ctx, repoRoot, dirPath, fixAttempt)
-            }
-        }
-        return git.Status{}, errLocalGitCannotGetStatusCannotRecover
-    }
+	args := []string{"--no-optional-locks", "status", "--porcelain"}
+	if dirPath != "" {
+		args = append(args, dirPath)
+	}
+	output, err := lg.exec.RunCommand(ctx, repoRoot, lg.gitPath, args...)
+	if err != nil {
+		var exitError *exec.ExitError
+		errors.As(err, &exitError)
+		if exitError != nil {
+			exitErr := string(exitError.Stderr)
+			if strings.Contains(exitErr, "detected dubious ownership in repository") {
+				err = lg.FixDubiousOwnershipConfig(repoRoot)
+				if err != nil {
+					return git.Status{}, errLocalGitCannotGetStatusCannotRecover
+				}
+				fixAttempt++
+				return lg.Status(ctx, repoRoot, dirPath, fixAttempt)
+			}
+		}
+		return git.Status{}, errLocalGitCannotGetStatusCannotRecover
+	}
 
-    status, err := lg.parseGitStatus(string(output))
-    if err != nil {
-        return git.Status{}, err
-    }
+	status, err := lg.parseGitStatus(string(output))
+	if err != nil {
+		return git.Status{}, err
+	}
 
-    return status, err
+	return status, err
 }
 
 // FixDubiousOwnershipConfig adds the given path to the git config safe.directory to avoid the dubious ownership error
 func (lg *LocalGit) FixDubiousOwnershipConfig(path string) error {
-    _, err := lg.exec.RunCommand(context.Background(), path, lg.gitPath, "config", "--global", "--add", "safe.directory", path)
-    return err
+	_, err := lg.exec.RunCommand(context.Background(), path, lg.gitPath, "config", "--global", "--add", "safe.directory", path)
+	return err
 }
 
 // Exists checks if git binary exists in the system
 func (lg *LocalGit) Exists() (string, error) {
-    var err error
-    lg.gitPath, err = lg.exec.LookPath("git")
-    return lg.gitPath, err
+	var err error
+	lg.gitPath, err = lg.exec.LookPath("git")
+	return lg.gitPath, err
 }
 
 func (*LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
-    lines := strings.Split(gitStatusOutput, "\n")
-    status := make(map[string]*git.FileStatus, len(lines))
+	lines := strings.Split(gitStatusOutput, "\n")
+	status := make(map[string]*git.FileStatus, len(lines))
 
-    for _, line := range lines {
-        if line == "" {
-            continue
-        }
-        maxValidGitStatusParts := 2
-        // line example values can be: "M modified-file.go", "?? new-file.go", etc
-        parts := strings.SplitN(strings.TrimLeft(line, " "), " ", maxValidGitStatusParts)
-        if len(parts) == maxValidGitStatusParts {
-            status[strings.Trim(parts[1], " ")] = &git.FileStatus{
-                Staging: git.StatusCode([]byte(parts[0])[0]),
-            }
-        } else {
-            return git.Status{}, errLocalGitInvalidStatusOutput
-        }
-    }
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		maxValidGitStatusParts := 2
+		// line example values can be: "M modified-file.go", "?? new-file.go", etc
+		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", maxValidGitStatusParts)
+		if len(parts) == maxValidGitStatusParts {
+			status[strings.Trim(parts[1], " ")] = &git.FileStatus{
+				Staging: git.StatusCode([]byte(parts[0])[0]),
+			}
+		} else {
+			return git.Status{}, errLocalGitInvalidStatusOutput
+		}
+	}
 
-    return status, nil
+	return status, nil
 }
 
 // GetDirContentSHA calculates the SHA of the content of the given directory using git ls-files and git hash-object
 // commands
 func (lg *LocalGit) GetDirContentSHA(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
-    if fixAttempt > 1 {
-        return "", errLocalGitCannotGetCommitTooManyAttempts
-    }
+	if fixAttempt > 1 {
+		return "", errLocalGitCannotGetCommitTooManyAttempts
+	}
 
-    lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
-    hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
+	lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
+	hashObjectCmdArgs := []string{"--no-optional-locks", "hash-objectasd", "--stdin"}
 
-    output, err := lg.exec.RunPipeCommands(ctx, gitPath, lg.gitPath, lsFilesCmdArgs, lg.gitPath, hashObjectCmdArgs)
-    if err != nil {
-        var exitError *exec.ExitError
-        errors.As(err, &exitError)
-        if exitError != nil {
-            exitErr := string(exitError.Stderr)
-            if strings.Contains(exitErr, "detected dubious ownership in repository") {
-                err = lg.FixDubiousOwnershipConfig(gitPath)
-                if err != nil {
-                    return "", errLocalGitCannotGetStatusCannotRecover
-                }
-                fixAttempt++
-                return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
-            }
-        }
-        return "", errLocalGitCannotGetStatusCannotRecover
-    }
-    return string(output), nil
+	output, err := lg.exec.RunPipeCommands(ctx, gitPath, lg.gitPath, lsFilesCmdArgs, lg.gitPath, hashObjectCmdArgs)
+	if err != nil {
+		var exitError *exec.ExitError
+		errors.As(err, &exitError)
+		if exitError != nil {
+			exitErr := string(exitError.Stderr)
+			if strings.Contains(exitErr, "detected dubious ownership in repository") {
+				err = lg.FixDubiousOwnershipConfig(gitPath)
+				if err != nil {
+					return "", errLocalGitCannotGetStatusCannotRecover
+				}
+				fixAttempt++
+				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
+			}
+		}
+		return "", errLocalGitCannotGetStatusCannotRecover
+	}
+	return string(output), nil
 }
 
 // Diff returns the diff of the repository at the given path
 func (lg *LocalGit) Diff(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
-    if fixAttempt > 1 {
-        return "", errLocalGitCannotGetCommitTooManyAttempts
-    }
+	if fixAttempt > 1 {
+		return "", errLocalGitCannotGetCommitTooManyAttempts
+	}
 
-    output, err := lg.exec.RunCommand(ctx, gitPath, lg.gitPath, "--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath)
-    if err != nil {
-        var exitError *exec.ExitError
-        errors.As(err, &exitError)
-        if exitError != nil {
-            exitErr := string(exitError.Stderr)
-            if strings.Contains(exitErr, "detected dubious ownership in repository") {
-                err = lg.FixDubiousOwnershipConfig(gitPath)
-                if err != nil {
-                    return "", errLocalGitCannotGetStatusCannotRecover
-                }
-                fixAttempt++
-                return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
-            }
-        }
-        return "", errLocalGitCannotGetStatusCannotRecover
-    }
-    return string(output), nil
+	output, err := lg.exec.RunCommand(ctx, gitPath, lg.gitPath, "--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath)
+	if err != nil {
+		var exitError *exec.ExitError
+		errors.As(err, &exitError)
+		if exitError != nil {
+			exitErr := string(exitError.Stderr)
+			if strings.Contains(exitErr, "detected dubious ownership in repository") {
+				err = lg.FixDubiousOwnershipConfig(gitPath)
+				if err != nil {
+					return "", errLocalGitCannotGetStatusCannotRecover
+				}
+				fixAttempt++
+				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
+			}
+		}
+		return "", errLocalGitCannotGetStatusCannotRecover
+	}
+	return string(output), nil
 }

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -14,258 +14,265 @@
 package repository
 
 import (
-	"bytes"
-	"context"
-	"errors"
-	"io"
-	"os"
-	"os/exec"
-	"runtime"
-	"strings"
-	"syscall"
-	"time"
+    "bytes"
+    "context"
+    "errors"
+    "io"
+    "os"
+    "os/exec"
+    "runtime"
+    "strings"
+    "syscall"
+    "time"
 
-	"github.com/go-git/go-git/v5"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
+    "github.com/go-git/go-git/v5"
+    oktetoLog "github.com/okteto/okteto/pkg/log"
 )
 
 var (
-	errLocalGitCannotGetStatusTooManyAttempts = errors.New("failed to get status: too many attempts")
-	errLocalGitCannotGetStatusCannotRecover   = errors.New("failed to get status: cannot recover")
-	errLocalGitInvalidStatusOutput            = errors.New("failed to get git status: unexpected status line")
-	errLocalGitCannotGetCommitTooManyAttempts = errors.New("failed to get latest dir commit: too many attempts")
+    errLocalGitCannotGetStatusTooManyAttempts = errors.New("failed to get status: too many attempts")
+    errLocalGitCannotGetStatusCannotRecover   = errors.New("failed to get status: cannot recover")
+    errLocalGitInvalidStatusOutput            = errors.New("failed to get git status: unexpected status line")
+    errLocalGitCannotGetCommitTooManyAttempts = errors.New("failed to get latest dir commit: too many attempts")
 )
 
 type CommandExecutor interface {
-	RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
-	RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
-	LookPath(file string) (string, error)
+    RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
+    RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
+    LookPath(file string) (string, error)
 }
 
 type LocalExec struct{}
 
 func (le *LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-	c := le.createCommand(ctx, dir, name, arg...)
+    c := le.createCommand(ctx, dir, name, arg...)
 
-	return c.Output()
+    return c.Output()
 }
 
 func (*LocalExec) LookPath(file string) (string, error) {
-	return exec.LookPath(file)
+    return exec.LookPath(file)
 }
 
 // RunPipeCommands runs two commands in a pipeline. cmd1 | cmd2. Example:
 // /usr/bin/git --no-optional-locks ls-files -s . | /usr/bin/git --no-optional-locks hash-object --stdin
 func (le *LocalExec) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-	c1 := le.createCommand(ctx, dir, cmd1, cmd1Args...)
-	c2 := le.createCommand(ctx, dir, cmd2, cmd2Args...)
+    c1 := le.createCommand(ctx, dir, cmd1, cmd1Args...)
+    c2 := le.createCommand(ctx, dir, cmd2, cmd2Args...)
 
-	// Create a pipe to connect the stdout of c1 to the stdin of c2
-	pipeReader, pipeWriter := io.Pipe()
-	c1.Stdout = pipeWriter
-	c2.Stdin = pipeReader
+    var errOut bytes.Buffer
+    var errOut2 bytes.Buffer
 
-	// Start both commands
-	if err := c1.Start(); err != nil {
-		return []byte{}, err
-	}
+    // Create a pipe to connect the stdout of c1 to the stdin of c2
+    pipeReader, pipeWriter := io.Pipe()
+    c1.Stdout = pipeWriter
+    c1.Stderr = &errOut
+    c2.Stdin = pipeReader
+    c2.Stderr = &errOut2
 
-	var b2 bytes.Buffer
-	c2.Stdout = &b2
-	if err := c2.Start(); err != nil {
-		return []byte{}, err
-	}
+    // Start both commands
+    if err := c1.Start(); err != nil {
+        return []byte{}, err
+    }
 
-	err := c1.Wait()
-	pipeWriter.Close()
-	if err != nil {
-		return []byte{}, err
-	}
+    var b2 bytes.Buffer
+    c2.Stdout = &b2
+    if err := c2.Start(); err != nil {
+        return []byte{}, err
+    }
 
-	if err := c2.Wait(); err != nil {
-		return []byte{}, err
-	}
+    err := c1.Wait()
+    pipeWriter.Close()
+    if err != nil {
+        oktetoLog.Infof("error executing command %q: %s", strings.Join(c1.Args, " "), errOut.String())
+        return []byte{}, err
+    }
 
-	output := strings.TrimSuffix(b2.String(), "\n")
-	return []byte(output), nil
+    if err := c2.Wait(); err != nil {
+        oktetoLog.Infof("error executing command %q: %s", strings.Join(c2.Args, " "), errOut2.String())
+        return []byte{}, err
+    }
+
+    output := strings.TrimSuffix(b2.String(), "\n")
+    return []byte(output), nil
 }
 
 func (*LocalExec) createCommand(ctx context.Context, dir, cmd string, args ...string) *exec.Cmd {
-	c := exec.CommandContext(ctx, cmd, args...)
-	c.Cancel = func() error {
-		// windows: https://pkg.go.dev/os#Signal
-		// Terminating the process with Signal is not implemented for windows.
-		// Windows platform will only be able to kill the process
-		if runtime.GOOS == "windows" {
-			return c.Process.Kill()
-		}
+    c := exec.CommandContext(ctx, cmd, args...)
+    c.Cancel = func() error {
+        // windows: https://pkg.go.dev/os#Signal
+        // Terminating the process with Signal is not implemented for windows.
+        // Windows platform will only be able to kill the process
+        if runtime.GOOS == "windows" {
+            return c.Process.Kill()
+        }
 
-		oktetoLog.Debugf("terminating %s - %s/%s", c.String(), dir, cmd)
-		if err := c.Process.Signal(syscall.SIGTERM); err != nil {
-			oktetoLog.Debugf("err at signal SIGTERM: %v", err)
-		}
+        oktetoLog.Debugf("terminating %s - %s/%s", c.String(), dir, cmd)
+        if err := c.Process.Signal(syscall.SIGTERM); err != nil {
+            oktetoLog.Debugf("err at signal SIGTERM: %v", err)
+        }
 
-		time.Sleep(3 * time.Second)
-		if err := c.Process.Signal(syscall.Signal(0)); err != nil {
-			if errors.Is(err, os.ErrProcessDone) {
-				return nil
-			}
-			oktetoLog.Debugf("reading signal with error %v", err)
-		}
-		oktetoLog.Debugf("killing %s - %s/%s", c.String(), dir, cmd)
-		return c.Process.Signal(syscall.SIGKILL)
-	}
+        time.Sleep(3 * time.Second)
+        if err := c.Process.Signal(syscall.Signal(0)); err != nil {
+            if errors.Is(err, os.ErrProcessDone) {
+                return nil
+            }
+            oktetoLog.Debugf("reading signal with error %v", err)
+        }
+        oktetoLog.Debugf("killing %s - %s/%s", c.String(), dir, cmd)
+        return c.Process.Signal(syscall.SIGKILL)
+    }
 
-	c.Env = os.Environ()
-	c.Dir = dir
-	return c
+    c.Env = os.Environ()
+    c.Dir = dir
+    return c
 }
 
 type LocalGitInterface interface {
-	Status(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (git.Status, error)
-	Exists() (string, error)
-	FixDubiousOwnershipConfig(path string) error
-	parseGitStatus(string) (git.Status, error)
-	GetDirContentSHA(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
-	Diff(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
+    Status(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (git.Status, error)
+    Exists() (string, error)
+    FixDubiousOwnershipConfig(path string) error
+    parseGitStatus(string) (git.Status, error)
+    GetDirContentSHA(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
+    Diff(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
 }
 
 type LocalGit struct {
-	exec    CommandExecutor
-	gitPath string
+    exec    CommandExecutor
+    gitPath string
 }
 
 func NewLocalGit(gitPath string, exec CommandExecutor) *LocalGit {
-	return &LocalGit{
-		gitPath: gitPath,
-		exec:    exec,
-	}
+    return &LocalGit{
+        gitPath: gitPath,
+        exec:    exec,
+    }
 }
 
 // Status returns the status of the repository at the given path
 func (lg *LocalGit) Status(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (git.Status, error) {
-	if fixAttempt > 1 {
-		return git.Status{}, errLocalGitCannotGetStatusTooManyAttempts
-	}
+    if fixAttempt > 1 {
+        return git.Status{}, errLocalGitCannotGetStatusTooManyAttempts
+    }
 
-	args := []string{"--no-optional-locks", "status", "--porcelain"}
-	if dirPath != "" {
-		args = append(args, dirPath)
-	}
-	output, err := lg.exec.RunCommand(ctx, repoRoot, lg.gitPath, args...)
-	if err != nil {
-		var exitError *exec.ExitError
-		errors.As(err, &exitError)
-		if exitError != nil {
-			exitErr := string(exitError.Stderr)
-			if strings.Contains(exitErr, "detected dubious ownership in repository") {
-				err = lg.FixDubiousOwnershipConfig(repoRoot)
-				if err != nil {
-					return git.Status{}, errLocalGitCannotGetStatusCannotRecover
-				}
-				fixAttempt++
-				return lg.Status(ctx, repoRoot, dirPath, fixAttempt)
-			}
-		}
-		return git.Status{}, errLocalGitCannotGetStatusCannotRecover
-	}
+    args := []string{"--no-optional-locks", "status", "--porcelain"}
+    if dirPath != "" {
+        args = append(args, dirPath)
+    }
+    output, err := lg.exec.RunCommand(ctx, repoRoot, lg.gitPath, args...)
+    if err != nil {
+        var exitError *exec.ExitError
+        errors.As(err, &exitError)
+        if exitError != nil {
+            exitErr := string(exitError.Stderr)
+            if strings.Contains(exitErr, "detected dubious ownership in repository") {
+                err = lg.FixDubiousOwnershipConfig(repoRoot)
+                if err != nil {
+                    return git.Status{}, errLocalGitCannotGetStatusCannotRecover
+                }
+                fixAttempt++
+                return lg.Status(ctx, repoRoot, dirPath, fixAttempt)
+            }
+        }
+        return git.Status{}, errLocalGitCannotGetStatusCannotRecover
+    }
 
-	status, err := lg.parseGitStatus(string(output))
-	if err != nil {
-		return git.Status{}, err
-	}
+    status, err := lg.parseGitStatus(string(output))
+    if err != nil {
+        return git.Status{}, err
+    }
 
-	return status, err
+    return status, err
 }
 
 // FixDubiousOwnershipConfig adds the given path to the git config safe.directory to avoid the dubious ownership error
 func (lg *LocalGit) FixDubiousOwnershipConfig(path string) error {
-	_, err := lg.exec.RunCommand(context.Background(), path, lg.gitPath, "config", "--global", "--add", "safe.directory", path)
-	return err
+    _, err := lg.exec.RunCommand(context.Background(), path, lg.gitPath, "config", "--global", "--add", "safe.directory", path)
+    return err
 }
 
 // Exists checks if git binary exists in the system
 func (lg *LocalGit) Exists() (string, error) {
-	var err error
-	lg.gitPath, err = lg.exec.LookPath("git")
-	return lg.gitPath, err
+    var err error
+    lg.gitPath, err = lg.exec.LookPath("git")
+    return lg.gitPath, err
 }
 
 func (*LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
-	lines := strings.Split(gitStatusOutput, "\n")
-	status := make(map[string]*git.FileStatus, len(lines))
+    lines := strings.Split(gitStatusOutput, "\n")
+    status := make(map[string]*git.FileStatus, len(lines))
 
-	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-		maxValidGitStatusParts := 2
-		// line example values can be: "M modified-file.go", "?? new-file.go", etc
-		parts := strings.SplitN(strings.TrimLeft(line, " "), " ", maxValidGitStatusParts)
-		if len(parts) == maxValidGitStatusParts {
-			status[strings.Trim(parts[1], " ")] = &git.FileStatus{
-				Staging: git.StatusCode([]byte(parts[0])[0]),
-			}
-		} else {
-			return git.Status{}, errLocalGitInvalidStatusOutput
-		}
-	}
+    for _, line := range lines {
+        if line == "" {
+            continue
+        }
+        maxValidGitStatusParts := 2
+        // line example values can be: "M modified-file.go", "?? new-file.go", etc
+        parts := strings.SplitN(strings.TrimLeft(line, " "), " ", maxValidGitStatusParts)
+        if len(parts) == maxValidGitStatusParts {
+            status[strings.Trim(parts[1], " ")] = &git.FileStatus{
+                Staging: git.StatusCode([]byte(parts[0])[0]),
+            }
+        } else {
+            return git.Status{}, errLocalGitInvalidStatusOutput
+        }
+    }
 
-	return status, nil
+    return status, nil
 }
 
 // GetDirContentSHA calculates the SHA of the content of the given directory using git ls-files and git hash-object
 // commands
 func (lg *LocalGit) GetDirContentSHA(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
-	if fixAttempt > 1 {
-		return "", errLocalGitCannotGetCommitTooManyAttempts
-	}
+    if fixAttempt > 1 {
+        return "", errLocalGitCannotGetCommitTooManyAttempts
+    }
 
-	lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
-	hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
+    lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
+    hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
 
-	output, err := lg.exec.RunPipeCommands(ctx, gitPath, lg.gitPath, lsFilesCmdArgs, lg.gitPath, hashObjectCmdArgs)
-	if err != nil {
-		var exitError *exec.ExitError
-		errors.As(err, &exitError)
-		if exitError != nil {
-			exitErr := string(exitError.Stderr)
-			if strings.Contains(exitErr, "detected dubious ownership in repository") {
-				err = lg.FixDubiousOwnershipConfig(gitPath)
-				if err != nil {
-					return "", errLocalGitCannotGetStatusCannotRecover
-				}
-				fixAttempt++
-				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
-			}
-		}
-		return "", errLocalGitCannotGetStatusCannotRecover
-	}
-	return string(output), nil
+    output, err := lg.exec.RunPipeCommands(ctx, gitPath, lg.gitPath, lsFilesCmdArgs, lg.gitPath, hashObjectCmdArgs)
+    if err != nil {
+        var exitError *exec.ExitError
+        errors.As(err, &exitError)
+        if exitError != nil {
+            exitErr := string(exitError.Stderr)
+            if strings.Contains(exitErr, "detected dubious ownership in repository") {
+                err = lg.FixDubiousOwnershipConfig(gitPath)
+                if err != nil {
+                    return "", errLocalGitCannotGetStatusCannotRecover
+                }
+                fixAttempt++
+                return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
+            }
+        }
+        return "", errLocalGitCannotGetStatusCannotRecover
+    }
+    return string(output), nil
 }
 
 // Diff returns the diff of the repository at the given path
 func (lg *LocalGit) Diff(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
-	if fixAttempt > 1 {
-		return "", errLocalGitCannotGetCommitTooManyAttempts
-	}
+    if fixAttempt > 1 {
+        return "", errLocalGitCannotGetCommitTooManyAttempts
+    }
 
-	output, err := lg.exec.RunCommand(ctx, gitPath, lg.gitPath, "--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath)
-	if err != nil {
-		var exitError *exec.ExitError
-		errors.As(err, &exitError)
-		if exitError != nil {
-			exitErr := string(exitError.Stderr)
-			if strings.Contains(exitErr, "detected dubious ownership in repository") {
-				err = lg.FixDubiousOwnershipConfig(gitPath)
-				if err != nil {
-					return "", errLocalGitCannotGetStatusCannotRecover
-				}
-				fixAttempt++
-				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
-			}
-		}
-		return "", errLocalGitCannotGetStatusCannotRecover
-	}
-	return string(output), nil
+    output, err := lg.exec.RunCommand(ctx, gitPath, lg.gitPath, "--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath)
+    if err != nil {
+        var exitError *exec.ExitError
+        errors.As(err, &exitError)
+        if exitError != nil {
+            exitErr := string(exitError.Stderr)
+            if strings.Contains(exitErr, "detected dubious ownership in repository") {
+                err = lg.FixDubiousOwnershipConfig(gitPath)
+                if err != nil {
+                    return "", errLocalGitCannotGetStatusCannotRecover
+                }
+                fixAttempt++
+                return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
+            }
+        }
+        return "", errLocalGitCannotGetStatusCannotRecover
+    }
+    return string(output), nil
 }

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -126,7 +126,7 @@ type LocalGitInterface interface {
 	Exists() (string, error)
 	FixDubiousOwnershipConfig(path string) error
 	parseGitStatus(string) (git.Status, error)
-	GetLatestCommit(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
+	GetDirContentSHA(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
 	Diff(ctx context.Context, repoRoot, dirPath string, fixAttempt int) (string, error)
 }
 
@@ -214,8 +214,9 @@ func (*LocalGit) parseGitStatus(gitStatusOutput string) (git.Status, error) {
 	return status, nil
 }
 
-// GetLatestCommit returns the latest commit of the repository at the given path
-func (lg *LocalGit) GetLatestCommit(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
+// GetDirContentSHA calculates the SHA of the content of the given directory using git ls-files and git hash-object
+// commands
+func (lg *LocalGit) GetDirContentSHA(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
 	if fixAttempt > 1 {
 		return "", errLocalGitCannotGetCommitTooManyAttempts
 	}
@@ -235,7 +236,7 @@ func (lg *LocalGit) GetLatestCommit(ctx context.Context, gitPath, dirPath string
 					return "", errLocalGitCannotGetStatusCannotRecover
 				}
 				fixAttempt++
-				return lg.GetLatestCommit(ctx, gitPath, dirPath, fixAttempt)
+				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
 			}
 		}
 		return "", errLocalGitCannotGetStatusCannotRecover
@@ -261,7 +262,7 @@ func (lg *LocalGit) Diff(ctx context.Context, gitPath, dirPath string, fixAttemp
 					return "", errLocalGitCannotGetStatusCannotRecover
 				}
 				fixAttempt++
-				return lg.GetLatestCommit(ctx, gitPath, dirPath, fixAttempt)
+				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
 			}
 		}
 		return "", errLocalGitCannotGetStatusCannotRecover

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -24,8 +24,9 @@ import (
 )
 
 type mockLocalExec struct {
-	runCommand func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
-	lookPath   func(file string) (string, error)
+	runCommand  func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
+	pipeCommand func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
+	lookPath    func(file string) (string, error)
 }
 
 func (mle *mockLocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
@@ -40,6 +41,14 @@ func (mle *mockLocalExec) LookPath(file string) (string, error) {
 		return mle.lookPath(file)
 	}
 	return "", assert.AnError
+}
+
+func (mle *mockLocalExec) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
+	if mle.pipeCommand != nil {
+		return mle.pipeCommand(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
+	}
+
+	return nil, assert.AnError
 }
 
 func TestLocalGit_Exists(t *testing.T) {
@@ -249,7 +258,7 @@ func TestLocalGit_GetLatestCommit(t *testing.T) {
 			fixAttempts: 0,
 			mock: func() *mockLocalExec {
 				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+					pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
 						return []byte("hash"), nil
 					},
 				}
@@ -261,7 +270,7 @@ func TestLocalGit_GetLatestCommit(t *testing.T) {
 			fixAttempts: 2,
 			mock: func() *mockLocalExec {
 				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+					pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
 						return nil, assert.AnError
 					},
 				}
@@ -273,7 +282,7 @@ func TestLocalGit_GetLatestCommit(t *testing.T) {
 			fixAttempts: 1,
 			mock: func() *mockLocalExec {
 				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+					pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
 						return nil, assert.AnError
 					},
 				}

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -246,7 +246,7 @@ func Test_LocalExec_RunCommand(t *testing.T) {
 	assert.Equal(t, "okteto\n", string(got))
 }
 
-func TestLocalGit_GetLatestCommit(t *testing.T) {
+func TestLocalGit_GetDirContentSHA(t *testing.T) {
 	tests := []struct {
 		expectedErr error
 		mock        func() *mockLocalExec
@@ -294,7 +294,7 @@ func TestLocalGit_GetLatestCommit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lg := NewLocalGit("git", tt.mock())
-			_, err := lg.GetLatestCommit(context.Background(), "", "/test/dir", tt.fixAttempts)
+			_, err := lg.GetDirContentSHA(context.Background(), "", "/test/dir", tt.fixAttempts)
 
 			assert.ErrorIs(t, err, tt.expectedErr)
 		})

--- a/pkg/repository/remote.go
+++ b/pkg/repository/remote.go
@@ -36,7 +36,7 @@ func (or oktetoRemoteRepoController) getSHA() (string, error) {
 	return or.gitCommit, nil
 }
 
-func (or oktetoRemoteRepoController) GetLatestDirCommit(string) (string, error) {
+func (or oktetoRemoteRepoController) GetLatestDirSHA(string) (string, error) {
 	return "", fmt.Errorf("not-implemented")
 }
 

--- a/pkg/repository/remote_test.go
+++ b/pkg/repository/remote_test.go
@@ -48,11 +48,11 @@ func TestRemoteGetSHA(t *testing.T) {
 	assert.Equal(t, remote.gitCommit, sha)
 }
 
-func TestRemoteGetLatestDirCommit(t *testing.T) {
+func TestRemoteGetLatestDirSHA(t *testing.T) {
 	remote := oktetoRemoteRepoController{
 		gitCommit: "123",
 	}
-	_, err := remote.GetLatestDirCommit("test")
+	_, err := remote.GetLatestDirSHA("test")
 	assert.Error(t, err, fmt.Errorf("not-implemented"))
 }
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -36,7 +36,7 @@ type Repository struct {
 type repositoryInterface interface {
 	isClean(ctx context.Context) (bool, error)
 	getSHA() (string, error)
-	GetLatestDirCommit(string) (string, error)
+	GetLatestDirSHA(string) (string, error)
 	GetDiffHash(string) (string, error)
 }
 
@@ -116,8 +116,8 @@ func (r Repository) GetAnonymizedRepo() string {
 	return r.url.String()
 }
 
-func (r Repository) GetLatestDirCommit(dir string) (string, error) {
-	return r.control.GetLatestDirCommit(dir)
+func (r Repository) GetLatestDirSHA(dir string) (string, error) {
+	return r.control.GetLatestDirSHA(dir)
 }
 
 func (r Repository) GetDiffHash(dir string) (string, error) {

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -59,7 +59,7 @@ func (fr fakeRepository) Head() (*plumbing.Reference, error) {
 	return fr.head, fr.err
 }
 
-func (fr fakeRepository) GetLatestCommit(context.Context, string, string, LocalGitInterface) (string, error) {
+func (fr fakeRepository) GetLatestSHA(context.Context, string, string, LocalGitInterface) (string, error) {
 	return fr.commit, fr.err
 }
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-258

As the installer is cloning repositories always using only one commit, the build context calculation doesn't work well because you have different behaviors from local and the installer, generating unnecessary builds. As cloning the whole history might impact performance, we are changing the CLI to not use the latest commit of the folder but instead, use a hash of the files tracked by git within that folder. 

The command to be used is `/usr/bin/git --no-optional-locks ls-files -s . | /usr/bin/git --no-optional-locks hash-object --stdin`

## How to validate

1. Verify general behavior of Smart Builds. Check that cache is being use correctly when it has to

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

## Tests done

* I tested that a simple commit in a repo without affecting to none of the build context don't trigger a build of any image in the installer if images were already build
* I tested that a change in a single build context only triggers the rebuild of that image within the installer
* I was testing that it works on windows machines
* I was testing also that locally, smart builds keeps working as expected
