### PR TITLE
fix: e2e test

### DIFF
--- a/cmd/stack/deploy.go
+++ b/cmd/stack/deploy.go
@@ -42,6 +42,7 @@ import (
 type DeployCommand struct {
 	K8sClient        kubernetes.Interface
 	analyticsTracker buildTrackerInterface
+	insights         buildTrackerInterface
 	Config           *rest.Config
 	ioCtrl           *io.Controller
 	DivertDriver     divert.Driver
@@ -49,7 +50,7 @@ type DeployCommand struct {
 }
 
 // deploy deploys a stack
-func deploy(ctx context.Context, at buildTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
+func deploy(ctx context.Context, at, insights buildTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
 	options := &stack.DeployOptions{}
 
 	cmd := &cobra.Command{
@@ -79,6 +80,7 @@ func deploy(ctx context.Context, at buildTrackerInterface, ioCtrl *io.Controller
 				K8sClient:        c,
 				Config:           config,
 				analyticsTracker: at,
+				insights:         insights,
 				ioCtrl:           ioCtrl,
 				DivertDriver:     divert.NewNoop(),
 			}
@@ -131,6 +133,7 @@ func (c *DeployCommand) RunDeploy(ctx context.Context, s *model.Stack, options *
 		AnalyticsTracker: c.analyticsTracker,
 		IoCtrl:           c.ioCtrl,
 		Divert:           c.DivertDriver,
+		Insights:         c.insights,
 	}
 	err := stackDeployer.Deploy(ctx, s, options)
 

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -27,14 +27,14 @@ type buildTrackerInterface interface {
 }
 
 // Stack stack management commands
-func Stack(ctx context.Context, at buildTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
+func Stack(ctx context.Context, at, insights buildTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "stack",
 		Short:  "Stack management commands",
 		Args:   utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy"),
 		Hidden: true,
 	}
-	cmd.AddCommand(deploy(ctx, at, ioCtrl))
+	cmd.AddCommand(deploy(ctx, at, insights, ioCtrl))
 	cmd.AddCommand(Destroy(ctx))
 	cmd.AddCommand(Endpoints(ctx))
 	return cmd

--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func main() {
 	root.AddCommand(cmd.Create(ctx))
 	root.AddCommand(cmd.List(ctx))
 	root.AddCommand(cmd.Delete(ctx))
-	root.AddCommand(stack.Stack(ctx, at, ioController))
+	root.AddCommand(stack.Stack(ctx, at, insights, ioController))
 	root.AddCommand(cmd.Push(ctx))
 	root.AddCommand(pipeline.Pipeline(ctx))
 


### PR DESCRIPTION
# Proposed changes

After introducing #4205 our e2e tests detected a panic while running okteto stack command. It was because we didn't initialise the insights tracker for that command.

## How to validate

1. On a directory with compose
1. Run `okteto stack deploy`


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
