### PR TITLE
Add dedicated test command for remote run

### DIFF
--- a/cmd/remoterun/command.go
+++ b/cmd/remoterun/command.go
@@ -39,6 +39,7 @@ func RemoteRun(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 
 	cmd.AddCommand(Deploy(ctx, k8sLogger))
 	cmd.AddCommand(Destroy(ctx))
+	cmd.AddCommand(Test(ctx))
 	return cmd
 }
 

--- a/cmd/remoterun/test_test.go
+++ b/cmd/remoterun/test_test.go
@@ -1,0 +1,81 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remoterun
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/deployable"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTestRunner struct {
+	mock.Mock
+}
+
+func (f *fakeTestRunner) RunTest(params deployable.TestParameters) error {
+	args := f.Called(params)
+	return args.Error(0)
+}
+
+func TestRun_TestCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected error
+		params   deployable.TestParameters
+	}{
+		{
+			name: "WithoutError",
+			params: deployable.TestParameters{
+				Name:      "test-destroy",
+				Namespace: "test-namespace",
+			},
+			expected: nil,
+		},
+		{
+			name: "WithError",
+			params: deployable.TestParameters{
+				Name:      "test-destroy",
+				Namespace: "test-namespace",
+			},
+			expected: fmt.Errorf("boooooom"),
+		},
+	}
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Token: "token",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeTestRunner{}
+			runner.On("RunTest", tt.params).Return(tt.expected)
+			command := &TestCommand{
+				runner: runner,
+			}
+			err := command.Run(tt.params)
+
+			require.Equal(t, err, tt.expected)
+			runner.AssertExpectations(t)
+		})
+	}
+
+}

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -235,9 +235,12 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 			DockerfileName:      "Dockerfile.test",
 			Deployable: deployable.Entity{
 				Commands: commands,
+				// Added this for backward compatibility. Before the refactor we were having the env variables for the external
+				// resources in the environment, so including it to set the env vars in the remote-run
+				External: manifest.External,
 			},
 			Manifest: manifest,
-			Command:  remote.DeployCommand, // TODO: use test?
+			Command:  remote.TestCommand,
 		}
 
 		ioCtrl.Logger().Infof("Executing test for: %s", name)

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployable
+
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/cmd/utils/executor"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+)
+
+// TestRunner is responsible for running the commands defined in a manifest when
+// running tests
+type TestRunner struct {
+	Executor executor.ManifestExecutor
+}
+
+// TestParameters represents the parameters for destroying a remote entity
+type TestParameters struct {
+	Name         string
+	Namespace    string
+	Deployable   Entity
+	Variables    []string
+	ForceDestroy bool
+}
+
+// RunTest executes the custom commands received as part of TestParameters
+func (dr *TestRunner) RunTest(params TestParameters) error {
+	var commandErr error
+	lastCommandName := ""
+	for _, command := range params.Deployable.Commands {
+		oktetoLog.Information("Running '%s'", command.Name)
+		lastCommandName = command.Name
+		oktetoLog.SetStage(command.Name)
+		if err := dr.Executor.Execute(command, params.Variables); err != nil {
+			err = fmt.Errorf("error executing command '%s': %w", command.Name, err)
+
+			// Store the error to return if the force destroy option is set
+			commandErr = err
+		}
+		oktetoLog.SetStage("")
+	}
+
+	// This is a hack for improving the logs until we refactor all that. The oktetoLog.Information('Running '%s'')
+	// should not appear under any stage, that is why we clear the stage after each execution. To keep backward compatibility
+	// in case of failure of command, we end up the function setting the stage to the last command executed.
+	oktetoLog.SetStage(lastCommandName)
+
+	return commandErr
+}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -44,6 +44,8 @@ import (
 )
 
 const (
+	// TestCommand is the command to run test remotely
+	TestCommand = "test"
 	// DeployCommand is the command to deploy a dev environment remotely
 	DeployCommand = "deploy"
 	// DestroyCommand is the command to destroy a dev environment remotely


### PR DESCRIPTION
Adds a dedicated `test` command for the remote run command

Fixes https://okteto.atlassian.net/browse/DEV-272

