### PR TITLE
fix: skip volume mount translation into okteto manifest build

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1004,29 +1004,14 @@ func (m *Manifest) InferFromStack(cwd string) (*Manifest, error) {
 			m.Dev[svcName] = d
 		}
 
-		if svcInfo.Build == nil && len(svcInfo.VolumeMounts) == 0 {
+		if svcInfo.Build == nil {
 			continue
 		}
 
 		buildInfo := svcInfo.Build
 
-		switch {
-		case buildInfo != nil && len(svcInfo.VolumeMounts) > 0:
-			if svcInfo.Image != "" {
-				buildInfo.Image = svcInfo.Image
-			}
-			buildInfo.VolumesToInclude = svcInfo.VolumeMounts
-		case buildInfo != nil:
-			if svcInfo.Image != "" {
-				buildInfo.Image = svcInfo.Image
-			}
-		case len(svcInfo.VolumeMounts) > 0:
-			buildInfo = &build.Info{
-				Image:            svcInfo.Image,
-				VolumesToInclude: svcInfo.VolumeMounts,
-			}
-		default:
-			oktetoLog.Infof("could not build service %s, due to not having Dockerfile defined or volumes to include", svcName)
+		if svcInfo.Image != "" {
+			buildInfo.Image = svcInfo.Image
 		}
 
 		for idx, volume := range buildInfo.VolumesToInclude {


### PR DESCRIPTION
# Proposed changes

If you try to run okteto build on a compose file that only have volume mounts We try to build the services but given that we've removed the build support for the volume mounts, we are not building anything which results into a weird case where the user get that it's going to build if it's not a git repo or no other output:
![Screenshot 2024-04-11 at 16 58 50](https://github.com/okteto/okteto/assets/25170843/d22c6513-426b-44e4-830d-e66a1d21c488)

The correct behaviour must be to fallback to the v1 given that we don't have any service to build.

## How to validate

1. Create the following `docker-compose.yml`:
```yaml
version: '2'
services:
  postgres:
    image: bitnami/postgresql:11.14.0-debian-10-r28
    environment:
      POSTGRES_USER: test
      POSTGRES_PASSWORD: test
      POSTGRES_DB: test
    volumes:
      - ./schema.sql:/test/schema.sql
```
2. Run `okteto build`
3. Check that it's fullbacking to the build v1

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
