### PR TITLE
[okteto test] Don't deploy if app already exists

### DIFF
--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -75,7 +75,10 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 			ManifestName: deployOptions.Manifest.Name,
 			ManifestPath: deployOptions.ManifestPathFlag,
 		}
-		deployOptions.Name = n.ResolveName(ctx)
+		name := n.ResolveName(ctx)
+		deployOptions.Name = name
+		deployOptions.Manifest.Name = name
+
 	} else {
 		if deployOptions.Manifest != nil {
 			deployOptions.Manifest.Name = deployOptions.Name

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -39,6 +39,21 @@ const (
 	httpsScheme = "https"
 )
 
+type Namer struct {
+	Workdir      string
+	KubeClient   kubernetes.Interface
+	ManifestName string
+	ManifestPath string
+}
+
+func (na Namer) ResolveName(ctx context.Context) string {
+	if na.ManifestName != "" {
+		return na.ManifestName
+	}
+	inferer := devenvironment.NewNameInferer(na.KubeClient)
+	return inferer.InferName(ctx, na.Workdir, okteto.GetContext().Namespace, na.ManifestPath)
+}
+
 func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Options, cwd string, c kubernetes.Interface, k8sLogger *ioCtrl.K8sLogger) error {
 
 	if deployOptions.Manifest.Context == "" {
@@ -49,18 +64,18 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 	}
 
 	if deployOptions.Name == "" {
-		if deployOptions.Manifest.Name != "" {
-			deployOptions.Name = deployOptions.Manifest.Name
-		} else {
-			c, _, err := okteto.NewK8sClientProviderWithLogger(k8sLogger).Provide(okteto.GetContext().Cfg)
-			if err != nil {
-				return err
-			}
-			inferer := devenvironment.NewNameInferer(c)
-			deployOptions.Name = inferer.InferName(ctx, cwd, okteto.GetContext().Namespace, deployOptions.ManifestPathFlag)
-			deployOptions.Manifest.Name = deployOptions.Name
+		c, _, err := okteto.NewK8sClientProviderWithLogger(k8sLogger).Provide(okteto.GetContext().Cfg)
+		if err != nil {
+			return err
 		}
 
+		n := Namer{
+			Workdir:      cwd,
+			KubeClient:   c,
+			ManifestName: deployOptions.Manifest.Name,
+			ManifestPath: deployOptions.ManifestPathFlag,
+		}
+		deployOptions.Name = n.ResolveName(ctx)
 	} else {
 		if deployOptions.Manifest != nil {
 			deployOptions.Manifest.Name = deployOptions.Name

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -218,7 +218,7 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 			return err
 		}
 	} else {
-		// The deploy operation expand environment variables in the manifest. If
+		// The deploy operation expands environment variables in the manifest. If
 		// we don't deploy, make sure to expand the envvars
 		if err := manifest.ExpandEnvVars(); err != nil {
 			return fmt.Errorf("failed to expand manifest environment variables.: %w", err)

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -119,13 +119,13 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 			return err
 		}
 	}
-	// if path is absolute, its transformed to rel from root
-	initialCWD, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get the current working directory: %w", err)
-	}
 
 	if options.ManifestPath != "" {
+		// if path is absolute, its transformed to rel from root
+		initialCWD, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get the current working directory: %w", err)
+		}
 		manifestPathFlag, err := oktetoPath.GetRelativePathFromCWD(initialCWD, options.ManifestPath)
 		if err != nil {
 			return err
@@ -162,9 +162,14 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 		return fmt.Errorf("could not instantiate kuberentes client: %w", err)
 	}
 
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory to resolve name: %w", err)
+	}
+
 	namer := deployCMD.Namer{
 		KubeClient:   kubeClient,
-		Workdir:      initialCWD,
+		Workdir:      cwd,
 		ManifestPath: options.ManifestPathFlag,
 		ManifestName: options.Name,
 	}
@@ -221,7 +226,7 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 		// The deploy operation expands environment variables in the manifest. If
 		// we don't deploy, make sure to expand the envvars
 		if err := manifest.ExpandEnvVars(); err != nil {
-			return fmt.Errorf("failed to expand manifest environment variables.: %w", err)
+			return fmt.Errorf("failed to expand manifest environment variables: %w", err)
 		}
 		oktetoLog.Information("'%s' was already deployed. To redeploy run 'okteto deploy'", name)
 	}


### PR DESCRIPTION
Skip deploy in `okteto test` if the deploy already exists. Fixes https://okteto.atlassian.net/browse/DEV-271


It required some minor refactor to be able to use the same logic than the deploy command

