### PR TITLE
fix: repo with double url

### DIFF
--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -612,3 +612,40 @@ func TestGetUntrackedContent(t *testing.T) {
 		})
 	}
 }
+
+func Test_gitRepoController_sanitiseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid URL",
+			input:    "https://github.com/okteto/test.git",
+			expected: "https://github.com/okteto/test.git",
+		},
+		{
+			name:     "URL with double slashes",
+			input:    "https://github.com//okteto//test.git",
+			expected: "https://github.com/okteto/test.git",
+		},
+		{
+			name:     "URL with multiple double slashes",
+			input:    "https://github.com//okteto//test//.git",
+			expected: "https://github.com/okteto/test/.git",
+		},
+		{
+			name:     "URL with no double slashes",
+			input:    "https://github.com/okteto/test/.git",
+			expected: "https://github.com/okteto/test/.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := gitRepoController{}
+			result := r.sanitiseURL(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Detected a bug where the repository URL could have double slash, making it weir in the UI and preventing to group the insights by repo.

| Before      | Now         |
|-------------|-------------|
| <img width="1410" alt="Screenshot 2024-04-12 at 12 56 54" src="https://github.com/okteto/okteto/assets/25170843/af1c863a-0574-480b-b407-1f68546b380d"> | <img width="1421" alt="Screenshot 2024-04-12 at 13 00 52" src="https://github.com/okteto/okteto/assets/25170843/5c10bcc6-a001-452b-8402-cfcac98dcee2"> |

## How to validate

There are two different scenarios

1. Run `git clone https://github.com//okteto/movies` or `git clone https://github.com/okteto//movies`
1. Run `cd movies`
1. Run `okteto deploy`
1. Run `kubectl get events.events.k8s.io -levents.okteto.com=true` and check that the repository is correct 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
