### PR TITLE
Support variable expansion in `.env`: `"VAR1=${VAR2:-default}"`

### DIFF
--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -750,6 +750,7 @@ func Test_replaceCredentialsTokenWithDynamicKubetoken(t *testing.T) {
 }
 
 func Test_loadDotEnv(t *testing.T) {
+	t.Setenv("VALUE4", "VALUE4")
 	type expected struct {
 		vars map[string]string
 		err  error
@@ -758,7 +759,7 @@ func Test_loadDotEnv(t *testing.T) {
 
 	setEnvFunc := func(k, v string) error {
 		var err error
-		if k != "" {
+		if k == "" {
 			err = assert.AnError
 		}
 		t.Setenv(k, v)
@@ -828,6 +829,23 @@ func Test_loadDotEnv(t *testing.T) {
 				vars: map[string]string{
 					"TEST":  "VALUE",
 					"TEST2": "VALUE2",
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "valid .env with multiple vars",
+			mockfs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				_ = afero.WriteFile(fs, ".env", []byte("VAR1=VALUE1\nVAR2=VALUE2\nVAR3=${VALUE3:-defaultValue3}\nVAR4=${VALUE4:-defaultValue4}"), 0644)
+				return fs
+			},
+			expected: expected{
+				vars: map[string]string{
+					"VAR1": "VALUE1",
+					"VAR2": "VALUE2",
+					"VAR3": "defaultValue3",
+					"VAR4": "VALUE4",
 				},
 				err: nil,
 			},

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -169,7 +169,7 @@ func (c *Command) RunStateless(ctx context.Context, ctxOptions *Options) (*oktet
 	}
 
 	oktetoContextStateless.SetCurrentCfg(cfg)
-	// Setting the global namespace becuase it is missing after reading again the context from the store path
+	// Setting the global namespace because it is missing after reading again the context from the store path
 	oktetoContextStateless.SetGlobalNamespace(globalNamespace)
 
 	return oktetoContextStateless, nil


### PR DESCRIPTION
# Proposed changes

Fixes DEV-279

Currently, the `.env` does not support default values for variables. The library go-dotenv doesn't support the notation `VAR="${VAR:-default}"`. (see https://github.com/joho/godotenv/issues/211).

With this change the Okteto CLI will be able to expand the vars in the `.env` adding support for such scenario.

## How to validate

1. Using latest stable test
1. Using the following manifest:
```
deploy:
  - env
```
1. Using the following `.env` file:
```
ANDREA="${ANDREA_DEFAULT:-foo}"
KEY='this is
a multiline
variable'
TEST=true
```
1. Run `okteto deploy`
1. Observe how `TEST` and `KEY` are populated correctly, while `ANDREA` is `:-foo}`

Repeat the steps with the changes and observe how all vars work as expected, by default you should get `ANDREA=foo`. If you run `ANDREA_DEAULT=testvalue okd deploy` observe the value `ANDREA=testvalue` in the output.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
