### PR TITLE
set okteto context and namespace from env vars

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -185,10 +185,6 @@ func (c *Command) UseContext(ctx context.Context, ctxOptions *Options) error {
 	}
 
 	ctxStore.CurrentContext = ctxOptions.Context
-	err := c.loadDotEnv(afero.NewOsFs(), os.Setenv)
-	if err != nil {
-		oktetoLog.Warning("Failed to load .env file: %s", err)
-	}
 
 	if ctxOptions.IsOkteto {
 		if err := c.initOktetoContext(ctx, ctxOptions); err != nil {

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -43,18 +43,15 @@ func (o *Options) InitFromContext() {
 	if o.IsCtxCommand {
 		return
 	}
-	ctxStore := okteto.GetContextStore()
-
-	cc := ctxStore.CurrentContext
 	if o.Context != "" {
-		cc = o.Context
+		return
 	}
-
-	if cc == "" {
+	ctxStore := okteto.GetContextStore()
+	if ctxStore.CurrentContext == "" {
 		return
 	}
 
-	if okCtx, ok := ctxStore.Contexts[cc]; ok {
+	if okCtx, ok := ctxStore.Contexts[ctxStore.CurrentContext]; ok {
 		o.Context = ctxStore.CurrentContext
 		if o.Namespace == "" {
 			o.Namespace = okCtx.Namespace

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -63,7 +63,7 @@ func (o *Options) InitFromContext() {
 func (o *Options) InitFromEnvVars() {
 	var usedEnvVars []string
 
-	if os.Getenv(model.OktetoURLEnvVar) != "" {
+	if o.Context == "" && os.Getenv(model.OktetoURLEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoURLEnvVar)
 		o.IsOkteto = true
 		usedEnvVars = append(usedEnvVars, model.OktetoURLEnvVar)

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -45,10 +45,21 @@ func (o *Options) InitFromContext() {
 	}
 
 	ctxStore := okteto.GetContextStore()
+
+	if ctxStore.Contexts == nil {
+		return
+	}
+
+	if len(ctxStore.Contexts) == 0 {
+		return
+	}
+
 	cc := ctxStore.CurrentContext
 
 	if o.Context != "" {
 		cc = o.Context
+	} else {
+		o.Context = cc
 	}
 
 	if cc == "" {
@@ -56,7 +67,6 @@ func (o *Options) InitFromContext() {
 	}
 
 	if okCtx, ok := ctxStore.Contexts[cc]; ok {
-		o.Context = ctxStore.CurrentContext
 		if o.Namespace == "" {
 			o.Namespace = okCtx.Namespace
 		}

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -43,15 +43,19 @@ func (o *Options) InitFromContext() {
 	if o.IsCtxCommand {
 		return
 	}
-	if o.Context != "" {
-		return
-	}
+
 	ctxStore := okteto.GetContextStore()
-	if ctxStore.CurrentContext == "" {
+	cc := ctxStore.CurrentContext
+
+	if o.Context != "" {
+		cc = o.Context
+	}
+
+	if cc == "" {
 		return
 	}
 
-	if okCtx, ok := ctxStore.Contexts[ctxStore.CurrentContext]; ok {
+	if okCtx, ok := ctxStore.Contexts[cc]; ok {
 		o.Context = ctxStore.CurrentContext
 		if o.Namespace == "" {
 			o.Namespace = okCtx.Namespace

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -69,7 +69,7 @@ func (o *Options) InitFromEnvVars() {
 		usedEnvVars = append(usedEnvVars, model.OktetoURLEnvVar)
 	}
 
-	if os.Getenv(model.OktetoContextEnvVar) != "" {
+	if o.Context == "" && os.Getenv(model.OktetoContextEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoContextEnvVar)
 		usedEnvVars = append(usedEnvVars, model.OktetoContextEnvVar)
 	}
@@ -90,7 +90,7 @@ func (o *Options) InitFromEnvVars() {
 		o.InferredToken = true
 	}
 
-	if os.Getenv(model.OktetoNamespaceEnvVar) != "" {
+	if o.Namespace == "" && os.Getenv(model.OktetoNamespaceEnvVar) != "" {
 		o.Namespace = os.Getenv(model.OktetoNamespaceEnvVar)
 		usedEnvVars = append(usedEnvVars, model.OktetoNamespaceEnvVar)
 	}

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -43,15 +43,18 @@ func (o *Options) InitFromContext() {
 	if o.IsCtxCommand {
 		return
 	}
-	if o.Context != "" {
-		return
-	}
 	ctxStore := okteto.GetContextStore()
-	if ctxStore.CurrentContext == "" {
+
+	cc := ctxStore.CurrentContext
+	if o.Context != "" {
+		cc = o.Context
+	}
+
+	if cc == "" {
 		return
 	}
 
-	if okCtx, ok := ctxStore.Contexts[ctxStore.CurrentContext]; ok {
+	if okCtx, ok := ctxStore.Contexts[cc]; ok {
 		o.Context = ctxStore.CurrentContext
 		if o.Namespace == "" {
 			o.Namespace = okCtx.Namespace

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -61,15 +61,15 @@ func (o *Options) InitFromContext() {
 }
 
 func (o *Options) InitFromEnvVars() {
-	usedEnvVars := []string{}
+	var usedEnvVars []string
 
-	if o.Context == "" && os.Getenv(model.OktetoURLEnvVar) != "" {
+	if os.Getenv(model.OktetoURLEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoURLEnvVar)
 		o.IsOkteto = true
 		usedEnvVars = append(usedEnvVars, model.OktetoURLEnvVar)
 	}
 
-	if o.Context == "" && os.Getenv(model.OktetoContextEnvVar) != "" {
+	if os.Getenv(model.OktetoContextEnvVar) != "" {
 		o.Context = os.Getenv(model.OktetoContextEnvVar)
 		usedEnvVars = append(usedEnvVars, model.OktetoContextEnvVar)
 	}
@@ -90,15 +90,16 @@ func (o *Options) InitFromEnvVars() {
 		o.InferredToken = true
 	}
 
-	if o.Namespace == "" && os.Getenv(model.OktetoNamespaceEnvVar) != "" {
+	if os.Getenv(model.OktetoNamespaceEnvVar) != "" {
 		o.Namespace = os.Getenv(model.OktetoNamespaceEnvVar)
 		usedEnvVars = append(usedEnvVars, model.OktetoNamespaceEnvVar)
 	}
 
-	if len(usedEnvVars) == 1 {
-		oktetoLog.Warning("Initializing context with the value of %s environment variable", usedEnvVars[0])
-	} else if len(usedEnvVars) > 1 {
-		oktetoLog.Warning("Initializing context with the value of %s and %s environment variables", strings.Join(usedEnvVars[0:len(usedEnvVars)-1], ", "), usedEnvVars[len(usedEnvVars)-1])
+	if o.Show {
+		if len(usedEnvVars) == 1 {
+			oktetoLog.Warning("Initializing context with the value of %s environment variable", usedEnvVars[0])
+		} else if len(usedEnvVars) > 1 {
+			oktetoLog.Warning("Initializing context with the value of %s and %s environment variables", strings.Join(usedEnvVars[0:len(usedEnvVars)-1], ", "), usedEnvVars[len(usedEnvVars)-1])
+		}
 	}
-
 }

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -36,7 +36,7 @@ func Show() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 
-			if err := NewContextCommand().Run(ctx, &Options{raiseNotCtxError: true}); err != nil {
+			if err := NewContextCommand().Run(ctx, &Options{raiseNotCtxError: true, Show: false}); err != nil {
 				return err
 			}
 			ctxStore := okteto.GetContextStore()

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -103,10 +103,9 @@ func (c *Command) Run(ctx context.Context, ctxOptions *Options) error {
 		ctxOptions.Save = true
 	}
 
-	// We have to maintain this order to not break some commands
-	// See https://github.com/okteto/okteto/issues/3247 for more information
-	ctxOptions.InitFromContext()
+	// env vars such as OKTETO_CONTEXT and OKTETO_NAMESPACE have priority, if set
 	ctxOptions.InitFromEnvVars()
+	ctxOptions.InitFromContext()
 
 	if ctxOptions.Token == "" && kubeconfig.InCluster() && !isValidCluster(ctxOptions.Context) {
 		if ctxOptions.IsCtxCommand {

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -113,6 +113,10 @@ func (c *Command) Run(ctx context.Context, ctxOptions *Options) error {
 	ctxOptions.InitFromEnvVars()
 	ctxOptions.InitFromContext()
 
+	if ctxOptions.IsOkteto && isUrl(ctxOptions.Context) {
+		ctxOptions.Context = strings.TrimSuffix(ctxOptions.Context, "/")
+	}
+
 	if ctxOptions.Token == "" && kubeconfig.InCluster() && !isValidCluster(ctxOptions.Context) {
 		if ctxOptions.IsCtxCommand {
 			return oktetoErrors.ErrTokenFlagNeeded

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -27,7 +27,6 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
-
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -16,7 +16,6 @@ package context
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/afero"
 	"os"
 	"strings"
 
@@ -28,6 +27,8 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -16,6 +16,7 @@ package context
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/afero"
 	"os"
 	"strings"
 
@@ -103,7 +104,12 @@ func (c *Command) Run(ctx context.Context, ctxOptions *Options) error {
 		ctxOptions.Save = true
 	}
 
-	// env vars such as OKTETO_CONTEXT and OKTETO_NAMESPACE have priority, if set
+	// if the --context and --namespace flags are set, they have priority over the env vars, and current context
+	// if env vars OKTETO_CONTEXT and OKTETO_NAMESPACE are set, they have priority over the current context
+	err := c.loadDotEnv(afero.NewOsFs(), os.Setenv)
+	if err != nil {
+		oktetoLog.Warning("Failed to load .env file: %s", err)
+	}
 	ctxOptions.InitFromEnvVars()
 	ctxOptions.InitFromContext()
 

--- a/cmd/namespace/create_test.go
+++ b/cmd/namespace/create_test.go
@@ -52,8 +52,9 @@ func Test_createNamespace(t *testing.T) {
 			okteto.CurrentStore = &okteto.ContextStore{
 				Contexts: map[string]*okteto.Context{
 					"test": {
-						Name:  "test",
-						Token: "test",
+						Name:     "test",
+						Token:    "test",
+						IsOkteto: true,
 					},
 				},
 				CurrentContext: "test",

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -67,30 +67,11 @@ func Push(ctx context.Context) *cobra.Command {
 			if !env.LoadBoolean(constants.OktetoWithinDeployCommandContextEnvVar) {
 				oktetoLog.Warning("'okteto push' is deprecated in favor of 'okteto deploy', and will be removed in a future version")
 			}
-			ctxResource, err := utils.LoadManifestContext(pushOpts.DevPath)
-			if err != nil {
-				if oktetoErrors.IsNotExist(err) && len(pushOpts.AppName) > 0 {
-					ctxResource = &model.ContextResource{}
-				} else {
+			// Loads, updates and uses the context from path. If not found, it creates and uses a new context
+			if err := contextCMD.LoadContextFromPath(ctx, pushOpts.Namespace, pushOpts.K8sContext, pushOpts.DevPath, contextCMD.Options{Show: true}); err != nil {
+				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: pushOpts.Namespace, Show: false}); err != nil {
 					return err
 				}
-			}
-
-			if err := ctxResource.UpdateNamespace(pushOpts.Namespace); err != nil {
-				return err
-			}
-
-			if err := ctxResource.UpdateContext(pushOpts.K8sContext); err != nil {
-				return err
-			}
-
-			ctxOptions := &contextCMD.Options{
-				Context:   ctxResource.Context,
-				Namespace: ctxResource.Namespace,
-				Show:      true,
-			}
-			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
-				return err
 			}
 
 			manifest, err := utils.DeprecatedLoadManifestOrDefault(pushOpts.DevPath, pushOpts.AppName, afero.NewOsFs())

--- a/integration/commands/stacks.go
+++ b/integration/commands/stacks.go
@@ -29,8 +29,8 @@ type StackDeployOptions struct {
 	ManifestPath string
 	OktetoHome   string
 	Token        string
-	Build        bool
 	Namespace    string
+	Build        bool
 }
 
 // StackDestroyOptions defines the options that can be added to a deploy command

--- a/integration/commands/stacks.go
+++ b/integration/commands/stacks.go
@@ -39,6 +39,7 @@ type StackDestroyOptions struct {
 	ManifestPath string
 	OktetoHome   string
 	Token        string
+	Namespace    string
 }
 
 // RunOktetoStackDeploy runs an okteto deploy command
@@ -79,24 +80,27 @@ func RunOktetoStackDeploy(oktetoPath string, deployOptions *StackDeployOptions) 
 }
 
 // RunOktetoStackDestroy runs an okteto deploy command
-func RunOktetoStackDestroy(oktetoPath string, deployOptions *StackDestroyOptions) error {
+func RunOktetoStackDestroy(oktetoPath string, destroyOptions *StackDestroyOptions) error {
 	cmd := exec.Command(oktetoPath, "stack", "destroy")
-	if deployOptions.Workdir != "" {
-		cmd.Dir = deployOptions.Workdir
+	if destroyOptions.Workdir != "" {
+		cmd.Dir = destroyOptions.Workdir
 	}
-	if deployOptions.ManifestPath != "" {
-		cmd.Args = append(cmd.Args, "-f", deployOptions.ManifestPath)
+	if destroyOptions.ManifestPath != "" {
+		cmd.Args = append(cmd.Args, "-f", destroyOptions.ManifestPath)
+	}
+	if destroyOptions.Namespace != "" {
+		cmd.Args = append(cmd.Args, "--namespace", destroyOptions.Namespace)
 	}
 
 	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))
 	}
 
-	if deployOptions.OktetoHome != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, deployOptions.OktetoHome))
+	if destroyOptions.OktetoHome != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, destroyOptions.OktetoHome))
 	}
-	if deployOptions.Token != "" {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, deployOptions.Token))
+	if destroyOptions.Token != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, destroyOptions.Token))
 	}
 	log.Printf("Running '%s'", cmd.String())
 

--- a/integration/commands/stacks.go
+++ b/integration/commands/stacks.go
@@ -30,6 +30,7 @@ type StackDeployOptions struct {
 	OktetoHome   string
 	Token        string
 	Build        bool
+	Namespace    string
 }
 
 // StackDestroyOptions defines the options that can be added to a deploy command
@@ -51,6 +52,9 @@ func RunOktetoStackDeploy(oktetoPath string, deployOptions *StackDeployOptions) 
 	}
 	if deployOptions.ManifestPath != "" {
 		cmd.Args = append(cmd.Args, "-f", deployOptions.ManifestPath)
+	}
+	if deployOptions.Namespace != "" {
+		cmd.Args = append(cmd.Args, "--namespace", deployOptions.Namespace)
 	}
 
 	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {

--- a/integration/deprecated/push/push_test.go
+++ b/integration/deprecated/push/push_test.go
@@ -91,7 +91,6 @@ func TestPush(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 	dir := t.TempDir()
-	fmt.Println("TestPush dir = ", dir)
 	testNamespace := integration.GetTestNamespace("Push", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
@@ -99,7 +98,7 @@ func TestPush(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -111,7 +110,6 @@ func TestPush(t *testing.T) {
 	require.NoError(t, commands.RunOktetoPush(oktetoPath, dir))
 
 	endpoint := fmt.Sprintf("https://push-test-%s.%s/index.html", testNamespace, appsSubdomain)
-	fmt.Println(endpoint)
 	require.NoError(t, waitUntilUpdatedContent(endpoint, dockerfile, timeout))
 
 	d, err := integration.GetDeployment(context.Background(), testNamespace, "push-test", c)

--- a/integration/deprecated/push/push_test.go
+++ b/integration/deprecated/push/push_test.go
@@ -91,7 +91,7 @@ func TestPush(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 	dir := t.TempDir()
-
+	fmt.Println("TestPush dir = ", dir)
 	testNamespace := integration.GetTestNamespace("Push", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,

--- a/integration/deprecated/push/push_test.go
+++ b/integration/deprecated/push/push_test.go
@@ -99,7 +99,7 @@ func TestPush(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -111,6 +111,7 @@ func TestPush(t *testing.T) {
 	require.NoError(t, commands.RunOktetoPush(oktetoPath, dir))
 
 	endpoint := fmt.Sprintf("https://push-test-%s.%s/index.html", testNamespace, appsSubdomain)
+	fmt.Println(endpoint)
 	require.NoError(t, waitUntilUpdatedContent(endpoint, dockerfile, timeout))
 
 	d, err := integration.GetDeployment(context.Background(), testNamespace, "push-test", c)

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -180,8 +180,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 
 	dir := t.TempDir()
 	require.NoError(t, createStacksScenario(dir))
-
-	fmt.Println("TestDeployPipelineFromOktetoStacks dir ---->", dir)
+	
 	testNamespace := integration.GetTestNamespace("PipeStacks", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
@@ -217,6 +216,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	destroyOptions := &commands.StackDestroyOptions{
 		Workdir:    dir,
 		OktetoHome: dir,
+		Namespace:  testNamespace,
 	}
 	require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
 }

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -188,7 +188,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -212,11 +212,11 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
-	//destroyOptions := &commands.StackDestroyOptions{
-	//	Workdir:    dir,
-	//	OktetoHome: dir,
-	//}
-	//require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
+	destroyOptions := &commands.StackDestroyOptions{
+		Workdir:    dir,
+		OktetoHome: dir,
+	}
+	require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
 }
 
 func createStacksScenario(dir string) error {

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -180,6 +180,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createStacksScenario(dir))
 
+	fmt.Println("TestDeployPipelineFromOktetoStacks dir ---->", dir)
 	testNamespace := integration.GetTestNamespace("PipeStacks", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
@@ -187,7 +188,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
+	//defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -215,7 +216,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		Workdir:    dir,
 		OktetoHome: dir,
 	}
-	require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
+	//require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
 }
 
 func createStacksScenario(dir string) error {

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -180,7 +180,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 
 	dir := t.TempDir()
 	require.NoError(t, createStacksScenario(dir))
-	
+
 	testNamespace := integration.GetTestNamespace("PipeStacks", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -212,10 +212,10 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
-	destroyOptions := &commands.StackDestroyOptions{
-		Workdir:    dir,
-		OktetoHome: dir,
-	}
+	//destroyOptions := &commands.StackDestroyOptions{
+	//	Workdir:    dir,
+	//	OktetoHome: dir,
+	//}
 	//require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
 }
 

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -130,6 +130,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 		Workdir:    dir,
 		OktetoHome: dir,
 		Token:      token,
+		Namespace:  testNamespace,
 	}
 	require.NoError(t, commands.RunOktetoStackDeploy(oktetoPath, deployOptions))
 
@@ -197,6 +198,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		Workdir:    dir,
 		OktetoHome: dir,
 		Token:      token,
+		Namespace:  testNamespace,
 	}
 	require.NoError(t, commands.RunOktetoStackDeploy(oktetoPath, deployOptions))
 

--- a/pkg/analytics/test.go
+++ b/pkg/analytics/test.go
@@ -22,7 +22,7 @@ const testEvent = "Test"
 // TestMetadata contains the metadata of a test command execution event
 type TestMetadata struct {
 	// Err is the error (if any) that occurred during test execution. Note that
-	// this is NOT an error in the test but rather a error encounterd in the setup
+	// this is NOT an error in the test but rather a error encountered in the setup
 	Err error
 
 	// Duration is the total duration of the test execution. Note that this includes

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -800,7 +800,7 @@ func isFileCompose(path string) bool {
 
 	stackDeprecationWarningOnce.Do(func() {
 		if !isComposeFileName {
-			oktetoLog.Warning(`Okteto Stack syntax is deprecated. 
+			oktetoLog.Warning(`Okteto Stack syntax is deprecated.
     Please consider migrating to Docker Compose syntax: https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262`)
 		}
 	})

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -35,7 +35,7 @@
                 if [[ $prerel =~ $beta_prerel_regex ]]; then
                         tags="${tags},okteto/okteto:beta"
                 elif [ -n "$version" ]; then
-                        tags="${tags},okteto/okteto:stable" 
+                        tags="${tags},okteto/okteto:stable"
                 fi
         fi
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-281

## How to validate

You need at least 2 different contexts to validate this change. 

### Scenario 1 - no context

Without any current context, or `--context`, or `OKTETO_CONTEXT` the CLI should tell you that you have no context.

Try the following:

```
OKTETO_HOME=$(mktemp -d) okteto endpoints
# or
OKTETO_HOME=$(mktemp -d) okteto context show
```

And validate that you get a message in both cases saying your context is not set.

### Scenario 2 - current context

Assuming you have a current context:

1. run `okteto context show`
2. validate that the context is correct


### Scenario 3 - current context + `--context` flag

The flag should have priority over the current context, to validate this scenario, run:

1. run `okteto context show`
2. observe which context you have as current (let's callit `<CTX1>`)
3. Run `okteto endpoints --context <CTX2>`
4. the CLI should say you are using `<CTX2>`
5. check that the namespace is also selected correctly based on `<CTX2>`
6. now run: `okteto endpoints --context <CTX2> --namespace <NS2>`
7. check that the `<NS2>` is picked up as expected


### Scenario 4 - current context + `OKTETO_CONTEXT`

1. run `okteto context show`
2. observe which context you have as current (let's callit `<CTX1>`)
3. Run `OKTETO_CONTEXT=<CTX2> okteto endpoints`
4. the CLI should say you are using `<CTX2>`
5. check that the namespace is also selected correctly based on `<CTX2>`
6. now run: `OKTETO_CONTEXT=<CTX2> OKTETO_NAMESPACE=<NS2> okteto endpoints`
7. check that the `<NS2>` is picked up as expected

### Scenario 5 - current context + `OKTETO_CONTEXT` + `--context`

For this scenario it's ideal to use 3 different contextes to avoid ambiguities.

1. run `okteto context show`
2. observe which context you have as current (let's callit `<CTX1>`)
3. Run `OKTETO_CONTEXT=<CTX2> okteto endpoints --context <CTX3>`
4. the CLI should say you are using `<CTX3>`
5. check that the namespace is also selected correctly based on `<CTX3>`
6. now run: `OKTETO_CONTEXT=<CTX2> OKTETO_NAMESPACE=<NS2> okteto endpoints --context <CTX3> --namespace <NS3>`
7. check that the `<NS3>` is picked up as expected

### Scenario 6 - current context + `.env` with `OKTETO_CONTEXT` + `--context`

1. run `okteto context show`
1. observe which context you have as current (let's callit `<CTX1>`)
1. create `.env` with `OKTETO_CONTEXT=<CTX2>`
1. Run `okteto endpoints --context <CTX3>`
1. the CLI should say you are using `<CTX3>`
1. check that the namespace is also selected correctly based on `<CTX3>`
1. now add `OKTETO_NAMESPACE=<NS2>` to the `.env`
1. Run: `okteto endpoints --context <CTX3> --namespace <NS3>`
1. check that the `<NS3>` is picked up as expected

### Scenario 7 - current context + manifest `context:` + `--context`

1. run `okteto context show`
1. observe which context you have as current (let's callit `<CTX1>`)
1. set `context: <CTX2>` in your manifest
1. Run `okteto endpoints --context <CTX3>`
1. the CLI should say you are using `<CTX2>`
1. check that the namespace is also selected correctly based on `<CTX2>`
1. now add `namespace: <NS2>` in your manifest
1. now run: `okteto endpoints --context <CTX3> --namespace <NS3>`
1. check that the `<NS2>` is picked up as expected


### Scenario 8 - current context + `OKTETO_URL`

1. run `okteto context show`
2. observe which context you have as current (let's callit `<CTX1>`)
3. Run `OKTETO_URL=<CTX2> okteto endpoints`
4. the CLI should say you are using `<CTX2>`
5. check that the namespace is also selected correctly based on `<CTX2>`
6. now run: `OKTETO_URL=<CTX2> OKTETO_NAMESPACE=<NS2> okteto endpoints`
7. check that the `<NS2>` is picked up as expected


### Out of scope scenarios:

These are lower-priority scenarios that may be worked on with a follow-up ticket/PR.

- Scenario 8 - current context + `OKTETO_CONTEXT` var set in Catalog
- Scenario 9 - current context + `OKTETO_CONTEXT` var set in Catalog + `--context`
- Scenario 10 - current context + `OKTETO_CONTEXT` set as `--var` flag in deploy
- Scenario 11 - current context + `OKTETO_CONTEXT` set as User variable
- Scenario 12- current context + `OKTETO_CONTEXT` set as Cluster variable

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
