### PR TITLE
Persist okteto env between deploy and test

### DIFF
--- a/cmd/remoterun/command.go
+++ b/cmd/remoterun/command.go
@@ -39,7 +39,7 @@ func RemoteRun(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 
 	cmd.AddCommand(Deploy(ctx, k8sLogger))
 	cmd.AddCommand(Destroy(ctx))
-	cmd.AddCommand(Test(ctx))
+	cmd.AddCommand(Test(ctx, k8sLogger))
 	return cmd
 }
 

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -15,17 +15,22 @@ package remoterun
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils/executor"
+	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/deployable"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -36,18 +41,14 @@ type testRunner interface {
 
 // TestOptions flags accepted by the remote-run test command
 type TestOptions struct {
-	Name      string
-	Variables []string
-}
-
-// TestCommand struct with the dependencies needed to run the test operation
-type TestCommand struct {
-	runner testRunner
+	Name       string
+	DevEnvName string
+	Variables  []string
 }
 
 // Test starts the test command remotely. This is the command executed in the
 // remote environment when running okteto test
-func Test(ctx context.Context) *cobra.Command {
+func Test(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 	options := &TestOptions{}
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -86,6 +87,11 @@ commands:
 				return fmt.Errorf("could not read information for tests: %w", err)
 			}
 
+			kubeClient, _, err := okteto.NewK8sClientProviderWithLogger(k8sLogger).ProvideWithLogger(okteto.GetContext().Cfg, k8sLogger)
+			if err != nil {
+				return fmt.Errorf("could not create kubernetes client: %s", err.Error())
+			}
+
 			// Set the default values for the external resources environment variables (endpoints)
 			for name, external := range dep.External {
 				external.SetDefaults(name)
@@ -93,9 +99,23 @@ commands:
 
 			runner := &deployable.TestRunner{
 				Executor: executor.NewExecutor(oktetoLog.GetOutputFormat(), false, ""),
-			}
-			if err != nil {
-				return fmt.Errorf("could not initialize the command properly: %w", err)
+				Fs:       afero.NewOsFs(),
+				GetDevEnvEnviron: func(devEnvName, namespace string) (map[string]string, error) {
+					if devEnvName == "" {
+						return nil, nil
+					}
+					base64Json, err := pipeline.GetConfigmapDependencyEnv(ctx, devEnvName, namespace, kubeClient)
+					if err != nil {
+						return nil, err
+					}
+					return decodeBase64JSON(base64Json)
+				},
+				SetDevEnvEnviron: func(devEnvName, namespace string, vars []string) (err error) {
+					if devEnvName != "" {
+						err = pipeline.UpdateEnvs(ctx, devEnvName, namespace, vars, kubeClient)
+					}
+					return
+				},
 			}
 
 			os.Setenv(constants.OktetoNameEnvVar, options.Name)
@@ -105,32 +125,36 @@ commands:
 				Namespace:  oktetoContext.GetCurrentNamespace(),
 				Deployable: dep,
 				Variables:  options.Variables,
+				DevEnvName: options.DevEnvName,
 			}
 
-			c := &TestCommand{
-				runner: runner,
+			// Token should be always masked from the logs
+			oktetoLog.AddMaskedWord(okteto.GetContext().Token)
+			keyValueVarParts := 2
+			// We mask all the variables received in the command
+			for _, variable := range params.Variables {
+				varParts := strings.SplitN(variable, "=", keyValueVarParts)
+				if len(varParts) >= keyValueVarParts && strings.TrimSpace(varParts[1]) != "" {
+					oktetoLog.AddMaskedWord(varParts[1])
+				}
 			}
 
-			return c.Run(params)
+			return runner.RunTest(params)
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
+	cmd.Flags().StringVar(&options.Name, "name", "", "test run name")
+	cmd.Flags().StringVar(&options.DevEnvName, "devenv-name", "", "development environment name")
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
 	return cmd
 }
 
-func (c *TestCommand) Run(params deployable.TestParameters) error {
-	// Token should be always masked from the logs
-	oktetoLog.AddMaskedWord(okteto.GetContext().Token)
-	keyValueVarParts := 2
-	// We mask all the variables received in the command
-	for _, variable := range params.Variables {
-		varParts := strings.SplitN(variable, "=", keyValueVarParts)
-		if len(varParts) >= keyValueVarParts && strings.TrimSpace(varParts[1]) != "" {
-			oktetoLog.AddMaskedWord(varParts[1])
-		}
+func decodeBase64JSON(base64Str string) (data map[string]string, err error) {
+	b, err := base64.StdEncoding.DecodeString(base64Str)
+	if err != nil {
+		return nil, err
 	}
-
-	return c.runner.RunTest(params)
+	data = make(map[string]string)
+	err = json.Unmarshal(b, &data)
+	return
 }

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -34,11 +34,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// testRunner interface with the operations needed to execute the test operations
-type testRunner interface {
-	RunTest(params deployable.TestParameters) error
-}
-
 // TestOptions flags accepted by the remote-run test command
 type TestOptions struct {
 	Name       string

--- a/cmd/remoterun/test_test.go
+++ b/cmd/remoterun/test_test.go
@@ -68,10 +68,7 @@ func TestRun_TestCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			runner := &fakeTestRunner{}
 			runner.On("RunTest", tt.params).Return(tt.expected)
-			command := &TestCommand{
-				runner: runner,
-			}
-			err := command.Run(tt.params)
+			err := runner.RunTest(tt.params)
 
 			require.Equal(t, err, tt.expected)
 			runner.AssertExpectations(t)

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -101,7 +101,7 @@ type phaseJSON struct {
 	Duration float64 `json:"duration"`
 }
 
-// GetConfigmapDepedencyEnv returns Data["variables"] content from Configmap
+// GetConfigmapDependencyEnv returns Data["variables"] content from Configmap
 func GetConfigmapDependencyEnv(ctx context.Context, name, namespace string, c kubernetes.Interface) (string, error) {
 	cmap, err := configmaps.Get(ctx, TranslatePipelineName(name), namespace, c)
 	if err != nil {

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -101,6 +101,20 @@ type phaseJSON struct {
 	Duration float64 `json:"duration"`
 }
 
+// GetConfigmapDepedencyEnv returns Data["variables"] content from Configmap
+func GetConfigmapDependencyEnv(ctx context.Context, name, namespace string, c kubernetes.Interface) (string, error) {
+	cmap, err := configmaps.Get(ctx, TranslatePipelineName(name), namespace, c)
+	if err != nil {
+		if !oktetoErrors.IsNotFound(err) {
+			return "", err
+		}
+		// if err Not Found, return empty variables but no error
+		return "", nil
+	}
+
+	return cmap.Data[constants.OktetoDependencyEnvsKey], nil
+}
+
 // GetConfigmapVariablesEncoded returns Data["variables"] content from Configmap
 func GetConfigmapVariablesEncoded(ctx context.Context, name, namespace string, c kubernetes.Interface) (string, error) {
 	cmap, err := configmaps.Get(ctx, TranslatePipelineName(name), namespace, c)

--- a/pkg/deployable/env_stepper.go
+++ b/pkg/deployable/env_stepper.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployable
 
 import (

--- a/pkg/deployable/env_stepper.go
+++ b/pkg/deployable/env_stepper.go
@@ -1,0 +1,68 @@
+package deployable
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/compose-spec/godotenv"
+	"github.com/spf13/afero"
+)
+
+// envStepper is an environment reader utility that reads the environment from
+// a temporary .env file and keeps a reference to it. It is meant to be called
+// to read environment variables in a command list loop
+type envStepper struct {
+	sync.RWMutex
+
+	filename string
+	env      map[string]string
+
+	fs afero.Fs
+}
+
+func (es *envStepper) WithFS(fs afero.Fs) {
+	es.fs = fs
+}
+func (es *envStepper) Step() ([]string, error) {
+	data, err := afero.ReadFile(es.fs, es.filename)
+	if err != nil {
+		return nil, err
+	}
+
+	current, err := godotenv.Unmarshal(string(data))
+	if err != nil {
+		return nil, err
+	}
+
+	list := mapToEnvList(current)
+
+	es.Lock()
+	es.env = current
+	es.Unlock()
+
+	return list, nil
+}
+
+func (es *envStepper) Map() (env map[string]string) {
+	es.RLock()
+	env = es.env
+	es.RUnlock()
+	return
+}
+
+func NewEnvStepper(filename string) *envStepper {
+	return &envStepper{
+		RWMutex:  sync.RWMutex{},
+		filename: filename,
+		env:      make(map[string]string),
+		fs:       afero.NewOsFs(),
+	}
+}
+
+func mapToEnvList(env map[string]string) []string {
+	list := make([]string, 0, len(env))
+	for k, v := range env {
+		list = append(list, fmt.Sprintf("%s=%s", k, v))
+	}
+	return list
+}

--- a/pkg/deployable/env_stepper.go
+++ b/pkg/deployable/env_stepper.go
@@ -25,12 +25,10 @@ import (
 // a temporary .env file and keeps a reference to it. It is meant to be called
 // to read environment variables in a command list loop
 type envStepper struct {
-	sync.RWMutex
-
-	filename string
+	fs       afero.Fs
 	env      map[string]string
-
-	fs afero.Fs
+	filename string
+	sync.RWMutex
 }
 
 func (es *envStepper) WithFS(fs afero.Fs) {

--- a/pkg/deployable/env_stepper_test.go
+++ b/pkg/deployable/env_stepper_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployable
 
 import (

--- a/pkg/deployable/env_stepper_test.go
+++ b/pkg/deployable/env_stepper_test.go
@@ -1,0 +1,45 @@
+package deployable
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvStepper(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	f, err := afero.TempFile(fs, "", "")
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	stepper := NewEnvStepper(f.Name())
+	stepper.WithFS(fs)
+
+	for i := 0; i < 10; i++ {
+		key := fmt.Sprintf("ENV%02v", i)
+		value := fmt.Sprintf("%v", i)
+		keyVal := fmt.Sprintf("%0s=%s", key, value)
+
+		f.WriteString(keyVal + "\n")
+
+		envvar, err := stepper.Step()
+		require.NoError(t, err)
+
+		// sort first. Order is not guaranteeed
+		sort.Strings(envvar)
+		require.Equal(t, keyVal, envvar[i])
+	}
+
+	result := stepper.Map()
+
+	for i := 0; i < 10; i++ {
+		val, ok := result[fmt.Sprintf("ENV%02v", i)]
+		require.True(t, ok)
+		require.Equal(t, fmt.Sprintf("%v", i), val)
+	}
+
+}

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -34,10 +34,10 @@ type TestRunner struct {
 type TestParameters struct {
 	Name         string
 	Namespace    string
+	DevEnvName   string
 	Deployable   Entity
 	Variables    []string
 	ForceDestroy bool
-	DevEnvName   string
 }
 
 // RunTest executes the custom commands received as part of TestParameters

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -18,12 +18,16 @@ import (
 
 	"github.com/okteto/okteto/cmd/utils/executor"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/spf13/afero"
 )
 
 // TestRunner is responsible for running the commands defined in a manifest when
 // running tests
 type TestRunner struct {
-	Executor executor.ManifestExecutor
+	Executor         executor.ManifestExecutor
+	Fs               afero.Fs
+	GetDevEnvEnviron func(devEnvName, namespace string) (map[string]string, error)
+	SetDevEnvEnviron func(devEnvName, namespace string, vars []string) error
 }
 
 // TestParameters represents the parameters for destroying a remote entity
@@ -33,29 +37,67 @@ type TestParameters struct {
 	Deployable   Entity
 	Variables    []string
 	ForceDestroy bool
+	DevEnvName   string
 }
 
 // RunTest executes the custom commands received as part of TestParameters
 func (dr *TestRunner) RunTest(params TestParameters) error {
-	var commandErr error
-	lastCommandName := ""
-	for _, command := range params.Deployable.Commands {
-		oktetoLog.Information("Running '%s'", command.Name)
-		lastCommandName = command.Name
-		oktetoLog.SetStage(command.Name)
-		if err := dr.Executor.Execute(command, params.Variables); err != nil {
-			err = fmt.Errorf("error executing command '%s': %w", command.Name, err)
+	oktetoLog.SetStage(params.Name)
 
-			// Store the error to return if the force destroy option is set
-			commandErr = err
-		}
-		oktetoLog.SetStage("")
+	oktetoEnvFile, unlinkEnv, err := createTempOktetoEnvFile(dr.Fs)
+	if err != nil {
+		return err
 	}
 
-	// This is a hack for improving the logs until we refactor all that. The oktetoLog.Information('Running '%s'')
-	// should not appear under any stage, that is why we clear the stage after each execution. To keep backward compatibility
-	// in case of failure of command, we end up the function setting the stage to the last command executed.
-	oktetoLog.SetStage(lastCommandName)
+	deployEnv, err := dr.getDeployEnv(params)
+	if err != nil {
+		return err
+	}
 
-	return commandErr
+	envStepper := NewEnvStepper(oktetoEnvFile.Name())
+	envStepper.WithFS(dr.Fs)
+
+	// Write back any variables written by the test into the deploy configmap
+	defer func() {
+		err := dr.SetDevEnvEnviron(params.DevEnvName, params.Namespace, append(deployEnv, params.Variables...))
+		if err != nil {
+			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error saving configmap environment: %s", err.Error())
+		}
+	}()
+	defer unlinkEnv()
+
+	for _, command := range params.Deployable.Commands {
+		oktetoLog.Information("Running '%s'", command.Name)
+
+		execEnv := []string{}
+		execEnv = append(execEnv, deployEnv...)
+		execEnv = append(execEnv, params.Variables...)
+
+		if err := dr.Executor.Execute(command, execEnv); err != nil {
+			return err
+		}
+
+		// Read variables that may have been written to OKTETO_ENV in the current step
+		envsFromOktetoEnvFile, err := envStepper.Step()
+		if err != nil {
+			oktetoLog.Warning("no valid format used in the okteto env file: %s", err.Error())
+		}
+
+		params.Variables = append(params.Variables, envsFromOktetoEnvFile...)
+	}
+
+	return nil
+}
+
+func (dr *TestRunner) getDeployEnv(params TestParameters) ([]string, error) {
+	deployEnv, err := dr.GetDevEnvEnviron(params.DevEnvName, params.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	list := make([]string, 0, len(deployEnv))
+	for k, v := range deployEnv {
+		list = append(list, fmt.Sprintf("%s=%s", k, v))
+	}
+	return list, nil
 }

--- a/pkg/deployable/test_test.go
+++ b/pkg/deployable/test_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deployable
 
 import (

--- a/pkg/deployable/test_test.go
+++ b/pkg/deployable/test_test.go
@@ -1,0 +1,49 @@
+package deployable
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestRunner(t *testing.T) {
+	executor := &fakeExecutor{}
+	runner := TestRunner{
+		Executor: executor,
+		Fs:       afero.NewMemMapFs(),
+		GetDevEnvEnviron: func(devEnvName, namespace string) (map[string]string, error) {
+			return map[string]string{
+				"DEPLOY_ENV_1": "deploy1",
+				"DEPLOY_ENV_2": "deploy2",
+			}, nil
+		},
+		SetDevEnvEnviron: func(devEnvName, namespace string, vars []string) error {
+			return nil
+		},
+	}
+
+	cmd1 := model.DeployCommand{
+		Name:    "run command",
+		Command: "echo this_is_my_command",
+	}
+
+	expectedVars := []string{
+		"DEPLOY_ENV_1=deploy1",
+		"DEPLOY_ENV_2=deploy2",
+	}
+	executor.On("Execute", cmd1, expectedVars).Return(nil).Once()
+
+	err := runner.RunTest(TestParameters{
+		Name:       "test",
+		Namespace:  "ns",
+		DevEnvName: "deploy",
+		Deployable: Entity{
+			Commands: []model.DeployCommand{cmd1},
+		},
+	})
+
+	require.NoError(t, err)
+	require.True(t, executor.AssertExpectations(t))
+}


### PR DESCRIPTION
The `okteto test` command now read `OKTETO_ENV` and the environment defined in the deploy section. This includes any dinamic values. Also, upon saving a value in `OKTETO_ENV` this value will be stored in the configmap and accesible in the deploy section.

To abe able to accomplish this, we had to add an extra argument `devenv-name` to the deploy-run to be able to retrieve and update the envvars.

## Testing

```yaml
deploy:
  - name: "set env"
    command: echo "DEPLOY_ENV=deploy-envvar" >> $OKTETO_ENV
  - name: "get deploy env"
    command: echo "deploy($DEPLOY_ENV)"
  - name: "get env from test"
    command: echo "test($TEST_ENV)"
  - name: "apply"
    command: kubectl apply -f k8s.yml


test:
  all:
    commands:
      - name: "set env"
        command: echo "TEST_ENV=test-envvar" >> $OKTETO_ENV
      - name: "get env from deploy"
        command: echo "deploy(${DEPLOY_ENV})"
      - name: "get env from test"
        command: echo "test(${TEST_ENV})"
```

Both envvars are accesible:

```
$ ok test
 i  Using maroshii-okteto-admin @ okteto.maroshii.dev.okteto.net as context
 i  'go-getting-started' was already deployed. To redeploy run 'okteto deploy'
 i  Running stage 'all'
 i  Running 'set env'
 i  Running 'get env from deploy'
deploy(deploy-envvar)
 i  Running 'get env from test'
test(test-envvar)
```

After running the tests, they are persisted in the cm:
```
kubectl get cm/okteto-git-go-getting-started -o jsonpath={.data.dependencyEnvs} | base64 -d | jq
{
  "DEPLOY_ENV": "deploy-envvar",
  "KUBECONFIG": "/.../.okteto/kubeconfig-deploy-go-getting-started-1713359524310",
  "OKTETO_AUTODISCOVERY_RELEASE_NAME": "go-getting-started",
  "OKTETO_DISABLE_SPINNER": "true",
  "OKTETO_DOMAIN": "...",
  "OKTETO_NAMESPACE": "...",
  "OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE": "true",
  "OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT": "true",
  "TEST_ENV": "test-envvar"
}
```