### PR TITLE
fix push script

### DIFF
--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -37,6 +37,6 @@
         fi
 
         echo "Pushing ${tags} to Docker Hub"
-        # okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${RELEASE_TAG}" -t "${tags}" -f Dockerfile .
+        okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${RELEASE_TAG}" -t "${tags}" -f Dockerfile .
 
 ); }

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -25,13 +25,14 @@
 
         beta_prerel_regex="beta\.[0-9]+"
         prerel="$(semver get prerel "${RELEASE_TAG}" || true)"
+        version="$(semver get release "${RELEASE_TAG}" || true)"
         tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev"
 
         # if release tag is  not empty, push the stable image
         if [ -n "$RELEASE_TAG" ]; then
                 if [[ $prerel =~ $beta_prerel_regex ]]; then
                         tags="${tags},okteto/okteto:beta"
-                elif [ -n "$prerel" ]; then
+                elif [ -n "$version" ]; then
                         tags="${tags},okteto/okteto:stable" 
                 fi
         fi

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -23,20 +23,20 @@
         fi
 
 
-        beta_prerel_regex="^beta\.[0-9]+"
+        beta_prerel_regex="beta\.[0-9]+"
         prerel="$(semver get prerel "${RELEASE_TAG}" || true)"
         tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev"
 
         # if release tag is  not empty, push the stable image
         if [ -n "$RELEASE_TAG" ]; then
-                if [ -n "$prerel" ]; then
-                        tags="${tags},okteto/okteto:stable"
-                elif [[ $prerel =~ $beta_prerel_regex ]]; then
+                if [[ $prerel =~ $beta_prerel_regex ]]; then
                         tags="${tags},okteto/okteto:beta"
+                elif [ -n "$prerel" ]; then
+                        tags="${tags},okteto/okteto:stable" 
                 fi
         fi
 
         echo "Pushing ${tags} to Docker Hub"
-        okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${RELEASE_TAG}" -t "${tags}" -f Dockerfile .
+        # okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${RELEASE_TAG}" -t "${tags}" -f Dockerfile .
 
 ); }

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -23,7 +23,7 @@
         fi
 
 
-        beta_prerel_regex="beta\.[0-9]+"
+        beta_prerel_regex="^beta\.[0-9]+"
         prerel="$(semver get prerel "${RELEASE_TAG}" || true)"
         version="$(semver get release "${RELEASE_TAG}" || true)"
         tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev"

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -30,6 +30,8 @@
 
         # if release tag is  not empty, push the stable image
         if [ -n "$RELEASE_TAG" ]; then
+                echo "prerel: ${prerel}"
+                echo "version ${version}"
                 if [[ $prerel =~ $beta_prerel_regex ]]; then
                         tags="${tags},okteto/okteto:beta"
                 elif [ -n "$version" ]; then


### PR DESCRIPTION
# Proposed changes

DEV-288

There was an issue in the regex check. We were comparing if the string started with beta but we had the circle tag starting with 2.26.0. 

Remove the ^ on the regex in order to check the whole string and not just if it starts with beta

## How to validate

1. Comment the line 40 (`okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${RELEASE_TAG}" -t "${tags}" -f Dockerfile .`)
1. Run ./scripts/ci/push-image.sh 2.26.0 "linux/amd64,linux/arm64" and check that the message is `Pushing okteto/okteto:2.26.0,okteto/okteto:dev,okteto/okteto:stable to Docker Hub`
1. Run ./scripts/ci/push-image.sh 2.26.0-beta.7 "linux/amd64,linux/arm64" and check that the message is `Pushing okteto/okteto:2.26.0-beta.7,okteto/okteto:dev,okteto/okteto:beta to Docker Hub`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
