### PR TITLE
Okteto Test Spike

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -252,7 +252,7 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 					namespace = options.Manifest.Namespace
 				}
 				c.insightsTracker.TrackDeploy(ctx, options.Name, namespace, err == nil)
-				c.trackDeploy(options.Manifest, options.RunInRemote, startTime, err)
+				c.TrackDeploy(options.Manifest, options.RunInRemote, startTime, err)
 				exit <- err
 			}()
 
@@ -647,7 +647,7 @@ func (dc *Command) recreateFailedPods(ctx context.Context, name string) error {
 	return nil
 }
 
-func (dc *Command) trackDeploy(manifest *model.Manifest, runInRemoteFlag bool, startTime time.Time, err error) {
+func (dc *Command) TrackDeploy(manifest *model.Manifest, runInRemoteFlag bool, startTime time.Time, err error) {
 	deployType := "custom"
 	hasDependencySection := false
 	hasBuildSection := false

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -821,7 +821,7 @@ func TestTrackDeploy(t *testing.T) {
 				AnalyticsTracker: &fakeTracker{},
 			}
 
-			dc.trackDeploy(tc.manifest, tc.remoteFlag, time.Now(), tc.commandErr)
+			dc.TrackDeploy(tc.manifest, tc.remoteFlag, time.Now(), tc.commandErr)
 		})
 	}
 }

--- a/cmd/destroy/build_control_test.go
+++ b/cmd/destroy/build_control_test.go
@@ -37,7 +37,7 @@ type fakeGetSvcs struct {
 	svcs []string
 }
 
-func (fb fakeBuilderV2) GetServicesToBuildDuringDeploy(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error) {
+func (fb fakeBuilderV2) GetServicesToBuildForImage(ctx context.Context, manifest *model.Manifest, imgFinder model.ImageFromManifest) ([]string, error) {
 	return fb.getSvcs.svcs, fb.getSvcs.err
 }
 

--- a/cmd/destroy/destroy_test.go
+++ b/cmd/destroy/destroy_test.go
@@ -203,6 +203,12 @@ func TestDestroyWithErrorGettingManifestButDestroySuccess(t *testing.T) {
 		ConfigMapHandler: NewConfigmapHandler(fakeClient),
 		nsDestroyer:      destroyer,
 		secrets:          &fakeSecretHandler{},
+		buildCtrl: buildCtrl{
+			builder: fakeBuilderV2{
+				getSvcs: fakeGetSvcs{},
+				build:   nil,
+			},
+		},
 	}
 
 	err = dc.destroy(context.Background(), &Options{})
@@ -300,6 +306,12 @@ func TestDestroyWithErrorOnCommands(t *testing.T) {
 		executor: &fakeExecutor{
 			err: assert.AnError,
 		},
+		buildCtrl: buildCtrl{
+			builder: fakeBuilderV2{
+				getSvcs: fakeGetSvcs{},
+				build:   nil,
+			},
+		},
 	}
 
 	err = dc.destroy(ctx, &Options{
@@ -335,6 +347,12 @@ func TestDestroyWithErrorOnCommandsForcingDestroy(t *testing.T) {
 		k8sClientProvider: k8sClientProvider,
 		executor: &fakeExecutor{
 			err: fmt.Errorf("error executing command"),
+		},
+		buildCtrl: buildCtrl{
+			builder: fakeBuilderV2{
+				getSvcs: fakeGetSvcs{},
+				build:   nil,
+			},
 		},
 	}
 
@@ -372,6 +390,12 @@ func TestDestroyWithErrorDestroyingK8sResources(t *testing.T) {
 		secrets:           &fakeSecretHandler{},
 		k8sClientProvider: k8sClientProvider,
 		executor:          &fakeExecutor{},
+		buildCtrl: buildCtrl{
+			builder: fakeBuilderV2{
+				getSvcs: fakeGetSvcs{},
+				build:   nil,
+			},
+		},
 	}
 
 	err = dc.destroy(ctx, &Options{

--- a/cmd/test/analytics.go
+++ b/cmd/test/analytics.go
@@ -1,0 +1,36 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+
+	"github.com/okteto/okteto/pkg/analytics"
+)
+
+// ProxyTracker is a dedicated wrapper for okteto test that intercepts deploy
+// operation to edit metadata prior to be sent to out analytics backend
+type ProxyTracker struct {
+	*analytics.Tracker
+}
+
+func (a *ProxyTracker) TrackDeploy(metadata analytics.DeployMetadata) {
+	metadata.DeployType = "test"
+	a.Tracker.TrackDeploy(metadata)
+}
+
+func (a *ProxyTracker) TrackImageBuild(ctx context.Context, m *analytics.ImageBuildMetadata) {
+	m.Initiator = "test"
+	a.Tracker.TrackImageBuild(ctx, m)
+}

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -334,7 +334,7 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 			},
 			Manifest:                    manifest,
 			Command:                     remote.TestCommand,
-			ContextAbsolutePathOverride: path.Clean(fmt.Sprintf("%s/%s", cwd, test.Context)),
+			ContextAbsolutePathOverride: path.Clean(path.Join(cwd, test.Context)),
 		}
 
 		if !options.NoCache {
@@ -343,7 +343,7 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 			params.CacheInvalidationKey = "const"
 		}
 
-		oktetoLog.Information("Executing '%s'", name)
+		ioCtrl.Out().Infof("Executing '%s'", name)
 		if err := runner.Run(ctx, params); err != nil {
 			return metadata, err
 		}

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path"
 	"time"
 
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
@@ -279,11 +280,12 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 				// resources in the environment, so including it to set the env vars in the remote-run
 				External: manifest.External,
 			},
-			Manifest: manifest,
-			Command:  remote.TestCommand,
+			Manifest:                    manifest,
+			Command:                     remote.TestCommand,
+			ContextAbsolutePathOverride: path.Clean(fmt.Sprintf("%s/%s", cwd, test.Context)),
 		}
 
-		ioCtrl.Logger().Infof("Executing test for: %s", name)
+		oktetoLog.Information("Executing '%s'", name)
 		if err := runner.Run(ctx, params); err != nil {
 			return err
 		}

--- a/pkg/analytics/imagebuild.go
+++ b/pkg/analytics/imagebuild.go
@@ -29,6 +29,7 @@ type ImageBuildMetadata struct {
 	RepoURL                  string
 	RepoHash                 string
 	BuildContextHash         string
+	Initiator                string
 	RepoHashDuration         time.Duration
 	BuildContextHashDuration time.Duration
 	CacheHitDuration         time.Duration
@@ -52,6 +53,7 @@ func (m *ImageBuildMetadata) toProps() map[string]interface{} {
 		"buildDurationSeconds":            m.BuildDuration.Seconds(),
 		"buildContextHash":                m.BuildContextHash,
 		"buildContextHashDurationSeconds": m.BuildContextHashDuration.Seconds(),
+		"initiator":                       m.Initiator,
 	}
 
 	if m.Name != "" {

--- a/pkg/analytics/imagebuild_test.go
+++ b/pkg/analytics/imagebuild_test.go
@@ -44,6 +44,7 @@ func TestAnalyticsTracker_TrackImageBuild(t *testing.T) {
 					"cacheHitDurationSeconds":         float64(0),
 					"buildDurationSeconds":            float64(0),
 					"buildContextHash":                "",
+					"initiator":                       "",
 					"buildContextHashDurationSeconds": float64(0),
 				},
 			},
@@ -63,6 +64,7 @@ func TestAnalyticsTracker_TrackImageBuild(t *testing.T) {
 					"cacheHitDurationSeconds":         float64(0),
 					"buildDurationSeconds":            float64(0),
 					"buildContextHash":                "",
+					"initiator":                       "",
 					"buildContextHashDurationSeconds": float64(0),
 				},
 			},
@@ -100,6 +102,7 @@ func Test_ImageBuildMetadata_toProps(t *testing.T) {
 		BuildDuration:            5 * time.Second,
 		BuildContextHash:         "contextHash",
 		BuildContextHashDuration: 5 * time.Second,
+		Initiator:                "me",
 	}
 
 	expectedProps := map[string]interface{}{
@@ -112,6 +115,7 @@ func Test_ImageBuildMetadata_toProps(t *testing.T) {
 		"buildDurationSeconds":            float64(5),
 		"buildContextHash":                "contextHash",
 		"buildContextHashDurationSeconds": float64(5),
+		"initiator":                       "me",
 	}
 
 	require.Equal(t, expectedProps, m.toProps())

--- a/pkg/analytics/test.go
+++ b/pkg/analytics/test.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analytics
+
+import (
+	"time"
+)
+
+const testEvent = "Test"
+
+// TestMetadata contains the metadata of a deploy event
+type TestMetadata struct {
+	// Err is the error (if any) that occurred during test execution. Note that
+	// this is NOT an error in the test but rather a error encounterd in the setup
+	Err error
+
+	// Duration is the total duration of the test execution. Not that this includes
+	// potential build and deploy times (not just the tests)
+	Duration time.Duration
+
+	// WasDeployed is whether a deploy was needed as part of the test
+	WasDeployed bool
+
+	// WasBuilt is whether at least one image had to be built to run the tests
+	WasBuilt bool
+
+	// Success is whether the tests succeeded or not
+	Success bool
+
+	// StagesCount is the number of services that were tested
+	StagesCount int
+}
+
+// TrackTest sends a tracking event to mixpanel when the user runs test through the command okteto test
+func (a *Tracker) TrackTest(metadata TestMetadata) {
+	props := map[string]any{
+		"duration":    metadata.Duration.Seconds(),
+		"wasDeployed": metadata.WasDeployed,
+		"wasBuilt":    metadata.WasBuilt,
+		"success":     metadata.Success,
+		"stagesCount": metadata.StagesCount,
+	}
+	if metadata.Err != nil {
+		props["error"] = metadata.Err.Error()
+	}
+	a.trackFn(testEvent, metadata.Success, props)
+}

--- a/pkg/analytics/test.go
+++ b/pkg/analytics/test.go
@@ -19,13 +19,13 @@ import (
 
 const testEvent = "Test"
 
-// TestMetadata contains the metadata of a deploy event
+// TestMetadata contains the metadata of a test command execution event
 type TestMetadata struct {
 	// Err is the error (if any) that occurred during test execution. Note that
 	// this is NOT an error in the test but rather a error encounterd in the setup
 	Err error
 
-	// Duration is the total duration of the test execution. Not that this includes
+	// Duration is the total duration of the test execution. Note that this includes
 	// potential build and deploy times (not just the tests)
 	Duration time.Duration
 
@@ -38,7 +38,7 @@ type TestMetadata struct {
 	// Success is whether the tests succeeded or not
 	Success bool
 
-	// StagesCount is the number of services that were tested
+	// StagesCount is the number of sections that were tested (entries in the manifest test map)
 	StagesCount int
 }
 

--- a/pkg/analytics/test_test.go
+++ b/pkg/analytics/test_test.go
@@ -1,0 +1,60 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analytics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackTest(t *testing.T) {
+	var event string
+	var success bool
+	var wasBuilt bool
+	var wasDeployed bool
+	var duration float64
+	var stagesCount int
+	var errStr string
+	tracker := Tracker{
+		trackFn: func(ev string, ok bool, props map[string]any) {
+			event = ev
+			success = ok
+			wasBuilt = props["wasBuilt"].(bool)
+			wasDeployed = props["wasDeployed"].(bool)
+			duration = props["duration"].(float64)
+			stagesCount = props["stagesCount"].(int)
+			errStr = props["error"].(string)
+		},
+	}
+
+	tracker.TrackTest(TestMetadata{
+		WasDeployed: true,
+		WasBuilt:    true,
+		Success:     false,
+		Duration:    time.Second * 5,
+		StagesCount: 3,
+		Err:         fmt.Errorf("my-error"),
+	})
+
+	require.True(t, wasDeployed)
+	require.True(t, wasBuilt)
+	require.False(t, success)
+	require.Equal(t, errStr, "my-error")
+	require.Equal(t, "Test", event)
+	require.Equal(t, float64(5), duration)
+	require.Equal(t, 3, stagesCount)
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -120,6 +120,11 @@ type ManifestDevs map[string]*Dev
 // ManifestTests defines all the test sections
 type ManifestTests map[string]*Test
 
+// ImageFromManifest is a thunk that returns an image value from a parsed manifest
+// This allows to implement general purpose logic on images without necessarily
+// referencing a specific image, for eg manifest.Deploy.Image or manifest.Destroy.Image
+type ImageFromManifest func(manifest *Manifest) string
+
 // NewManifest creates a new empty manifest
 func NewManifest() *Manifest {
 	return &Manifest{

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -214,7 +214,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.Sync":                 {"rescanInterval", "compression", "verbose"},
 				"model.Timeout":              {"default", "resources"},
 				"model.VolumeSpec":           {"labels", "annotations", "class"},
-				"model.Test":                 {"image", "depends_on"},
+				"model.Test":                 {"image", "depends_on", "context"},
 			},
 		},
 	}

--- a/pkg/model/test.go
+++ b/pkg/model/test.go
@@ -16,6 +16,7 @@ import "github.com/okteto/okteto/pkg/env"
 
 type Test struct {
 	Image     string        `yaml:"image,omitempty"`
+	Context   string        `yaml:"context,omitempty"`
 	Commands  []TestCommand `yaml:"commands,omitempty"`
 	DependsOn []string      `yaml:"depends_on,omitempty"`
 }
@@ -28,6 +29,20 @@ func (test *Test) expandEnvVars() error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (t *Test) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type alias Test
+	var tt alias
+	err := unmarshal(&tt)
+	if err != nil {
+		return err
+	}
+	if tt.Context == "" {
+		tt.Context = "."
+	}
+	*t = Test(tt)
 	return nil
 }
 

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -131,11 +131,14 @@ type Params struct {
 	ManifestPathFlag    string
 	TemplateName        string
 	DockerfileName      string
-	// KnownHostsPath  is the default known_hosts file path. Provided mostly for testing
-	KnownHostsPath string
-	Command        string
-	Deployable     deployable.Entity
-	CommandFlags   []string
+	KnownHostsPath      string
+	Command             string
+	// ContextAbsolutePathOverride is the absolute path for the build context. Optional.
+	// If this values is not defined it will default to the folder location of the
+	// okteto manifest which is resolved through params.ManifestPathFlag
+	ContextAbsolutePathOverride string
+	Deployable                  deployable.Entity
+	CommandFlags                []string
 }
 
 // dockerfileTemplateProperties internal struct with the information needed by the Dockerfile template
@@ -215,9 +218,16 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		}
 	}()
 
+	var buildCtx string
+	if params.ContextAbsolutePathOverride != "" {
+		buildCtx = params.ContextAbsolutePathOverride
+	} else {
+		buildCtx = r.getContextPath(cwd, params.ManifestPathFlag)
+	}
+
 	buildInfo := &build.Info{
 		Dockerfile: dockerfile,
-		Context:    r.getContextPath(cwd, params.ManifestPathFlag),
+		Context:    buildCtx,
 	}
 
 	// undo modification of CWD for Build command

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -137,8 +138,12 @@ type Params struct {
 	// If this values is not defined it will default to the folder location of the
 	// okteto manifest which is resolved through params.ManifestPathFlag
 	ContextAbsolutePathOverride string
-	Deployable                  deployable.Entity
-	CommandFlags                []string
+	// CacheInvalidationKey is the value use to invalidate the cache. Defaults
+	// to a random value which essentially means no-cache. Setting this to a
+	// static or known value will reuse the build cache
+	CacheInvalidationKey string
+	Deployable           deployable.Entity
+	CommandFlags         []string
 }
 
 // dockerfileTemplateProperties internal struct with the information needed by the Dockerfile template
@@ -235,9 +240,13 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		return err
 	}
 
-	randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000000))
-	if err != nil {
-		return err
+	cacheKey := params.CacheInvalidationKey
+	if cacheKey == "" {
+		randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000000))
+		if err != nil {
+			return err
+		}
+		cacheKey = strconv.Itoa(int(randomNumber.Int64()))
 	}
 
 	b, err := yaml.Marshal(params.Deployable)
@@ -261,7 +270,7 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		fmt.Sprintf("%s=%s", constants.OktetoGitCommitEnvVar, os.Getenv(constants.OktetoGitCommitEnvVar)),
 		fmt.Sprintf("%s=%s", constants.OktetoGitBranchEnvVar, os.Getenv(constants.OktetoGitBranchEnvVar)),
 		fmt.Sprintf("%s=%s", constants.OktetoTlsCertBase64EnvVar, base64.StdEncoding.EncodeToString(sc.Certificate)),
-		fmt.Sprintf("%s=%d", constants.OktetoInvalidateCacheEnvVar, int(randomNumber.Int64())),
+		fmt.Sprintf("%s=%s", constants.OktetoInvalidateCacheEnvVar, cacheKey),
 		fmt.Sprintf("%s=%s", constants.OktetoDeployableEnvVar, base64.StdEncoding.EncodeToString(b)),
 		fmt.Sprintf("%s=%s", model.GithubRepositoryEnvVar, os.Getenv(model.GithubRepositoryEnvVar)),
 		fmt.Sprintf("%s=%s", model.OktetoRegistryURLEnvVar, os.Getenv(model.OktetoRegistryURLEnvVar)),


### PR DESCRIPTION
Adds the `context` field to `okteto test` to run tests. Tested a combination of scenarios with the manifest in subfolders, different manifest name etc and it all seems to work.

Tested it through the following change: https://github.com/okteto/go-getting-started/pull/19