### PR TITLE
mask multiline variables

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -313,13 +313,18 @@ func IsInteractive() bool {
 
 // AddMaskedWord adds a new word to be redacted, only if longer than 5 chars
 func AddMaskedWord(word string) {
+	clean := strings.TrimSpace(word)
+
+	// only mask words longer than 5 chars (i.e. 'true' and 'false' will not be masked)
 	minCharsToMask := 5
-	lines := strings.Split(word, "\n")
-	for _, line := range lines {
-		if strings.TrimSpace(word) != "" && len(line) > minCharsToMask {
-			log.maskedWords = append(log.maskedWords, line)
-		}
+	if len(clean) < minCharsToMask {
+		return
 	}
+	log.maskedWords = append(log.maskedWords, clean)
+
+	// multi-line support
+	lines := strings.Split(clean, "\n")
+	log.maskedWords = append(log.maskedWords, lines...)
 }
 
 // EnableMasking starts redacting all variables

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -314,8 +314,11 @@ func IsInteractive() bool {
 // AddMaskedWord adds a new word to be redacted, only if longer than 5 chars
 func AddMaskedWord(word string) {
 	minCharsToMask := 5
-	if strings.TrimSpace(word) != "" && len(word) > minCharsToMask {
-		log.maskedWords = append(log.maskedWords, word)
+	lines := strings.Split(word, "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(word) != "" && len(line) > minCharsToMask {
+			log.maskedWords = append(log.maskedWords, line)
+		}
 	}
 }
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -322,7 +322,8 @@ func AddMaskedWord(word string) {
 	}
 	log.maskedWords = append(log.maskedWords, clean)
 
-	lines := strings.Split(clean, "\n")
+	crossPlatformCleanWord := strings.ReplaceAll(clean, "\r\n", "\n")
+	lines := strings.Split(crossPlatformCleanWord, "\n")
 	for _, line := range lines {
 		cleanLine := strings.TrimSpace(line)
 		if len(cleanLine) <= minCharsToMask {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -315,18 +315,17 @@ func IsInteractive() bool {
 func AddMaskedWord(word string) {
 	clean := strings.TrimSpace(word)
 
-	// only mask words longer than 5 chars (i.e. 'true' and 'false' will not be masked)
+	// only mask words longer than 5 chars (i.e. 'true' and 'false' won't be masked)
 	minCharsToMask := 5
-	if len(clean) < minCharsToMask {
+	if len(clean) <= minCharsToMask {
 		return
 	}
 	log.maskedWords = append(log.maskedWords, clean)
 
-	// multi-line support
 	lines := strings.Split(clean, "\n")
 	for _, line := range lines {
 		cleanLine := strings.TrimSpace(line)
-		if len(cleanLine) < minCharsToMask {
+		if len(cleanLine) <= minCharsToMask {
 			continue
 		}
 		log.maskedWords = append(log.maskedWords, cleanLine)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -324,7 +324,13 @@ func AddMaskedWord(word string) {
 
 	// multi-line support
 	lines := strings.Split(clean, "\n")
-	log.maskedWords = append(log.maskedWords, lines...)
+	for _, line := range lines {
+		cleanLine := strings.TrimSpace(line)
+		if len(cleanLine) < minCharsToMask {
+			continue
+		}
+		log.maskedWords = append(log.maskedWords, cleanLine)
+	}
 }
 
 // EnableMasking starts redacting all variables


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-293

Currently, multiline variables are not masked by the CLI. This is not intended, it's just the current behaviour because logs are printed line by line, therefore are never matched with the multi-line words that are passed to `AddMaskedWord`.

This solution is not so clean because it adds `***` for each line. However, it's the quickest and less intruisive. Let's discuss if there are other approaches that make sense!

## How to validate

1. Create a multi line variable in the UI or locally
1. Modify a manifest to print such var
1. Run `okteto deploy`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
