### PR TITLE
chore: add devcontainer to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .idea
 .atom
 
+# VSCode Plugins
+.devcontainer
+
 # Golang binary
 cli
 .syncthing*


### PR DESCRIPTION
# Proposed changes

Adds `.devcontainer` to the `.gitignore`. We can discuss here if it's worth to have it. I need it in order to test all the scripts that runs on CI to have the same configuration as the one in CI


## How to validate

1. Create a `.devcontainer` folder 
1. Check that it can't be added to the git status

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
