### PR TITLE
feat: deprecate compose file detection by naming

### DIFF
--- a/cmd/utils/stack_test.go
+++ b/cmd/utils/stack_test.go
@@ -43,7 +43,7 @@ const (
 func Test_multipleStack(t *testing.T) {
 	dir := t.TempDir()
 	log.Printf("created tempdir: %s", dir)
-
+	t.Setenv("OKTETO_SUPPORT_STACKS_ENABLED", "true")
 	path, err := createFile(dir, "docker-compose.yml", firstStack)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -792,8 +792,8 @@ func isFileCompose(path string) bool {
 	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, false)
 	if !isStackSupported {
 		oktetoLog.Infof("%s is set to false. File will be treated as compose", stackSupportEnabledEnvVar)
-		if isComposeFileName {
-			oktetoLog.Warning("The file %s will be deprecated as a default compose file name in a future version. Please consider renaming your compose file to 'okteto-stack.yml'", base)
+		if !isComposeFileName {
+			oktetoLog.Warning("The file %s will be deprecated as a stack file name in a future version. Please consider migrating your file to a compose", base)
 		}
 		return true
 	}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -883,7 +883,7 @@ func getOverrideFile(stackPath string, fs afero.Fs) (*Stack, error) {
 	fileName := strings.TrimSuffix(stackPath, extension)
 	overridePath := fmt.Sprintf("%s.override%s", fileName, extension)
 	var isCompose bool
-	if filesystem.FileExists(stackPath) {
+	if filesystem.FileExists(overridePath) {
 		if isFileCompose(stackPath) {
 			isCompose = true
 		}

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -789,7 +789,7 @@ func (svcResources *ServiceResources) IsDefaultValue() bool {
 func isFileCompose(path string) bool {
 	base := filepath.Base(path)
 	isComposeFileName := strings.HasPrefix(base, "compose") || strings.HasPrefix(base, "docker-compose") || strings.HasPrefix(base, "okteto-compose")
-	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, false)
+	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, true)
 	if !isStackSupported {
 		oktetoLog.Infof("%s is set to false. File will be treated as compose", stackSupportEnabledEnvVar)
 		if !isComposeFileName {

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -792,10 +792,10 @@ func isFileCompose(path string) bool {
 	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, true)
 	if !isStackSupported {
 		oktetoLog.Infof("%s is set to false. File will be treated as compose", stackSupportEnabledEnvVar)
-		if !isComposeFileName {
-			oktetoLog.Warning("The file %s will be deprecated as a stack file name in a future version. Please consider migrating your file to a compose", base)
-		}
 		return true
+	}
+	if !isComposeFileName {
+		oktetoLog.Warning("okteto stack syntax is deprecated. Please consider migrating to compose syntax: https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262")
 	}
 	oktetoLog.Infof("%s is set to true. Detecting if file is compose by name", stackSupportEnabledEnvVar)
 	return isComposeFileName

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -789,7 +789,8 @@ func (svcResources *ServiceResources) IsDefaultValue() bool {
 func isFileCompose(path string) bool {
 	base := filepath.Base(path)
 	isComposeFileName := strings.HasPrefix(base, "compose") || strings.HasPrefix(base, "docker-compose") || strings.HasPrefix(base, "okteto-compose")
-	if !env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, false) {
+	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, false)
+	if !isStackSupported {
 		oktetoLog.Infof("%s is set to false. File will be treated as compose", stackSupportEnabledEnvVar)
 		if isComposeFileName {
 			oktetoLog.Warning("The file %s will be deprecated as a default compose file name in a future version. Please consider renaming your compose file to 'okteto-stack.yml'", base)

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -1427,37 +1427,49 @@ func TestValidateServices(t *testing.T) {
 }
 func Test_isPathAComposeFile(t *testing.T) {
 	tests := []struct {
-		path     string
-		expected bool
+		name        string
+		path        string
+		envVarValue string
+		expected    bool
 	}{
 		{
+			name:     "compose file - no env var",
 			path:     "compose.yml",
 			expected: true,
 		},
 		{
+			name:     "compose file - no env var",
 			path:     "docker-compose.yaml",
 			expected: true,
 		},
 		{
+			name:     "compose file - no env var",
 			path:     "okteto-compose.yml",
 			expected: true,
 		},
 		{
+			name:     "compose file - no env var",
 			path:     "docker-compose-dev.yml",
 			expected: true,
 		},
 		{
+			name:     "no compose file - no env var",
 			path:     "okteto-stack.yml",
-			expected: false,
+			expected: true,
+		},
+		{
+			name:        "no compose file - env var set to true",
+			envVarValue: "true",
+			path:        "stack.yml",
+			expected:    false,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.path, func(t *testing.T) {
-			result := isPathAComposeFile(test.path)
-			if result != test.expected {
-				t.Errorf("Expected %v but got %v", test.expected, result)
-			}
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(stackSupportEnabledEnvVar, test.envVarValue)
+			result := isFileCompose(test.path)
+			assert.Equal(t, test.expected, result)
 		})
 	}
 }

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -1455,7 +1455,7 @@ func Test_isPathAComposeFile(t *testing.T) {
 		{
 			name:     "no compose file - no env var",
 			path:     "okteto-stack.yml",
-			expected: true,
+			expected: false,
 		},
 		{
 			name:        "no compose file - env var set to true",


### PR DESCRIPTION
# Proposed changes

Partly fixes DEV-248.

We are deprecating the detection of a compose or stack file based on the name of the file. Now the users will have to use `OKTETO_SUPPORT_STACKS_ENABLED=true` in order to have previous behaviour.

- Adds new env var `OKTETO_SUPPORT_STACKS_ENABLED` ([Documentation PR](https://github.com/okteto/docs/pull/706)/[Stack vs Compose community post](https://www.notion.so/okteto/Important-Update-Migrating-from-Okteto-Stacks-to-Docker-Compose-53292a7f72324beca9e0f6b9eddcc217?pvs=4))
- The new env var is the one that says if a file is a compose or not


## How to validate

1. From https://github.com/okteto/movies-with-compose
2. Rename `docker-compose.yml` to `stack.yml`
3. Run `okteto deploy`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
