### PR TITLE
Add --no-cache to tests

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -137,8 +138,12 @@ type Params struct {
 	// If this values is not defined it will default to the folder location of the
 	// okteto manifest which is resolved through params.ManifestPathFlag
 	ContextAbsolutePathOverride string
-	Deployable                  deployable.Entity
-	CommandFlags                []string
+	// CacheInvalidationKey is the value use to invalidate the cache. Defaults
+	// to a random value which essentially means no-cache. Setting this to a
+	// static or known value will reuse the build cache
+	CacheInvalidationKey string
+	Deployable           deployable.Entity
+	CommandFlags         []string
 }
 
 // dockerfileTemplateProperties internal struct with the information needed by the Dockerfile template
@@ -235,9 +240,13 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		return err
 	}
 
-	randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000000))
-	if err != nil {
-		return err
+	cacheKey := params.CacheInvalidationKey
+	if cacheKey == "" {
+		randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000000))
+		if err != nil {
+			return err
+		}
+		cacheKey = strconv.Itoa(int(randomNumber.Int64()))
 	}
 
 	b, err := yaml.Marshal(params.Deployable)
@@ -261,7 +270,7 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		fmt.Sprintf("%s=%s", constants.OktetoGitCommitEnvVar, os.Getenv(constants.OktetoGitCommitEnvVar)),
 		fmt.Sprintf("%s=%s", constants.OktetoGitBranchEnvVar, os.Getenv(constants.OktetoGitBranchEnvVar)),
 		fmt.Sprintf("%s=%s", constants.OktetoTlsCertBase64EnvVar, base64.StdEncoding.EncodeToString(sc.Certificate)),
-		fmt.Sprintf("%s=%d", constants.OktetoInvalidateCacheEnvVar, int(randomNumber.Int64())),
+		fmt.Sprintf("%s=%s", constants.OktetoInvalidateCacheEnvVar, cacheKey),
 		fmt.Sprintf("%s=%s", constants.OktetoDeployableEnvVar, base64.StdEncoding.EncodeToString(b)),
 		fmt.Sprintf("%s=%s", model.GithubRepositoryEnvVar, os.Getenv(model.GithubRepositoryEnvVar)),
 		fmt.Sprintf("%s=%s", model.OktetoRegistryURLEnvVar, os.Getenv(model.OktetoRegistryURLEnvVar)),


### PR DESCRIPTION
Adds `--no-cache` to `okteto test`. By default the `OKTETO_INVALIDATE_CACHE` during a remote deploy is set to a random value which invalidates the buildkit cache. For tests that will now be set the string `"const"` which would make the cache stick across builds unless `--no-cache` is used, in which case we'll default back to a random int.

NOTE: Opened against https://github.com/okteto/okteto/pull/4250 to avoid conflicts