### PR TITLE
`okteto up`: display warning when available disk space is running low

### DIFF
--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -61,9 +61,6 @@ func (up *upContext) sync(ctx context.Context) error {
 		return err
 	}
 
-	// check for system errors
-	up.checkForSystemErrors(ctx)
-
 	startSyncFiles := time.Now()
 	if err := up.synchronizeFiles(ctx); err != nil {
 		return err

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -61,6 +61,8 @@ func (up *upContext) sync(ctx context.Context) error {
 		return err
 	}
 
+	up.checkForSystemErrors(ctx)g
+
 	startSyncFiles := time.Now()
 	if err := up.synchronizeFiles(ctx); err != nil {
 		return err

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -61,7 +61,7 @@ func (up *upContext) sync(ctx context.Context) error {
 		return err
 	}
 
-	up.checkForSystemErrors(ctx)g
+	up.checkForSystemErrors(ctx)
 
 	startSyncFiles := time.Now()
 	if err := up.synchronizeFiles(ctx); err != nil {

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -149,7 +149,7 @@ func (up *upContext) checkForSystemErrors(ctx context.Context) {
 	defer oktetoLog.StopSpinner()
 
 	if up.Sy.IsLocalRunningOutOfSpace(ctx) {
-		oktetoLog.Warning("Your local disk is almost full. This can cause synchronization issues. Please free up some space to use Okteto.")
+		oktetoLog.Warning("Your local disk is almost full. Please free up some space to avoid synchronization issues.")
 	}
 }
 

--- a/cmd/up/syncthing.go
+++ b/cmd/up/syncthing.go
@@ -61,6 +61,9 @@ func (up *upContext) sync(ctx context.Context) error {
 		return err
 	}
 
+	// check for system errors
+	up.checkForSystemErrors(ctx)
+
 	startSyncFiles := time.Now()
 	if err := up.synchronizeFiles(ctx); err != nil {
 		return err
@@ -136,6 +139,21 @@ func (up *upContext) startSyncthing(ctx context.Context) error {
 	}
 
 	return up.Sy.WaitForConnected(ctx)
+}
+
+// checkForSystemErrors is called when syncthing is started to check for system errors (ie. available disk space is lower than 1%) and print a warning
+func (up *upContext) checkForSystemErrors(ctx context.Context) {
+	if up.Dev.IsHybridModeEnabled() {
+		return
+	}
+
+	oktetoLog.Spinner("Verifying synchronization errors...")
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
+
+	if up.Sy.IsLocalRunningOutOfSpace(ctx) {
+		oktetoLog.Warning("Your local disk is almost full. This can cause synchronization issues. Please free up some space to use Okteto.")
+	}
 }
 
 func (up *upContext) synchronizeFiles(ctx context.Context) error {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-316

If a user has very low available disk space (< 1%) syncthing is at risk of failing, therefore the `okteto up` sessions can result in a bad experence. 

With this PR we aim to inform the users that such scenario might happen, by warning them that their disk is almost full.

<img width="814" alt="Screenshot 2024-04-24 at 16 58 35" src="https://github.com/okteto/okteto/assets/2318450/0299c542-01ac-4abf-af64-8d0bcef9f090">



## How to validate

Similar to https://github.com/okteto/okteto/pull/4261

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
