### PR TITLE
fix: hash on untracked folders

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -464,7 +464,7 @@ func (ogr oktetoGitWorktree) ListUntrackedFiles(ctx context.Context, workdir str
 		return files, nil
 	}
 
-	untrackedFiles, err := localGit.ListUntrackedFiles(ctx, ogr.GetRoot(), 0)
+	untrackedFiles, err := localGit.ListUntrackedFiles(ctx, ogr.GetRoot(), workdir, 0)
 	if err != nil {
 		return []string{}, fmt.Errorf("failed to get untrackedFiles: %w", err)
 	}

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -304,8 +304,8 @@ func TestLocalGit_ListUntrackedFiles(t *testing.T) {
 	tests := []struct {
 		expectedErr   error
 		execMock      func() *mockLocalExec
-		expectedFiles []string
 		name          string
+		expectedFiles []string
 		fixAttempt    int
 	}{
 		{

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -302,11 +302,11 @@ func TestLocalGit_GetDirContentSHA(t *testing.T) {
 }
 func TestLocalGit_ListUntrackedFiles(t *testing.T) {
 	tests := []struct {
-		name          string
-		fixAttempt    int
+		expectedErr   error
 		execMock      func() *mockLocalExec
 		expectedFiles []string
-		expectedErr   error
+		name          string
+		fixAttempt    int
 	}{
 		{
 			name:       "success",

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -369,7 +369,7 @@ func TestLocalGit_ListUntrackedFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lg := NewLocalGit("git", tt.execMock())
-			files, err := lg.ListUntrackedFiles(context.Background(), "/test/dir", tt.fixAttempt)
+			files, err := lg.ListUntrackedFiles(context.Background(), "/test/dir", "/test", tt.fixAttempt)
 
 			assert.Equal(t, tt.expectedFiles, files)
 			assert.ErrorIs(t, err, tt.expectedErr)

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -300,3 +300,79 @@ func TestLocalGit_GetDirContentSHA(t *testing.T) {
 		})
 	}
 }
+func TestLocalGit_ListUntrackedFiles(t *testing.T) {
+	tests := []struct {
+		name          string
+		fixAttempt    int
+		execMock      func() *mockLocalExec
+		expectedFiles []string
+		expectedErr   error
+	}{
+		{
+			name:       "success",
+			fixAttempt: 0,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return []byte("file1.txt\nfile2.txt\nfile3.txt"), nil
+					},
+				}
+			},
+			expectedFiles: []string{"file1.txt", "file2.txt", "file3.txt"},
+			expectedErr:   nil,
+		},
+		{
+			name:       "failure - exit error",
+			fixAttempt: 0,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, &exec.ExitError{
+							Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+						}
+					},
+				}
+			},
+			expectedFiles: []string{},
+			expectedErr:   errLocalGitCannotGetStatusCannotRecover,
+		},
+		{
+			name:       "failure - fix attempt limit reached",
+			fixAttempt: 2,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, &exec.ExitError{
+							Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+						}
+					},
+				}
+			},
+			expectedFiles: []string{},
+			expectedErr:   errLocalGitCannotGetCommitTooManyAttempts,
+		},
+		{
+			name:       "failure - cannot recover",
+			fixAttempt: 1,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedFiles: []string{},
+			expectedErr:   errLocalGitCannotGetStatusCannotRecover,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.execMock())
+			files, err := lg.ListUntrackedFiles(context.Background(), "/test/dir", tt.fixAttempt)
+
+			assert.Equal(t, tt.expectedFiles, files)
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
+}

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -76,9 +76,10 @@ func (fr fakeRepository) calculateUntrackedFiles(ctx context.Context, contextDir
 }
 
 type fakeWorktree struct {
-	err    error
-	status oktetoGitStatus
-	root   string
+	err            error
+	status         oktetoGitStatus
+	root           string
+	untrackedFiles []string
 }
 
 func (fw fakeWorktree) GetRoot() string {
@@ -87,6 +88,10 @@ func (fw fakeWorktree) GetRoot() string {
 
 func (fw fakeWorktree) Status(context.Context, string, LocalGitInterface) (oktetoGitStatus, error) {
 	return fw.status, fw.err
+}
+
+func (fw fakeWorktree) ListUntrackedFiles(context.Context, string, LocalGitInterface) ([]string, error) {
+	return fw.untrackedFiles, fw.err
 }
 
 func TestNewRepo(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-231

- Use `git ls-files--others --exclude-standard` in order to get the files that are untracked. 
- Previous method was getting the folders and we were not iterating through them making it impossible to track if there was a file in a untracked folder

## How to validate

1. create a new dir `mkdir new-dir && cd new-dir`
1. Create the following `okteto.yml`:
```yaml
build:
  test-service:
    context: test
```
3. commit the file: `git init && git add . && git commit -m "initial commit"`
4. create the context folder `mkdir test`
5. Create the following `Dockerfile` inside:
```Dockerfile
FROM alpine
```
6. Create other files on the root of the project and check that it's not building
7. Create other files on the `test` folder and check that we are always returning the same order (I tested with 20 files and check that is only building the first time)

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
