### PR TITLE
Don't read nor persist OKTETO_ENV in test cmd

### DIFF
--- a/cmd/remoterun/command.go
+++ b/cmd/remoterun/command.go
@@ -39,7 +39,7 @@ func RemoteRun(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 
 	cmd.AddCommand(Deploy(ctx, k8sLogger))
 	cmd.AddCommand(Destroy(ctx))
-	cmd.AddCommand(Test(ctx, k8sLogger))
+	cmd.AddCommand(Test(ctx))
 	return cmd
 }
 

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -23,7 +23,6 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils/executor"
-	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/deployable"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
@@ -82,11 +81,6 @@ commands:
 				return fmt.Errorf("could not read information for tests: %w", err)
 			}
 
-			kubeClient, _, err := okteto.NewK8sClientProviderWithLogger(k8sLogger).ProvideWithLogger(okteto.GetContext().Cfg, k8sLogger)
-			if err != nil {
-				return fmt.Errorf("could not create kubernetes client: %s", err.Error())
-			}
-
 			// Set the default values for the external resources environment variables (endpoints)
 			for name, external := range dep.External {
 				external.SetDefaults(name)
@@ -95,22 +89,6 @@ commands:
 			runner := &deployable.TestRunner{
 				Executor: executor.NewExecutor(oktetoLog.GetOutputFormat(), false, ""),
 				Fs:       afero.NewOsFs(),
-				GetDevEnvEnviron: func(devEnvName, namespace string) (map[string]string, error) {
-					if devEnvName == "" {
-						return nil, nil
-					}
-					base64Json, err := pipeline.GetConfigmapDependencyEnv(ctx, devEnvName, namespace, kubeClient)
-					if err != nil {
-						return nil, err
-					}
-					return decodeBase64JSON(base64Json)
-				},
-				SetDevEnvEnviron: func(devEnvName, namespace string, vars []string) (err error) {
-					if devEnvName != "" {
-						err = pipeline.UpdateEnvs(ctx, devEnvName, namespace, vars, kubeClient)
-					}
-					return
-				},
 			}
 
 			os.Setenv(constants.OktetoNameEnvVar, options.Name)

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -32,9 +32,8 @@ import (
 
 // TestOptions flags accepted by the remote-run test command
 type TestOptions struct {
-	Name       string
-	DevEnvName string
-	Variables  []string
+	Name      string
+	Variables []string
 }
 
 // Test starts the test command remotely. This is the command executed in the
@@ -95,7 +94,6 @@ commands:
 				Namespace:  oktetoContext.GetCurrentNamespace(),
 				Deployable: dep,
 				Variables:  options.Variables,
-				DevEnvName: options.DevEnvName,
 			}
 
 			// Token should be always masked from the logs
@@ -114,7 +112,6 @@ commands:
 	}
 
 	cmd.Flags().StringVar(&options.Name, "name", "", "test run name")
-	cmd.Flags().StringVar(&options.DevEnvName, "devenv-name", "", "development environment name")
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
 	return cmd
 }

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -15,8 +15,6 @@ package remoterun
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -27,7 +25,6 @@ import (
 	"github.com/okteto/okteto/pkg/deployable"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -42,7 +39,7 @@ type TestOptions struct {
 
 // Test starts the test command remotely. This is the command executed in the
 // remote environment when running okteto test
-func Test(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
+func Test(ctx context.Context) *cobra.Command {
 	options := &TestOptions{}
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -120,14 +117,4 @@ commands:
 	cmd.Flags().StringVar(&options.DevEnvName, "devenv-name", "", "development environment name")
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
 	return cmd
-}
-
-func decodeBase64JSON(base64Str string) (data map[string]string, err error) {
-	b, err := base64.StdEncoding.DecodeString(base64Str)
-	if err != nil {
-		return nil, err
-	}
-	data = make(map[string]string)
-	err = json.Unmarshal(b, &data)
-	return
 }

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -32,7 +32,6 @@ type TestRunner struct {
 type TestParameters struct {
 	Name         string
 	Namespace    string
-	DevEnvName   string
 	Deployable   Entity
 	Variables    []string
 	ForceDestroy bool

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -24,8 +24,6 @@ import (
 type TestRunner struct {
 	Executor executor.ManifestExecutor
 	Fs       afero.Fs
-	// GetDevEnvEnviron func(devEnvName, namespace string) (map[string]string, error)
-	// SetDevEnvEnviron func(devEnvName, namespace string, vars []string) error
 }
 
 // TestParameters represents the parameters for destroying a remote entity

--- a/pkg/deployable/test_test.go
+++ b/pkg/deployable/test_test.go
@@ -40,9 +40,8 @@ func TestTestRunner(t *testing.T) {
 	executor.On("Execute", cmd1, expectedVars).Return(nil).Once()
 
 	err := runner.RunTest(TestParameters{
-		Name:       "test",
-		Namespace:  "ns",
-		DevEnvName: "deploy",
+		Name:      "test",
+		Namespace: "ns",
 		Deployable: Entity{
 			Commands: []model.DeployCommand{cmd1},
 		},

--- a/pkg/deployable/test_test.go
+++ b/pkg/deployable/test_test.go
@@ -26,15 +26,6 @@ func TestTestRunner(t *testing.T) {
 	runner := TestRunner{
 		Executor: executor,
 		Fs:       afero.NewMemMapFs(),
-		GetDevEnvEnviron: func(devEnvName, namespace string) (map[string]string, error) {
-			return map[string]string{
-				"DEPLOY_ENV_1": "deploy1",
-				"DEPLOY_ENV_2": "deploy2",
-			}, nil
-		},
-		SetDevEnvEnviron: func(devEnvName, namespace string, vars []string) error {
-			return nil
-		},
 	}
 
 	cmd1 := model.DeployCommand{
@@ -55,6 +46,7 @@ func TestTestRunner(t *testing.T) {
 		Deployable: Entity{
 			Commands: []model.DeployCommand{cmd1},
 		},
+		Variables: expectedVars,
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
As discuss, don't read not persist `OKTETO_ENV` in test commands. Each test section will have its own OKTETO_ENV and it won't inherit the dev environment environment.

Fixes https://okteto.atlassian.net/browse/DEV-325