### PR TITLE
Add targets to test command

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -66,14 +66,14 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 		Short:        "Run tests",
 		Hidden:       true,
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
 			stop := make(chan os.Signal, 1)
 			signal.Notify(stop, os.Interrupt)
 			exit := make(chan error, 1)
 
 			go func() {
 				startTime := time.Now()
-				metadata, err := doRun(ctx, options, ioCtrl, k8sLogger, &ProxyTracker{at})
+				metadata, err := doRun(ctx, servicesToTest, options, ioCtrl, k8sLogger, &ProxyTracker{at})
 				metadata.Err = err
 				metadata.Duration = time.Since(startTime)
 				at.TrackTest(metadata)
@@ -105,7 +105,7 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 	return cmd
 }
 
-func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, tracker *ProxyTracker) (analytics.TestMetadata, error) {
+func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, tracker *ProxyTracker) (analytics.TestMetadata, error) {
 	fs := afero.NewOsFs()
 
 	// Loads, updates and uses the context from path. If not found, it creates and uses a new context
@@ -189,6 +189,11 @@ func doRun(ctx context.Context, options *Options, ioCtrl *io.Controller, k8sLogg
 	}
 
 	tree, err := dag.From(nodes...)
+	if err != nil {
+		return analytics.TestMetadata{}, err
+	}
+
+	tree, err = tree.Subtree(servicesToTest...)
 	if err != nil {
 		return analytics.TestMetadata{}, err
 	}

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -309,7 +309,6 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		if err != nil {
 			return metadata, err
 		}
-		commandFlags = append(commandFlags, fmt.Sprintf("--devenv-name=%s", devenvName))
 
 		runner := remote.NewRunner(ioCtrl, buildCMD.NewOktetoBuilder(
 			&okteto.ContextStateless{

--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -33,6 +33,39 @@ type Tree struct {
 	graph *dag.DAG
 }
 
+func (tree *Tree) Subtree(nodeIds ...string) (*Tree, error) {
+	if len(nodeIds) < 1 {
+		return tree, nil
+	}
+
+	selection := make(map[string]Node)
+
+	for _, nodeId := range nodeIds {
+		nI, err := tree.graph.GetVertex(nodeId)
+		if err != nil {
+			return nil, err
+		}
+		// Add the node to the subnode list
+		selection[nodeId] = nI.(Node)
+
+		// resolve depends_on by getting nodes' ancestors
+		ancestor, err := tree.graph.GetAncestors(nodeId)
+		if err != nil {
+			return nil, err
+		}
+		for childID, nI := range ancestor {
+			selection[childID] = nI.(Node)
+		}
+	}
+
+	var subnodes []Node
+	for _, n := range selection {
+		subnodes = append(subnodes, n)
+	}
+
+	return From(subnodes...)
+}
+
 func (tree *Tree) Traverse(fn func(n Node)) {
 	tree.graph.OrderedWalk(callback(fn))
 }

--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -14,6 +14,8 @@
 package dag
 
 import (
+	"fmt"
+
 	"github.com/heimdalr/dag"
 )
 
@@ -46,7 +48,11 @@ func (tree *Tree) Subtree(nodeIds ...string) (*Tree, error) {
 			return nil, err
 		}
 		// Add the node to the subnode list
-		selection[nodeId] = nI.(Node)
+		n, ok := nI.(Node)
+		if !ok {
+			return nil, fmt.Errorf("fail to cast tree vertex to Node type")
+		}
+		selection[nodeId] = n
 
 		// resolve depends_on by getting nodes' ancestors
 		ancestor, err := tree.graph.GetAncestors(nodeId)
@@ -54,7 +60,11 @@ func (tree *Tree) Subtree(nodeIds ...string) (*Tree, error) {
 			return nil, err
 		}
 		for childID, nI := range ancestor {
-			selection[childID] = nI.(Node)
+			n, ok := nI.(Node)
+			if !ok {
+				return nil, fmt.Errorf("fail to cast tree vertex to Node type")
+			}
+			selection[childID] = n
 		}
 	}
 

--- a/pkg/dag/dag_test.go
+++ b/pkg/dag/dag_test.go
@@ -152,3 +152,67 @@ func TestTraverse(t *testing.T) {
 		})
 	}
 }
+
+func TestSubtree(t *testing.T) {
+	v99 := &testNode{id: "v99"}
+	v4 := &testNode{id: "v4", dependsOn: []string{"v3"}}
+	v3 := &testNode{id: "v3", dependsOn: []string{"v2"}}
+	v2 := &testNode{id: "v2", dependsOn: []string{"v1"}}
+	v1 := &testNode{id: "v1", dependsOn: []string{"v0"}}
+	v0 := &testNode{id: "v0"}
+
+	tree, err := From(v99, v4, v3, v2, v1, v0)
+	require.NoError(t, err)
+
+	tt := []struct {
+		name     string
+		subnodes []string
+		expected []string
+	}{
+		{
+			name:     "orphans",
+			subnodes: []string{"v99", "v0"},
+			expected: []string{"v99", "v0"},
+		},
+		{
+			name:     "nested1",
+			subnodes: []string{"v99", "v1"},
+			expected: []string{"v99", "v1", "v0"},
+		},
+		{
+			name:     "nested2",
+			subnodes: []string{"v99", "v2"},
+			expected: []string{"v99", "v2", "v1", "v0"},
+		},
+		{
+			name:     "nested3",
+			subnodes: []string{"v99", "v3"},
+			expected: []string{"v99", "v3", "v2", "v1", "v0"},
+		},
+		{
+			name:     "nested4",
+			subnodes: []string{"v99", "v4"},
+			expected: []string{"v99", "v4", "v3", "v2", "v1", "v0"},
+		},
+		{
+			name:     "all_no_orphan",
+			subnodes: []string{"v4"},
+			expected: []string{"v4", "v3", "v2", "v1", "v0"},
+		},
+		{
+			name:     "half",
+			subnodes: []string{"v2"},
+			expected: []string{"v2", "v1", "v0"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			subtree, err := tree.Subtree(tc.subnodes...)
+			require.NoError(t, err)
+			result := subtree.Ordered()
+			require.Len(t, result, len(tc.expected))
+			require.ElementsMatch(t, result, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
Allow to select tests when running `okteto test`:

```bash
okteto test unit integration ...
```

This is a bit trickier than in sounds given that we need to follow the `depends_on` field. In this case, for example, when I run `okteto test unit` the _setup_ target should also get executed as a prerequisite of _unit_:


```yaml
test:
  setup:
    image: okteto/golang:1
    commands:
      - "echo this is my test setup"
  unit:
    depends_on:
      - setup
    image: okteto/golang:1
    commands:
      - "go test . -v"
  integration:
    depends_on:
      - setup
    context: integration
    commands:
      - "./run-tests.sh"
```