### PR TITLE
fix: dont include dockerfilepath for hash calculation

### DIFF
--- a/cmd/build/v2/environment_test.go
+++ b/cmd/build/v2/environment_test.go
@@ -125,7 +125,7 @@ func TestExpandStackVariables(t *testing.T) {
 		isOkteto: true,
 	}
 
-	err := registry.AddImageByName("okteto.global/test-test:5f2d51f7ce48b2d3396d2a38c8e7f2010234d3e6c2c17566f93f9c27532037d5")
+	err := registry.AddImageByName("okteto.global/test-test:a32545ef109a8f1e44b67b9c90727db563e88c5898c228bdb922ce555cec2856")
 	require.NoError(t, err)
 	bc := NewFakeBuilder(builder, registry, fakeConfig)
 	stack := &model.Stack{

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -146,7 +146,6 @@ func (sh *serviceHasher) hash(buildInfo *build.Info, commitHash string, diff str
 	fmt.Fprintf(&b, "build_args:%s;", argsText)
 	fmt.Fprintf(&b, "secrets:%s;", secretsText)
 	fmt.Fprintf(&b, "context:%s;", buildInfo.Context)
-	fmt.Fprintf(&b, "dockerfile:%s;", buildInfo.Dockerfile)
 	fmt.Fprintf(&b, "dockerfile_content:%s;", sh.getDockerfileContent(buildInfo.Context, buildInfo.Dockerfile))
 	fmt.Fprintf(&b, "diff:%s;", diff)
 	fmt.Fprintf(&b, "image:%s;", buildInfo.Image)

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -35,7 +35,7 @@ func TestServiceHasher_HashProjectCommit(t *testing.T) {
 			repoCtrl: fakeConfigRepo{
 				sha: "testsha",
 			},
-			expectedHash: "cf0ff0bb100ae8a121de62276a5004349dcd6b349ceaecb3ba75ac344152dbe0",
+			expectedHash: "832d66070268d5a47860e9bd4402f504a1c0fe8d0c2dc1ecf814af610de72f0e",
 			expectedErr:  nil,
 		},
 		{
@@ -71,14 +71,14 @@ func TestServiceHasher_HashBuildContext(t *testing.T) {
 			repoCtrl: fakeConfigRepo{
 				sha: "testtreehash",
 			},
-			expectedHash: "52d0cacde546dd525296ab1893ea73b08e3033538c235ef3ac0a451aa6810ef0",
+			expectedHash: "b6f9d71cf55933c6e385102e196522fd73c279c1edaa919b565706fb0bc3d8ce",
 		},
 		{
 			name: "error",
 			repoCtrl: fakeConfigRepo{
 				err: fakeErr,
 			},
-			expectedHash: "cf48b78ffb42fc6141950268bc89a13add4ae1efc92c9fa9342ce5d6b8cb6901",
+			expectedHash: "11cf9a064fe9b8419441515afbc33d22257ce11269ecbea211575f8cf4a33fac",
 		},
 	}
 

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -292,7 +292,7 @@ func Test_getBuildHashFromCommit(t *testing.T) {
 					Image:      "image",
 				},
 			},
-			expected: "commit:1234567890;target:target;build_args:foo=bar;key=value;secrets:secret=secret;context:context;dockerfile:dockerfile;dockerfile_content:;diff:;image:image;",
+			expected: "commit:1234567890;target:target;build_args:foo=bar;key=value;secrets:secret=secret;context:context;dockerfile_content:;diff:;image:image;",
 		},
 		{
 			name: "invalid commit",
@@ -367,7 +367,7 @@ func Test_getBuildHashFromCommit(t *testing.T) {
 					Image:      "image",
 				},
 			},
-			expected: "commit:123;target:target;build_args:foo=bar;secrets:secret=secret;context:context;dockerfile:dockerfile;dockerfile_content:;diff:;image:image;",
+			expected: "commit:123;target:target;build_args:foo=bar;secrets:secret=secret;context:context;dockerfile_content:;diff:;image:image;",
 		},
 	}
 	for _, tc := range tt {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-321

## How to validate

1. Create the following `okteto.yml`:
```yaml
services:
  nginx:
    image: nginx
    volumes: 
    - proxy:/etc/nginx/conf.d
```
2. Check that `okteto build`  builds
3. Check that `okteto build` uses the smart build logic

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
