### PR TITLE
tests(fix): remove defer on tests

### DIFF
--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -130,7 +130,6 @@ func TestBuildCommandV1(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedImage := fmt.Sprintf("%s/%s/test:okteto", okteto.GetContext().Registry, testNamespace)
 	require.False(t, isImageBuilt(expectedImage))
@@ -145,6 +144,7 @@ func TestBuildCommandV1(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedImage))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestBuildInferredDockerfile tests the following scenario:
@@ -165,7 +165,6 @@ func TestBuildInferredDockerfile(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedImage := fmt.Sprintf("%s/%s/test:okteto", okteto.GetContext().Registry, testNamespace)
 	require.False(t, isImageBuilt(expectedImage))
@@ -179,6 +178,7 @@ func TestBuildInferredDockerfile(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedImage))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestBuildCommandV2 tests the following scenario:
@@ -199,7 +199,6 @@ func TestBuildCommandV2(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedAppImage))
@@ -217,6 +216,7 @@ func TestBuildCommandV2(t *testing.T) {
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedAppImage))
 	require.True(t, isImageBuilt(expectedApiImage))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestBuildCommandV2UsingDepot tests the following scenario:
@@ -238,7 +238,6 @@ func TestBuildCommandV2UsingDepot(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedAppImage))
@@ -272,6 +271,7 @@ func TestBuildCommandV2UsingDepot(t *testing.T) {
 	require.NoError(t, commands.ExecOktetoBuildCmd(cmd))
 	require.True(t, isImageBuilt(expectedAppImage))
 	require.True(t, isImageBuilt(expectedApiImage))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestBuildCommandV2OnlyOneService tests the following scenario:
@@ -293,7 +293,6 @@ func TestBuildCommandV2OnlyOneService(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedImage))
@@ -308,6 +307,7 @@ func TestBuildCommandV2OnlyOneService(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedImage))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestBuildCommandV2SpecifyingServices tests the following scenario:
@@ -329,7 +329,6 @@ func TestBuildCommandV2SpecifyingServices(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedAppImage))
@@ -348,6 +347,7 @@ func TestBuildCommandV2SpecifyingServices(t *testing.T) {
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedAppImage))
 	require.True(t, isImageBuilt(expectedApiImage))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestBuildCommandV2FromCompose tests the following scenario:
@@ -368,7 +368,6 @@ func TestBuildCommandV2FromCompose(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedBuildImage := fmt.Sprintf("%s/%s/%s-vols:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedBuildImage))
@@ -381,6 +380,7 @@ func TestBuildCommandV2FromCompose(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedBuildImage), "%s not found", expectedBuildImage)
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestBuildCommandV2FromCompose tests the following scenario:
@@ -407,7 +407,6 @@ func TestBuildCommandV2WithVolumeMounts(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedBuildImage := fmt.Sprintf("%s/%s/%s-nginx:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedBuildImage))
@@ -420,6 +419,7 @@ func TestBuildCommandV2WithVolumeMounts(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedBuildImage), "%s not found", expectedBuildImage)
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestTestBuildCommandV2Secrets tests the following scenario:
@@ -442,7 +442,6 @@ func TestBuildCommandV2Secrets(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	expectedBuildImage := fmt.Sprintf("%s/%s/%s-test:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedBuildImage))
@@ -456,6 +455,7 @@ func TestBuildCommandV2Secrets(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
 	require.True(t, isImageBuilt(expectedBuildImage), "%s not found", expectedBuildImage)
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createDockerfile(dir string) error {

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -233,7 +233,6 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -302,6 +301,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployPipelineFromComposeWithVolumeMounts tests the following scenario:
@@ -334,7 +334,6 @@ func TestDeployPipelineFromComposeWithVolumeMounts(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -403,6 +402,7 @@ func TestDeployPipelineFromComposeWithVolumeMounts(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestReDeployPipelineFromCompose tests the following scenario:
@@ -426,7 +426,6 @@ func TestReDeployPipelineFromCompose(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -485,6 +484,7 @@ func TestReDeployPipelineFromCompose(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployPipelineFromComposeOnlyOneSvc tests the following scenario:
@@ -507,7 +507,6 @@ func TestDeployPipelineFromComposeOnlyOneSvc(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -545,6 +544,7 @@ func TestDeployPipelineFromComposeOnlyOneSvc(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployPipelineFromOktetoStacks tests the following scenario:
@@ -568,7 +568,6 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -620,6 +619,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployPipelineFromCompose tests the following scenario:
@@ -644,7 +644,6 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -700,6 +699,7 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "nginx", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 func TestComposeDependsOnNonExistingService(t *testing.T) {
 	t.Parallel()
@@ -726,7 +726,6 @@ services:
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -748,6 +747,7 @@ services:
 	output, err = commands.GetOktetoDeployCmdOutput(oktetoPath, deployOptionsWithFile)
 	require.Error(t, err)
 	require.Contains(t, strings.ToLower(string(output)), "invalid depends_on: service 'app' depends on service 'nginx' which is undefined")
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createComposeScenario(dir string) error {

--- a/integration/deploy/endpoints_test.go
+++ b/integration/deploy/endpoints_test.go
@@ -295,7 +295,6 @@ func Test_EndpointsFromStackWith_InferredName(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
-	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createStackWithEndpointsInferredNameScenario(dir string) error {

--- a/integration/deploy/endpoints_test.go
+++ b/integration/deploy/endpoints_test.go
@@ -156,7 +156,6 @@ func Test_EndpointsFromOktetoManifest_InferredName(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -187,6 +186,7 @@ func Test_EndpointsFromOktetoManifest_InferredName(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createEndpointsFromOktetoManifestInferredName(dir string) error {
@@ -219,7 +219,6 @@ func Test_EndpointsFromOktetoManifest_Name(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	deployOptions := &commands.DeployOptions{
@@ -245,6 +244,7 @@ func Test_EndpointsFromOktetoManifest_Name(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createEndpointsFromOktetoManifestName(dir string) error {
@@ -274,7 +274,6 @@ func Test_EndpointsFromStackWith_InferredName(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	deployOptions := &commands.DeployOptions{
@@ -296,6 +295,7 @@ func Test_EndpointsFromStackWith_InferredName(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createStackWithEndpointsInferredNameScenario(dir string) error {
@@ -344,7 +344,6 @@ func Test_EndpointsFromStack_Name(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	deployOptions := &commands.DeployOptions{
@@ -365,6 +364,7 @@ func Test_EndpointsFromStack_Name(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createStackWithEndpointsNameScenario(dir string) error {
@@ -414,7 +414,6 @@ func Test_EndpointsFromStackAndManifest(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	deployOptions := &commands.DeployOptions{
@@ -435,6 +434,7 @@ func Test_EndpointsFromStackAndManifest(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // Test_EndpointsFromOktetoManifest_NameOption tests the following scenario:
@@ -458,7 +458,6 @@ func Test_EndpointsFromOktetoManifest_NameOption(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -490,6 +489,7 @@ func Test_EndpointsFromOktetoManifest_NameOption(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // Test_EndpointsFromStackWithEndpoints_InferredName tests the following scenario:
@@ -510,7 +510,6 @@ func Test_EndpointsFromStackWith_NameOption(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	deployOptions := &commands.DeployOptions{
@@ -533,4 +532,5 @@ func Test_EndpointsFromStackWith_NameOption(t *testing.T) {
 		Name:       "my test",
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/deploy/external_test.go
+++ b/integration/deploy/external_test.go
@@ -66,7 +66,6 @@ func Test_ExternalsFromOktetoManifestWithNotesContent(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	deployOptions := &commands.DeployOptions{
@@ -115,6 +114,7 @@ func Test_ExternalsFromOktetoManifestWithNotesContent(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createExternalNotes(dir string) error {

--- a/integration/deploy/helm_test.go
+++ b/integration/deploy/helm_test.go
@@ -110,7 +110,6 @@ func TestDeployPipelineFromHelm(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -133,6 +132,7 @@ func TestDeployPipelineFromHelm(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployFromHelmNameOK tests the following scenario:
@@ -154,7 +154,6 @@ func TestDeployFromHelmNameOK(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -179,6 +178,7 @@ func TestDeployFromHelmNameOK(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createHelmChart(dir string) error {

--- a/integration/deploy/k8s_manifest_test.go
+++ b/integration/deploy/k8s_manifest_test.go
@@ -96,7 +96,6 @@ func TestDeployDevEnvFromK8s(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -120,4 +119,5 @@ func TestDeployDevEnvFromK8s(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -132,7 +132,6 @@ func TestDeployOktetoManifest(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -163,6 +162,7 @@ func TestDeployOktetoManifest(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployOktetoManifest tests the following scenario:
@@ -186,7 +186,6 @@ func TestRedeployOktetoManifestForImages(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -234,6 +233,7 @@ func TestRedeployOktetoManifestForImages(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployOktetoManifestWithDestroy tests the following scenario:
@@ -258,7 +258,6 @@ func TestDeployOktetoManifestWithDestroy(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -298,6 +297,7 @@ func TestDeployOktetoManifestWithDestroy(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployOktetoManifestExportCache tests the following scenario:
@@ -316,7 +316,6 @@ func TestDeployOktetoManifestExportCache(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -345,6 +344,7 @@ func TestDeployOktetoManifestExportCache(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployRemoteOktetoManifest tests the following scenario:
@@ -363,7 +363,6 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -401,6 +400,7 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 
 	_, err = integration.GetDeployment(context.Background(), testNamespace, "my-dep", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployRemoteOktetoManifest tests the following scenario:
@@ -420,7 +420,6 @@ func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -451,6 +450,7 @@ func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
 
 	_, err = integration.GetDeployment(context.Background(), testNamespace, "my-dep", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func isImageBuilt(image string) bool {

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -64,7 +64,6 @@ func TestDeployPipelineManifest(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -89,7 +88,7 @@ func TestDeployPipelineManifest(t *testing.T) {
 
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
-
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployPipelineManifestInsidePipeline tests the following scenario:
@@ -109,7 +108,6 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -152,6 +150,7 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	// Check that the e2etest service is not running
 	_, err = integration.GetService(context.Background(), testNamespace, "e2etest", c)
 	require.True(t, k8sErrors.IsNotFound(err))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createPipelineInsidePipelineManifest(dir, oktetoPath, namespace string) error {

--- a/integration/deploy/variables_test.go
+++ b/integration/deploy/variables_test.go
@@ -66,7 +66,6 @@ func TestDeployAndDestroyOktetoManifestWithEnv(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -108,4 +107,5 @@ func TestDeployAndDestroyOktetoManifestWithEnv(t *testing.T) {
 
 	require.Equal(t, true, strings.Contains(o, "DESTROY_MASKED_VAR=***"))
 	require.Equal(t, true, strings.Contains(o, "DESTROY_UNMASKED_SHORT_VAR=false"))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/deprecated/push/push_test.go
+++ b/integration/deprecated/push/push_test.go
@@ -99,7 +99,6 @@ func TestPush(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -118,7 +117,7 @@ func TestPush(t *testing.T) {
 
 	imageName := fmt.Sprintf("registry.%s/%s/push-test:okteto", appsSubdomain, testNamespace)
 	require.Equal(t, imageName, d.Spec.Template.Spec.Containers[0].Image)
-
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createDockerfile(dir string) error {

--- a/integration/deprecated/stack/compose_test.go
+++ b/integration/deprecated/stack/compose_test.go
@@ -121,7 +121,6 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -164,6 +163,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestDeployPipelineFromOktetoStacks tests the following scenario:
@@ -187,7 +187,6 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -216,6 +215,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoStackDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createStacksScenario(dir string) error {

--- a/integration/okteto/autowake_test.go
+++ b/integration/okteto/autowake_test.go
@@ -175,7 +175,6 @@ func TestAutoWakeFromURL(t *testing.T) {
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	// Prepare test environment
 	require.NoError(t, writeDeployment(dir))
@@ -214,7 +213,7 @@ func TestAutoWakeFromURL(t *testing.T) {
 	// Wake resources from url
 	require.NotEmpty(t, integration.GetContentFromURL(autowakeURL, timeout))
 	require.NoError(t, waitUntilUpdatedContent(autowakeURL, "test", timeout))
-
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestAutoWakeFromURL tests the following scenario:
@@ -239,7 +238,6 @@ func TestAutoWakeFromRunningUp(t *testing.T) {
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	// Prepare test environment
 	require.NoError(t, writeDeployment(dir))
@@ -291,6 +289,7 @@ func TestAutoWakeFromRunningUp(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDown(oktetoPath, downOpts))
 	require.True(t, commands.HasUpCommandFinished(upCommand.Pid.Pid))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func writeDeployment(dir string) error {

--- a/integration/okteto/build_test.go
+++ b/integration/okteto/build_test.go
@@ -59,7 +59,6 @@ func TestBuildReplaceSecretsInManifest(t *testing.T) {
 	}
 
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	options := &commands.BuildOptions{
 		Workdir:    dir,
@@ -69,6 +68,7 @@ func TestBuildReplaceSecretsInManifest(t *testing.T) {
 	}
 
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, options))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createDockerfile(dir string) error {

--- a/integration/okteto/dependencies_test.go
+++ b/integration/okteto/dependencies_test.go
@@ -79,7 +79,6 @@ func TestDependencies(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
@@ -99,7 +98,7 @@ func TestDependencies(t *testing.T) {
 
 	contentURL := fmt.Sprintf("https://movies-%s.%s", testDeployNamespace, appsSubdomain)
 	require.NotEmpty(t, integration.GetContentFromURL(contentURL, timeout))
-
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestDependenciesOnRemote(t *testing.T) {
@@ -125,7 +124,6 @@ func TestDependenciesOnRemote(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
@@ -145,7 +143,7 @@ func TestDependenciesOnRemote(t *testing.T) {
 
 	contentURL := fmt.Sprintf("https://movies-%s.%s", testDeployNamespace, appsSubdomain)
 	require.NotEmpty(t, integration.GetContentFromURL(contentURL, timeout))
-
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createDependenciesManifest(dir, namespace, manifest string) error {

--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -106,7 +106,6 @@ func TestDeploySuccessOutput(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -151,8 +150,8 @@ func TestDeploySuccessOutput(t *testing.T) {
 				t.Fatalf("Not sending build output on stage %s. Output:%s", ss, stageLines[ss])
 			}
 		}
-
 	}
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestDeployWithNonSanitizedOK(t *testing.T) {
@@ -172,7 +171,6 @@ func TestDeployWithNonSanitizedOK(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -187,7 +185,7 @@ func TestDeployWithNonSanitizedOK(t *testing.T) {
 	require.NoError(t, err)
 	_, err = integration.GetConfigmap(context.Background(), testNamespace, fmt.Sprintf("okteto-git-%s", "test-my-deployment"), c)
 	require.NoError(t, err)
-
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestCmdFailOutput(t *testing.T) {
@@ -207,7 +205,6 @@ func TestCmdFailOutput(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -253,6 +250,7 @@ func TestCmdFailOutput(t *testing.T) {
 			t.Fatalf("deploy didn't have the stage '%s'", ss)
 		}
 	}
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestRemoteMaskVariables(t *testing.T) {
@@ -272,7 +270,6 @@ func TestRemoteMaskVariables(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -360,6 +357,7 @@ func TestRemoteMaskVariables(t *testing.T) {
 	if !found {
 		t.Fatal("destroy does not have the expected output.")
 	}
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestComposeFailOutput(t *testing.T) {
@@ -379,7 +377,6 @@ func TestComposeFailOutput(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
@@ -425,6 +422,7 @@ func TestComposeFailOutput(t *testing.T) {
 			t.Fatalf("deploy didn't have the stage '%s'", ss)
 		}
 	}
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createCommandWitMaskValuesManifest(dir string) error {

--- a/integration/okteto/pipeline_test.go
+++ b/integration/okteto/pipeline_test.go
@@ -49,7 +49,6 @@ func TestPipelineCommand(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	pipelineOptions := &commands.DeployPipelineOptions{
 		Namespace:  testNamespace,
@@ -71,6 +70,7 @@ func TestPipelineCommand(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoPipelineDestroy(oktetoPath, pipelineDestroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestPipelineDeployWithReuse(t *testing.T) {
@@ -87,7 +87,6 @@ func TestPipelineDeployWithReuse(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
@@ -128,5 +127,5 @@ func TestPipelineDeployWithReuse(t *testing.T) {
 
 	require.Contains(t, cmapRedeploy.Labels, "label.okteto.com/test-label")
 	require.Equal(t, cmap.CreationTimestamp, cmapRedeploy.CreationTimestamp)
-
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/up/autocreate_test.go
+++ b/integration/up/autocreate_test.go
@@ -102,7 +102,6 @@ func TestUpAutocreate(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -174,6 +173,7 @@ func TestUpAutocreate(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDown(oktetoPath, downOpts))
 
 	require.True(t, commands.HasUpCommandFinished(upResult.Pid.Pid))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestUpAutocreateV2(t *testing.T) {
@@ -190,7 +190,6 @@ func TestUpAutocreateV2(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -262,6 +261,7 @@ func TestUpAutocreateV2(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDown(oktetoPath, downOpts))
 
 	require.True(t, commands.HasUpCommandFinished(upResult.Pid.Pid))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestUpAutocreateV2WithBuild(t *testing.T) {
@@ -278,7 +278,6 @@ func TestUpAutocreateV2WithBuild(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -352,4 +351,5 @@ func TestUpAutocreateV2WithBuild(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDown(oktetoPath, downOpts))
 
 	require.True(t, commands.HasUpCommandFinished(upResult.Pid.Pid))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/up/compose_test.go
+++ b/integration/up/compose_test.go
@@ -89,7 +89,6 @@ func TestUpCompose(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	indexPath := filepath.Join(dir, "index.html")
@@ -169,6 +168,7 @@ func TestUpCompose(t *testing.T) {
 
 	// Test that original hasn't change
 	require.NoError(t, compareDeployment(context.Background(), originalDeployment, c))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createAppDockerfile(dir string) error {

--- a/integration/up/deploy_remote_test.go
+++ b/integration/up/deploy_remote_test.go
@@ -66,7 +66,6 @@ func TestUpWithDeployRemote(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -139,4 +138,5 @@ func TestUpWithDeployRemote(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDown(oktetoPath, downOpts))
 
 	require.True(t, commands.HasUpCommandFinished(upResult.Pid.Pid))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/up/deploy_test.go
+++ b/integration/up/deploy_test.go
@@ -19,11 +19,12 @@ package up
 import (
 	"context"
 	"fmt"
-	"github.com/okteto/okteto/pkg/log/io"
 	"log"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/okteto/okteto/pkg/log/io"
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
@@ -67,7 +68,6 @@ func TestUpWithDeploy(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -142,6 +142,7 @@ func TestUpWithDeploy(t *testing.T) {
 	k8sLogs, err := os.ReadFile(k8sLogsFilePath)
 	require.NoError(t, err)
 	require.Contains(t, string(k8sLogs), fmt.Sprintf("running cmd: up --deploy=true --namespace=%s", testNamespace))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func getImageWithSHA(devImage string) string {

--- a/integration/up/deployment_test.go
+++ b/integration/up/deployment_test.go
@@ -123,7 +123,6 @@ func TestUpDeploymentV1(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -221,6 +220,7 @@ func TestUpDeploymentV1(t *testing.T) {
 
 	// Test that original hasn't change
 	require.NoError(t, compareDeployment(context.Background(), originalDeployment, c))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestUpDeploymentV2(t *testing.T) {
@@ -237,7 +237,6 @@ func TestUpDeploymentV2(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -335,6 +334,7 @@ func TestUpDeploymentV2(t *testing.T) {
 
 	// Test that original hasn't change
 	require.NoError(t, compareDeployment(context.Background(), originalDeployment, c))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func compareDeployment(ctx context.Context, deployment *appsv1.Deployment, c kubernetes.Interface) error {

--- a/integration/up/globalforward_test.go
+++ b/integration/up/globalforward_test.go
@@ -104,7 +104,6 @@ func TestUpGlobalForwarding(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
 	require.NoError(t, writeFile(filepath.Join(dir, "docker-compose.yml"), globalForwardCompose))
@@ -180,4 +179,5 @@ func TestUpGlobalForwarding(t *testing.T) {
 	require.Equal(t, integration.GetContentFromURL(svc1LocalEndpoint, 20*time.Second), "")
 	require.Equal(t, integration.GetContentFromURL(svc2LocalEndpoint, 5*time.Second), "")
 	require.Equal(t, integration.GetContentFromURL(svc3LocalEndpoint, 5*time.Second), "")
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -18,15 +18,16 @@ package up
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 const (
@@ -110,7 +111,6 @@ func TestUpUsingHybridMode(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -161,4 +161,5 @@ func TestUpUsingHybridMode(t *testing.T) {
 		Token:     token,
 	}
 	require.NoError(t, commands.RunOktetoDown(oktetoPath, down1Opts))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/up/statefulset_test.go
+++ b/integration/up/statefulset_test.go
@@ -122,7 +122,6 @@ func TestUpStatefulsetV1(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -219,6 +218,7 @@ func TestUpStatefulsetV1(t *testing.T) {
 
 	// Test that original hasn't change
 	require.NoError(t, compareStatefulSet(context.Background(), originalStatefulSet, c))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func TestUpStatefulsetV2(t *testing.T) {
@@ -235,7 +235,6 @@ func TestUpStatefulsetV2(t *testing.T) {
 		Token:      token,
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	defer commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts)
 	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
@@ -332,6 +331,7 @@ func TestUpStatefulsetV2(t *testing.T) {
 
 	// Test that original hasn't change
 	require.NoError(t, compareStatefulSet(context.Background(), originalStatefulSet, c))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func compareStatefulSet(ctx context.Context, deployment *appsv1.StatefulSet, c kubernetes.Interface) error {


### PR DESCRIPTION
# Proposed changes

Fixes Make explicit call to remove namespace. We have a bug that the defer was not executed on the last tests, leaving a namespace without deleting.

This change has one side effect. Now the tests that fails will not remove the ns that fails in order to look into it

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
