### PR TITLE
fix: exec args retrieval

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -41,10 +41,9 @@ import (
 
 // execFlags is the input of the user to exec command
 type execFlags struct {
-	manifestPath     string
-	namespace        string
-	k8sContext       string
-	commandToExecute []string
+	manifestPath string
+	namespace    string
+	k8sContext   string
 }
 
 // Exec executes a command on the CND container

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -90,57 +90,49 @@ func TestGetDevFromArgs(t *testing.T) {
 
 func TestGetCommandFromArgs(t *testing.T) {
 	tests := []struct {
-		name         string
-		manifest     *model.Manifest
-		args         []string
-		expectedArgs []string
+		name        string
+		devs        model.ManifestDevs
+		args        []string
+		expectedCmd string
 	}{
 		{
 			name: "first arg is on dev section",
-			manifest: &model.Manifest{
-				Dev: model.ManifestDevs{
-					"autocreate": &model.Dev{},
-				},
+			devs: model.ManifestDevs{
+				"autocreate": &model.Dev{},
 			},
-			args:         []string{"autocreate", "sh"},
-			expectedArgs: []string{"sh"},
+			args:        []string{"autocreate", "sh"},
+			expectedCmd: "sh",
 		},
 		{
 			name: "only one argument/same name as dev",
-			manifest: &model.Manifest{
-				Dev: model.ManifestDevs{
-					"sh": &model.Dev{},
-				},
+			devs: model.ManifestDevs{
+				"sh": &model.Dev{},
 			},
-			args:         []string{"sh"},
-			expectedArgs: []string{"sh"},
+			args:        []string{"sh"},
+			expectedCmd: "sh",
 		},
 		{
 			name: "several argument/first argument same name as dev",
-			manifest: &model.Manifest{
-				Dev: model.ManifestDevs{
-					"sh": &model.Dev{},
-				},
+			devs: model.ManifestDevs{
+				"sh": &model.Dev{},
 			},
-			args:         []string{"sh", "autocreate"},
-			expectedArgs: []string{"autocreate"},
+			args:        []string{"sh", "autocreate"},
+			expectedCmd: "autocreate",
 		},
 		{
 			name: "dev is not found ",
-			manifest: &model.Manifest{
-				Dev: model.ManifestDevs{
-					"api":       &model.Dev{},
-					"other-dev": &model.Dev{},
-				},
+			devs: model.ManifestDevs{
+				"api":       &model.Dev{},
+				"other-dev": &model.Dev{},
 			},
-			args:         []string{"not-api", "autocreate"},
-			expectedArgs: []string{"not-api", "autocreate"},
+			args:        []string{"not-api", "autocreate"},
+			expectedCmd: "not-api autocreate",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			dev := getCommandToRunFromArgs(tt.manifest, tt.args)
-			assert.Equal(t, tt.expectedArgs, dev)
+			dev := getCommandToRunFromArgs(tt.devs, tt.args)
+			assert.Equal(t, tt.expectedCmd, dev)
 		})
 	}
 }

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -90,10 +90,10 @@ func TestGetDevFromArgs(t *testing.T) {
 
 func TestGetCommandFromArgs(t *testing.T) {
 	tests := []struct {
-		name        string
 		devs        model.ManifestDevs
-		args        []string
+		name        string
 		expectedCmd string
+		args        []string
 	}{
 		{
 			name: "first arg is on dev section",


### PR DESCRIPTION
# Proposed changes

Fixes DEV-327

- Modify the function to return a string instead of a list of strings. This makes the executor execute the command correctly
- Modify the test in order to get only the part that is needed

With this change both use cases works:
![Screenshot 2024-04-30 at 16 22 13](https://github.com/okteto/okteto/assets/25170843/878eb349-040a-4349-b1b1-2606b58fcc01)


## How to validate

1. Run okteto exec api -- echo "this is a test"
2. See that it's printing this is a test
3. Run okteto exec api -- "echo this is a test"
4. See that it's printing this is a test

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
