### PR TITLE
Add test action to CLI release

### DIFF
--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -70,6 +70,7 @@
                 destroy-stack
                 apply
                 context
+                test
         )
 
         for repo in "${repos[@]}"; do

--- a/scripts/set_latest_actions.sh
+++ b/scripts/set_latest_actions.sh
@@ -22,6 +22,7 @@ actionsRepos=(delete-namespace
         destroy-stack
         apply
         context
+        test
 )
 
 for repo in "${actionsRepos[@]}"; do


### PR DESCRIPTION
Add https://github.com/okteto/test to the list of github action to release as part of the CLI release. The script will automatically create the `v2` and the current cli release version.