### PR TITLE
fix: not show unwanted warning

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -154,8 +154,13 @@ func Build(ctx context.Context, ioCtrl *io.Controller, at, insights buildTracker
 //   - If the manifest is found and it is a V2 manifest and the build section has some image, the builder is V2
 //   - If the manifest is found and it is a V1 manifest or the build section is empty, the builder fallsback to V1
 func (bc *Command) getBuilder(options *types.BuildOptions, okCtx *okteto.ContextStateless) (Builder, error) {
-	var builder Builder
+	// the file flag is a Dockerfile
+	isDockerfileValid := validateDockerfile(options.File) == nil
+	if options.File != "" && isDockerfileValid {
+		return buildv1.NewBuilder(bc.Builder, bc.ioCtrl), nil
+	}
 
+	var builder Builder
 	manifest, err := bc.GetManifest(options.File, afero.NewOsFs())
 	if err != nil {
 		if options.File != "" && errors.Is(err, oktetoErrors.ErrInvalidManifest) && validateDockerfile(options.File) != nil {


### PR DESCRIPTION
# Proposed changes

While doing the release manual testing we discovered that there was an unwanted warning caused by https://github.com/okteto/okteto/pull/4254

Given the current implementation the only way to not show that warning was to calculate if the file was a Dockerfile before checking if it was an okteto manifest or a compose/stack file.



## How to validate

1. Run `okteto build -f Dockerfile` on a file that is a valid Dockerfile and check that the warning is not shown

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
