### PR TITLE
fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ linters-settings:
       regexp:
         YEAR: 2023|2024
     template-path: .copyright-header.tmpl
-  gomnd:
+  mnd:
     checks:
       - argument
       - case
@@ -84,7 +84,7 @@ linters:
     - decorder
     - exportloopref
     - makezero
-    - gomnd
+    - mnd
     - musttag
     - bodyclose
     - durationcheck

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 
 .PHONY: lint-fix
 lint-fix:
-	golangci-lint run --fix
+	golangci-lint run --fix --timeout 5m
 
 .PHONY: install-fieldalignment
 install-fieldalignment:

--- a/pkg/analytics/test.go
+++ b/pkg/analytics/test.go
@@ -22,7 +22,7 @@ const testEvent = "Test"
 // TestMetadata contains the metadata of a test command execution event
 type TestMetadata struct {
 	// Err is the error (if any) that occurred during test execution. Note that
-	// this is NOT an error in the test but rather a error encounterd in the setup
+	// this is NOT an error in the test but rather a error encountered in the setup
 	Err error
 
 	// Duration is the total duration of the test execution. Note that this includes

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -800,7 +800,7 @@ func isFileCompose(path string) bool {
 
 	stackDeprecationWarningOnce.Do(func() {
 		if !isComposeFileName {
-			oktetoLog.Warning(`Okteto Stack syntax is deprecated. 
+			oktetoLog.Warning(`Okteto Stack syntax is deprecated.
     Please consider migrating to Docker Compose syntax: https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262`)
 		}
 	})

--- a/pkg/registry/image.go
+++ b/pkg/registry/image.go
@@ -98,7 +98,7 @@ func (ImageCtrl) GetRegistryAndRepo(tag string) (string, string) {
 
 	if len(splittedImage) == 1 {
 		imageTag = splittedImage[0]
-	} else if len(splittedImage) == 2 { //nolint:gomnd
+	} else if len(splittedImage) == 2 { //nolint:mnd
 		if strings.Contains(splittedImage[0], ".") {
 			return splittedImage[0], splittedImage[1]
 		}

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -35,7 +35,7 @@
                 if [[ $prerel =~ $beta_prerel_regex ]]; then
                         tags="${tags},okteto/okteto:beta"
                 elif [ -n "$version" ]; then
-                        tags="${tags},okteto/okteto:stable" 
+                        tags="${tags},okteto/okteto:stable"
                 fi
         fi
 


### PR DESCRIPTION
Fix the linter (`gomnd` has been deprecated in favor of `mnd`).

Eventually, we can add the spellchecker in CI