### PR TITLE
fix: retry builds on depot

### DIFF
--- a/pkg/cmd/build/depot_test.go
+++ b/pkg/cmd/build/depot_test.go
@@ -165,7 +165,7 @@ func TestDepotRun(t *testing.T) {
 				Tag:       "okteto.dev/test:okteto",
 				DevTag:    "okteto.dev/test:okteto",
 			}
-			runAndHandle := func(ctx context.Context, c *client.Client, opt *client.SolveOpt, buildOptions *types.BuildOptions, okCtx OktetoContextInterface, ioCtrl *io.Controller) error {
+			runAndHandle := func(ctx context.Context, c *client.Client, opt *client.SolveOpt, progress string, ioCtrl *io.Controller) error {
 				return nil
 			}
 			err := db.Run(context.Background(), opts, runAndHandle)


### PR DESCRIPTION
# Proposed changes

Transient errors on depot were broken. We were trying to reuse the machine that was already used for the previous build which was unavailable


## How to validate

I couldn't figure out how to force a transient error on depot. Here are the steps followed in order to test it.
1. Return always true on shouldRetry func: https://github.com/okteto/okteto/compare/jlo/fix-retry-builds-on-depot?expand=1#diff-13e727e603e4c9bb0fc05b1f058dc88b9a1d21aa410fdfd3659499086d6eb457R395
1. Create a `Dockerfile` with a wrong  step:
```Dockerfile
FROM okteto/pipeline-runner:1.0.2

RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.18.3

RaUN echo exit 1
```
1. Check that is retried

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
