### PR TITLE
chore: upgrade deps (PLAT-485)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.4.0
+      - image: okteto/golang-ci:2.4.1
 
 jobs:
   golangci-lint:


### PR DESCRIPTION
bump to go 1.22.3 to patch CVE-2024-24788