### PR TITLE
chore: use debian bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 ARG KUBECTL_VERSION=1.29.4
 ARG HELM_VERSION=3.14.4
 ARG KUSTOMIZE_VERSION=5.4.1
+FROM golang:1.22-bookworm as golang-builder
 
-
-FROM golang:1.22-bullseye as kubectl-builder
+FROM golang-builder as kubectl-builder
 
 ARG TARGETARCH
 ARG KUBECTL_VERSION
@@ -14,7 +14,7 @@ RUN curl -sLf --retry 3 -o kubectl https://storage.googleapis.com/kubernetes-rel
     chmod +x /usr/local/bin/kubectl && \
     /usr/local/bin/kubectl version --client=true
 
-FROM golang:1.22-bullseye as helm-builder
+FROM golang-builder as helm-builder
 
 ARG TARGETARCH
 ARG HELM_VERSION
@@ -24,7 +24,7 @@ RUN curl -sLf --retry 3 -o helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}
     chmod +x /usr/local/bin/helm && \
     /usr/local/bin/helm version
 
-FROM golang:1.22-bullseye as kustomize-builder
+FROM golang-builder as kustomize-builder
 ARG TARGETARCH
 ARG KUSTOMIZE_VERSION
 RUN curl -sLf --retry 3 -o kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz \
@@ -32,7 +32,7 @@ RUN curl -sLf --retry 3 -o kustomize.tar.gz https://github.com/kubernetes-sigs/k
     && chmod +x /usr/local/bin/kustomize \
     && /usr/local/bin/kustomize version
 
-FROM golang:1.22-bullseye as builder
+FROM golang-builder as builder
 WORKDIR /okteto
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Debian Bullseye security support ends in 31 Jul 2024.

https://endoflife.date/debian

This PR upgrades to Bookworm.