### PR TITLE
Account for no tags in github action script

### DIFF
--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -89,7 +89,7 @@
                 git checkout "${LTS_BRANCH}" 2>/dev/null || git checkout -b "${LTS_BRANCH}"
 
                 # get the latest tag from the lts branch
-                current_tag="$(git describe --tags --abbrev=0 --match "*.*.*")"
+                current_tag="$(git describe --tags --abbrev=0 --match "*.*.*" || echo "0.0.0")"
                 diff="$(semver compare "${current_tag}" "$RELEASE_TAG")"
 
                 # RELEASE_TAG must be a newer release


### PR DESCRIPTION
Release fails for github actions if no previous semver tag exists. This happens for new repos (happened for the new [okteto/test](https://github.com/okteto/test) repo).

Now, if there are no semver tags, we default to 0.0.0 guaranteeing that the new tag will be newer

CircleCI Job: https://app.circleci.com/pipelines/github/okteto/okteto/14161/workflows/2bff9590-a548-4a97-9823-54afbe1635b9/jobs/50681