### PR TITLE
Add ignore root section to .oktetoignore

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -331,7 +331,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		}
 
 		// Read "test" and "test.{name}" sections from the .oktetoignore file
-		testIgnoreRules, err := ig.Rules("test", fmt.Sprintf("test.%s", name))
+		testIgnoreRules, err := ig.Rules(ignore.RootSection, "test", fmt.Sprintf("test.%s", name))
 		if err != nil {
 			return analytics.TestMetadata{}, fmt.Errorf("failed to create ignore rules for %s: %w", name, err)
 		}

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -146,8 +146,8 @@ chart
 backend
 `
 	ig := NewFromReader(strings.NewReader(input))
-	f, err := ig.Rules("test", "test.frontend")
+	f, err := ig.Rules(RootSection, "test", "test.frontend")
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, f, []string{"chart", "backend"})
+	assert.ElementsMatch(t, f, []string{".git", "chart", "backend"})
 
 }


### PR DESCRIPTION
Include root section of the `.oktetoignore` file for `okteto test`

Prior to this change, in this example the `.git` folder was not being included in the rules:

```
.git
[test]
manifests
[test.frontend]
backend
```

