### PR TITLE
Fix regression with `OKTETO_TOKEN` and improve DevX for invalid token

### DIFF
--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -91,9 +91,6 @@ func (o *Options) InitFromEnvVars() {
 	envToken := os.Getenv(model.OktetoTokenEnvVar)
 	if o.Token != "" || envToken != "" {
 		o.IsOkteto = true
-		if o.Context == "" {
-			o.Context = okteto.CloudURL
-		}
 	}
 
 	if o.Token == "" && envToken != "" {

--- a/cmd/context/options_test.go
+++ b/cmd/context/options_test.go
@@ -142,7 +142,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			},
 			want: &Options{
 				Token:    "token",
-				Context:  okteto.CloudURL,
+				Context:  "",
 				IsOkteto: true,
 			},
 		},
@@ -159,7 +159,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			},
 			want: &Options{
 				Token:    "token",
-				Context:  okteto.CloudURL,
+				Context:  "",
 				IsOkteto: true,
 			},
 		},
@@ -174,7 +174,7 @@ func Test_initFromEnvVars(t *testing.T) {
 			},
 			want: &Options{
 				Token:         "token",
-				Context:       okteto.CloudURL,
+				Context:       "",
 				IsOkteto:      true,
 				InferredToken: true,
 			},

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -181,7 +181,7 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 
 			// Loads, updates and uses the context from path. If not found, it creates and uses a new context
 			if err := contextCMD.LoadContextFromPath(ctx, options.Namespace, options.K8sContext, options.ManifestPath, contextCMD.Options{Show: true}); err != nil {
-				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.CloudURL).Error() {
+				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.GetContext().Name).Error() {
 					return err
 				}
 				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: options.Namespace}); err != nil {

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -80,7 +80,7 @@ func NewEndpointGetter(k8sLogger *io.K8sLogger) (EndpointGetter, error) {
 
 }
 
-// Endpoints deploys the okteto manifest
+// Endpoints lists the endpoints for a development environment
 func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 	options := &EndpointsOptions{}
 	fs := afero.NewOsFs()
@@ -107,6 +107,9 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 			showCtxHeader := options.Output == ""
 			// Loads, updates and uses the context from path. If not found, it creates and uses a new context
 			if err := contextCMD.LoadContextFromPath(ctx, options.Namespace, options.K8sContext, options.ManifestPath, contextCMD.Options{Show: showCtxHeader}); err != nil {
+				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.GetContext().Name).Error() {
+					return err
+				}
 				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: options.Namespace, Show: showCtxHeader}); err != nil {
 					return err
 				}

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -161,7 +161,7 @@ func Destroy(ctx context.Context, at analyticsTrackerInterface, insights buildTr
 				options.ManifestPath = uptManifestPath
 			}
 			if err := contextCMD.LoadContextFromPath(ctx, options.Namespace, options.K8sContext, options.ManifestPath, contextCMD.Options{Show: true}); err != nil {
-				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.CloudURL).Error() {
+				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.GetContext().Name).Error() {
 					return err
 				}
 				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: options.Namespace}); err != nil {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -69,6 +69,9 @@ func Push(ctx context.Context, at analyticsTrackerInterface) *cobra.Command {
 			}
 			// Loads, updates and uses the context from path. If not found, it creates and uses a new context
 			if err := contextCMD.LoadContextFromPath(ctx, pushOpts.Namespace, pushOpts.K8sContext, pushOpts.DevPath, contextCMD.Options{Show: true}); err != nil {
+				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.GetContext().Name).Error() {
+					return err
+				}
 				if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: pushOpts.Namespace, Show: false}); err != nil {
 					return err
 				}

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -111,6 +111,9 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 
 	// Loads, updates and uses the context from path. If not found, it creates and uses a new context
 	if err := contextCMD.LoadContextFromPath(ctx, options.Namespace, options.K8sContext, options.ManifestPath, contextCMD.Options{Show: true}); err != nil {
+		if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.GetContext().Name).Error() {
+			return analytics.TestMetadata{}, err
+		}
 		if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: options.Namespace}); err != nil {
 			return analytics.TestMetadata{}, err
 		}

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -344,6 +344,8 @@ func translateAPIErr(err error) error {
 		return fmt.Errorf("server temporarily unavailable, please try again")
 	case "non-200 OK status code: 401 Unauthorized body: \"\"":
 		return fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")
+	case "non-200 OK status code: 401 Unauthorized body: \"not-authorized\\n\"":
+		return fmt.Errorf(oktetoErrors.ErrNotLogged, GetContext().Name)
 	case "non-200 OK status code: 401 Unauthorized body: \"not-authorized: token is expired\\n\"":
 		return oktetoErrors.ErrTokenExpired
 	case "not-found":


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-344

This PR mainly includes a fix for a regression introduced in `2.27.1` causing the Okteto CLI to attempt calling the [sunsetted Okteto Cloud](https://www.okteto.com/okteto-cloud-2024/) when setting `OKTETO_TOKEN` without specifying the context. Additionally, the change also aims to improve the DevX of other scenario or misconfiguration of credentials when using  the environment variable `OKTETO_TOKEN`.

In a [previous PR](https://github.com/okteto/okteto/pull/4247) we changed the order in which credentials are checked, causing the unsedired behavior because of left over logic from Okteto Cloud.

I've listed below the tested scenarios. A is the actual regression. From B onwards, are improvements, mainly making sure that for invalid token the error message is meaningful.

Note: all the tests below are `okteto deploy` tests, but this regression also applies to `destroy` and other commands. I've tested some of them, there are a lot of permutations, but I've tested the main ones.

## How to validate

### Scenario A (Regression)

**Description**: Context file configured correctly with an Okteto context + setting a **valid**  `OKTETO_TOKEN` ✅ 
**Command**: `OKTETO_TOKEN=$VALID_TOKEN okteto deploy` (export `VALID_TOKEN` with a valid token)

| 2.26.0                                                                                                                                               | 2.27.1                                                                                                                                               | NEW                                                                                                                                                  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="730" alt="Screenshot 2024-05-17 at 23 24 58" src="https://github.com/okteto/okteto/assets/2318450/14c8287f-bb0f-47ec-b457-114d117d22af"> | <img width="636" alt="Screenshot 2024-05-17 at 23 25 46" src="https://github.com/okteto/okteto/assets/2318450/c82959c0-16c0-4a01-ab71-5c69059d2d75"> | <img width="724" alt="Screenshot 2024-05-17 at 23 26 07" src="https://github.com/okteto/okteto/assets/2318450/14b5cfc4-6253-49e5-9f85-6dc416c43416"> |
|                                                                                                                                                      |                                                                                                                                                      |                                                                                                                                                      |

### Scenario B

**Description**: Context file configured correctly with an Okteto context + setting an **invalid**  `OKTETO_TOKEN` ❌ 
**Command**: `OKTETO_TOKEN=123 okteto deploy`

| 2.26.0                                                                                                                                               | 2.27.1                                                                                                                                               | NEW                                                                                                                                                  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="633" alt="Screenshot 2024-05-17 at 23 33 40" src="https://github.com/okteto/okteto/assets/2318450/c6b01d10-56f1-4888-9860-d69097a07667"> | <img width="624" alt="Screenshot 2024-05-17 at 23 33 56" src="https://github.com/okteto/okteto/assets/2318450/736a8d0a-9cc7-4de7-8162-b5cd29c66d2b"> | <img width="806" alt="Screenshot 2024-05-17 at 23 34 11" src="https://github.com/okteto/okteto/assets/2318450/e22ea39e-eb90-44f4-a645-17b10c2aa416"> |
|                                                                                                                                                      |                                                                                                                                                      |                                                                                                                                                      |


### Scenario C

**Description**: Empty context file + **invalid** `OKTETO_TOKEN` ❌ 
**Command**: `OKTETO_HOME=$(mktemp -d) OKTETO_TOKEN=123 okteto-2.26.0 deploy`

| 2.26.0                                                                                                                                               | 2.27.1                                                                                                                                               | NEW                                                                                                                                                  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="629" alt="Screenshot 2024-05-17 at 22 49 37" src="https://github.com/okteto/okteto/assets/2318450/ddbaa52c-ad8a-4cb2-a38e-98e4544da9cc"> | <img width="628" alt="Screenshot 2024-05-17 at 22 49 51" src="https://github.com/okteto/okteto/assets/2318450/df0fa6ec-407d-4043-9a91-c49e48de6acb"> | <img width="812" alt="Screenshot 2024-05-17 at 22 50 15" src="https://github.com/okteto/okteto/assets/2318450/aec6430e-8ed7-4e6c-8c04-b818360ccb47"> |

### Scenario D

**Description**: Empty context file + **valid** `OKTETO_TOKEN` ✅ 
**Command**: `OKTETO_HOME=$(mktemp -d) OKTETO_TOKEN=$VALID_TOKEN okteto-2.26.0 deploy` (export `VALID_TOKEN` with a valid token)

| 2.26.0                                                                                                                                               | 2.27.1                                                                                                                                               | NEW                                                                                                                                                  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="625" alt="Screenshot 2024-05-17 at 22 55 08" src="https://github.com/okteto/okteto/assets/2318450/c9889ce9-c8fd-48db-be79-dc7b5814c4c2"> | <img width="632" alt="Screenshot 2024-05-17 at 22 55 53" src="https://github.com/okteto/okteto/assets/2318450/185e9112-cf11-493c-8d59-6d477b249581"> | <img width="774" alt="Screenshot 2024-05-17 at 22 56 48" src="https://github.com/okteto/okteto/assets/2318450/fc655192-6712-4a64-9b72-84d27de07e1b"> |
|                                                                                                                                                      |                                                                                                                                                      |                                                                                                                                                      |


### Scenario E

**Description**: context file without current context + **invalid** `OKTETO_TOKEN` ❌ 
**Command**: 
```bash
cd $(mktemp -d)
export OKTETO_HOME=$(pwd)
okteto context use <CTX> # open browser and login successfully

# delete the property `current-context` from the config.json
vim .okteto/context/config.json

OKTETO_TOKEN=123 okteto deploy`
```

| 2.26.0                                                                                                                                               | 2.27.1                                                                                                                                               | NEW                                                                                                                                                  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="632" alt="Screenshot 2024-05-17 at 23 12 19" src="https://github.com/okteto/okteto/assets/2318450/09dc32e2-dbd5-434f-af94-ed7b813faf1f"> | <img width="621" alt="Screenshot 2024-05-17 at 23 11 57" src="https://github.com/okteto/okteto/assets/2318450/161dba1a-4f6b-4d93-b190-e527fc1525e4"> | <img width="797" alt="Screenshot 2024-05-17 at 23 10 12" src="https://github.com/okteto/okteto/assets/2318450/c8252a81-a77e-417e-8952-dafd53a0d035"> |
|                                                                                                                                                      |                                                                                                                                                      |                                                                                                                                                      |


### Scenario F

**Description**: context file without current context + **valid** `OKTETO_TOKEN` ✅ 
**Command**: 
```bash
cd $(mktemp -d)
export OKTETO_HOME=$(pwd)
okteto context use <CTX> # open browser and login successfully

# delete the property `current-context` from the config.json
vim .okteto/context/config.json

OKTETO_TOKEN=$VALID_TOKEN okteto deploy` (export `VALID_TOKEN` with a valid token)
```

| 2.26.0                                                                                                                                               | 2.27.1                                                                                                                                               | NEW                                                                                                                                                  |
|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="639" alt="Screenshot 2024-05-17 at 23 17 00" src="https://github.com/okteto/okteto/assets/2318450/b1748b00-a32c-4136-8bdc-d853ddc3d06d"> | <img width="649" alt="Screenshot 2024-05-17 at 23 17 27" src="https://github.com/okteto/okteto/assets/2318450/e27a2d4b-12df-42aa-bd09-34819ed6f93a"> | <img width="722" alt="Screenshot 2024-05-17 at 23 15 56" src="https://github.com/okteto/okteto/assets/2318450/8e31a689-9080-4f93-b6a9-1a778c706fda"> |
|                                                                                                                                                      |                                                                                                                                                      |                                                                                                                                                      |

## CLI Quality Reminders

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
