### PR TITLE
`Preserve local env vars if also declared in `.env` + Add E2E test for Okteto Variables

### DIFF
--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -466,7 +466,7 @@ func (c Command) getUserContext(ctx context.Context, ctxName, ns, token string) 
 	return nil, oktetoErrors.ErrInternalServerError
 }
 
-func (*Command) loadDotEnv(fs afero.Fs, setEnvFunc func(key, value string) error) error {
+func (*Command) loadDotEnv(fs afero.Fs, setEnvFunc func(key, value string) error, lookupEnv func(key string) (string, bool)) error {
 	dotEnvFile := ".env"
 	if filesystem.FileExistsWithFilesystem(dotEnvFile, fs) {
 		content, err := afero.ReadFile(fs, dotEnvFile)
@@ -482,6 +482,9 @@ func (*Command) loadDotEnv(fs afero.Fs, setEnvFunc func(key, value string) error
 			return fmt.Errorf("error parsing dot env file: %w", err)
 		}
 		for k, v := range vars {
+			if _, exists := lookupEnv(k); exists {
+				continue
+			}
 			err := setEnvFunc(k, v)
 			if err != nil {
 				return fmt.Errorf("error setting env var: %w", err)

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -106,7 +106,7 @@ func (c *Command) Run(ctx context.Context, ctxOptions *Options) error {
 
 	// if the --context and --namespace flags are set, they have priority over the env vars, and current context
 	// if env vars OKTETO_CONTEXT and OKTETO_NAMESPACE are set, they have priority over the current context
-	err := c.loadDotEnv(afero.NewOsFs(), os.Setenv)
+	err := c.loadDotEnv(afero.NewOsFs(), os.Setenv, os.LookupEnv)
 	if err != nil {
 		oktetoLog.Warning("Failed to load .env file: %s", err)
 	}

--- a/integration/deploy/variables_test.go
+++ b/integration/deploy/variables_test.go
@@ -38,6 +38,22 @@ deploy:
 destroy:
   - echo "DESTROY_MASKED_VAR=${EXTERNAL_VARIABLE}"
   - echo "DESTROY_UNMASKED_SHORT_VAR=${EXTERNAL_BOOL_VARIABLE}"`
+
+	dotEnvContent = `
+CLI_TEST_MY_VAR1=.env
+CLI_TEST_MY_VAR2=.env
+CLI_TEST_MY_VAR3=.env
+CLI_TEST_MY_VAR4=.env
+`
+	oktetoManifestWithVars = `
+deploy:
+  commands:
+  - printenv
+  
+destroy:
+  commands:
+  - printenv
+`
 )
 
 const (
@@ -107,5 +123,81 @@ func TestDeployAndDestroyOktetoManifestWithEnv(t *testing.T) {
 
 	require.Equal(t, true, strings.Contains(o, "DESTROY_MASKED_VAR=***"))
 	require.Equal(t, true, strings.Contains(o, "DESTROY_UNMASKED_SHORT_VAR=false"))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+}
+
+// TestDeployVariablesOrder validates the order of precedence of the different Okteto Variable types as documented in:
+// https://www.okteto.com/docs/1.20/core/okteto-variables/#types-of-variables
+// Note: this test requires two variables configured in the Okteto UI Admin Variables:
+// 'CLI_TEST_MY_VAR4=admin' and 'CLI_TEST_MY_VAR5=admin'
+func TestDeployVariablesOrder(t *testing.T) {
+	t.Setenv("CLI_TEST_MY_VAR3", "local")
+
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+
+	testNamespace := integration.GetTestNamespace("DeployVariablesOrder", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+
+	manifestPath := filepath.Join(dir, oktetoManifestName)
+	manifestContent := []byte(oktetoManifestWithVars)
+	err = os.WriteFile(manifestPath, manifestContent, 0600)
+	require.NoError(t, err)
+
+	dotEnvPath := filepath.Join(dir, ".env")
+	err = os.WriteFile(dotEnvPath, []byte(dotEnvContent), 0600)
+	require.NoError(t, err)
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		Variables: []string{
+			"CLI_TEST_MY_VAR1=flag",
+		},
+	}
+
+	deployOutput, deployErr := commands.RunOktetoDeployAndGetOutput(oktetoPath, deployOptions)
+
+	require.NoError(t, deployErr)
+	require.Contains(t, deployOutput, "CLI_TEST_MY_VAR1=flag")
+	require.Contains(t, deployOutput, "CLI_TEST_MY_VAR2=.env")
+	require.Contains(t, deployOutput, "CLI_TEST_MY_VAR3=local")
+	require.Contains(t, deployOutput, "CLI_TEST_MY_VAR4=.env")
+	require.Contains(t, deployOutput, "CLI_TEST_MY_VAR5=admin")
+	require.Contains(t, deployOutput, "Okteto Variable 'CLI_TEST_MY_VAR4' is overridden by a local environment variable with the same name")
+
+	// reset all values to make sure destroy is not affected by what was set in deploy
+	os.Unsetenv("CLI_TEST_MY_VAR1")
+	os.Unsetenv("CLI_TEST_MY_VAR2")
+	os.Unsetenv("CLI_TEST_MY_VAR3")
+	os.Unsetenv("CLI_TEST_MY_VAR4")
+	os.Unsetenv("CLI_TEST_MY_VAR5")
+
+	// setting again the local variable needed for destroy
+	t.Setenv("CLI_TEST_MY_VAR3", "local")
+
+	destroyOptions := &commands.DestroyOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+	}
+	destroyOutput, destroyErr := commands.RunOktetoDestroyAndGetOutput(oktetoPath, destroyOptions)
+	require.NoError(t, destroyErr)
+	require.Contains(t, destroyOutput, "CLI_TEST_MY_VAR1=flag")
+	require.Contains(t, destroyOutput, "CLI_TEST_MY_VAR2=.env")
+	require.Contains(t, destroyOutput, "CLI_TEST_MY_VAR3=local")
+	require.Contains(t, destroyOutput, "CLI_TEST_MY_VAR4=.env")
+	require.Contains(t, destroyOutput, "CLI_TEST_MY_VAR5=admin")
+	require.Contains(t, deployOutput, "Okteto Variable 'CLI_TEST_MY_VAR4' is overridden by a local environment variable with the same name")
+
 	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }


### PR DESCRIPTION
Fixes: DEV-283

This PR includes a fix for Okteto Variables logic that currently the `.env` has more priority over local env vars. Our desired goal is the opposite, as documented [here](https://www.okteto.com/docs/1.20/core/okteto-variables/#types-of-variables).

It also includes an E2E test thanks to which I've noticed the incorrect behaviour.


## How to validate

If you want to validate the `.env` logic, simply create an `.env` file next to your `okteto.yml` then, set a variable in the `.env` and export the same locally when executing `okteto deploy` or `okteto destroy`.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
