### PR TITLE
fix: warning displayed even when the file was invalid

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -798,14 +798,20 @@ func isFileCompose(path string) bool {
 		return true
 	}
 
-	stackDeprecationWarningOnce.Do(func() {
-		if !isComposeFileName {
-			oktetoLog.Warning(`Okteto Stack syntax is deprecated.
-    Please consider migrating to Docker Compose syntax: https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262`)
-		}
-	})
 	oktetoLog.Infof("%s is set to true. Detecting if file is compose by name", stackSupportEnabledEnvVar)
 	return isComposeFileName
+}
+
+func warnAboutComposeFileName(path string) {
+	base := filepath.Base(path)
+	isComposeFileName := strings.HasPrefix(base, "compose") || strings.HasPrefix(base, "docker-compose") || strings.HasPrefix(base, "okteto-compose")
+	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, true)
+	if !isComposeFileName && isStackSupported {
+		stackDeprecationWarningOnce.Do(func() {
+			oktetoLog.Warning(`Okteto Stack syntax is deprecated.
+    Please consider migrating to Docker Compose syntax: https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262`)
+		})
+	}
 }
 
 // LoadStack loads an okteto stack manifest checking "yml" and "yaml"
@@ -841,6 +847,9 @@ func LoadStack(name string, stackPaths []string, validate bool, fs afero.Fs) (*S
 		if err := resultStack.Validate(); err != nil {
 			return nil, err
 		}
+	}
+	for _, path := range resultStack.Paths {
+		warnAboutComposeFileName(path)
 	}
 
 	return resultStack, nil


### PR DESCRIPTION
# Proposed changes

Fixes DEV-347

This PR only shows the warning if the stack file is a valid stack. We're losing the warning on non valid compose but we are reducing the noise for other file types

## How to validate

1. Create the following `okteto.yml`:
```yaml
deploy
  - kubectl apply -f k8s.yml

dev:
  hello-world:
    image: okteto/golang:1
    command: bash
    sync:
      - .:/usr/src/app
    volumes:
      - /go
      - /root/.cache
    securityContext:
      capabilities:
        add:
          - SYS_PTRACE
    forward:
      - 2345:2345
```
1. Run `okteto deploy`
1. See that the error is not shown

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
