### PR TITLE
Validate Test section to avoid panic if test section is not populated properly

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -10,6 +10,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package test
 
 import (
@@ -160,6 +161,10 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 
 	manifest, err := model.GetManifestV2(options.ManifestPath, fs)
 	if err != nil {
+		return analytics.TestMetadata{}, err
+	}
+
+	if err := manifest.Test.Validate(); err != nil {
 		return analytics.TestMetadata{}, err
 	}
 

--- a/pkg/model/test.go
+++ b/pkg/model/test.go
@@ -10,9 +10,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package model
 
-import "github.com/okteto/okteto/pkg/env"
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/env"
+)
 
 type Test struct {
 	Image     string        `yaml:"image,omitempty"`
@@ -20,6 +25,31 @@ type Test struct {
 	Commands  []TestCommand `yaml:"commands,omitempty"`
 	DependsOn []string      `yaml:"depends_on,omitempty"`
 	Caches    []string      `yaml:"caches,omitempty"`
+}
+
+var (
+	// TODO: add link to docs when available
+	errNoTestsDefined = fmt.Errorf("there are no tests configured in your Okteto Manifest")
+)
+
+func (test ManifestTests) Validate() error {
+	if test == nil {
+		return errNoTestsDefined
+	}
+
+	hasAtLeastOne := false
+	for _, t := range test {
+		if t != nil {
+			hasAtLeastOne = true
+			break
+		}
+	}
+
+	if !hasAtLeastOne {
+		return errNoTestsDefined
+	}
+
+	return nil
 }
 
 func (test *Test) expandEnvVars() error {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-348

In this PR we're adding a validation layer for the Test section of the Okteto Manifest. Currently, passing empty section, or empty test throws panics.

Important Note: Curently, if no tests are configured, the Okteto CLI will just deploy the application. But there is no logs or anything that informs the user that "nothing" has been done test-wise. With this change we make sure they are informed if they run `test` without configuring them. It also exit non-zero, so if this was intended to always exit 0 (for CI reasons for example), I can make it a warning.

## How to validate

Using the following manifests, and run `okteto test`

**Missing `test` section**
 
```
dev:
  hello-world:
    image: okteto/golang:1
    command: bash
    sync:
      - .:/usr/src/app
    volumes:
      - /go
      - /root/.cache
    securityContext:
      capabilities:
        add:
          - SYS_PTRACE
    forward:
      - 2345:2345
```


**Empty `test` section**
 
```
test:

dev:
  hello-world:
    image: okteto/golang:1
    command: bash
    sync:
      - .:/usr/src/app
    volumes:
      - /go
      - /root/.cache
    securityContext:
      capabilities:
        add:
          - SYS_PTRACE
    forward:
      - 2345:2345
```


**Empty test**
 
```
test:
  unit:

dev:
  hello-world:
    image: okteto/golang:1
    command: bash
    sync:
      - .:/usr/src/app
    volumes:
      - /go
      - /root/.cache
    securityContext:
      capabilities:
        add:
          - SYS_PTRACE
    forward:
      - 2345:2345
```



## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
