### PR TITLE
remove unused code (build)

### DIFF
--- a/cmd/build/basic/build.go
+++ b/cmd/build/basic/build.go
@@ -21,12 +21,10 @@ import (
 
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
-	buildCmd "github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/log/io"
-	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/afero"
 )
@@ -41,21 +39,6 @@ type BuildRunner interface {
 type Builder struct {
 	BuildRunner BuildRunner
 	IoCtrl      *io.Controller
-}
-
-// NewBuilderFromScratch creates a new okteto builder
-func NewBuilderFromScratch(ioCtrl *io.Controller) *Builder {
-	builder := buildCmd.NewOktetoBuilder(
-		&okteto.ContextStateless{
-			Store: okteto.GetContextStore(),
-		},
-		afero.NewOsFs(),
-	)
-
-	return &Builder{
-		BuildRunner: builder,
-		IoCtrl:      ioCtrl,
-	}
 }
 
 // Build builds the image defined by the BuildOptions used the BuildRunner passed as dependency

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -173,13 +173,3 @@ func (sh *serviceHasher) getDockerfileContent(dockerfileContext, dockerfilePath 
 	encodedFile := sha256.Sum256(content)
 	return hex.EncodeToString(encodedFile[:])
 }
-
-func (sh *serviceHasher) getServiceShaInCache(service string) string {
-	sh.lock.RLock()
-	defer sh.lock.RUnlock()
-	v, ok := sh.serviceShaCache[service]
-	if !ok {
-		return ""
-	}
-	return v
-}

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -97,35 +97,3 @@ func TestServiceHasher_HashBuildContext(t *testing.T) {
 		})
 	}
 }
-
-func TestGetBuildContextHashInCache(t *testing.T) {
-	tests := []struct {
-		name           string
-		buildContext   string
-		cacheValue     string
-		expectedResult string
-	}{
-		{
-			name:           "Cache Hit",
-			buildContext:   "test",
-			cacheValue:     "hash123",
-			expectedResult: "hash123",
-		},
-		{
-			name:           "Cache Miss",
-			buildContext:   "nonexistentBuildContext",
-			cacheValue:     "",
-			expectedResult: "",
-		},
-	}
-
-	// Run tests
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sh := newServiceHasher(nil, afero.NewMemMapFs())
-			sh.serviceShaCache["test"] = tt.cacheValue
-			result := sh.getServiceShaInCache(tt.buildContext)
-			assert.Equal(t, tt.expectedResult, result)
-		})
-	}
-}

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -43,7 +43,6 @@ type repositoryInterface interface {
 type hasherController interface {
 	hashProjectCommit(*build.Info) (string, error)
 	hashWithBuildContext(*build.Info, string) string
-	getServiceShaInCache(string) string
 }
 
 // Ctrl is the controller for smart builds

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -53,7 +53,6 @@ func (fh fakeHasher) hashProjectCommit(*build.Info) (string, error) { return fh.
 func (fh fakeHasher) hashWithBuildContext(*build.Info, string) string {
 	return fh.hash
 }
-func (fh fakeHasher) getServiceShaInCache(string) string { return fh.hash }
 
 func TestNewSmartBuildCtrl(t *testing.T) {
 	type input struct {

--- a/cmd/build/v2/tagger.go
+++ b/cmd/build/v2/tagger.go
@@ -25,7 +25,6 @@ import (
 type imageTaggerInterface interface {
 	getServiceImageReference(manifestName, svcName string, b *build.Info, buildHash string) string
 	getImageReferencesForTag(manifestName, svcToBuildName, tag string) []string
-	getImageReferencesForTagWithDefaults(manifestName, svcToBuildName, tag string) []string
 	getImageReferencesForDeploy(manifestName, svcToBuildName string) []string
 }
 
@@ -106,22 +105,6 @@ func (it imageTagger) getImageReferencesForTag(manifestName, svcToBuildName, tag
 		referencesToCheck = append(referencesToCheck, useReferenceTemplate(targetRegistry, sanitizedName, svcToBuildName, tag))
 	}
 	return referencesToCheck
-}
-
-// getImageReferencesForTagWithDefaults returns all the possible image references for a given service, options include
-// the given tag and the default okteto tag. For the default tag, we only use dev registry.
-func (it imageTagger) getImageReferencesForTagWithDefaults(manifestName, svcToBuildName, tag string) []string {
-	var imageReferences []string
-	if it.smartBuildController.IsEnabled() {
-		imageReferences = append(imageReferences, it.getImageReferencesForTag(manifestName, svcToBuildName, tag)...)
-	}
-
-	// The default tag (okteto) should be considered only with the dev registry. It should never be used with the global
-	// registry
-	sanitizedName := format.ResourceK8sMetaString(manifestName)
-	imageReferences = append(imageReferences, useReferenceTemplate(constants.DevRegistry, sanitizedName, svcToBuildName, model.OktetoDefaultImageTag))
-
-	return imageReferences
 }
 
 // getImageReferencesForDeploy returns the list of images references for a service when deploying it. In case of deploy,

--- a/cmd/build/v2/tagger_test.go
+++ b/cmd/build/v2/tagger_test.go
@@ -222,50 +222,6 @@ func TestImageTaggerGetPossibleHashImages(t *testing.T) {
 	}
 }
 
-func TestImageTaggerGetPossibleTags(t *testing.T) {
-	tt := []struct {
-		name                 string
-		sha                  string
-		expectedImages       []string
-		isSmartBuildsEnabled bool
-	}{
-		{
-			name: "no sha",
-			sha:  "",
-			expectedImages: []string{
-				"okteto.dev/test-test:okteto",
-			},
-			isSmartBuildsEnabled: true,
-		},
-		{
-			name: "sha",
-			sha:  "sha",
-			expectedImages: []string{
-				"okteto.dev/test-test:sha",
-				"okteto.global/test-test:sha",
-				"okteto.dev/test-test:okteto",
-			},
-			isSmartBuildsEnabled: true,
-		},
-		{
-			name: "sha but smart builds not enabled",
-			sha:  "sha",
-			expectedImages: []string{
-				"okteto.dev/test-test:okteto",
-			},
-			isSmartBuildsEnabled: false,
-		},
-	}
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			tagger := newImageTagger(fakeConfig{isOkteto: true}, &fakeSmartBuildCtrl{
-				isEnabled: tc.isSmartBuildsEnabled,
-			})
-			assert.Equal(t, tc.expectedImages, tagger.getImageReferencesForTagWithDefaults("test", "test", tc.sha))
-		})
-	}
-}
-
 func Test_getTargetRegistries(t *testing.T) {
 	tt := []struct {
 		name     string


### PR DESCRIPTION
Removing unused code:

- basic builder `NewBuilderFromScratch` is never called
- `getServiceShaInCache` is never called (only in tests)
- `getImageReferencesForTagWithDefaults`  is never called (only in tests)