### PR TITLE
fix panic when inferring stack with empty image

### DIFF
--- a/integration/up/compose_with_okteto_manifest_test.go
+++ b/integration/up/compose_with_okteto_manifest_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+// +build integration
+
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/okteto/okteto/integration"
+	"github.com/okteto/okteto/integration/commands"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	apiDockerfile = `FROM alpine`
+
+	oktetoManifest = `build:
+  api:
+    context: api
+
+deploy:
+  compose: docker-compose.yml
+`
+
+	composeTemplateWithoutBuild = `services:
+  api:
+    image: ${OKTETO_BUILD_API_IMAGE}
+    command: /bin/sh
+    workdir: /usr/src
+    volumes:
+    - .:/usr/src
+`
+)
+
+// TestUpComposeWithOktetoManifest validates the scenario where the docker-compose defines a service, but it relies
+// on the okteto manifest to build the image. This test ensures commands like 'down' and 'destroy' that do not build the
+// service, work as expected.
+func TestUpComposeWithOktetoManifest(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	testNamespace := integration.GetTestNamespace("UpComposeAndManifest", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "api"), 0700))
+	require.NoError(t, writeFile(filepath.Join(dir, "api", "Dockerfile"), apiDockerfile))
+	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), oktetoManifest))
+	require.NoError(t, writeFile(filepath.Join(dir, "docker-compose.yml"), composeTemplateWithoutBuild))
+	require.NoError(t, writeFile(filepath.Join(dir, ".stignore"), stignoreContent))
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+
+	upOptions := &commands.UpOptions{
+		Name:       "api",
+		Namespace:  testNamespace,
+		Workdir:    dir,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	upResult, err := commands.RunOktetoUp(oktetoPath, upOptions)
+	require.NoError(t, err)
+
+	// Test okteto down command
+	downOpts := &commands.DownOptions{
+		Namespace: testNamespace,
+		Workdir:   dir,
+		Token:     token,
+	}
+	require.NoError(t, commands.RunOktetoDown(oktetoPath, downOpts))
+
+	require.True(t, commands.HasUpCommandFinished(upResult.Pid.Pid))
+
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -35,7 +35,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model/forward"
 	"github.com/spf13/afero"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	yaml3 "gopkg.in/yaml.v3"
 )
 
@@ -1052,6 +1052,14 @@ func (m *Manifest) InferFromStack(cwd string) (*Manifest, error) {
 
 			svcInfo.Build = buildInfo
 		} else {
+			if buildInfo == nil {
+				buildInfo = &build.Info{}
+			}
+
+			if len(svcInfo.VolumeMounts) > 0 {
+				buildInfo.VolumesToInclude = svcInfo.VolumeMounts
+			}
+
 			if svcInfo.Image != "" {
 				buildInfo.Image = svcInfo.Image
 			}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -795,6 +795,51 @@ func TestInferFromStack(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "infer from stack empty build section and empty image",
+			currentManifest: &Manifest{
+				Deploy: &DeployInfo{
+					Image: constants.OktetoPipelineRunnerImage,
+					ComposeSection: &ComposeSectionInfo{
+						Stack: &Stack{
+							Services: map[string]*Service{
+								"test": {
+									Build: nil,
+									Image: "",
+									Ports: []Port{
+										{
+											HostPort:      8080,
+											ContainerPort: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedManifest: &Manifest{
+				Destroy: &DestroyInfo{},
+				Deploy: &DeployInfo{
+					Image: constants.OktetoPipelineRunnerImage,
+					ComposeSection: &ComposeSectionInfo{
+						Stack: &Stack{
+							Services: map[string]*Service{
+								"test": {
+									Image: "",
+									Ports: []Port{
+										{
+											HostPort:      8080,
+											ContainerPort: 8080,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-368

This PR fixes a panic that is caused when using Docker Compose and Okteto Manifests together and the `Image` field of the service is empty. For example, when running `okteto down` or `okteto destroy` the image is not built, which may cause the image field to be empty, in case the compose rely on built-in Okteto Variables such as `${OKTETO_BUILD_<SERVICE>_IMAGE}`

This is a panic that was introduced in `2.27.x` because of recent changes.

## How to validate

1. Using https://github.com/okteto/movies-with-compose
1. Change `services.app.image` to `${OKTETO_BUILD_APP_IMAGE}`
3. Create the following `okteto.yml`
```
build:
  app:
    context: api
deploy:
  compose: docker-compose.yml
```
4. Run `okteto build` and observe the panic
5. Now repeat with the new build and validate that the panic does not occurr
6. Now test that `deploy` + `up` + `down` and `destroy` work as expected and cause no panics.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
