### PR TITLE
Fix okteto test logs

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -369,6 +369,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		if err := runner.Run(ctx, params); err != nil {
 			return metadata, err
 		}
+		oktetoLog.Success("Test container '%s' executed successfully", name)
 	}
 	metadata.Success = true
 	return metadata, nil

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -365,11 +365,11 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			params.CacheInvalidationKey = "const"
 		}
 
-		ioCtrl.Out().Infof("Executing '%s'", name)
+		ioCtrl.Out().Infof("Executing test container '%s'", name)
 		if err := runner.Run(ctx, params); err != nil {
 			return metadata, err
 		}
-		oktetoLog.Success("Test container '%s' executed successfully", name)
+		oktetoLog.Success("Test container '%s' passed", name)
 	}
 	metadata.Success = true
 	return metadata, nil

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -86,7 +86,7 @@ func (ob *OktetoBuilder) GetBuilder() string {
 
 // Run runs the build sequence
 func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptions, ioCtrl *io.Controller) error {
-	isDeployOrDestroy := buildOptions.OutputMode == DeployOutputModeOnBuild || buildOptions.OutputMode == DestroyOutputModeOnBuild
+	isDeployOrDestroy := buildOptions.OutputMode == DeployOutputModeOnBuild || buildOptions.OutputMode == DestroyOutputModeOnBuild || buildOptions.OutputMode == TestOutputModeOnBuild
 	buildOptions.OutputMode = setOutputMode(buildOptions.OutputMode)
 	depotToken := os.Getenv(DepotTokenEnvVar)
 	depotProject := os.Getenv(DepotProjectEnvVar)

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -86,12 +86,12 @@ func (ob *OktetoBuilder) GetBuilder() string {
 
 // Run runs the build sequence
 func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptions, ioCtrl *io.Controller) error {
-	isDeployOrDestroy := buildOptions.OutputMode == DeployOutputModeOnBuild || buildOptions.OutputMode == DestroyOutputModeOnBuild || buildOptions.OutputMode == TestOutputModeOnBuild
+	isRemoteExecution := buildOptions.OutputMode == DeployOutputModeOnBuild || buildOptions.OutputMode == DestroyOutputModeOnBuild || buildOptions.OutputMode == TestOutputModeOnBuild
 	buildOptions.OutputMode = setOutputMode(buildOptions.OutputMode)
 	depotToken := os.Getenv(DepotTokenEnvVar)
 	depotProject := os.Getenv(DepotProjectEnvVar)
 
-	if !isDeployOrDestroy {
+	if !isRemoteExecution {
 		builder := ob.GetBuilder()
 		buildMsg := fmt.Sprintf("Building '%s'", buildOptions.File)
 		depotEnabled := IsDepotEnabled()
@@ -108,7 +108,7 @@ func (ob *OktetoBuilder) Run(ctx context.Context, buildOptions *types.BuildOptio
 	// When depot is available we only go to depot if it's not a deploy or a destroy.
 	// On depot the workload id is not working correctly and the users would not be able to
 	// use the internal cluster ip as if they were running their scripts on the k8s cluster
-	case IsDepotEnabled() && !isDeployOrDestroy:
+	case IsDepotEnabled() && !isRemoteExecution:
 		depotManager := newDepotBuilder(depotProject, depotToken, ob.OktetoContext, ioCtrl)
 		return depotManager.Run(ctx, buildOptions, solveBuild)
 	case ob.OktetoContext.GetCurrentBuilder() == "":

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -364,7 +364,7 @@ func solveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 			// We need to wait until the tty channel is closed to avoid writing to stdout while the tty is being used
 			_, err := progressui.DisplaySolveStatus(context.TODO(), c, ioCtrl.Out(), ttyChannel)
 			return err
-		case DeployOutputModeOnBuild, DestroyOutputModeOnBuild:
+		case DeployOutputModeOnBuild, DestroyOutputModeOnBuild, TestOutputModeOnBuild:
 			err := deployDisplayer(context.TODO(), plainChannel, &types.BuildOptions{OutputMode: progress})
 			commandFailChannel <- err
 			return err

--- a/pkg/cmd/build/constants.go
+++ b/pkg/cmd/build/constants.go
@@ -18,4 +18,6 @@ const (
 	DeployOutputModeOnBuild = "deploy"
 	// DestroyOutputModeOnBuild Defines the output mode set to BuildOptions when running a remote destroy
 	DestroyOutputModeOnBuild = "destroy"
+	// TestOutputModeOnBuild Defines the output mode set to BuildOptions when running a remote test
+	TestOutputModeOnBuild = "test"
 )

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -69,7 +69,7 @@ func deployDisplayer(ctx context.Context, ch chan *client.SolveStatus, o *types.
 		case <-timeout.C:
 		case ss, ok := <-ch:
 			if ok {
-				if err := t.update(ss, outputMode); err != nil {
+				if err := t.update(ss); err != nil {
 					oktetoLog.Info(err.Error())
 					continue
 				}
@@ -117,7 +117,7 @@ func newTrace() *trace {
 	}
 }
 
-func (t *trace) update(ss *client.SolveStatus, outputMode string) error {
+func (t *trace) update(ss *client.SolveStatus) error {
 	for _, rawVertex := range ss.Vertexes {
 		v, ok := t.ongoing[rawVertex.Digest.Encoded()]
 		if !ok {

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -201,7 +201,9 @@ func (t *trace) display(progress string) {
 				default:
 					// Print the information message about the stage if needed
 					if _, ok := t.stages[text.Stage]; !ok {
-						oktetoLog.Information("Running stage '%s'", text.Stage)
+						if progress != TestOutputModeOnBuild {
+							oktetoLog.Information("Running stage '%s'", text.Stage)
+						}
 						t.stages[text.Stage] = true
 					}
 					if text.Level == "error" {

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -67,6 +67,6 @@ func (dr *TestRunner) RunTest(params TestParameters) error {
 
 		params.Variables = append(params.Variables, envsFromOktetoEnvFile...)
 	}
-
+	oktetoLog.Success("Test container '%s' executed successfully", params.Name)
 	return nil
 }

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -58,6 +58,7 @@ func (dr *TestRunner) RunTest(params TestParameters) error {
 		if err := dr.Executor.Execute(command, execEnv); err != nil {
 			return err
 		}
+		oktetoLog.Success("Command '%s' successfully executed", command.Name)
 
 		// Read variables that may have been written to OKTETO_ENV in the current step
 		envsFromOktetoEnvFile, err := envStepper.Step()
@@ -67,6 +68,5 @@ func (dr *TestRunner) RunTest(params TestParameters) error {
 
 		params.Variables = append(params.Variables, envsFromOktetoEnvFile...)
 	}
-	oktetoLog.Success("Test container '%s' executed successfully", params.Name)
 	return nil
 }

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -265,11 +265,18 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		return err
 	}
 
-	outputMode := buildCmd.DeployOutputModeOnBuild
-	if params.Command == DestroyCommand {
+	var outputMode string
+	switch params.Command {
+	case TestCommand:
+		outputMode = buildCmd.TestOutputModeOnBuild
+	case DeployCommand:
+		outputMode = buildCmd.DeployOutputModeOnBuild
+	case DestroyCommand:
 		outputMode = buildCmd.DestroyOutputModeOnBuild
-
+	default:
+		outputMode = buildCmd.DeployOutputModeOnBuild
 	}
+
 	buildOptions := buildCmd.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{OutputMode: outputMode})
 	buildOptions.Manifest = params.Manifest
 	buildOptions.BuildArgs = append(


### PR DESCRIPTION
# Proposed changes

Fixes DEV-357


- Successful execution:

<img width="558" alt="Screenshot 2024-05-23 at 12 07 23" src="https://github.com/okteto/okteto/assets/25170843/d772d629-2c71-4905-becf-0574d6b55a11">


- Tests are cached. I think the message should be more like a normal print on white to distinct it with the other messages. WDYT @codyjlandstrom @pchico83? :

<img width="557" alt="Screenshot 2024-05-23 at 12 07 48" src="https://github.com/okteto/okteto/assets/25170843/c6c2fef5-0eb0-4f90-86a0-b7c373bfdeb0">


- Failed execution

<img width="535" alt="Screenshot 2024-05-23 at 12 25 34" src="https://github.com/okteto/okteto/assets/25170843/7ca365b1-9cc3-4c68-af6e-6c3959456c4f">


- Spinner executing tests:

<img width="547" alt="Screenshot 2024-05-23 at 12 28 56" src="https://github.com/okteto/okteto/assets/25170843/1ea8b47f-1516-486f-8665-d456ef7d4220">


- Large context:

<img width="467" alt="Screenshot 2024-05-23 at 12 29 43" src="https://github.com/okteto/okteto/assets/25170843/d3eef96b-7e04-4abf-b8e5-1d7353d43492">


## How to validate

1. With the following manifest:
```yaml
deploy:
  - echo hello
test:
  backend:
    image: okteto/golang:1
    context: .
    commands:
      - name: command1
        command: echo "this is command 1"
      - name: command2
        command: echo "this is command 2"
```
2. Run `okteto test` several times, one for running it and another one for the cache
3. Modify one of the test command to have a failure and check the output
4. Modify one of the commands to be sleep 5000 to check the spinner
5. Create a big file using dd (`dd if=/dev/zero of=bigfile bs=1M count=1000`). After executing tests remember to delete it

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
