### PR TITLE
Make sure /var/lib exists in remote runner image

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -91,7 +91,7 @@ ARG {{ .GitCommitArgName }}
 ARG {{ .GitBranchArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
-RUN mkdir -p /var/lib && echo "${{ .InvalidateCacheArgName }}" > /var/lib/.oktetocachekey
+RUN echo "${{ .InvalidateCacheArgName }}" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
 RUN \
@@ -106,7 +106,7 @@ FROM scratch
 COPY --from=runner /okteto/src/{{$artifact.Path}} {{$artifact.Destination}}
 {{ end }}
 {{ else -}}
-COPY --from=runner /var/lib/.oktetocachekey .oktetocachekey
+COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 {{ end }}
 `
 )

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -373,7 +373,7 @@ ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
-RUN mkdir -p /var/lib && echo "$OKTETO_INVALIDATE_CACHE" > /var/lib/.oktetocachekey
+RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
 RUN \
@@ -383,7 +383,7 @@ RUN \
   /okteto/bin/okteto remote-run deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test"
 
 FROM scratch
-COPY --from=runner /var/lib/.oktetocachekey .oktetocachekey
+COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 
 `,
 				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},


### PR DESCRIPTION
When using a custom image for deploy, destroy or test the directory `/var/lib` may not exist. We need to make sure it exists or the redirection fails. This was caught by integration tests