### PR TITLE
okteto test: return info log instead of failing when no tests defined

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -15,6 +15,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -165,6 +166,12 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 	}
 
 	if err := manifest.Test.Validate(); err != nil {
+		if errors.Is(err, model.ErrNoTestsDefined) {
+			// TODO: add link to docs when available
+			oktetoLog.Information("There are no tests configured in your Okteto Manifest")
+			return analytics.TestMetadata{}, nil
+		}
+
 		return analytics.TestMetadata{}, err
 	}
 

--- a/pkg/model/test.go
+++ b/pkg/model/test.go
@@ -29,13 +29,12 @@ type Test struct {
 }
 
 var (
-	// TODO: add link to docs when available
-	errNoTestsDefined = fmt.Errorf("there are no tests configured in your Okteto Manifest")
+	ErrNoTestsDefined = fmt.Errorf("no tests defined")
 )
 
 func (test ManifestTests) Validate() error {
 	if test == nil {
-		return errNoTestsDefined
+		return ErrNoTestsDefined
 	}
 
 	hasAtLeastOne := false
@@ -47,7 +46,7 @@ func (test ManifestTests) Validate() error {
 	}
 
 	if !hasAtLeastOne {
-		return errNoTestsDefined
+		return ErrNoTestsDefined
 	}
 
 	return nil


### PR DESCRIPTION
# Proposed changes

As discussed offline, we want to return an info log instead of an error in case `okteto test` is executed with an Okteto Manifest that have no tests defined within it.

**Before**
<img width="525" alt="Screenshot 2024-05-24 at 14 26 47" src="https://github.com/okteto/okteto/assets/2318450/10d33c19-4a08-4edb-86a9-a6789040e7ab">

**After**
<img width="516" alt="Screenshot 2024-05-24 at 14 27 42" src="https://github.com/okteto/okteto/assets/2318450/b98da191-448e-4aaa-9d05-44aae835d97d">



## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
