### PR TITLE
[okteto test] only deploy when using `--deploy` flag

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -263,7 +263,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			Namespace:        options.Namespace,
 			K8sContext:       options.K8sContext,
 			Variables:        options.Variables,
-			Build:            false,
+			Build:            true,
 			Dependencies:     false,
 			Timeout:          options.Timeout,
 			RunWithoutBash:   false,

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -258,9 +258,9 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		namespace = okteto.GetContext().Namespace
 	}
 
-	needsDeploy := options.Deploy || !pipeline.IsDeployed(ctx, devenvName, namespace, kubeClient)
+	wasDeployed := pipeline.IsDeployed(ctx, devenvName, namespace, kubeClient)
 
-	if needsDeploy {
+	if options.Deploy {
 		c := deployCMD.Command{
 			GetManifest: func(path string, fs afero.Fs) (*model.Manifest, error) {
 				return manifest, nil
@@ -308,12 +308,11 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		if err := manifest.ExpandEnvVars(); err != nil {
 			return analytics.TestMetadata{}, fmt.Errorf("failed to expand manifest environment variables: %w", err)
 		}
-		oktetoLog.Information("'%s' was already deployed. To redeploy run 'okteto deploy'", devenvName)
 	}
 
 	metadata := analytics.TestMetadata{
 		StagesCount: len(testServices),
-		WasDeployed: needsDeploy,
+		WasDeployed: wasDeployed,
 		WasBuilt:    wasBuilt,
 	}
 

--- a/pkg/analytics/test.go
+++ b/pkg/analytics/test.go
@@ -29,8 +29,8 @@ type TestMetadata struct {
 	// potential build and deploy times (not just the tests)
 	Duration time.Duration
 
-	// WasDeployed is whether a deploy was needed as part of the test
-	WasDeployed bool
+	// Deployed is whether a deploy was done as part of the test
+	Deployed bool
 
 	// WasBuilt is whether at least one image had to be built to run the tests
 	WasBuilt bool
@@ -46,7 +46,7 @@ type TestMetadata struct {
 func (a *Tracker) TrackTest(metadata TestMetadata) {
 	props := map[string]any{
 		"duration":    metadata.Duration.Seconds(),
-		"wasDeployed": metadata.WasDeployed,
+		"deployed":    metadata.Deployed,
 		"wasBuilt":    metadata.WasBuilt,
 		"success":     metadata.Success,
 		"stagesCount": metadata.StagesCount,

--- a/pkg/analytics/test_test.go
+++ b/pkg/analytics/test_test.go
@@ -25,7 +25,7 @@ func TestTrackTest(t *testing.T) {
 	var event string
 	var success bool
 	var wasBuilt bool
-	var wasDeployed bool
+	var deployed bool
 	var duration float64
 	var stagesCount int
 	var errStr string
@@ -34,7 +34,7 @@ func TestTrackTest(t *testing.T) {
 			event = ev
 			success = ok
 			wasBuilt = props["wasBuilt"].(bool)
-			wasDeployed = props["wasDeployed"].(bool)
+			deployed = props["deployed"].(bool)
 			duration = props["duration"].(float64)
 			stagesCount = props["stagesCount"].(int)
 			errStr = props["error"].(string)
@@ -42,7 +42,7 @@ func TestTrackTest(t *testing.T) {
 	}
 
 	tracker.TrackTest(TestMetadata{
-		WasDeployed: true,
+		Deployed:    true,
 		WasBuilt:    true,
 		Success:     false,
 		Duration:    time.Second * 5,
@@ -50,7 +50,7 @@ func TestTrackTest(t *testing.T) {
 		Err:         fmt.Errorf("my-error"),
 	})
 
-	require.True(t, wasDeployed)
+	require.True(t, deployed)
 	require.True(t, wasBuilt)
 	require.False(t, success)
 	require.Equal(t, errStr, "my-error")


### PR DESCRIPTION
# Proposed changes

Fixes DEV-358 & DEV-359

This PR changes `okteto test` to only deploy when requested by the user using the `--deploy` flag. Additionally, it makes sure that if the `deploy` section is missing, the CLI does not panic.

With the new change, when using `--deploy`, it will deploy or redeploy.

## How to validate

1. Using https://github.com/okteto/go-getting-started
2. Create a new namespace or make sure the sample is not deployed to the current ns
3. Add the following section to the `okteto.yml`
```yaml
test:
  unit:
    context: .
    commands:
      - name: "Run unit tests"
        command: echo 1
```
4. Run `okteto test` and observe that the application doesn't get deployed by default
5. Now run `okteto test --deploy` and observe the app being deployed

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
