### PR TITLE
fix: panics on command initialsation

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -118,7 +118,7 @@ type Command struct {
 	AnalyticsTracker  AnalyticsTrackerInterface
 	IoCtrl            *io.Controller
 	K8sLogger         *io.K8sLogger
-	insightsTracker   buildDeployTrackerInterface
+	InsightsTracker   buildDeployTrackerInterface
 
 	PipelineType model.Archetype
 	// onCleanUp is a list of functions to be executed when the execution is interrupted. This is a hack
@@ -238,7 +238,7 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 				K8sLogger:          k8sLogger,
 
 				onCleanUp:       []cleanUpFunc{},
-				insightsTracker: insightsTracker,
+				InsightsTracker: insightsTracker,
 			}
 			startTime := time.Now()
 
@@ -252,7 +252,7 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 				if options.Manifest != nil {
 					namespace = options.Manifest.Namespace
 				}
-				c.insightsTracker.TrackDeploy(ctx, options.Name, namespace, err == nil)
+				c.InsightsTracker.TrackDeploy(ctx, options.Name, namespace, err == nil)
 				c.TrackDeploy(options.Manifest, options.RunInRemote, startTime, err)
 				exit <- err
 			}()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -79,6 +79,7 @@ func Init(at buildTrackerInterface, insights buildDeployTrackerInterface, ioCtrl
 				AnalyticsTracker:  at,
 				InsightsTracker:   insights,
 				IoCtrl:            ioCtrl,
+				K8sLogger:         io.NewK8sLogger(),
 			}
 
 			if opts.Version1 {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -41,8 +41,13 @@ type buildDeployTrackerInterface interface {
 	deployTrackerInterface
 }
 
+type analyticsTracker interface {
+	buildTrackerInterface
+	TrackDeploy(analytics.DeployMetadata)
+}
+
 // Init creates okteto manifest
-func Init(at buildTrackerInterface, insights buildDeployTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
+func Init(at analyticsTracker, insights buildDeployTrackerInterface, ioCtrl *io.Controller) *cobra.Command {
 	opts := &manifest.InitOpts{}
 	cmd := &cobra.Command{
 		Use:   "init",

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -249,6 +249,7 @@ func (mc *Command) deploy(ctx context.Context, opts *InitOpts) error {
 		DeployWaiter:      deploy.NewDeployWaiter(mc.K8sClientProvider, mc.K8sLogger),
 		EndpointGetter:    deploy.NewEndpointGetter,
 		IoCtrl:            mc.IoCtrl,
+		InsightsTracker:   mc.InsightsTracker,
 	}
 
 	err = c.Run(ctx, &deploy.Options{

--- a/cmd/manifest/init-v2.go
+++ b/cmd/manifest/init-v2.go
@@ -60,7 +60,7 @@ type buildDeployTrackerInterface interface {
 type Command struct {
 	manifest          *model.Manifest
 	K8sClientProvider okteto.K8sClientProviderWithLogger
-	AnalyticsTracker  buildTrackerInterface
+	AnalyticsTracker  deploy.AnalyticsTrackerInterface
 	InsightsTracker   buildDeployTrackerInterface
 
 	IoCtrl    *io.Controller
@@ -250,6 +250,8 @@ func (mc *Command) deploy(ctx context.Context, opts *InitOpts) error {
 		EndpointGetter:    deploy.NewEndpointGetter,
 		IoCtrl:            mc.IoCtrl,
 		InsightsTracker:   mc.InsightsTracker,
+		K8sLogger:         mc.K8sLogger,
+		AnalyticsTracker:  mc.AnalyticsTracker,
 	}
 
 	err = c.Run(ctx, &deploy.Options{

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -48,7 +48,16 @@ type analyticsTrackerInterface interface {
 }
 
 type buildTrackerInterface interface {
-	TrackImageBuild(context.Context, *analytics.ImageBuildMetadata)
+	TrackImageBuild(ctx context.Context, meta *analytics.ImageBuildMetadata)
+}
+
+type deployTrackerInterface interface {
+	TrackDeploy(ctx context.Context, name, namespace string, success bool)
+}
+
+type buildDeployTrackerInterface interface {
+	buildTrackerInterface
+	deployTrackerInterface
 }
 
 // upContext is the common context of all operations performed during the up command


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-378

We have detected several panics that have been fixed on this PR. Summarising them in bullet points:

1. okteto up:
  1.1  Fixes a panic when `okteto up` is executed on a manifest without dev section 
  1.2 Fixes a panic when `okteto up` is executed on a folder without manifest and infering it
2. okteto init
  2.1  Fixes a panic when `okteto init` has to deploy (need to click on yes)
  2.2 Fixes a panic when `okteto init` is set with k8sLogger

## How to validate

Check that the scenarios described above are working without a panic

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
