### PR TITLE
Add OKTETO_DOMAIN to remote test runner

### DIFF
--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/okteto/okteto/pkg/deployable"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -88,6 +89,12 @@ commands:
 			}
 
 			os.Setenv(constants.OktetoNameEnvVar, options.Name)
+
+			options.Variables = append(
+				options.Variables,
+				// Set OKTETO_DOMAIN=okteto-subdomain env variable
+				fmt.Sprintf("%s=%s", model.OktetoDomainEnvVar, okteto.GetSubdomain()),
+			)
 
 			params := deployable.TestParameters{
 				Name:       options.Name,

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -14,12 +14,8 @@
 package deployable
 
 import (
-	"fmt"
-
 	"github.com/okteto/okteto/cmd/utils/executor"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/model"
-	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/spf13/afero"
 )
 
@@ -52,12 +48,6 @@ func (dr *TestRunner) RunTest(params TestParameters) error {
 	envStepper.WithFS(dr.Fs)
 
 	defer unlinkEnv()
-
-	params.Variables = append(
-		params.Variables,
-		// Set OKTETO_DOMAIN=okteto-subdomain env variable
-		fmt.Sprintf("%s=%s", model.OktetoDomainEnvVar, okteto.GetSubdomain()),
-	)
 
 	for _, command := range params.Deployable.Commands {
 		oktetoLog.Information("Running '%s'", command.Name)


### PR DESCRIPTION
# Proposed changes

The remote test runner doesn't inject the known okteto values. This was carryover from when we decided not to share OKTETO_ENV from deploy section.

Still TBD whether we want to add all the other envvars from the remote deploy command: https://github.com/okteto/okteto/blob/ad8c37c3002a2b123134af95fd865b94b1101c0d/pkg/deployable/deploy.go#L244-L267

# Validation

```yaml
test:
  env:
    commands:
      - printenv | grep OKTETO_DOMAIN
```

Before this change, this was returning and error. After this change this works and the full env is printed to stdout
