### PR TITLE
fix: only use requirements from yaml

### DIFF
--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -1055,16 +1055,8 @@ func Test_translateResources(t *testing.T) {
 				},
 				r: model.ResourceRequirements{},
 			},
-			expectedRequests: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory:           resource.MustParse("2Gi"),
-				apiv1.ResourceCPU:              resource.MustParse("1"),
-				apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
-			},
-			expectedLimits: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory:           resource.MustParse("0.250Gi"),
-				apiv1.ResourceCPU:              resource.MustParse("0.125"),
-				apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
-			},
+			expectedRequests: map[apiv1.ResourceName]resource.Quantity{},
+			expectedLimits:   map[apiv1.ResourceName]resource.Quantity{},
 		},
 		{
 			name: "limits-in-yaml-limits-in-container",
@@ -1095,14 +1087,12 @@ func Test_translateResources(t *testing.T) {
 				},
 			},
 			expectedRequests: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory:           resource.MustParse("4Gi"),
-				apiv1.ResourceCPU:              resource.MustParse("0.125"),
-				apiv1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
+				apiv1.ResourceMemory: resource.MustParse("4Gi"),
+				apiv1.ResourceCPU:    resource.MustParse("0.125"),
 			},
 			expectedLimits: map[apiv1.ResourceName]resource.Quantity{
-				apiv1.ResourceMemory:           resource.MustParse("1Gi"),
-				apiv1.ResourceCPU:              resource.MustParse("2"),
-				apiv1.ResourceEphemeralStorage: resource.MustParse("0.500Gi"),
+				apiv1.ResourceMemory: resource.MustParse("1Gi"),
+				apiv1.ResourceCPU:    resource.MustParse("2"),
 			},
 		},
 	}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-224

This PR aims to use only the resources requests and limits that the user has set in the yaml for the dev container and remove the ones that the original container could have. 

I also had to modify the names because while reading it several times was hard for me to follow what was the meaning of the them.


## How to validate
Via compose:
1. Copy the following compose:
```yaml
version: '3.8'

services:
  nginx:
    image: nginx
    ports:
      - "1222:80"
    deploy:
      resources:
        limits:
          cpus: '0.5'
          memory: 512M
        reservations:
          cpus: '0.2'
          memory: 256M
    volumes:
    - .:/usr/share/nginx/html
```
2. Run `okteto deploy` and check that the resources have been set correctly
3. Run `okteto up` and check that there is no resources set on the dev container

Via deployment/sfs 
1. Create a deployment with resources:
```yaml
# nginx-deployment.yaml

apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx
        resources:
          requests:
            memory: "64Mi"
            cpu: "250m"
          limits:
            memory: "128Mi"
            cpu: "500m"
```
2. Create the following `okteto.yml`:
```yaml
deploy:
- kubectl apply -f k8s.yml

dev:
  nginx-deployment:
    image: nginx
    command: ["nginx", "-g", "daemon off;"]
    sync:
    - .:/usr/share/nginx/html
    forward:
    - 1234:80
```
3. Run `okteto deploy` and check that the resources have been set correctly
4. Run `okteto up` and check that there is no resources set on the dev container

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
Edit: formatting