### PR TITLE
Reserved variable names

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -643,7 +643,7 @@ func (dc *Command) deployDependencies(ctx context.Context, deployOptions *Option
 		oktetoLog.Information("Deploying dependency  '%s'", depName)
 		oktetoLog.SetStage(fmt.Sprintf("Deploying dependency %s", depName))
 
-		if err := validator.CheckForbiddenEnvName(dep.Variables); err != nil {
+		if err := validator.CheckReservedEnvName(dep.Variables); err != nil {
 			return err
 		}
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -643,7 +643,7 @@ func (dc *Command) deployDependencies(ctx context.Context, deployOptions *Option
 		oktetoLog.Information("Deploying dependency  '%s'", depName)
 		oktetoLog.SetStage(fmt.Sprintf("Deploying dependency %s", depName))
 
-		if err := validator.CheckReservedEnvName(dep.Variables); err != nil {
+		if err := validator.CheckReservedVarName(dep.Variables); err != nil {
 			return err
 		}
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -48,6 +48,7 @@ import (
 	oktetoPath "github.com/okteto/okteto/pkg/path"
 	"github.com/okteto/okteto/pkg/repository"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -641,6 +642,11 @@ func (dc *Command) deployDependencies(ctx context.Context, deployOptions *Option
 	for depName, dep := range deployOptions.Manifest.Dependencies {
 		oktetoLog.Information("Deploying dependency  '%s'", depName)
 		oktetoLog.SetStage(fmt.Sprintf("Deploying dependency %s", depName))
+
+		if err := validator.CheckForbiddenEnvName(dep.Variables); err != nil {
+			return err
+		}
+
 		dep.Variables = append(dep.Variables, env.Var{
 			Name:  "OKTETO_ORIGIN",
 			Value: "okteto-deploy",

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -21,7 +21,7 @@ import (
 // validateAndSet returns error when variables dont have expected format NAME=VALUE or NAME is not allowed
 // when variable is valid, it sets its value as env variable
 func validateAndSet(variables []string, setEnv func(key, value string) error) error {
-	if err := validator.CheckForbiddenVariablesNameOption(variables); err != nil {
+	if err := validator.CheckReservedVariablesNameOption(variables); err != nil {
 		return err
 	}
 

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -15,9 +15,16 @@ package deploy
 
 import (
 	"github.com/okteto/okteto/pkg/env"
+	"github.com/okteto/okteto/pkg/validator"
 )
 
+// validateAndSet returns error when variables dont have expected format NAME=VALUE or NAME is not allowed
+// when variable is valid, it sets its value as env variable
 func validateAndSet(variables []string, setEnv func(key, value string) error) error {
+	if err := validator.CheckVariablesFlag(variables); err != nil {
+		return err
+	}
+
 	envVars, err := env.Parse(variables)
 	if err != nil {
 		return err

--- a/cmd/deploy/validate.go
+++ b/cmd/deploy/validate.go
@@ -21,7 +21,7 @@ import (
 // validateAndSet returns error when variables dont have expected format NAME=VALUE or NAME is not allowed
 // when variable is valid, it sets its value as env variable
 func validateAndSet(variables []string, setEnv func(key, value string) error) error {
-	if err := validator.CheckVariablesFlag(variables); err != nil {
+	if err := validator.CheckForbiddenVariablesNameOption(variables); err != nil {
 		return err
 	}
 

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -57,9 +57,9 @@ func Test_validateAndSet(t *testing.T) {
 			expectedEnvs:  map[string]string{"NAME": "test", "BASE64": "something=="},
 		},
 		{
-			name:          "forbidden variable name",
+			name:          "reserved variable name",
 			variables:     []string{"OKTETO_CONTEXT=value"},
-			expectedError: validator.ErrForbiddenVariableName,
+			expectedError: validator.ErrReservedVariableName,
 			expectedEnvs:  map[string]string{},
 		},
 	}

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/validator"
 	"github.com/stretchr/testify/assert"
 )
@@ -57,10 +58,13 @@ func Test_validateAndSet(t *testing.T) {
 			expectedEnvs:  map[string]string{"NAME": "test", "BASE64": "something=="},
 		},
 		{
-			name:          "reserved variable name",
-			variables:     []string{"OKTETO_CONTEXT=value"},
-			expectedError: fmt.Errorf("%s is %w", "OKTETO_CONTEXT", validator.ErrReservedVariableName),
-			expectedEnvs:  map[string]string{},
+			name:      "reserved variable name",
+			variables: []string{"OKTETO_CONTEXT=value"},
+			expectedError: errors.UserError{
+				E:    fmt.Errorf("%s is %w.", "OKTETO_CONTEXT", validator.ErrReservedVariableName),
+				Hint: "See documentation for more info: https://www.okteto.com/docs/core/credentials/environment-variables/",
+			},
+			expectedEnvs: map[string]string{},
 		},
 	}
 

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -59,7 +59,7 @@ func Test_validateAndSet(t *testing.T) {
 		{
 			name:          "reserved variable name",
 			variables:     []string{"OKTETO_CONTEXT=value"},
-			expectedError: validator.ErrReservedVariableName,
+			expectedError: fmt.Errorf("%s is %w", "OKTETO_CONTEXT", validator.ErrReservedVariableName),
 			expectedEnvs:  map[string]string{},
 		},
 	}

--- a/cmd/deploy/validate_test.go
+++ b/cmd/deploy/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,6 +55,12 @@ func Test_validateAndSet(t *testing.T) {
 			},
 			expectedError: nil,
 			expectedEnvs:  map[string]string{"NAME": "test", "BASE64": "something=="},
+		},
+		{
+			name:          "forbidden variable name",
+			variables:     []string{"OKTETO_CONTEXT=value"},
+			expectedError: validator.ErrForbiddenVariableName,
+			expectedEnvs:  map[string]string{},
 		},
 	}
 

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -38,6 +38,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/repository"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 )
@@ -88,6 +89,11 @@ func deploy(ctx context.Context) *cobra.Command {
 		Short: "Deploy an okteto pipeline",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if err := validator.CheckVariablesFlag(flags.variables); err != nil {
+				return err
+			}
+
 			ctxResource := &model.ContextResource{}
 			if err := ctxResource.UpdateNamespace(flags.namespace); err != nil {
 				return err

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -90,7 +90,7 @@ func deploy(ctx context.Context) *cobra.Command {
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := validator.CheckVariablesFlag(flags.variables); err != nil {
+			if err := validator.CheckForbiddenVariablesNameOption(flags.variables); err != nil {
 				return err
 			}
 

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -90,7 +90,7 @@ func deploy(ctx context.Context) *cobra.Command {
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if err := validator.CheckForbiddenVariablesNameOption(flags.variables); err != nil {
+			if err := validator.CheckReservedVariablesNameOption(flags.variables); err != nil {
 				return err
 			}
 

--- a/cmd/preview/deploy_utils.go
+++ b/cmd/preview/deploy_utils.go
@@ -32,7 +32,7 @@ var (
 )
 
 func optionsSetup(cwd string, opts *DeployOptions, args []string) error {
-	if err := validator.CheckForbiddenVariablesNameOption(opts.variables); err != nil {
+	if err := validator.CheckReservedVariablesNameOption(opts.variables); err != nil {
 		return err
 	}
 

--- a/cmd/preview/deploy_utils.go
+++ b/cmd/preview/deploy_utils.go
@@ -24,6 +24,7 @@ import (
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	modelUtils "github.com/okteto/okteto/pkg/model/utils"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/validator"
 )
 
 var (
@@ -31,6 +32,10 @@ var (
 )
 
 func optionsSetup(cwd string, opts *DeployOptions, args []string) error {
+	if err := validator.CheckVariablesFlag(opts.variables); err != nil {
+		return err
+	}
+
 	if len(args) == 0 {
 		opts.name = getRandomName(opts.scope)
 	} else {

--- a/cmd/preview/deploy_utils.go
+++ b/cmd/preview/deploy_utils.go
@@ -32,7 +32,7 @@ var (
 )
 
 func optionsSetup(cwd string, opts *DeployOptions, args []string) error {
-	if err := validator.CheckVariablesFlag(opts.variables); err != nil {
+	if err := validator.CheckForbiddenVariablesNameOption(opts.variables); err != nil {
 		return err
 	}
 

--- a/cmd/preview/deploy_utils_test.go
+++ b/cmd/preview/deploy_utils_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,6 +102,13 @@ func Test_optionsSetup(t *testing.T) {
 				branch:     "test-branch",
 			},
 			expectError: ErrNotValidPreviewScope,
+		},
+		{
+			name: "invalid-variable-name",
+			opts: &DeployOptions{
+				variables: []string{"OKTETO_CONTEXT=value"},
+			},
+			expectError: validator.ErrForbiddenVariableName,
 		},
 	}
 

--- a/cmd/preview/deploy_utils_test.go
+++ b/cmd/preview/deploy_utils_test.go
@@ -108,7 +108,7 @@ func Test_optionsSetup(t *testing.T) {
 			opts: &DeployOptions{
 				variables: []string{"OKTETO_CONTEXT=value"},
 			},
-			expectError: validator.ErrForbiddenVariableName,
+			expectError: validator.ErrReservedVariableName,
 		},
 	}
 

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -45,6 +45,7 @@ import (
 	oktetoPath "github.com/okteto/okteto/pkg/path"
 	"github.com/okteto/okteto/pkg/remote"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -75,6 +76,11 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 		Hidden:       true,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
+
+			if err := validator.CheckVariablesFlag(options.Variables); err != nil {
+				return err
+			}
+
 			stop := make(chan os.Signal, 1)
 			signal.Notify(stop, os.Interrupt)
 			exit := make(chan error, 1)

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -77,7 +77,7 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
 
-			if err := validator.CheckVariablesFlag(options.Variables); err != nil {
+			if err := validator.CheckForbiddenVariablesNameOption(options.Variables); err != nil {
 				return err
 			}
 

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -77,7 +77,7 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
 
-			if err := validator.CheckForbiddenVariablesNameOption(options.Variables); err != nil {
+			if err := validator.CheckReservedVariablesNameOption(options.Variables); err != nil {
 				return err
 			}
 

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -19,17 +19,21 @@ import (
 	"strings"
 
 	"github.com/okteto/okteto/pkg/env"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 )
 
 // ErrReservedVariableName is raised when a variable from cmd option has invalid name
-var ErrReservedVariableName = errors.New("reserved variable name. See documentation for more info: https://www.okteto.com/docs/core/credentials/environment-variables/")
+var ErrReservedVariableName = errors.New("reserved variable name")
 
 // CheckReservedVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
 func CheckReservedVariablesNameOption(variables []string) error {
 	for _, v := range variables {
 		name, _, ok := strings.Cut(v, "=")
 		if ok && isReservedVariableName(name) {
-			return fmt.Errorf("%s is %w", name, ErrReservedVariableName)
+			return oktetoErrors.UserError{
+				E:    fmt.Errorf("%s is %w.", name, ErrReservedVariableName),
+				Hint: "See documentation for more info: https://www.okteto.com/docs/core/credentials/environment-variables/",
+			}
 		}
 	}
 	return nil

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -21,8 +21,8 @@ import (
 // errForbiddenVariableName is raised when a variable from cmd option has invalid name
 var errForbiddenVariableName = errors.New("variable name not allowed: <placeholder>")
 
-// CheckVariablesFlag returns an error when any of the variable names from command flags are not allowed as input
-func CheckVariablesFlag(variables []string) error {
+// CheckForbiddenVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
+func CheckForbiddenVariablesNameOption(variables []string) error {
 	for _, v := range variables {
 		name, _, ok := strings.Cut(v, "=")
 		if ok && isForbiddenVariableName(name) {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -18,15 +18,15 @@ import (
 	"strings"
 )
 
-// errForbiddenVariableName is raised when a variable from cmd option has invalid name
-var errForbiddenVariableName = errors.New("variable name not allowed: <placeholder>")
+// ErrForbiddenVariableName is raised when a variable from cmd option has invalid name
+var ErrForbiddenVariableName = errors.New("variable name not allowed: <placeholder>")
 
 // CheckForbiddenVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
 func CheckForbiddenVariablesNameOption(variables []string) error {
 	for _, v := range variables {
 		name, _, ok := strings.Cut(v, "=")
 		if ok && isForbiddenVariableName(name) {
-			return errForbiddenVariableName
+			return ErrForbiddenVariableName
 		}
 	}
 	return nil

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -21,8 +21,7 @@ import (
 )
 
 // ErrForbiddenVariableName is raised when a variable from cmd option has invalid name
-var ErrForbiddenVariableName = errors.New(`Error: Forbidden variable names
-    Some of these variable names can override built-in variables and are not allowed. Learn more about built-in variables at https://www.okteto.com/docs/core/okteto-variables/#built-in-by-okteto`)
+var ErrForbiddenVariableName = errors.New("Overriding environment variables is not allowed. See documentation for more info https://www.okteto.com/docs/core/credentials/environment-variables/")
 
 // CheckForbiddenVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
 func CheckForbiddenVariablesNameOption(variables []string) error {
@@ -51,6 +50,7 @@ func isForbiddenVariableName(name string) bool {
 		"OKTETO_CONTEXT":   true,
 		"OKTETO_NAMESPACE": true,
 		"OKTETO_URL":       true,
+		"OKTETO_TOKEN":     true,
 	}
 
 	return forbidden[strings.ToUpper(name)]

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -19,7 +19,8 @@ import (
 )
 
 // ErrForbiddenVariableName is raised when a variable from cmd option has invalid name
-var ErrForbiddenVariableName = errors.New("variable name not allowed: <placeholder>")
+var ErrForbiddenVariableName = errors.New(`Error: Forbidden variable names
+    Some of these variable names can override built-in variables and are not allowed. Learn more about built-in variables at https://www.okteto.com/docs/core/okteto-variables/#built-in-by-okteto`)
 
 // CheckForbiddenVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
 func CheckForbiddenVariablesNameOption(variables []string) error {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -16,6 +16,8 @@ package validator
 import (
 	"errors"
 	"strings"
+
+	"github.com/okteto/okteto/pkg/env"
 )
 
 // ErrForbiddenVariableName is raised when a variable from cmd option has invalid name
@@ -27,6 +29,16 @@ func CheckForbiddenVariablesNameOption(variables []string) error {
 	for _, v := range variables {
 		name, _, ok := strings.Cut(v, "=")
 		if ok && isForbiddenVariableName(name) {
+			return ErrForbiddenVariableName
+		}
+	}
+	return nil
+}
+
+// CheckForbiddenEnvName returns an error when any of the variable names from dependency manifest
+func CheckForbiddenEnvName(variables []env.Var) error {
+	for _, v := range variables {
+		if isForbiddenVariableName(v.Name) {
 			return ErrForbiddenVariableName
 		}
 	}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -15,30 +15,31 @@ package validator
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/okteto/okteto/pkg/env"
 )
 
 // ErrReservedVariableName is raised when a variable from cmd option has invalid name
-var ErrReservedVariableName = errors.New("Reserved variable name. See documentation for more info: https://www.okteto.com/docs/core/credentials/environment-variables/")
+var ErrReservedVariableName = errors.New("reserved variable name. See documentation for more info: https://www.okteto.com/docs/core/credentials/environment-variables/")
 
 // CheckReservedVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
 func CheckReservedVariablesNameOption(variables []string) error {
 	for _, v := range variables {
 		name, _, ok := strings.Cut(v, "=")
 		if ok && isReservedVariableName(name) {
-			return ErrReservedVariableName
+			return fmt.Errorf("%s is %w", name, ErrReservedVariableName)
 		}
 	}
 	return nil
 }
 
-// CheckReservedEnvName returns an error when any of the variable names from dependency manifest
-func CheckReservedEnvName(variables []env.Var) error {
+// CheckReservedVarName returns an error when any of the variable names from dependency manifest
+func CheckReservedVarName(variables []env.Var) error {
 	for _, v := range variables {
 		if isReservedVariableName(v.Name) {
-			return ErrReservedVariableName
+			return fmt.Errorf("%s is %w", v.Name, ErrReservedVariableName)
 		}
 	}
 	return nil

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -20,38 +20,38 @@ import (
 	"github.com/okteto/okteto/pkg/env"
 )
 
-// ErrForbiddenVariableName is raised when a variable from cmd option has invalid name
-var ErrForbiddenVariableName = errors.New("Overriding environment variables is not allowed. See documentation for more info https://www.okteto.com/docs/core/credentials/environment-variables/")
+// ErrReservedVariableName is raised when a variable from cmd option has invalid name
+var ErrReservedVariableName = errors.New("Reserved variable name. See documentation for more info: https://www.okteto.com/docs/core/credentials/environment-variables/")
 
-// CheckForbiddenVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
-func CheckForbiddenVariablesNameOption(variables []string) error {
+// CheckReservedVariablesNameOption returns an error when any of the variable names from command flags are not allowed as input
+func CheckReservedVariablesNameOption(variables []string) error {
 	for _, v := range variables {
 		name, _, ok := strings.Cut(v, "=")
-		if ok && isForbiddenVariableName(name) {
-			return ErrForbiddenVariableName
+		if ok && isReservedVariableName(name) {
+			return ErrReservedVariableName
 		}
 	}
 	return nil
 }
 
-// CheckForbiddenEnvName returns an error when any of the variable names from dependency manifest
-func CheckForbiddenEnvName(variables []env.Var) error {
+// CheckReservedEnvName returns an error when any of the variable names from dependency manifest
+func CheckReservedEnvName(variables []env.Var) error {
 	for _, v := range variables {
-		if isForbiddenVariableName(v.Name) {
-			return ErrForbiddenVariableName
+		if isReservedVariableName(v.Name) {
+			return ErrReservedVariableName
 		}
 	}
 	return nil
 }
 
-// isForbiddenVariableName returns true when variable name is not allowed
-func isForbiddenVariableName(name string) bool {
-	forbidden := map[string]bool{
+// isReservedVariableName returns true when variable name is not allowed
+func isReservedVariableName(name string) bool {
+	reserved := map[string]bool{
 		"OKTETO_CONTEXT":   true,
 		"OKTETO_NAMESPACE": true,
 		"OKTETO_URL":       true,
 		"OKTETO_TOKEN":     true,
 	}
 
-	return forbidden[strings.ToUpper(name)]
+	return reserved[strings.ToUpper(name)]
 }

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,0 +1,44 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"errors"
+	"strings"
+)
+
+// errForbiddenVariableName is raised when a variable from cmd option has invalid name
+var errForbiddenVariableName = errors.New("variable name not allowed: <placeholder>")
+
+// CheckVariablesFlag returns an error when any of the variable names from command flags are not allowed as input
+func CheckVariablesFlag(variables []string) error {
+	for _, v := range variables {
+		name, _, ok := strings.Cut(v, "=")
+		if ok && isForbiddenVariableName(name) {
+			return errForbiddenVariableName
+		}
+	}
+	return nil
+}
+
+// isForbiddenVariableName returns true when variable name is not allowed
+func isForbiddenVariableName(name string) bool {
+	forbidden := map[string]bool{
+		"OKTETO_CONTEXT":   true,
+		"OKTETO_NAMESPACE": true,
+		"OKTETO_URL":       true,
+	}
+
+	return forbidden[strings.ToUpper(name)]
+}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -15,6 +15,8 @@ package validator
 
 import (
 	"testing"
+
+	"github.com/okteto/okteto/pkg/env"
 )
 
 func Test_isForbiddenVariableName(t *testing.T) {
@@ -113,6 +115,49 @@ func TestCheckForbiddenVariablesNameOption(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := CheckForbiddenVariablesNameOption(tt.args.variables); (err != nil) != tt.wantErr {
 				t.Errorf("CheckForbiddenVariablesNameOption() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckForbiddenEnvName(t *testing.T) {
+	type args struct {
+		variables env.Environment
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "invalid name should return err",
+			args: args{
+				variables: []env.Var{
+					{
+						Name:  "OKTETO_CONTEXT",
+						Value: "value",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid name should not return err",
+			args: args{
+				variables: []env.Var{
+					{
+						Name:  "NAME",
+						Value: "value",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CheckForbiddenEnvName(tt.args.variables); (err != nil) != tt.wantErr {
+				t.Errorf("CheckForbiddenEnvName() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -1,0 +1,119 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"testing"
+)
+
+func Test_isForbiddenVariableName(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "OKTETO_NAMESPACE should not be allowed",
+			args: args{
+				name: "OKTETO_NAMESPACE",
+			},
+			want: true,
+		},
+		{
+			name: "OKTETO_CONTEXT should not be allowed",
+			args: args{
+				name: "OKTETO_CONTEXT",
+			},
+			want: true,
+		},
+		{
+			name: "OKTETO_URL should not be allowed",
+			args: args{
+				name: "OKTETO_URL",
+			},
+			want: true,
+		},
+		{
+			name: "lowercase or uppercase should have the same output",
+			args: args{
+				name: "okteto_url",
+			},
+			want: true,
+		},
+		{
+			name: "any value not listed should be allowed",
+			args: args{
+				name: "ANY",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isForbiddenVariableName(tt.args.name); got != tt.want {
+				t.Errorf("isForbiddenVariableName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckVariablesFlag(t *testing.T) {
+	type args struct {
+		variables []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "malformed variable string should return nil",
+			args: args{
+				variables: []string{"not", "=value"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "all variables are forbidden",
+			args: args{
+				variables: []string{"OKTETO_CONTEXT=value", "OKTETO_NAMESPACE=value"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "some variables are forbidden",
+			args: args{
+				variables: []string{"OKTETO_CONTEXT=value", "VARIABLENAME=value"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid variables should not return error",
+			args: args{
+				variables: []string{"VALID1=value", "VALID2=value"},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CheckVariablesFlag(tt.args.variables); (err != nil) != tt.wantErr {
+				t.Errorf("CheckVariablesFlag() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/okteto/okteto/pkg/env"
 )
 
-func Test_isForbiddenVariableName(t *testing.T) {
+func Test_isReservedVariableName(t *testing.T) {
 	type args struct {
 		name string
 	}
@@ -66,14 +66,14 @@ func Test_isForbiddenVariableName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isForbiddenVariableName(tt.args.name); got != tt.want {
-				t.Errorf("isForbiddenVariableName() = %v, want %v", got, tt.want)
+			if got := isReservedVariableName(tt.args.name); got != tt.want {
+				t.Errorf("isReservedVariableName() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestCheckForbiddenVariablesNameOption(t *testing.T) {
+func TestCheckReservedVariablesNameOption(t *testing.T) {
 	type args struct {
 		variables []string
 	}
@@ -90,14 +90,14 @@ func TestCheckForbiddenVariablesNameOption(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "all variables are forbidden",
+			name: "all variables are reserved",
 			args: args{
 				variables: []string{"OKTETO_CONTEXT=value", "OKTETO_NAMESPACE=value"},
 			},
 			wantErr: true,
 		},
 		{
-			name: "some variables are forbidden",
+			name: "some variables are reserved",
 			args: args{
 				variables: []string{"OKTETO_CONTEXT=value", "VARIABLENAME=value"},
 			},
@@ -113,14 +113,14 @@ func TestCheckForbiddenVariablesNameOption(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckForbiddenVariablesNameOption(tt.args.variables); (err != nil) != tt.wantErr {
-				t.Errorf("CheckForbiddenVariablesNameOption() error = %v, wantErr %v", err, tt.wantErr)
+			if err := CheckReservedVariablesNameOption(tt.args.variables); (err != nil) != tt.wantErr {
+				t.Errorf("CheckReservedVariablesNameOption() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
 }
 
-func TestCheckForbiddenEnvName(t *testing.T) {
+func TestCheckReservedEnvName(t *testing.T) {
 	type args struct {
 		variables env.Environment
 	}
@@ -156,8 +156,8 @@ func TestCheckForbiddenEnvName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckForbiddenEnvName(tt.args.variables); (err != nil) != tt.wantErr {
-				t.Errorf("CheckForbiddenEnvName() error = %v, wantErr %v", err, tt.wantErr)
+			if err := CheckReservedEnvName(tt.args.variables); (err != nil) != tt.wantErr {
+				t.Errorf("CheckReservedEnvName() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -120,7 +120,7 @@ func TestCheckReservedVariablesNameOption(t *testing.T) {
 	}
 }
 
-func TestCheckReservedEnvName(t *testing.T) {
+func TestCheckReservedVarName(t *testing.T) {
 	type args struct {
 		variables env.Environment
 	}
@@ -156,8 +156,8 @@ func TestCheckReservedEnvName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckReservedEnvName(tt.args.variables); (err != nil) != tt.wantErr {
-				t.Errorf("CheckReservedEnvName() error = %v, wantErr %v", err, tt.wantErr)
+			if err := CheckReservedVarName(tt.args.variables); (err != nil) != tt.wantErr {
+				t.Errorf("CheckReservedVarName() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -71,7 +71,7 @@ func Test_isForbiddenVariableName(t *testing.T) {
 	}
 }
 
-func TestCheckVariablesFlag(t *testing.T) {
+func TestCheckForbiddenVariablesNameOption(t *testing.T) {
 	type args struct {
 		variables []string
 	}
@@ -111,8 +111,8 @@ func TestCheckVariablesFlag(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := CheckVariablesFlag(tt.args.variables); (err != nil) != tt.wantErr {
-				t.Errorf("CheckVariablesFlag() error = %v, wantErr %v", err, tt.wantErr)
+			if err := CheckForbiddenVariablesNameOption(tt.args.variables); (err != nil) != tt.wantErr {
+				t.Errorf("CheckForbiddenVariablesNameOption() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://okteto.atlassian.net/browse/DEV-408

We are restricting certain variable names when the user uses `--var` flag input.
Commands affected are:
- okteto deploy
- okteto pipeline deploy
- okteto preview deploy
- okteto test
- okteto deploy --dependencies (manifest might have variables for the dependencies)

The PR adds a check when the cmd is run in order to validate the name. As the validation is shared across commands a new package validator has been created with this function.


Tests:
- Running CLI commands affected with variables
- Used CLI bult-in at installer and check compatibility

Screenshots from testing

![Screenshot 2024-06-10 at 08 54 44](https://github.com/okteto/okteto/assets/40767058/9ab4c045-f1e6-4f71-843d-33279ee222d5)

![Screenshot 2024-06-10 at 08 54 56](https://github.com/okteto/okteto/assets/40767058/e9afcfd8-833b-4241-a6ba-b8e40f2ea5a1)

![Screenshot 2024-06-10 at 09 00 00](https://github.com/okteto/okteto/assets/40767058/13a8466f-dc8c-4fc9-ba9a-d46e693c0798)

Using custom okteto yaml with dependencies with variable https://github.com/teresaromero/go-getting-started/blob/tere/installer-dependencies/okteto.yml 

![Screenshot 2024-06-10 at 08 56 53](https://github.com/okteto/okteto/assets/40767058/bd56c3e8-7aac-4b51-a9eb-55fe6a4797f8)
