### PR TITLE
Show test command when running 'okteto --help'

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -71,7 +71,7 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 	options := &Options{}
 	cmd := &cobra.Command{
 		Use:   "test",
-		Short: "Run tests defined in your okteto manifest",
+		Short: "Run unit and e2e tests defined in your okteto manifest. More information available here: https://www.okteto.com/docs/reference/okteto-cli/#test",
 		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
 			stop := make(chan os.Signal, 1)
 			signal.Notify(stop, os.Interrupt)
@@ -99,12 +99,12 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the okteto manifest file")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
-	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
-	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
-	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
-	cmd.Flags().StringVar(&options.Name, "name", "", "name of the development environment name to be deployed")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "Path to the okteto manifest file")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Overwrites the namespace where the development environment is deployed")
+	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "Context where the development environment is deployed")
+	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "Set a variable (can be set more than once)")
+	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "The length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
+	cmd.Flags().StringVar(&options.Name, "name", "", "Name of the development environment name to be deployed")
 	cmd.Flags().BoolVar(&options.Deploy, "deploy", false, "Always deploy the dev environment. If it's already deployed it will be redeployed")
 	cmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "Do not use cache for running tests")
 

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -70,10 +70,8 @@ type builder interface {
 func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at *analytics.Tracker) *cobra.Command {
 	options := &Options{}
 	cmd := &cobra.Command{
-		Use:          "test",
-		Short:        "Run tests",
-		Hidden:       true,
-		SilenceUsage: true,
+		Use:   "test",
+		Short: "Run tests defined in your okteto manifest",
 		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
 			stop := make(chan os.Signal, 1)
 			signal.Notify(stop, os.Interrupt)

--- a/main.go
+++ b/main.go
@@ -141,7 +141,7 @@ func main() {
 		},
 	}
 
-	root.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "warn", "amount of information outputted (debug, info, warn, error)")
+	root.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "warn", "amount of information output (debug, info, warn, error)")
 	root.PersistentFlags().StringVar(&outputMode, "log-output", oktetoLog.TTYFormat, "output format for logs (tty, plain, json)")
 
 	root.PersistentFlags().StringVarP(&serverNameOverride, "server-name", "", "", "The address and port of the Okteto Ingress server")


### PR DESCRIPTION
Sending PR to show the `test` command when running `okteto --help`. Changed a bit the description of the command