### PR TITLE
Generate artifacts in `okteto test` including when tests fail

### DIFF
--- a/integration/commands/test.go
+++ b/integration/commands/test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/model"
+)
+
+// TestOptions defines the options that can be added to a test command
+type TestOptions struct {
+	TestName     string
+	Workdir      string
+	ManifestPath string
+	LogLevel     string
+	LogOutput    string
+	Namespace    string
+	OktetoHome   string
+	Token        string
+	NoCache      bool
+}
+
+// RunOktetoTestAndGetOutput runs an okteto deploy command and returns the output
+func RunOktetoTestAndGetOutput(oktetoPath string, testOptions *TestOptions) (string, error) {
+	cmd := getTestCmd(oktetoPath, testOptions)
+	log.Printf("Running '%s'", cmd.String())
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(o), fmt.Errorf("okteto test failed: %s - %w", string(o), err)
+	}
+	log.Printf("okteto test success")
+	return string(o), nil
+}
+
+func getTestCmd(oktetoPath string, testOptions *TestOptions) *exec.Cmd {
+	cmd := exec.Command(oktetoPath, "test")
+	if testOptions.Workdir != "" {
+		cmd.Dir = testOptions.Workdir
+	}
+	if len(testOptions.TestName) > 0 {
+		cmd.Args = append(cmd.Args, testOptions.TestName)
+	}
+	if testOptions.NoCache {
+		cmd.Args = append(cmd.Args, "--no-cache")
+	}
+	cmd.Env = os.Environ()
+	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))
+	}
+	if testOptions.ManifestPath != "" {
+		cmd.Args = append(cmd.Args, "-f", testOptions.ManifestPath)
+	}
+	if testOptions.LogLevel != "" {
+		cmd.Args = append(cmd.Args, "--log-level", testOptions.LogLevel)
+	}
+	if testOptions.Namespace != "" {
+		cmd.Args = append(cmd.Args, "--namespace", testOptions.Namespace)
+	}
+	if testOptions.LogOutput != "" {
+		cmd.Args = append(cmd.Args, "--log-output", testOptions.LogOutput)
+	}
+	if testOptions.OktetoHome != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, testOptions.OktetoHome))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", constants.KubeConfigEnvVar, filepath.Join(testOptions.OktetoHome, ".kube", "config")))
+	}
+	if testOptions.Token != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, testOptions.Token))
+	}
+
+	return cmd
+}

--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -1,0 +1,205 @@
+//go:build integration
+// +build integration
+
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/okteto/okteto/integration"
+	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	oktetoManifestWithPassingTest = `
+test:
+  unit:
+    context: .
+    image: alpine
+    commands:
+      - echo "OK"
+
+deploy:
+  - echo "deploying"
+`
+
+	oktetoManifestWithPassingTestAndArtifacts = `
+test:
+  unit:
+    context: .
+    image: alpine
+    commands:
+      - echo "OK" > coverage.txt
+    artifacts:
+      - coverage.txt
+
+deploy:
+  - echo "deploying"
+`
+
+	oktetoManifestWithFailingTestAndArtifacts = `
+test:
+  unit:
+    context: .
+    image: alpine
+    commands:
+      - echo "NOT-OK" > coverage.txt
+      - exit 1
+    artifacts:
+      - coverage.txt
+
+deploy:
+  - echo "deploying"
+`
+)
+
+var (
+	user  = ""
+	token = ""
+)
+
+func TestMain(m *testing.M) {
+	if u, ok := os.LookupEnv(model.OktetoUserEnvVar); !ok {
+		log.Println("OKTETO_USER is not defined")
+		os.Exit(1)
+	} else {
+		user = u
+	}
+
+	token = integration.GetToken()
+
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+// TestOktetoTestsWithPassingTests validates the simplest happy path of okteto test
+func TestOktetoTestsWithPassingTests(t *testing.T) {
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
+
+	testNamespace := integration.GetTestNamespace("TestsWithPassingTests", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+
+	testOptions := &commands.TestOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		NoCache:    true,
+	}
+	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Test container 'unit' passed")
+
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+}
+
+// TestOktetoTestsWithPassingTestsAndArtifacts validates the happy path of okteto test with the export of artifacts
+func TestOktetoTestsWithPassingTestsAndArtifacts(t *testing.T) {
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTestAndArtifacts), 0600))
+
+	testNamespace := integration.GetTestNamespace("PassingTestsAndArtifacts", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+
+	testOptions := &commands.TestOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		NoCache:    true,
+	}
+	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Test container 'unit' passed")
+	coveragePath := filepath.Join(dir, "coverage.txt")
+	coverage, err := os.ReadFile(coveragePath)
+	require.NoError(t, err)
+	assert.Equal(t, "OK\n", string(coverage))
+
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+}
+
+// TestOktetoTestsWithFailingTestsAndArtifacts validates the scenario where tests fail but we are able to export artifacts anyway
+func TestOktetoTestsWithFailingTestsAndArtifacts(t *testing.T) {
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithFailingTestAndArtifacts), 0600))
+
+	testNamespace := integration.GetTestNamespace("FailingTestsAndArtifacts", user)
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+
+	testOptions := &commands.TestOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		NoCache:    true,
+	}
+	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+	require.Error(t, err)
+	assert.Contains(t, out, "Test container 'unit' failed")
+	coveragePath := filepath.Join(dir, "coverage.txt")
+	coverage, err := os.ReadFile(coveragePath)
+	require.NoError(t, err)
+	assert.Equal(t, "NOT-OK\n", string(coverage))
+
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+}

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -181,6 +181,9 @@ func (t *trace) display(progress string) {
 			}
 
 			for _, log := range v.logs {
+				if strings.Contains(log, "OKTETO_TEST_COMMANDS_") {
+					continue
+				}
 				var text oktetoLog.JSONLogFormat
 				if err := json.Unmarshal([]byte(log), &text); err != nil {
 					oktetoLog.Infof("could not parse %s: %s", log, err)

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -181,9 +181,6 @@ func (t *trace) display(progress string) {
 			}
 
 			for _, log := range v.logs {
-				if strings.Contains(log, "OKTETO_TEST_COMMANDS_") {
-					continue
-				}
 				var text oktetoLog.JSONLogFormat
 				if err := json.Unmarshal([]byte(log), &text); err != nil {
 					oktetoLog.Infof("could not parse %s: %s", log, err)

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -98,13 +98,18 @@ RUN \
   {{range $key, $path := .Caches }}--mount=type=cache,target={{$path}} {{end}}\
   --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
-  /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }} || true
+  /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }}{{ if eq .Command "test" }} || true{{ end }}
+
+{{range $key, $artifact := .Artifacts }}
+RUN if [ -f /okteto/src/{{$artifact.Path}} ]; then \
+    mkdir -p $(dirname /okteto/artifacts/{{$artifact.Destination}}) && \
+    cp /okteto/src/{{$artifact.Path}} /okteto/artifacts/{{$artifact.Destination}}; \
+  fi
+{{end}}
 
 FROM scratch
 {{ if gt (len .Artifacts) 0 -}}
-{{ range $key, $artifact := .Artifacts -}}
-COPY --from=runner /okteto/src/{{$artifact.Path}} {{$artifact.Destination}}
-{{ end }}
+COPY --from=runner /okteto/artifacts/ /
 {{ else -}}
 COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 {{ end }}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -94,11 +94,20 @@ ARG {{ .InvalidateCacheArgName }}
 RUN echo "${{ .InvalidateCacheArgName }}" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
+RUN cat <<EOF > /okteto/bin/remote-run.sh && chmod +x /okteto/bin/remote-run.sh
+#!/bin/sh
+if /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }} ;then
+  echo "{\"message\": \"OKTETO_TEST_COMMANDS_SUCCEEDED\"}"
+else
+  echo "{\"message\": \"OKTETO_TEST_COMMANDS_FAILED\"}"
+fi
+EOF
+
 RUN \
   {{range $key, $path := .Caches }}--mount=type=cache,target={{$path}} {{end}}\
   --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
-  /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }}
+  /okteto/bin/remote-run.sh
 
 FROM scratch
 {{ if gt (len .Artifacts) 0 -}}

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -384,10 +384,109 @@ RUN \
   \
   --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
-  /okteto/bin/okteto remote-run deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test" || true
+  /okteto/bin/okteto remote-run deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test"
+
+
 
 FROM scratch
 COPY --from=runner /etc/.oktetocachekey .oktetocachekey
+
+`,
+				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},
+				dependencyEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
+			},
+		},
+		{
+			name: "okteto test",
+			config: config{
+				params: &Params{
+					BaseImage:           "test-image",
+					Manifest:            fakeManifest,
+					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},
+					DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
+					DockerfileName:      "Dockerfile.test",
+					Command:             "test",
+					CommandFlags:        []string{"--name \"test\""},
+					Artifacts: []model.Artifact{
+						{
+							Path:        "coverage.txt",
+							Destination: "coverage.txt",
+						},
+						{
+							Path:        "report.json",
+							Destination: "/testing/report.json",
+						},
+					},
+				},
+			},
+			expected: expected{
+				dockerfileName: filepath.Clean("/test/Dockerfile.test"),
+				dockerfileContent: `
+FROM okteto/okteto:latest as okteto-cli
+
+FROM test-image as runner
+
+ENV PATH="${PATH}:/okteto/bin"
+COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
+
+
+ENV OKTETO_DEPLOY_REMOTE true
+ARG OKTETO_NAMESPACE
+ARG OKTETO_CONTEXT
+ARG OKTETO_TOKEN
+ARG OKTETO_ACTION_NAME
+ARG OKTETO_TLS_CERT_BASE64
+ARG INTERNAL_SERVER_NAME
+ARG OKTETO_DEPLOYABLE
+ARG GITHUB_REPOSITORY
+ARG BUILDKIT_HOST
+ARG OKTETO_REGISTRY_URL
+ARG OKTETO_IS_PREVIEW_ENVIRONMENT
+RUN mkdir -p /etc/ssl/certs/
+RUN echo "$OKTETO_TLS_CERT_BASE64" | base64 -d > /etc/ssl/certs/okteto.crt
+
+COPY . /okteto/src
+WORKDIR /okteto/src
+
+
+ENV OKTETO_BUIL_SVC2_IMAGE TWO_VALUE
+
+ENV OKTETO_BUIL_SVC_IMAGE ONE_VALUE
+
+
+
+ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD dependency_pass
+
+ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME dependency_user
+
+
+ARG OKTETO_GIT_COMMIT
+ARG OKTETO_GIT_BRANCH
+ARG OKTETO_INVALIDATE_CACHE
+
+RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
+RUN okteto registrytoken install --force --log-output=json
+
+RUN \
+  \
+  --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
+  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
+  /okteto/bin/okteto remote-run test --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test" || true
+
+
+RUN if [ -f /okteto/src/coverage.txt ]; then \
+    mkdir -p $(dirname /okteto/artifacts/coverage.txt) && \
+    cp /okteto/src/coverage.txt /okteto/artifacts/coverage.txt; \
+  fi
+
+RUN if [ -f /okteto/src/report.json ]; then \
+    mkdir -p $(dirname /okteto/artifacts//testing/report.json) && \
+    cp /okteto/src/report.json /okteto/artifacts//testing/report.json; \
+  fi
+
+
+FROM scratch
+COPY --from=runner /okteto/artifacts/ /
 
 `,
 				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -325,7 +325,7 @@ func TestCreateDockerfile(t *testing.T) {
 				params: &Params{
 					BaseImage:           "test-image",
 					Manifest:            fakeManifest,
-					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},
+					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
 					DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
 					DockerfileName:      "Dockerfile.deploy",
 					Command:             "deploy",
@@ -362,7 +362,7 @@ COPY . /okteto/src
 WORKDIR /okteto/src
 
 
-ENV OKTETO_BUIL_SVC2_IMAGE TWO_VALUE
+ENV OKTETO_BUILD_SVC2_IMAGE TWO_VALUE
 
 ENV OKTETO_BUIL_SVC_IMAGE ONE_VALUE
 
@@ -392,7 +392,7 @@ FROM scratch
 COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 
 `,
-				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},
+				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
 				dependencyEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
 			},
 		},
@@ -402,7 +402,7 @@ COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 				params: &Params{
 					BaseImage:           "test-image",
 					Manifest:            fakeManifest,
-					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},
+					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
 					DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
 					DockerfileName:      "Dockerfile.test",
 					Command:             "test",
@@ -449,7 +449,7 @@ COPY . /okteto/src
 WORKDIR /okteto/src
 
 
-ENV OKTETO_BUIL_SVC2_IMAGE TWO_VALUE
+ENV OKTETO_BUILD_SVC2_IMAGE TWO_VALUE
 
 ENV OKTETO_BUIL_SVC_IMAGE ONE_VALUE
 
@@ -489,7 +489,7 @@ FROM scratch
 COPY --from=runner /okteto/artifacts/ /
 
 `,
-				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUIL_SVC2_IMAGE": "TWO_VALUE"},
+				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
 				dependencyEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
 			},
 		},

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -384,7 +384,7 @@ RUN \
   \
   --mount=type=secret,id=known_hosts --mount=id=remote,type=ssh \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
-  /okteto/bin/okteto remote-run deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test"
+  /okteto/bin/okteto remote-run deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test" || true
 
 FROM scratch
 COPY --from=runner /etc/.oktetocachekey .oktetocachekey


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-382

This change allows exporting artifacts from `okteto test` including when tests fail. Previously, because the docker build failed, the artifacts were not exported. With this change, the build will never fail due to failing tests, so artifacts can always be retrieved.

## Other approaches considered

The initial attempt at making this change was moving the `remote-run` inside a `sh` script with `set +e` but that didn't work, especially the `set +e`, despite having a reproduced the same scenario outside of the remote-run in a vanilla Dockerfile it would work. Another way to swallow the failure was wrapping the cmd inside an `if` - that worked well and we could also differenciate between success / failure, however we don't need to handle such signals because the current implementation already makes the test container failure message appear accordingly, because the logs of the remote-run are still parsed (the cmd exit code is swallowed but everything else stays as is). So I've decided to simplify and go with the `|| true` approach. In [this commit](https://github.com/okteto/okteto/pull/4334/commits/fa18546ad6e14a460f884be6c1759d0e0af1ff2d) you can see the other implementation, keeping it for futurew references.

## How to validate

Important: Make sure to use `--no-cache` and check the exit code of the Okteto CLI using `echo $?` after each test. You can use `make clean` between tests to remove the generated artifacts.

1. Check out the branch `af/okteto-test-dev-382` of https://github.com/okteto/go-getting-started
1. Run `okteto test --no-cache` with the latest stable `2.28.0` and observe all artifacts being exported because tests are passing. 
1. Modify the tests (unit/e2e) and break them
1. Re-run with latest stable and observe that no artifacts were exported.
1. Now repest the validation with the CLI from branch and observe artifacts always being exported
1. Check with `echo $?` that the CLI exits non-zero when the tests fail

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
