### PR TITLE
fix: build friendly err

### DIFF
--- a/pkg/model/manifest_friendly_err.go
+++ b/pkg/model/manifest_friendly_err.go
@@ -41,7 +41,7 @@ func getManifestSuggestionRules(manifestSchema interface{}) []*suggest.Rule {
 	// add levenshtein rules to suggest similar field names
 	manifestKeys := getStructKeys(manifestSchema)
 	manifestKeys["model.manifestRaw"] = manifestKeys["model.Manifest"]
-	manifestKeys["build.buildInfoRaw"] = manifestKeys["build.BuildInfo"]
+	manifestKeys["build.infoRaw"] = manifestKeys["build.Info"]
 	manifestKeys["model.DevRC"] = manifestKeys["model.Dev"]
 	manifestKeys["model.devType"] = manifestKeys["model.Dev"]
 	manifestKeys["model.testAlias"] = manifestKeys["model.Test"]
@@ -72,7 +72,7 @@ func getManifestSuggestionRules(manifestSchema interface{}) []*suggest.Rule {
 		suggest.NewStrReplaceRule("in type model.manifestRaw", "the okteto manifest"),
 		suggest.NewStrReplaceRule("in type model.ManifestBuild", "the 'build' section"),
 		suggest.NewStrReplaceRule("into model.ManifestBuild", "into a 'build' object"),
-		suggest.NewStrReplaceRule("in type build.buildInfoRaw", "the 'build' object"),
+		suggest.NewStrReplaceRule("in type build.infoRaw", "the 'build' object"),
 		suggest.NewStrReplaceRule("in type model.devType", "the 'dev' object"),
 		suggest.NewStrReplaceRule("into model.devType", "the 'dev' object"),
 		suggest.NewStrReplaceRule("in type model.testCommandAlias", "the 'test commands' object"),


### PR DESCRIPTION
# Proposed changes

In previous refactors we removed the `build` prefix from the structs, causing this to be out of date. Potentially we can add some tests to improve this part, but I don't think we have capacity now, so I am opening this PR to adress the specific issue.

## How to validate

1. Using a manifest with the incorrect `build` syntax, for example:
 ```
 build:
  api:
    contex: api
```
2. Run any command (quick one can be `okteto endpoints`) and observe how without this change, it fails with: `field 'contex' is not a property of in type build.infoRaw`
3. Now try with this version and it should fail with: `field 'contex' is not a property of the 'build' object. Did you mean "context"?`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
