### PR TITLE
Added transient error to retry on build operation

### DIFF
--- a/pkg/cmd/build/errors.go
+++ b/pkg/cmd/build/errors.go
@@ -90,6 +90,10 @@ func isTransientError(err error) bool {
 		return true
 	case strings.Contains(err.Error(), "Canceled") && strings.Contains(err.Error(), "context canceled"):
 		return true
+
+	// Transient error connection to Depot's machine
+	case strings.Contains(err.Error(), "timed out connecting to machine"):
+		return true
 	default:
 		return false
 	}

--- a/pkg/cmd/build/errors_test.go
+++ b/pkg/cmd/build/errors_test.go
@@ -177,6 +177,11 @@ func Test_isTransientError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "contains 'timed out connecting to machine'",
+			err:      fmt.Errorf("timed out connecting to machine: failed to dial \"tcp://44.222.105.67:443\" . make sure buildkitd is running: context deadline exceeded"),
+			expected: true,
+		},
+		{
 			name:     "contains other error",
 			err:      fmt.Errorf("some other error"),
 			expected: false,


### PR DESCRIPTION
# Proposed changes

Added a transient error we have seen when connecting to Depot to be retried automatically when happens building an image