### PR TITLE
ignore stack syntax by default

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -43,8 +43,9 @@ import (
 
 const (
 	// stacksSupportEnabledEnvVar is the environment variable to know if we should use compose or stacks
-	// Default is false
 	stackSupportEnabledEnvVar = "OKTETO_SUPPORT_STACKS_ENABLED"
+	// defaultValueStackSupportEnabledEnvVar is the default value for stackSupportEnabledEnvVar
+	defaultValueStackSupportEnabledEnvVar = false
 )
 
 var (
@@ -792,7 +793,7 @@ func (svcResources *ServiceResources) IsDefaultValue() bool {
 func isFileCompose(path string) bool {
 	base := filepath.Base(path)
 	isComposeFileName := strings.HasPrefix(base, "compose") || strings.HasPrefix(base, "docker-compose") || strings.HasPrefix(base, "okteto-compose")
-	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, true)
+	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, defaultValueStackSupportEnabledEnvVar)
 	if !isStackSupported {
 		oktetoLog.Infof("%s is set to false. File will be treated as compose", stackSupportEnabledEnvVar)
 		return true
@@ -805,7 +806,7 @@ func isFileCompose(path string) bool {
 func warnAboutComposeFileName(path string) {
 	base := filepath.Base(path)
 	isComposeFileName := strings.HasPrefix(base, "compose") || strings.HasPrefix(base, "docker-compose") || strings.HasPrefix(base, "okteto-compose")
-	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, true)
+	isStackSupported := env.LoadBooleanOrDefault(stackSupportEnabledEnvVar, defaultValueStackSupportEnabledEnvVar)
 	if !isComposeFileName && isStackSupported {
 		stackDeprecationWarningOnce.Do(func() {
 			oktetoLog.Warning(`Okteto Stack syntax is deprecated.

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -1465,32 +1465,40 @@ func Test_isPathAComposeFile(t *testing.T) {
 		expected    bool
 	}{
 		{
-			name:     "compose file - no env var",
+			name:     "compose file - default value for OKTETO_SUPPORT_STACKS_ENABLED",
 			path:     "compose.yml",
 			expected: true,
 		},
 		{
-			name:     "compose file - no env var",
-			path:     "docker-compose.yaml",
-			expected: true,
+			name:        "compose file - OKTETO_SUPPORT_STACKS_ENABLED=true",
+			envVarValue: "true",
+			path:        "compose.yml",
+			expected:    true,
 		},
 		{
-			name:     "compose file - no env var",
+			name:        "compose file - OKTETO_SUPPORT_STACKS_ENABLED=false",
+			envVarValue: "false",
+			path:        "compose.yml",
+			expected:    true,
+		},
+		{
+			name:     "compose file - default value for OKTETO_SUPPORT_STACKS_ENABLED",
 			path:     "okteto-compose.yml",
 			expected: true,
 		},
 		{
-			name:     "compose file - no env var",
+			name:     "compose file - default value for OKTETO_SUPPORT_STACKS_ENABLED",
 			path:     "docker-compose-dev.yml",
 			expected: true,
 		},
 		{
-			name:     "no compose file - no env var",
-			path:     "okteto-stack.yml",
-			expected: false,
+			name:        "no compose file - OKTETO_SUPPORT_STACKS_ENABLED=false",
+			envVarValue: "false",
+			path:        "okteto-stack.yml",
+			expected:    true,
 		},
 		{
-			name:        "no compose file - env var set to true",
+			name:        "no compose file - OKTETO_SUPPORT_STACKS_ENABLED=true",
 			envVarValue: "true",
 			path:        "stack.yml",
 			expected:    false,
@@ -1513,13 +1521,13 @@ func Test_warnAboutComposeFileName(t *testing.T) {
 	assert.Contains(t, writer.String(), "")
 	writer.Reset()
 	warnAboutComposeFileName("stack.yml")
+	assert.Equal(t, writer.String(), "")
+	// Check that the warning is printed if the env var is set to true
+	t.Setenv(stackSupportEnabledEnvVar, "true")
+	warnAboutComposeFileName("stack.yml")
 	assert.Equal(t, writer.String(), " !  Okteto Stack syntax is deprecated.\n    Please consider migrating to Docker Compose syntax: https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262\n")
 	// Check that the warning is only printed once even if the function is called multiple times
 	warnAboutComposeFileName("stack.yml")
 	assert.Equal(t, writer.String(), " !  Okteto Stack syntax is deprecated.\n    Please consider migrating to Docker Compose syntax: https://community.okteto.com/t/important-update-migrating-from-okteto-stacks-to-docker-compose/1262\n")
 	writer.Reset()
-	// Check that the warning is not printed if the env var is set to false
-	t.Setenv(stackSupportEnabledEnvVar, "false")
-	warnAboutComposeFileName("stack.yml")
-	assert.Equal(t, writer.String(), "")
 }


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-436

Ignore the deprecated stack syntax by default.


## How to validate

1. Using https://github.com/okteto/stacks
1. Deploy with debug logs
1. Observe the log: `OKTETO_SUPPORT_STACKS_ENABLED is set to false. File will be treated as compose`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
