### PR TITLE
feat: up --deploy always build the latest changes

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -618,7 +618,7 @@ func (up *upContext) deployApp(ctx context.Context, ioCtrl *io.Controller, k8slo
 		ManifestPathFlag: up.Options.ManifestPathFlag,
 		ManifestPath:     up.Options.ManifestPath,
 		Timeout:          5 * time.Minute,
-		Build:            false,
+		Build:            true,
 	})
 	up.analyticsMeta.HasRunDeploy()
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-437

The command `okteto up` combined with the flag `--deploy` now builds with the latest local changes. 

## How to validate


1. Using https://www.github.com/okteto/movies-with-compose
1.Run `okteto up --deploy` and notice that there is a build
1. Exit and run it again. Notice that the smart build is working correctly

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
