### PR TITLE
Admins to be able to deploy into namespaces or previews

### DIFF
--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -55,10 +55,10 @@ func Test_createContext(t *testing.T) {
 	var tests = []struct {
 		ctxStore         *okteto.ContextStore
 		ctxOptions       *Options
+		fakeOktetoClient *client.FakeOktetoClient
 		name             string
 		kubeconfigCtx    test.KubeconfigFields
 		fakeObjects      []runtime.Object
-		fakeOktetoClient *client.FakeOktetoClient
 		expectedErr      bool
 	}{
 		{
@@ -440,8 +440,8 @@ func TestCheckAccessToNamespace(t *testing.T) {
 	// TODO: add unit-test to cover preview environments access from context
 	var tests = []struct {
 		ctxOptions       *Options
-		name             string
 		fakeOktetoClient *client.FakeOktetoClient
+		name             string
 		expectedAccess   bool
 	}{
 		{

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -48,15 +48,18 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User, fakeObj
 
 func Test_createContext(t *testing.T) {
 	ctx := context.Background()
+	user := &types.User{
+		Token: "test",
+	}
 
 	var tests = []struct {
-		ctxStore      *okteto.ContextStore
-		ctxOptions    *Options
-		user          *types.User
-		name          string
-		kubeconfigCtx test.KubeconfigFields
-		fakeObjects   []runtime.Object
-		expectedErr   bool
+		ctxStore         *okteto.ContextStore
+		ctxOptions       *Options
+		name             string
+		kubeconfigCtx    test.KubeconfigFields
+		fakeObjects      []runtime.Object
+		fakeOktetoClient *client.FakeOktetoClient
+		expectedErr      bool
 	}{
 		{
 			name: "change namespace",
@@ -72,8 +75,11 @@ func Test_createContext(t *testing.T) {
 				Context:   "https://okteto.cloud.com",
 				Namespace: "test",
 			},
-			user: &types.User{
-				Token: "test",
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			kubeconfigCtx: test.KubeconfigFields{
 				Name:           []string{"cloud_okteto_com"},
@@ -96,13 +102,17 @@ func Test_createContext(t *testing.T) {
 				Namespace:            "not-found",
 				CheckNamespaceAccess: true,
 			},
-			user: &types.User{
-				Token: "test",
-			},
+
 			kubeconfigCtx: test.KubeconfigFields{
 				Name:           []string{"cloud_okteto_com"},
 				Namespace:      []string{"test"},
 				CurrentContext: "",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, oktetoErrors.ErrNamespaceNotFound),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{ErrGetPreview: oktetoErrors.ErrNamespaceNotFound}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: true,
 		},
@@ -120,13 +130,16 @@ func Test_createContext(t *testing.T) {
 				Context:   "https://okteto.cloud.com",
 				Namespace: "not-found",
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			kubeconfigCtx: test.KubeconfigFields{
 				Name:           []string{"cloud_okteto_com"},
 				Namespace:      []string{"test"},
 				CurrentContext: "",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, oktetoErrors.ErrNamespaceNotFound),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{ErrGetPreview: oktetoErrors.ErrNamespaceNotFound}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: false,
 		},
@@ -143,9 +156,6 @@ func Test_createContext(t *testing.T) {
 				Name:      []string{"cloud_okteto_com"},
 				Namespace: []string{"test"},
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			fakeObjects: []runtime.Object{
 				&corev1.Namespace{
 					ObjectMeta: v1.ObjectMeta{
@@ -159,6 +169,12 @@ func Test_createContext(t *testing.T) {
 					},
 				},
 			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
+			},
 			expectedErr: false,
 		},
 		{
@@ -170,12 +186,15 @@ func Test_createContext(t *testing.T) {
 				IsOkteto: false,
 				Context:  "cloud_okteto_com",
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			kubeconfigCtx: test.KubeconfigFields{
 				Name:      []string{"cloud_okteto_com"},
 				Namespace: []string{"test"},
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: false,
 		},
@@ -188,12 +207,15 @@ func Test_createContext(t *testing.T) {
 				IsOkteto: false,
 				Context:  "cloud_okteto_com",
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			kubeconfigCtx: test.KubeconfigFields{
 				Name:      []string{"cloud_okteto_com"},
 				Namespace: []string{"test"},
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: false,
 		},
@@ -207,12 +229,15 @@ func Test_createContext(t *testing.T) {
 				IsOkteto: false,
 				Context:  "cloud_okteto_com",
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			kubeconfigCtx: test.KubeconfigFields{
 				Name:      []string{"cloud_okteto_com"},
 				Namespace: []string{""},
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: false,
 		},
@@ -226,9 +251,6 @@ func Test_createContext(t *testing.T) {
 					},
 				},
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			ctxOptions: &Options{
 				IsOkteto: false,
 				Context:  "cloud_okteto_com",
@@ -237,6 +259,12 @@ func Test_createContext(t *testing.T) {
 				Name:           []string{"cloud_okteto_com"},
 				Namespace:      []string{"test"},
 				CurrentContext: "",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: false,
 		},
@@ -249,9 +277,6 @@ func Test_createContext(t *testing.T) {
 						IsOkteto: true,
 					},
 				},
-			},
-			user: &types.User{
-				Token: "test",
 			},
 			ctxOptions: &Options{
 				IsOkteto: true,
@@ -263,6 +288,12 @@ func Test_createContext(t *testing.T) {
 				Namespace:      []string{"test"},
 				CurrentContext: "",
 			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
+			},
 			expectedErr: false,
 		},
 		{
@@ -275,9 +306,6 @@ func Test_createContext(t *testing.T) {
 					},
 				},
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			ctxOptions: &Options{
 				IsOkteto: true,
 				Context:  "https://cloud.okteto.com",
@@ -286,6 +314,12 @@ func Test_createContext(t *testing.T) {
 				Name:           []string{"cloud_okteto_com"},
 				Namespace:      []string{"test"},
 				CurrentContext: "",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: false,
 		},
@@ -299,13 +333,16 @@ func Test_createContext(t *testing.T) {
 				Context:  "https://okteto.cloud.com",
 				Token:    "this is a token",
 			},
-			user: &types.User{
-				Token: "test",
-			},
 			kubeconfigCtx: test.KubeconfigFields{
 				Name:           []string{"cloud_okteto_com"},
 				Namespace:      []string{"test"},
 				CurrentContext: "",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{}, nil),
+				Users:           client.NewFakeUsersClient(user),
+				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			},
 			expectedErr: false,
 		},
@@ -319,14 +356,7 @@ func Test_createContext(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			fakeOktetoClient := &client.FakeOktetoClient{
-				Namespace:       client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
-				Users:           client.NewFakeUsersClient(tt.user),
-				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
-				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
-			}
-
-			ctxController := newFakeContextCommand(fakeOktetoClient, tt.user, tt.fakeObjects)
+			ctxController := newFakeContextCommand(tt.fakeOktetoClient, user, tt.fakeObjects)
 			okteto.CurrentStore = tt.ctxStore
 
 			if err := ctxController.UseContext(ctx, tt.ctxOptions); err != nil && !tt.expectedErr {
@@ -407,31 +437,36 @@ func TestCheckAccessToNamespace(t *testing.T) {
 		Token: "test",
 	}
 
-	fakeOktetoClient := &client.FakeOktetoClient{
-		Namespace: client.NewFakeNamespaceClient([]types.Namespace{{ID: "test"}}, nil),
-		Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
-		Preview:   client.NewFakePreviewClient(&client.FakePreviewResponse{}),
-	}
-
-	fakeCtxCommand := newFakeContextCommand(fakeOktetoClient, user, []runtime.Object{
-		&corev1.Namespace{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "test",
-			},
-		},
-	})
-
 	// TODO: add unit-test to cover preview environments access from context
 	var tests = []struct {
-		ctxOptions     *Options
-		name           string
-		expectedAccess bool
+		ctxOptions       *Options
+		name             string
+		fakeOktetoClient *client.FakeOktetoClient
+		expectedAccess   bool
 	}{
 		{
 			name: "okteto client can access to namespace",
 			ctxOptions: &Options{
 				IsOkteto:  true,
 				Namespace: "test",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace: client.NewFakeNamespaceClient(nil, nil),
+				Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
+				Preview:   client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+			},
+			expectedAccess: true,
+		},
+		{
+			name: "okteto client can access to preview",
+			ctxOptions: &Options{
+				IsOkteto:  true,
+				Namespace: "test",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace: client.NewFakeNamespaceClient(nil, oktetoErrors.ErrNamespaceNotFound),
+				Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
+				Preview:   client.NewFakePreviewClient(&client.FakePreviewResponse{}),
 			},
 			expectedAccess: true,
 		},
@@ -441,6 +476,13 @@ func TestCheckAccessToNamespace(t *testing.T) {
 				IsOkteto:  true,
 				Namespace: "non-ccessible-ns",
 			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace: client.NewFakeNamespaceClient(nil, oktetoErrors.ErrNamespaceNotFound),
+				Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
+				Preview: client.NewFakePreviewClient(&client.FakePreviewResponse{
+					ErrGetPreview: oktetoErrors.ErrNamespaceNotFound,
+				}),
+			},
 			expectedAccess: false,
 		},
 		{
@@ -448,6 +490,11 @@ func TestCheckAccessToNamespace(t *testing.T) {
 			ctxOptions: &Options{
 				IsOkteto:  false,
 				Namespace: "test",
+			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace: client.NewFakeNamespaceClient(nil, nil),
+				Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
+				Preview:   client.NewFakePreviewClient(&client.FakePreviewResponse{}),
 			},
 			expectedAccess: true,
 		},
@@ -457,6 +504,11 @@ func TestCheckAccessToNamespace(t *testing.T) {
 				IsOkteto:  false,
 				Namespace: "test",
 			},
+			fakeOktetoClient: &client.FakeOktetoClient{
+				Namespace: client.NewFakeNamespaceClient(nil, nil),
+				Users:     client.NewFakeUsersClient(user, fmt.Errorf("unauthorized. Please run 'okteto context url' and try again")),
+				Preview:   client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+			},
 			expectedAccess: false,
 		},
 	}
@@ -465,12 +517,21 @@ func TestCheckAccessToNamespace(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			fakeCtxCommand := newFakeContextCommand(tt.fakeOktetoClient, user, []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test",
+					},
+				},
+			})
+
 			currentCtxCommand := *fakeCtxCommand
 			if tt.ctxOptions.IsOkteto {
 				currentCtxCommand.K8sClientProvider = nil
 			} else {
 				if !tt.expectedAccess {
-					currentCtxCommand = *newFakeContextCommand(fakeOktetoClient, user, []runtime.Object{})
+					currentCtxCommand = *newFakeContextCommand(tt.fakeOktetoClient, user, []runtime.Object{})
 				}
 				currentCtxCommand.OktetoClientProvider = nil
 			}

--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -89,7 +89,9 @@ func askForOktetoURL(message string) (string, error) {
 		return "", err
 	}
 	var oktetoURL string
-	fmt.Scanln(&oktetoURL)
+	if _, err := fmt.Scanln(&oktetoURL); err != nil {
+		return "", err
+	}
 
 	url, err := url.Parse(oktetoURL)
 	if err != nil {

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -161,7 +161,9 @@ func askForOktetoNamespace() (string, error) {
 	if err := oktetoLog.Question("Enter the namespace you want to use: "); err != nil {
 		return "", err
 	}
-	fmt.Scanln(&namespace)
+	if _, err := fmt.Scanln(&namespace); err != nil {
+		return "", err
+	}
 	return namespace, nil
 }
 

--- a/cmd/namespace/use_test.go
+++ b/cmd/namespace/use_test.go
@@ -28,11 +28,11 @@ func Test_useNamespace(t *testing.T) {
 	ctx := context.Background()
 	currentNs := "test"
 	var tests = []struct {
+		errGetNamespace   error
+		errGetPreview     error
 		name              string
 		changeToNs        string
 		currentNamespaces []types.Namespace
-		errGetNamespace   error
-		errGetPreview     error
 		expectedErr       bool
 	}{
 		{

--- a/cmd/namespace/use_test.go
+++ b/cmd/namespace/use_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/internal/test/client"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,8 @@ func Test_useNamespace(t *testing.T) {
 		name              string
 		changeToNs        string
 		currentNamespaces []types.Namespace
+		errGetNamespace   error
+		errGetPreview     error
 		expectedErr       bool
 	}{
 		{
@@ -60,8 +63,10 @@ func Test_useNamespace(t *testing.T) {
 					ID: currentNs,
 				},
 			},
-			changeToNs:  "test-1",
-			expectedErr: true,
+			errGetNamespace: oktetoErrors.ErrNamespaceNotFound,
+			errGetPreview:   oktetoErrors.ErrNamespaceNotFound,
+			changeToNs:      "test-1",
+			expectedErr:     true,
 		},
 	}
 
@@ -82,8 +87,10 @@ func Test_useNamespace(t *testing.T) {
 				Token: "test",
 			}
 			fakeOktetoClient := &client.FakeOktetoClient{
-				Namespace:       client.NewFakeNamespaceClient(tt.currentNamespaces, nil),
-				Preview:         client.NewFakePreviewClient(&client.FakePreviewResponse{}),
+				Namespace: client.NewFakeNamespaceClient(tt.currentNamespaces, tt.errGetNamespace),
+				Preview: client.NewFakePreviewClient(&client.FakePreviewResponse{
+					ErrGetPreview: tt.errGetPreview,
+				}),
 				Users:           client.NewFakeUsersClient(usr),
 				KubetokenClient: client.NewFakeKubetokenClient(client.FakeKubetokenResponse{}),
 			}

--- a/internal/test/client/namespace.go
+++ b/internal/test/client/namespace.go
@@ -85,3 +85,7 @@ func (c *FakeNamespaceClient) Wake(_ context.Context, _ string) error {
 	c.WakeCalls++
 	return nil
 }
+
+func (c *FakeNamespaceClient) Get(_ context.Context, _ string) (*types.Namespace, error) {
+	return &types.Namespace{}, nil
+}

--- a/internal/test/client/namespace.go
+++ b/internal/test/client/namespace.go
@@ -87,5 +87,5 @@ func (c *FakeNamespaceClient) Wake(_ context.Context, _ string) error {
 }
 
 func (c *FakeNamespaceClient) Get(_ context.Context, _ string) (*types.Namespace, error) {
-	return &types.Namespace{}, nil
+	return &types.Namespace{}, c.err
 }

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -31,6 +31,7 @@ type FakePreviewResponse struct {
 	ErrDestroyPreview error
 	ErrSleepPreview   error
 	ErrWakePreview    error
+	ErrGetPreview     error
 
 	Preview             *types.PreviewResponse
 	ResourceStatus      map[string]string
@@ -72,6 +73,6 @@ func (*FakePreviewsClient) ListEndpoints(_ context.Context, _ string) ([]types.E
 	return nil, nil
 }
 
-func (*FakePreviewsClient) Get(_ context.Context, _ string) (*types.Preview, error) {
-	return nil, nil
+func (c *FakePreviewsClient) Get(_ context.Context, _ string) (*types.Preview, error) {
+	return &types.Preview{}, c.response.ErrGetPreview
 }

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -71,3 +71,7 @@ func (c *FakePreviewsClient) Destroy(_ context.Context, _ string) error {
 func (*FakePreviewsClient) ListEndpoints(_ context.Context, _ string) ([]types.Endpoint, error) {
 	return nil, nil
 }
+
+func (*FakePreviewsClient) Get(_ context.Context, _ string) (*types.Preview, error) {
+	return nil, nil
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -208,6 +208,9 @@ var (
 
 	// ErrTokenExpired is raised when token used for API auth is expired
 	ErrTokenExpired = errors.New("your token has expired")
+
+	// ErrNamespaceNotFound is raised when the get namespace query returns a namespace not found
+	ErrNamespaceNotFound = errors.New("namespace-not-found")
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -355,6 +355,8 @@ func translateAPIErr(err error) error {
 		return oktetoErrors.ErrTokenExpired
 	case "not-found":
 		return oktetoErrors.ErrNotFound
+	case "namespace-not-found":
+		return oktetoErrors.ErrNamespaceNotFound
 
 	default:
 		if unauthorizedTokenRegex.MatchString(err.Error()) {

--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -55,6 +55,10 @@ type listNamespacesQuery struct {
 	Response []namespaceStatus `graphql:"spaces"`
 }
 
+type getNamespaceQuery struct {
+	Response namespaceStatus `graphql:"space(id: $id)"`
+}
+
 type wakeNamespaceMutation struct {
 	Response namespaceID `graphql:"wakeSpace(space: $space)"`
 }
@@ -190,4 +194,22 @@ func (c *namespaceClient) Wake(ctx context.Context, namespace string) error {
 	}
 
 	return nil
+}
+
+// Get returns the given namespace id and status if found
+func (c *namespaceClient) Get(ctx context.Context, namespace string) (*types.Namespace, error) {
+	var queryStruct getNamespaceQuery
+	variables := map[string]interface{}{
+		"id": graphql.String(namespace),
+	}
+
+	err := query(ctx, &queryStruct, variables, c.client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.Namespace{
+		ID:     string(queryStruct.Response.Id),
+		Status: string(queryStruct.Response.Status),
+	}, nil
 }

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -414,7 +414,7 @@ func (c *previewClient) Get(ctx context.Context, previewName string) (*types.Pre
 	queryStruct := getPreviewQuery{}
 
 	variables := map[string]interface{}{
-		"id": previewName,
+		"id": graphql.String(previewName),
 	}
 	err := query(ctx, &queryStruct, variables, c.client)
 	if err != nil {

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -406,6 +406,9 @@ func (*previewClient) translateErr(err error, name string) error {
 		return oktetoErrors.UserError{E: ErrUnauthorizedGlobalCreation,
 			Hint: "Please log in with an administrator account or use a personal preview environment"}
 	}
+	if err.Error() == "namespace-not-found" {
+		return oktetoErrors.ErrNamespaceNotFound
+	}
 	return err
 }
 

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -406,9 +406,6 @@ func (*previewClient) translateErr(err error, name string) error {
 		return oktetoErrors.UserError{E: ErrUnauthorizedGlobalCreation,
 			Hint: "Please log in with an administrator account or use a personal preview environment"}
 	}
-	if err.Error() == "namespace-not-found" {
-		return oktetoErrors.ErrNamespaceNotFound
-	}
 	return err
 }
 

--- a/pkg/okteto/preview.go
+++ b/pkg/okteto/preview.go
@@ -155,6 +155,10 @@ type previewIDStruct struct {
 	Id graphql.String
 }
 
+type getPreviewQuery struct {
+	Response previewIDStruct `graphql:"preview(id: $id)"`
+}
+
 // DeployPreview creates a preview environment
 func (c *previewClient) DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []types.Variable, labels []string) (*types.PreviewResponse, error) {
 	if err := c.namespaceValidator.validate(name, previewEnvObject); err != nil {
@@ -403,4 +407,21 @@ func (*previewClient) translateErr(err error, name string) error {
 			Hint: "Please log in with an administrator account or use a personal preview environment"}
 	}
 	return err
+}
+
+// Get gets the given preview environment, returns its ID if found
+func (c *previewClient) Get(ctx context.Context, previewName string) (*types.Preview, error) {
+	queryStruct := getPreviewQuery{}
+
+	variables := map[string]interface{}{
+		"id": previewName,
+	}
+	err := query(ctx, &queryStruct, variables, c.client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.Preview{
+		ID: string(queryStruct.Response.Id),
+	}, nil
 }

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -908,3 +908,58 @@ func TestTranslatePreviewErr(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPreview(t *testing.T) {
+	type input struct {
+		client *fakeGraphQLClient
+	}
+	type expected struct {
+		err    error
+		result *types.Preview
+	}
+	testCases := []struct {
+		expected expected
+		cfg      input
+		name     string
+	}{
+		{
+			name: "error in graphql",
+			cfg: input{
+				client: &fakeGraphQLClient{
+					err: assert.AnError,
+				},
+			},
+			expected: expected{
+				err: assert.AnError,
+			},
+		},
+		{
+			name: "graphql response is an preview",
+			cfg: input{
+				client: &fakeGraphQLClient{
+					queryResult: &getPreviewQuery{
+						Response: previewIDStruct{
+							Id: "test",
+						},
+					},
+				},
+			},
+			expected: expected{
+				result: &types.Preview{
+					ID: "test",
+				},
+				err: nil,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pc := &previewClient{
+				client: tc.cfg.client,
+			}
+			p, err := pc.Get(context.Background(), "")
+			assert.ErrorIs(t, err, tc.expected.err)
+			assert.Equal(t, tc.expected.result, p)
+		})
+	}
+}

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -49,6 +49,7 @@ type NamespaceInterface interface {
 	Sleep(ctx context.Context, namespace string) error
 	DestroyAll(ctx context.Context, namespace string, destroyVolumes bool) error
 	Wake(ctx context.Context, namespace string) error
+	Get(ctx context.Context, namespace string) (*Namespace, error)
 }
 
 // PreviewInterface represents the client that connects to the preview functions
@@ -58,6 +59,7 @@ type PreviewInterface interface {
 	GetResourcesStatus(ctx context.Context, previewName, devName string) (map[string]string, error)
 	Destroy(ctx context.Context, previewName string) error
 	ListEndpoints(ctx context.Context, previewName string) ([]Endpoint, error)
+	Get(ctx context.Context, previewName string) (*Preview, error)
 }
 
 // PipelineInterface represents the client that connects to the pipeline functions


### PR DESCRIPTION
# Proposed changes

Resolves https://okteto.atlassian.net/browse/DEV-247

In order to deploy dev environments into any namespace or preview being an admin, some changes needed to be done.
When checking the user access to a namespace, query namespace and preview to check with API in there is access.

Tests where fixed for the changes introduced on the function.

## How to validate

This change needs current changes for backend https://github.com/okteto/app/pull/8231 
- using the preview environment from backend PR
- create additional user not admin and try to run `okteto deploy` or `okteto pipeline deploy` with the --namespace flag pointing to the user namespace
- the command deploy will fail (pending more changes regarding serviceaccounts)
- the command pipeline deploy will succeed but the pipeline will fail due to the pending changes
- run `okteto namespace use` with previews and namespaces
