### PR TITLE
refactor: add test to manifestFields at isManifestFieldNotFound

### DIFF
--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -1002,7 +1002,7 @@ func (d *ManifestDevs) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func isManifestFieldNotFound(err error) bool {
-	manifestFields := []string{"devs", "dev", "name", "icon", "variables", "deploy", "destroy", "build", "namespace", "context", "dependencies"}
+	manifestFields := []string{"devs", "dev", "name", "icon", "variables", "deploy", "destroy", "build", "namespace", "context", "dependencies", "test"}
 	for _, field := range manifestFields {
 		if strings.Contains(err.Error(), fmt.Sprintf("field %s not found", field)) {
 			return true


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-401

Marshalling of the manifest was failing as `test` was not being recognized as manifest key

## How to validate

Using `go-getting-started`m with some test, leave the manifest just with the test section, then run `okteto test`
![Screenshot 2024-06-25 at 12 38 29](https://github.com/okteto/okteto/assets/40767058/71149686-1f37-4d5a-aae2-35b297dd33c3)

