### PR TITLE
fix: smart build stuck on untracked files

### DIFF
--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -14,6 +14,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -536,7 +537,7 @@ func TestGetUntrackedContent(t *testing.T) {
 			gitRepoController := gitRepoController{
 				fs: fs,
 			}
-			content, err := gitRepoController.getUntrackedContent(tt.input.files)
+			content, err := gitRepoController.getUntrackedContent(context.Background(), tt.input.files)
 			assert.Equal(t, tt.output.untrackedContent, content)
 			assert.ErrorIs(t, err, tt.output.expectedErr)
 		})

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -230,6 +230,7 @@ func (lg *LocalGit) ListUntrackedFiles(ctx context.Context, repoRoot, workdir st
 
 	lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "--others", "--exclude-standard", workdir}
 
+	oktetoLog.Infof("running command: %s %s %s %s %s", lg.gitPath, "--no-optional-locks", "ls-files", "--others", "--exclude-standard")
 	output, err := lg.exec.RunCommand(ctx, repoRoot, lg.gitPath, lsFilesCmdArgs...)
 	if err != nil {
 		var exitError *exec.ExitError
@@ -250,14 +251,17 @@ func (lg *LocalGit) ListUntrackedFiles(ctx context.Context, repoRoot, workdir st
 
 	lines := strings.Split(string(output), "\n")
 	untrackedFiles := []string{}
+	totalFiles := 0
 	for _, line := range lines {
 		if line == "" {
 			continue
 		}
 		untrackedFiles = append(untrackedFiles, line)
+		totalFiles++
 	}
 	// We need to sort the untracked files to make deterministic the order of the files
 	sort.Strings(untrackedFiles)
+	oktetoLog.Infof("found %d untracked files", totalFiles)
 	return untrackedFiles, nil
 }
 


### PR DESCRIPTION
# Issue

Fixes a bug when calculating the untracked file content didn't timeout correctly. In order to reproduce follow the following steps:

1. On a large JavaScript repo run `yarn install`
2. Don't add `node_modules` to the `.gitignore` or remove the line that adds it
3. Run `okteto build` and check that the 5 second timeout is not working

As part of this PR we have also checked that [exec.CommandContext](https://pkg.go.dev/os/exec#CommandContext) fails correctly after the timeout. If you want to try this, you should change the git command with `"/bin/sleep", "9999")`. 

## Proposed changes

Fixes DEV-479

- Fixes the error by checking if the context has already been cancelled
- Add a log to know when it's running the `git status` command
- Add a log to know the number of files we have to calculate the content (untracked files). If this number is high we should probably need to add some files/folders to the `.dockerignore` to speed up the builds

## How to validate

1. On a large JavaScript repo run `yarn install`
2. Don't add `node_modules` to the `.dockerignore` or remove the line that adds it
3.  Run `okteto build` and check that the 5 second timeout is not working

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
