### PR TITLE
feat: change the default behavior of OKTETO_LOCAL_REGISTRY_STORE_ENABLED

### DIFF
--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -120,8 +120,8 @@ func (*authProvider) VerifyTokenAuthority(_ context.Context, _ *auth.VerifyToken
 
 // Credentials returns the credentials for the given host.
 // If the host is the okteto registry, it returns the credentials from the config file.
-// If the host is not the okteto registry, it returns the credentials from the config file if the OKTETO_LOCAL_REGISTRY_STORE_ENABLED is unset or true.
-// If the host is not the okteto registry and the OKTETO_LOCAL_REGISTRY_STORE_ENABLED is false, it returns the credentials retrieved from the okteto credentials store.
+// If the host is not the okteto registry and the OKTETO_LOCAL_REGISTRY_STORE_ENABLED is false or unset, it returns the credentials retrieved from the okteto credentials store.
+// If the host is not the okteto registry, it returns the credentials from the config file if the OKTETO_LOCAL_REGISTRY_STORE_ENABLED is true.
 func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
 	if req.Host == oktetoRegistry {
 		return &auth.CredentialsResponse{
@@ -150,7 +150,7 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 
 	credentials := ap.getOktetoCredentials(originalHost, c)
 
-	retrieveFromLocal := env.LoadBooleanOrDefault(oktetoLocalRegistryStoreEnabledEnvVarKey, true)
+	retrieveFromLocal := env.LoadBooleanOrDefault(oktetoLocalRegistryStoreEnabledEnvVarKey, false)
 	if !retrieveFromLocal {
 		return credentials, nil
 	}

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -270,8 +270,8 @@ func TestCredentials(t *testing.T) {
 			localCredentials:  true,
 			oktetoCredentials: false,
 			expected: &auth.CredentialsResponse{
-				Username: "local",
-				Secret:   "local",
+				Username: "",
+				Secret:   "",
 			},
 		},
 		{
@@ -296,8 +296,8 @@ func TestCredentials(t *testing.T) {
 			localCredentials:  true,
 			oktetoCredentials: true,
 			expected: &auth.CredentialsResponse{
-				Username: "local",
-				Secret:   "local",
+				Username: "okteto",
+				Secret:   "okteto",
 			},
 		},
 		{

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -186,7 +186,7 @@ func (c client) getAuthentication(ref name.Reference) remote.Option {
 		authn.DefaultKeychain,
 		authn.NewKeychainFromHelper(inlineHelper(c.config.GetExternalRegistryCredentials)),
 	)
-	if !env.LoadBooleanOrDefault(oktetoLocalRegistryStoreEnabledEnvVarKey, true) {
+	if !env.LoadBooleanOrDefault(oktetoLocalRegistryStoreEnabledEnvVarKey, false) {
 		kc = authn.NewMultiKeychain(
 			authn.NewKeychainFromHelper(inlineHelper(c.config.GetExternalRegistryCredentials)),
 			authn.DefaultKeychain,


### PR DESCRIPTION
# Proposed changes

Fixes DEV-440

Change the default behaviour for `OKTETO_LOCAL_REGISTRY_STORE_ENABLED` env var.
The only two scenarios that has change are:

- local env var: unset / local credentials: true / okteto credentials: true -> It was returning the local registry credentials instead of the ones stored in okteto
- local env var: unset / local credentials: true / okteto credentials: false -> It was returning the local registry credentials. Now we return empty

## How to validate

1. Build and push an image to a personal dockerhub registry (where you are already logged in) using `okteto build`
1. Check that there is an error
1. Create a new credentials entry for that registry in the Admin view
1. Build the same image and check that now it's building correctly


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
