### PR TITLE
okteto deploy always tries to rebuild local changes

### DIFF
--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -78,7 +78,7 @@ func (bc *OktetoBuilder) GetServicesToBuildDuringExecution(ctx context.Context, 
 	close(toBuildCh)
 
 	if len(toBuildCh) == 0 {
-		bc.ioCtrl.Out().Infof("Images were already built. To rebuild your images run 'okteto build' or 'okteto deploy --build'")
+		bc.ioCtrl.Out().Infof("Images were already built. To rebuild your images run 'okteto build'")
 		if err := manifest.ExpandEnvVars(); err != nil {
 			return nil, err
 		}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -162,6 +162,15 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 	cmd := &cobra.Command{
 		Use:   "deploy [service...]",
 		Short: "Execute the list of commands specified in the 'deploy' section of your okteto manifest",
+		Example: `# Execute okteto deploy
+$ okteto deploy
+
+# Execute okteto deploy in remote
+$ okteto deploy --remote 
+
+
+# Execute okteto deploy skipping the build
+$ okteto deploy --build=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// validate cmd options
 			if options.Dependencies && !okteto.IsOkteto() {
@@ -278,7 +287,7 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
-	cmd.Flags().BoolVarP(&options.Build, "build", "", false, "force build of images when deploying the development environment")
+	cmd.Flags().BoolVarP(&options.Build, "build", "", true, "enable/disable building images. Default is true")
 	cmd.Flags().BoolVarP(&options.Dependencies, "dependencies", "", false, "deploy the dependencies from manifest")
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")
 	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "force run deploy commands in remote")

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -289,7 +289,6 @@ func TestDeployOktetoManifestWithDestroy(t *testing.T) {
 	require.NotEmpty(t, integration.GetContentFromURL(autowakeURL, timeout))
 
 	deployOptions.LogLevel = "debug"
-	// Test redeploy is not building any image
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
 	_, err = integration.GetConfigmap(context.Background(), testNamespace, fmt.Sprintf("okteto-git-%s", filepath.Base(dir)), c)
@@ -675,7 +674,7 @@ func createOktetoManifest(dir, content string) error {
 }
 
 func expectImageFoundSkippingBuild(output string) error {
-	if ok := strings.Contains(output, "Skipping build for image for service"); !ok {
+	if ok := strings.Contains(output, "Skipping build for image for service"); ok {
 		log.Print(output)
 		return errors.New("expected image found, skipping build")
 	}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-439

In this PR okteto will always try to rebuild the images by default. 
- Adds example in the `okteto deploy  --help`
- Modified e2e tests

## How to validate

1. Run `okteto deploy` on any repo
1. Modify a file that is on a build image
1. Run `okteto deploy` and check that the image is build again

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
