### PR TITLE
up: skip refresh token for vanilla clusters

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -748,11 +748,13 @@ func (up *upContext) activateLoop() {
 		if err != nil {
 			oktetoLog.Infof("activate failed with: %s", err)
 
-			oktetoLog.Info("updating kubeconfig token")
-			if err := up.tokenUpdater.UpdateKubeConfigToken(); err != nil {
-				oktetoLog.Infof("error updating k8s token: %s", err)
-				isTransientError = true
-				continue
+			if okteto.IsOkteto() {
+				oktetoLog.Info("updating kubeconfig token")
+				if err := up.tokenUpdater.UpdateKubeConfigToken(); err != nil {
+					oktetoLog.Infof("error updating k8s token: %s", err)
+					isTransientError = true
+					continue
+				}
 			}
 
 			if err == oktetoErrors.ErrLostSyncthing {


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-490

the logic that refreshes the kubetoken should only be executed for clusters which have Okteto installed.


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
