### PR TITLE
feat: remove support for deploy certain services

### DIFF
--- a/cmd/deploy/build.go
+++ b/cmd/deploy/build.go
@@ -30,7 +30,7 @@ func buildImages(ctx context.Context, builder builderInterface, deployOptions *O
 
 	allServicesWithBuildSection := deployOptions.Manifest.GetBuildServices()
 	oktetoManifestServicesWithBuild := setDifference(allServicesWithBuildSection, stackServicesWithBuild) // Warning: this way of getting the oktetoManifestServicesWithBuild is highly dependent on the manifest struct as it is now. We are assuming that: *okteto* manifest build = manifest build - stack build section
-	servicesToDeployWithBuild := setIntersection(allServicesWithBuildSection, sliceToSet(deployOptions.ServicesToDeploy))
+	servicesToDeployWithBuild := setIntersection(allServicesWithBuildSection, sliceToSet(deployOptions.StackServicesToDeploy))
 	// We need to build:
 	// - All the services that have a build section defined in the *okteto* manifest
 	// - Services from *deployOptions.servicesToDeploy* that have a build section

--- a/cmd/deploy/build_test.go
+++ b/cmd/deploy/build_test.go
@@ -133,7 +133,7 @@ func TestBuildImages(t *testing.T) {
 						},
 					},
 				},
-				ServicesToDeploy: testCase.servicesToDeploy,
+				StackServicesToDeploy: testCase.servicesToDeploy,
 			}
 
 			for _, service := range testCase.buildServices {

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -101,9 +101,8 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 func getStackServicesToDeploy(ctx context.Context, composeSectionInfo *model.ComposeSectionInfo, c kubernetes.Interface) ([]string, error) {
 	svcs := []string{}
 
-	for service := range composeSectionInfo.Stack.Services {
-		svcs = append(svcs, service)
-
+	for _, composeInfo := range composeSectionInfo.ComposesInfo {
+		svcs = append(svcs, composeInfo.ServicesToDeploy...)
 	}
 	if len(composeSectionInfo.ComposesInfo) > 0 {
 		if err := stack.ValidateDefinedServices(composeSectionInfo.Stack, svcs); err != nil {

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"net/url"
 	"os"
-	"reflect"
 
 	giturls "github.com/chainguard-dev/git-urls"
 	"github.com/okteto/okteto/cmd/utils"
@@ -89,53 +88,30 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 			deployOptions.Manifest.Deploy.ComposeSection.Stack.Name = deployOptions.Name
 		}
 	}
-
-	if deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection != nil && deployOptions.Manifest.Deploy.ComposeSection.Stack != nil {
-
-		mergeServicesToDeployFromOptionsAndManifest(deployOptions)
-		if len(deployOptions.ServicesToDeploy) == 0 {
-			deployOptions.ServicesToDeploy = []string{}
-			for service := range deployOptions.Manifest.Deploy.ComposeSection.Stack.Services {
-				deployOptions.ServicesToDeploy = append(deployOptions.ServicesToDeploy, service)
-			}
+	if deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection != nil {
+		svcs, err := getStackServicesToDeploy(ctx, deployOptions.Manifest.Deploy.ComposeSection, c)
+		if err != nil {
+			return err
 		}
-		if len(deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo) > 0 {
-			if err := stack.ValidateDefinedServices(deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.ServicesToDeploy); err != nil {
-				return err
-			}
-			deployOptions.ServicesToDeploy = stack.AddDependentServicesIfNotPresent(ctx, deployOptions.Manifest.Deploy.ComposeSection.Stack, deployOptions.ServicesToDeploy, c)
-			deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo[0].ServicesToDeploy = deployOptions.ServicesToDeploy
-		}
+		deployOptions.StackServicesToDeploy = svcs
 	}
 	return nil
 }
 
-func mergeServicesToDeployFromOptionsAndManifest(deployOptions *Options) {
-	var manifestDeclaredServicesToDeploy []string
-	for _, composeInfo := range deployOptions.Manifest.Deploy.ComposeSection.ComposesInfo {
-		manifestDeclaredServicesToDeploy = append(manifestDeclaredServicesToDeploy, composeInfo.ServicesToDeploy...)
-	}
+func getStackServicesToDeploy(ctx context.Context, composeSectionInfo *model.ComposeSectionInfo, c kubernetes.Interface) ([]string, error) {
+	svcs := []string{}
 
-	manifestDeclaredServicesToDeploySet := map[string]bool{}
-	for _, service := range manifestDeclaredServicesToDeploy {
-		manifestDeclaredServicesToDeploySet[service] = true
-	}
+	for service := range composeSectionInfo.Stack.Services {
+		svcs = append(svcs, service)
 
-	commandDeclaredServicesToDeploy := map[string]bool{}
-	for _, service := range deployOptions.ServicesToDeploy {
-		commandDeclaredServicesToDeploy[service] = true
 	}
-
-	if reflect.DeepEqual(manifestDeclaredServicesToDeploySet, commandDeclaredServicesToDeploy) {
-		return
+	if len(composeSectionInfo.ComposesInfo) > 0 {
+		if err := stack.ValidateDefinedServices(composeSectionInfo.Stack, svcs); err != nil {
+			return []string{}, err
+		}
+		svcs = stack.AddDependentServicesIfNotPresent(ctx, composeSectionInfo.Stack, svcs, c)
 	}
-
-	if len(deployOptions.ServicesToDeploy) > 0 && len(manifestDeclaredServicesToDeploy) > 0 {
-		oktetoLog.Warning("overwriting manifest's `services to deploy` with command line arguments")
-	}
-	if len(deployOptions.ServicesToDeploy) == 0 && len(manifestDeclaredServicesToDeploy) > 0 {
-		deployOptions.ServicesToDeploy = manifestDeclaredServicesToDeploy
-	}
+	return svcs, nil
 }
 
 func (dc *Command) addEnvVars(cwd string) {

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -16,7 +16,6 @@ package deploy
 import (
 	"context"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/okteto/okteto/internal/test"
@@ -215,14 +214,10 @@ func Test_getStackServicesToDeploy(t *testing.T) {
 			ctx := context.Background()
 			c := fake.NewSimpleClientset()
 
-			svcs, err := getStackServicesToDeploy(ctx, tt.composeSectionInfo, c)
-			if err != nil {
-				t.Fatalf("failed to get stack services to deploy: %s", err)
-			}
+			svcs, _ := getStackServicesToDeploy(ctx, tt.composeSectionInfo, c)
 
-			if !reflect.DeepEqual(svcs, tt.expected) {
-				t.Errorf("got stack services to deploy %v, expected %v", svcs, tt.expected)
-			}
+			assert.Equal(t, tt.expected, svcs)
+
 		})
 	}
 }

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -16,13 +16,11 @@ package deploy
 import (
 	"context"
 	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
-	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
@@ -95,81 +93,6 @@ devs:
 	assert.Equal(t, expectedCfg.Labels, currentCfg.Labels)
 	assert.Equal(t, expectedCfg.Data, currentCfg.Data)
 	assert.NotEmpty(t, currentCfg.Annotations[constants.LastUpdatedAnnotation])
-}
-
-func Test_mergeServicesToDeployFromOptionsAndManifest(t *testing.T) {
-	tests := []struct {
-		name             string
-		options          *Options
-		expectedServices []string
-	}{
-		{
-			name: "no manifest services to deploy",
-			options: &Options{
-				ServicesToDeploy: []string{"a", "b"},
-				Manifest: &model.Manifest{
-					Deploy: &model.DeployInfo{
-						ComposeSection: &model.ComposeSectionInfo{
-							ComposesInfo: []model.ComposeInfo{},
-						},
-					},
-				},
-			},
-			expectedServices: []string{"a", "b"},
-		},
-		{
-			name: "no options services to deploy",
-			options: &Options{
-				Manifest: &model.Manifest{
-					Deploy: &model.DeployInfo{
-						ComposeSection: &model.ComposeSectionInfo{
-							ComposesInfo: []model.ComposeInfo{
-								{ServicesToDeploy: []string{"a", "b"}},
-								{ServicesToDeploy: []string{"c", "d"}},
-							},
-						},
-					},
-				},
-			},
-			expectedServices: []string{"a", "b", "c", "d"},
-		},
-		{
-			name: "both",
-			options: &Options{
-				ServicesToDeploy: []string{"from command a", "from command b"},
-				Manifest: &model.Manifest{
-					Deploy: &model.DeployInfo{
-						ComposeSection: &model.ComposeSectionInfo{
-							ComposesInfo: []model.ComposeInfo{
-								{ServicesToDeploy: []string{"c", "d"}},
-							},
-						},
-					},
-				},
-			},
-			expectedServices: []string{"from command a", "from command b"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			mergeServicesToDeployFromOptionsAndManifest(test.options)
-			// We have to check them as if they were sets to account for order
-			expected := map[string]bool{}
-			for _, service := range test.expectedServices {
-				expected[service] = true
-			}
-
-			got := map[string]bool{}
-			for _, service := range test.options.ServicesToDeploy {
-				got[service] = true
-			}
-
-			if !reflect.DeepEqual(expected, got) {
-				t.Errorf("expected %v, got %v", expected, got)
-			}
-		})
-	}
 }
 
 func Test_switchSSHRepoToHTTPS(t *testing.T) {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -162,6 +162,7 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Execute the list of commands specified in the 'deploy' section of your okteto manifest",
+		Args:  utils.NoArgsAccepted(""),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// validate cmd options
 			if options.Dependencies && !okteto.IsOkteto() {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -72,19 +72,19 @@ type Options struct {
 	ManifestPathFlag string
 	// ManifestPath is the path to the manifest used though the command execution.
 	// This might change its value during execution
-	ManifestPath     string
-	Name             string
-	Namespace        string
-	K8sContext       string
-	Variables        []string
-	ServicesToDeploy []string
-	Timeout          time.Duration
-	Build            bool
-	Dependencies     bool
-	RunWithoutBash   bool
-	RunInRemote      bool
-	Wait             bool
-	ShowCTA          bool
+	ManifestPath          string
+	Name                  string
+	Namespace             string
+	K8sContext            string
+	Variables             []string
+	StackServicesToDeploy []string
+	Timeout               time.Duration
+	Build                 bool
+	Dependencies          bool
+	RunWithoutBash        bool
+	RunInRemote           bool
+	Wait                  bool
+	ShowCTA               bool
 }
 
 type builderInterface interface {
@@ -160,9 +160,9 @@ type Deployer interface {
 func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker buildDeployTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLogger) *cobra.Command {
 	options := &Options{}
 	cmd := &cobra.Command{
-		Use:   "deploy [service...]",
+		Use:   "deploy",
 		Short: "Execute the list of commands specified in the 'deploy' section of your okteto manifest",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			// validate cmd options
 			if options.Dependencies && !okteto.IsOkteto() {
 				return fmt.Errorf("'dependencies' is only supported in contexts that have Okteto installed")
@@ -208,7 +208,6 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 			}
 
 			options.ShowCTA = oktetoLog.IsInteractive()
-			options.ServicesToDeploy = args
 
 			k8sClientProvider := okteto.NewK8sClientProviderWithLogger(k8sLogger)
 			pc, err := pipelineCMD.NewCommand()
@@ -325,10 +324,6 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 
 	if deployOptions.Manifest.Deploy == nil && !deployOptions.Manifest.HasDependencies() {
 		return oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands
-	}
-
-	if len(deployOptions.ServicesToDeploy) > 0 && deployOptions.Manifest.Deploy != nil && deployOptions.Manifest.Deploy.ComposeSection == nil {
-		return oktetoErrors.ErrDeployCantDeploySvcsIfNotCompose
 	}
 
 	// We need to create a client that doesn't go through the proxy to create
@@ -755,7 +750,7 @@ func (dc *Command) deployStack(ctx context.Context, opts *Options) error {
 		ForceBuild:       false,
 		Wait:             opts.Wait,
 		Timeout:          opts.Timeout,
-		ServicesToDeploy: opts.ServicesToDeploy,
+		ServicesToDeploy: opts.StackServicesToDeploy,
 		InsidePipeline:   true,
 	}
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -312,37 +312,6 @@ func TestDeployWithNeitherDeployNorDependencyInManifestFile(t *testing.T) {
 	fakeDeployer.AssertNotCalled(t, "Get")
 }
 
-func TestDeployWithServicesToBuildWithoutComposeSection(t *testing.T) {
-	fakeDeployer := &fakeDeployer{}
-	okteto.CurrentStore = &okteto.ContextStore{
-		Contexts: map[string]*okteto.Context{
-			"test": {
-				Namespace: "test",
-				Cfg:       &api.Config{},
-			},
-		},
-		CurrentContext: "test",
-	}
-	c := &Command{
-		GetManifest:       getFakeManifest,
-		GetDeployer:       fakeDeployer.Get,
-		K8sClientProvider: test.NewFakeK8sProvider(),
-	}
-	ctx := context.Background()
-	opts := &Options{
-		Name:             "movies",
-		ManifestPath:     "",
-		Variables:        []string{},
-		ServicesToDeploy: []string{"service1"},
-	}
-
-	err := c.Run(ctx, opts)
-
-	assert.ErrorIs(t, err, oktetoErrors.ErrDeployCantDeploySvcsIfNotCompose)
-	// Verify the deploy phase is not even reached
-	fakeDeployer.AssertNotCalled(t, "Get")
-}
-
 func TestCreateConfigMapWithBuildError(t *testing.T) {
 	fakeK8sClientProvider := test.NewFakeK8sProvider()
 	opts := &Options{

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -157,9 +157,6 @@ var (
 	// ErrManifestFoundButNoDeployAndDependenciesCommands raised when a manifest is found but no deploy or dependencies commands are defined
 	ErrManifestFoundButNoDeployAndDependenciesCommands = errors.New("found okteto manifest, but no deploy or dependencies commands were defined")
 
-	// ErrDeployCantDeploySvcsIfNotCompose raised when a manifest is found but no compose info is detected and args are passed to deploy command
-	ErrDeployCantDeploySvcsIfNotCompose = errors.New("services args are can only be used while trying to deploy a compose")
-
 	// ErrGitHubNotVerifiedEmail is raised when github login has not a verified email
 	ErrGitHubNotVerifiedEmail = errors.New("github-not-verified-email")
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-445

This PR removes the support for deploying several stack services from an `okteto deploy` command. 


## How to validate

1. Run `okteto deploy api` and check that an error is thrown
1. Using a compose file with dependant services
1. Run just one of the services that depends on another


Example: 
```yaml
version: '3'
services:
  a:
    image: nginx
    container_name: a

  b:
    image: nginx
    container_name: b
    depends_on:
      - a

  c:
    image: nginx
    container_name: c
```


``` yaml
deploy:
  compose:
    - file: docker-compose.yml
      services:
        - b
```
## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
