### PR TITLE
Allow remote deploy inside remote deploy

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -563,11 +563,6 @@ func getDefaultTimeout() time.Duration {
 }
 
 func shouldRunInRemote(opts *Options) bool {
-	// already in remote so we need to deploy locally
-	if env.LoadBoolean(constants.OktetoDeployRemote) {
-		return false
-	}
-
 	// --remote flag enabled from command line
 	if opts.RunInRemote {
 		return true

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -53,7 +53,7 @@ func TestDeployInDeployRemote(t *testing.T) {
 	require.NoError(t, createOktetoManifestWithName(dir, parentManifestContent, "okteto.yml"))
 	require.NoError(t, createOktetoManifestWithName(dir, childManifestContent, "other-okteto.yml"))
 
-	testNamespace := "teresaromero-depindep"
+	testNamespace := integration.GetTestNamespace("DeployInDeployRemote", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		Token:      token,

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 // +build integration
 
-// Copyright 2023 The Okteto Authors
+// Copyright 2024 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -28,18 +28,14 @@ var (
 	parentManifestContent = `
 deploy:
   remote: true
-  image: golang:1.22.5-bookworm
   commands:
-    - go version
-    - version=$(go version); if [ $version -ne "go version go1.22.5 linux/amd64" ]; then exit 1; fi
     - okteto deploy -f other-okteto.yml --remote`
 
 	childManifestContent = `
 deploy:
-  image: golang:1.21.12-bookworm
+  image: aquasec/trivy:latest
   commands:
-    - go version
-    - version=$(go version); if [ $version -ne "go version go1.21.12 linux/amd64" ]; then exit 1; fi`
+    - trivy -q image alpine:3.14`
 )
 
 // TestDeployInDeployRemote test the scenario where an okteto deploy is run inside an okteto deploy in remote

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+// +build integration
+
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/integration"
+	"github.com/okteto/okteto/integration/commands"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	parentManifestContent = `
+deploy:
+  remote: true
+  image: golang:1.22.5-bookworm
+  commands:
+    - go version
+    - version=$(go version); if [ $version -ne "go version go1.22.5 linux/amd64" ]; then exit 1; fi
+    - okteto deploy -f other-okteto.yml --remote`
+
+	childManifestContent = `
+deploy:
+  image: golang:1.21.12-bookworm
+  commands:
+    - go version
+    - version=$(go version); if [ $version -ne "go version go1.21.12 linux/amd64" ]; then exit 1; fi`
+)
+
+// TestDeployInDeployRemote test the scenario where an okteto deploy is run inside an okteto deploy in remote
+// image base for the child deploy should be the specified at the child manifest and not the parent
+func TestDeployInDeployRemote(t *testing.T) {
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+
+	require.NoError(t, createOktetoManifestWithName(dir, parentManifestContent, "okteto.yml"))
+	require.NoError(t, createOktetoManifestWithName(dir, childManifestContent, "other-okteto.yml"))
+
+	testNamespace := "teresaromero-depindep"
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		Token:      token,
+		OktetoHome: dir,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+
+	destroyOptions := &commands.DestroyOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+}

--- a/integration/deploy/endpoints_test.go
+++ b/integration/deploy/endpoints_test.go
@@ -295,6 +295,7 @@ func Test_EndpointsFromStackWith_InferredName(t *testing.T) {
 		OktetoHome: dir,
 	}
 	require.NoError(t, commands.RunOktetoDestroy(oktetoPath, destroyOptions))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 func createStackWithEndpointsInferredNameScenario(dir string) error {

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -675,6 +675,15 @@ func createOktetoManifest(dir, content string) error {
 	return nil
 }
 
+func createOktetoManifestWithName(dir, content, name string) error {
+	manifestPath := filepath.Join(dir, name)
+	manifestContent := []byte(content)
+	if err := os.WriteFile(manifestPath, manifestContent, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
 func expectImageFoundSkippingBuild(output string) error {
 	if ok := strings.Contains(output, "Skipping build for image for service"); !ok {
 		log.Print(output)

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -488,7 +488,7 @@ func TestDeployOktetoManifestWithinRepository(t *testing.T) {
 
 	require.NoError(t, createOktetoManifest(dir, simpleOktetoManifestContent))
 
-	testNamespace := integration.GetTestNamespace("ifbyol-DeployManifestWithinRepo", user)
+	testNamespace := integration.GetTestNamespace("DeployManifestWithinRepo", user)
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -371,7 +371,7 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 	if len(params.Artifacts) > 0 {
 		buildOptions.LocalOutputPath = buildCtx
 	}
-	r.ioCtrl.Logger().Infof("Executing test with the following image: %s", params.BaseImage)
+	r.ioCtrl.Logger().Infof("Executing remote with the following base image: %s", params.BaseImage)
 
 	// we need to call Run() method using a remote builder. This Builder will have
 	// the same behavior as the V1 builder but with a different output taking into


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-214

When running an `okteto deploy` with a deploy remote command as part of the deploy manifest, the deploy inside deploy was not being run remotly, but locally based on the runner of the "parent" deploy.

This was caused as we where skippping a remote deploy if we already where inside a remote deploy, this PR removes this check.

Other related changes:
- Remove the remote check from NewConfigmapHandler, as this was causing the child deploy to not create a configmap
- Small fix on log, the log was appearing when deploy and its being reused for testing, used this PR to change this.

## How to validate

- Build the image with the changes and locally use the env OKTETO_REMOTE_CLI_IMAGE to use it on remote runners
- Using 2 manifests

```
# okteto.yml
deploy:
  remote: true
  commands:
    - git clone https://github.com/okteto/movies.git
    - cd movies && okteto deploy --remote
    - echo "hello from okteto.yml"
    - okteto deploy -f other-okteto.yml --remote
```

```
# other-okteto.yml
deploy:
  image: aquasec/trivy:latest
  commands:
    - echo "hello from other-okteto.yml"
    - trivy image python:3.4-alpine
```

run `okteto deploy` will deploy the parent manifest,
-  a configmap for movies should be created and all resources should be under the movies dev environment
- trivy command from child manifest should be run without error

## Tests
integration test && Manual testing running locally and inside the pipeline installer

