### PR TITLE
Migrate circleci deploy to run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - f7:81:9f:b4:31:3a:4d:46:ce:cf:54:a2:70:46:5a:df
-      - deploy:
+      - run:
           name: Update brew formula
           command: |
             sha=$(cat ./artifacts/bin/okteto-Darwin-x86_64.sha256 | awk '{print $1}')
@@ -358,7 +358,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - f7:81:9f:b4:31:3a:4d:46:ce:cf:54:a2:70:46:5a:df
-      - deploy:
+      - run:
           name: Update brew formula
           command: |
             sha=$(cat ./artifacts/bin/okteto-Darwin-x86_64.sha256 | awk '{print $1}')
@@ -366,7 +366,7 @@ jobs:
             ./scripts/update_homebrew_formula.sh $CIRCLE_TAG $sha $sha_arm
             pushd homebrew-cli
             git push git@github.com:okteto/homebrew-cli.git master
-      - deploy:
+      - run:
           name: Auto-update-actions
           command: ./scripts/ci/release-github-actions.sh $CIRCLE_TAG
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ parameters:
     type: string
     default: ""
 
-
 orbs:
   win: circleci/windows@5.0.0
+
 commands:
   integration-actions:
     steps:
@@ -67,7 +67,7 @@ commands:
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             make integration-up
           environment:
-            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_SKIP_CLEANUP: "true"
 
   integration-okteto:
     steps:
@@ -82,7 +82,6 @@ commands:
       - run:
           name: Run deprecated integration tests
           command: make integration-deprecated
-
 
 executors:
   golang-ci:
@@ -273,7 +272,7 @@ jobs:
           name: Run deprecated integration tests
           environment:
             OKTETO_URL: https://staging.okteto.dev/
-            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_SKIP_CLEANUP: "true"
             OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
@@ -284,7 +283,7 @@ jobs:
           name: Run build integration tests
           environment:
             OKTETO_URL: https://staging.okteto.dev/
-            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_SKIP_CLEANUP: "true"
             OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
           command: |
             $env:DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
@@ -295,7 +294,7 @@ jobs:
           name: Run deploy integration tests
           environment:
             OKTETO_URL: https://staging.okteto.dev/
-            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_SKIP_CLEANUP: "true"
             OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
@@ -308,7 +307,7 @@ jobs:
           name: Run up integration tests
           environment:
             OKTETO_URL: https://staging.okteto.dev/
-            OKTETO_SKIP_CLEANUP: 'true'
+            OKTETO_SKIP_CLEANUP: "true"
             OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
@@ -388,7 +387,6 @@ jobs:
           fingerprints:
             - a1:66:22:e1:67:66:fb:d6:3b:a2:7a:6c:d9:9a:46:ba
       - run: ./scripts/ci/release-branch.sh
-
 
 workflows:
   upload-static:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
       - run: *docker-login
       - run: ./scripts/ci/push-image.sh latest "linux/amd64"
 
-  upload-static:
+  upload-static-job:
     executor: golang-ci
     steps:
       - checkout
@@ -370,7 +370,7 @@ jobs:
           name: Auto-update-actions
           command: ./scripts/ci/release-github-actions.sh $CIRCLE_TAG
 
-  release:
+  release-job:
     executor: golang-ci
     steps:
       - checkout
@@ -379,7 +379,7 @@ jobs:
       - run: *init-gcloud
       - run: ./scripts/ci/release.sh
 
-  release-branch:
+  release-branch-job:
     executor: golang-ci
     steps:
       - checkout
@@ -392,7 +392,7 @@ jobs:
 workflows:
   upload-static:
     jobs:
-      - upload-static:
+      - upload-static-job:
           context: GKE
           filters:
             branches:
@@ -491,7 +491,7 @@ workflows:
               only: *release-branch-regex
           requires:
             - build-binaries
-      - release-branch:
+      - release-branch-job:
           requires:
             - build-binaries
             - test-integration
@@ -514,7 +514,7 @@ workflows:
           context: Product-okteto-dev
           requires:
             - build-binaries
-      - release:
+      - release-job:
           context: GKE
           requires:
             - build-binaries
@@ -554,7 +554,7 @@ workflows:
             tags:
               only:
                 - *release-regex
-      - release:
+      - release-job:
           context: GKE
           requires:
             - build-binaries
@@ -568,7 +568,7 @@ workflows:
       - release-external:
           context: GKE
           requires:
-            - release
+            - release-job
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-# https://circleci.com/docs/2.0/configuration-reference/
+# https://circleci.com/docs/2.1/configuration-reference/
+version: 2.1
+
 aliases:
   - &init-gcloud |
     echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
@@ -13,7 +15,6 @@ aliases:
     touch $HOME/.okteto/.noanalytics
     okteto context use ${OKTETO_URL} --token ${OKTETO_TOKEN}
   - &docker-login echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-version: 2.1
 
 parameters:
   # The following parameters are filled by GH Actions to run CircleCI jobs


### PR DESCRIPTION
# Proposed changes

This PR updates the circleci config to use `run` instead of `deploy` following https://circleci.com/docs/migrate-from-deploy-to-run/. We do not run parallelism so the change is just replace deploy to run

Additionally, some jobs have been renamed to follow the recommendation of not sharing names between jobs and workflows.
General format changes are also applied.