### PR TITLE
fix: okteto test can export artifact dirs

### DIFF
--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -49,8 +49,10 @@ test:
     image: alpine
     commands:
       - echo "OK" > coverage.txt
+      - mkdir -p reports && echo "OK" > reports/additional-coverage.txt
     artifacts:
       - coverage.txt
+      - reports
 
 deploy:
   - echo "deploying"
@@ -180,6 +182,20 @@ func TestOktetoTestsWithPassingTestsAndArtifacts(t *testing.T) {
 	coverage, err := os.ReadFile(coveragePath)
 	require.NoError(t, err)
 	assert.Equal(t, "OK\n", string(coverage))
+
+	// check that 'reports' exists and is a directory
+	reportsDirPath := filepath.Join(dir, "reports")
+	reportsDir, err := os.Open(reportsDirPath)
+	assert.NoError(t, err)
+	reportsInfo, err := reportsDir.Stat()
+	require.NoError(t, err)
+	assert.True(t, reportsInfo.IsDir())
+
+	// check that additional-coverage.txt exists and has the expected content
+	additionalCoveragePath := filepath.Join(reportsDirPath, "additional-coverage.txt")
+	additionalCoverage, err := os.ReadFile(additionalCoveragePath)
+	require.NoError(t, err)
+	assert.Equal(t, "OK\n", string(additionalCoverage))
 
 	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/pkg/model/manifest_friendly_err.go
+++ b/pkg/model/manifest_friendly_err.go
@@ -76,6 +76,7 @@ func getManifestSuggestionRules(manifestSchema interface{}) []*suggest.Rule {
 		suggest.NewStrReplaceRule("in type model.devType", "the 'dev' object"),
 		suggest.NewStrReplaceRule("into model.devType", "the 'dev' object"),
 		suggest.NewStrReplaceRule("in type model.testCommandAlias", "the 'test commands' object"),
+		suggest.NewStrReplaceRule("into model.testAlias", "into a 'test' object"),
 		suggest.NewStrReplaceRule("in type model.testAlias", "the 'test' object"),
 
 		// yaml types

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -104,9 +104,9 @@ RUN \
   /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }}{{ if eq .Command "test" }} || true{{ end }}
 
 {{range $key, $artifact := .Artifacts }}
-RUN if [ -f /okteto/src/{{$artifact.Path}} ]; then \
+RUN if [ -e /okteto/src/{{$artifact.Path}} ]; then \
     mkdir -p $(dirname /okteto/artifacts/{{$artifact.Destination}}) && \
-    cp /okteto/src/{{$artifact.Path}} /okteto/artifacts/{{$artifact.Destination}}; \
+    cp -r /okteto/src/{{$artifact.Path}} /okteto/artifacts/{{$artifact.Destination}}; \
   fi
 {{end}}
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -476,14 +476,14 @@ RUN \
   /okteto/bin/okteto remote-run test --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test" || true
 
 
-RUN if [ -f /okteto/src/coverage.txt ]; then \
+RUN if [ -e /okteto/src/coverage.txt ]; then \
     mkdir -p $(dirname /okteto/artifacts/coverage.txt) && \
-    cp /okteto/src/coverage.txt /okteto/artifacts/coverage.txt; \
+    cp -r /okteto/src/coverage.txt /okteto/artifacts/coverage.txt; \
   fi
 
-RUN if [ -f /okteto/src/report.json ]; then \
+RUN if [ -e /okteto/src/report.json ]; then \
     mkdir -p $(dirname /okteto/artifacts//testing/report.json) && \
-    cp /okteto/src/report.json /okteto/artifacts//testing/report.json; \
+    cp -r /okteto/src/report.json /okteto/artifacts//testing/report.json; \
   fi
 
 


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-502

`okteto test` is not exporting artifacts that are directories. This change is to fix that.

## How to validate

1. Clone https://github.com/okteto/go-getting-started
1. Add this block to the the `okteto.yml`
```
test:
  unit:
    commands:
      - mkdir -p test-reports
      - echo "1" > test-reports/test1.txt
      - echo "2" > test-reports/test2.txt
      - echo "3" > test-reports/test3.txt
    artifacts:
      - test-reports
```
1. Run `okteto test`
1. Observe the success and the copy on your host of the folder `test-reports`.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
