### PR TITLE
`-f` must specify a file

### DIFF
--- a/cmd/build/basic/build.go
+++ b/cmd/build/basic/build.go
@@ -61,8 +61,16 @@ func (ob *Builder) Build(ctx context.Context, options *types.BuildOptions) error
 		options.File = filepath.Join(path, "Dockerfile")
 	}
 
-	if exists := filesystem.FileExistsAndNotDir(options.File, afero.NewOsFs()); !exists {
-		return fmt.Errorf("%s: '%s' is not a regular file", oktetoErrors.InvalidDockerfile, options.File)
+	fs := afero.NewOsFs()
+
+	// check that the manifest file exists
+	if !filesystem.FileExistsWithFilesystem(options.File, fs) {
+		return oktetoErrors.ErrManifestPathNotFound
+	}
+
+	// the Okteto manifest flag should specify a file, not a directory
+	if filesystem.IsDir(options.File, fs) {
+		return oktetoErrors.ErrManifestPathIsDir
 	}
 
 	var err error

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -133,7 +133,7 @@ func Build(ctx context.Context, ioCtrl *io.Controller, at, insights buildTracker
 	}
 
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the build command is executed")
-	cmd.Flags().StringVarP(&options.File, "file", "f", "", "path to the Okteto Manifest (default is 'okteto.yml')")
+	cmd.Flags().StringVarP(&options.File, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringVarP(&options.Tag, "tag", "t", "", "name and optionally a tag in the 'name:tag' format (it is automatically pushed)")
 	cmd.Flags().StringVarP(&options.Target, "target", "", "", "set the target build stage to build")
 	cmd.Flags().BoolVarP(&options.NoCache, "no-cache", "", false, "do not use cache when building the image")

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -276,7 +276,7 @@ $ okteto deploy --build=false`,
 	}
 
 	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the okteto manifest file")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
 	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
@@ -822,30 +822,38 @@ func GetDependencyEnvVars(environGetter environGetter) map[string]string {
 }
 
 func checkOktetoManifestPathFlag(options *Options, fs afero.Fs) error {
-	if options.ManifestPath != "" {
-		// if path is absolute, its transformed from root path to a rel path
-		initialCWD, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("failed to get the current working directory: %w", err)
-		}
-		manifestPathFlag, err := oktetoPath.GetRelativePathFromCWD(initialCWD, options.ManifestPath)
-		if err != nil {
-			return err
-		}
-		// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
-		options.ManifestPathFlag = manifestPathFlag
-
-		// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir
-		uptManifestPath, err := filesystem.UpdateCWDtoManifestPath(options.ManifestPath)
-		if err != nil {
-			return err
-		}
-		options.ManifestPath = uptManifestPath
-
-		// check whether the manifest file provided by -f exists or not
-		if _, err := fs.Stat(options.ManifestPath); err != nil {
-			return fmt.Errorf("%s file doesn't exist", options.ManifestPath)
-		}
+	if options.ManifestPath == "" {
+		return nil
 	}
+
+	// if path is absolute, its transformed from root path to a rel path
+	initialCWD, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get the current working directory: %w", err)
+	}
+	manifestPathFlag, err := oktetoPath.GetRelativePathFromCWD(initialCWD, options.ManifestPath)
+	if err != nil {
+		return err
+	}
+	// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
+	options.ManifestPathFlag = manifestPathFlag
+
+	// check that the manifest file exists
+	if !filesystem.FileExistsWithFilesystem(manifestPathFlag, fs) {
+		return oktetoErrors.ErrManifestPathNotFound
+	}
+
+	// the Okteto manifest flag should specify a file, not a directory
+	if filesystem.IsDir(manifestPathFlag, fs) {
+		return oktetoErrors.ErrManifestPathIsDir
+	}
+
+	// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir
+	uptManifestPath, err := filesystem.UpdateCWDtoManifestPath(options.ManifestPath)
+	if err != nil {
+		return err
+	}
+	options.ManifestPath = uptManifestPath
+
 	return nil
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -350,7 +350,7 @@ func TestCreateConfigMapWithBuildError(t *testing.T) {
 	err := c.Run(ctx, opts)
 
 	// we should get a build error because Dockerfile does not exist
-	assert.True(t, strings.Contains(err.Error(), oktetoErrors.InvalidDockerfile))
+	assert.True(t, strings.Contains(err.Error(), oktetoErrors.ErrManifestPathNotFound.Error()))
 
 	fakeClient, _, err := c.K8sClientProvider.ProvideWithLogger(clientcmdapi.NewConfig(), nil)
 	if err != nil {
@@ -919,7 +919,7 @@ func TestOktetoManifestPathFlag(t *testing.T) {
 		{
 			name:        "manifest file path doesn't exist",
 			manifest:    "nonexistent.yml",
-			expectedErr: fmt.Errorf("nonexistent.yml file doesn't exist"),
+			expectedErr: oktetoErrors.ErrManifestPathNotFound,
 		},
 	}
 

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
+	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	"github.com/okteto/okteto/pkg/endpoints"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -95,12 +96,15 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 					return err
 				}
 				options.ManifestPath = filesystem.GetManifestPathFromWorkdir(options.ManifestPath, workdir)
-				// check whether the manifest file provided by -f exists or not
-				if _, err := fs.Stat(options.ManifestPath); err != nil {
-					return oktetoErrors.UserError{
-						E:    fmt.Errorf("the okteto manifest file '%s' does not exist", options.ManifestPath),
-						Hint: "Check the path to the okteto manifest file",
-					}
+
+				// check that the manifest file exists
+				if !filesystem.FileExistsWithFilesystem(options.ManifestPath, fs) {
+					return oktetoErrors.ErrManifestPathNotFound
+				}
+
+				// the Okteto manifest flag should specify a file, not a directory
+				if filesystem.IsDir(options.ManifestPath, fs) {
+					return oktetoErrors.ErrManifestPathIsDir
 				}
 			}
 
@@ -149,7 +153,7 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the okteto manifest file")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/cmd/down"
 	"github.com/okteto/okteto/pkg/config"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -39,7 +40,7 @@ type analyticsTrackerInterface interface {
 }
 
 // Down deactivates the development container
-func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger) *cobra.Command {
+func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger, fs afero.Fs) *cobra.Command {
 	var devPath string
 	var namespace string
 	var k8sContext string
@@ -73,8 +74,18 @@ func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger) *cobra.Comman
 					return err
 				}
 				devPath = filesystem.GetManifestPathFromWorkdir(devPath, workdir)
+
+				// check that the manifest file exists
+				if !filesystem.FileExistsWithFilesystem(devPath, fs) {
+					return oktetoErrors.ErrManifestPathNotFound
+				}
+
+				// the Okteto manifest flag should specify a file, not a directory
+				if filesystem.IsDir(devPath, fs) {
+					return oktetoErrors.ErrManifestPathIsDir
+				}
 			}
-			manifest, err := model.GetManifestV2(manifestOpts.Filename, afero.NewOsFs())
+			manifest, err := model.GetManifestV2(manifestOpts.Filename, fs)
 			if err != nil {
 				return err
 			}
@@ -84,7 +95,7 @@ func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger) *cobra.Comman
 				return err
 			}
 
-			dc := down.New(afero.NewOsFs(), okteto.NewK8sClientProviderWithLogger(k8sLogsCtrl), at)
+			dc := down.New(fs, okteto.NewK8sClientProviderWithLogger(k8sLogsCtrl), at)
 
 			if all {
 				err := dc.AllDown(ctx, manifest, okteto.GetContext().Namespace, rm)
@@ -142,7 +153,7 @@ func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger) *cobra.Comman
 		},
 	}
 
-	cmd.Flags().StringVarP(&devPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
+	cmd.Flags().StringVarP(&devPath, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().BoolVarP(&rm, "volumes", "v", false, "remove persistent volume")
 	cmd.Flags().BoolVarP(&all, "all", "A", false, "deactivate all running dev containers")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the down command is executed")

--- a/cmd/exec/cmd.go
+++ b/cmd/exec/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	okerrors "github.com/okteto/okteto/pkg/errors"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -95,6 +96,18 @@ okteto exec my-pod -- echo this is a test
 # Get an interactive shell session inside the pod named 'my-pod'
 okteto exec my-pod`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if execFlags.manifestPath != "" {
+				// check that the manifest file exists
+				if !filesystem.FileExistsWithFilesystem(execFlags.manifestPath, e.fs) {
+					return oktetoErrors.ErrManifestPathNotFound
+				}
+
+				// the Okteto manifest flag should specify a file, not a directory
+				if filesystem.IsDir(execFlags.manifestPath, e.fs) {
+					return oktetoErrors.ErrManifestPathIsDir
+				}
+			}
+
 			ctxOpts := &contextCMD.Options{
 				Show:      true,
 				Context:   execFlags.k8sContext,
@@ -127,7 +140,7 @@ okteto exec my-pod`,
 			return e.Run(ctx, argsResult, manifest.Dev[argsResult.DevName], okteto.GetContext().Namespace)
 		},
 	}
-	cmd.Flags().StringVarP(&execFlags.manifestPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
+	cmd.Flags().StringVarP(&execFlags.manifestPath, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringVarP(&execFlags.namespace, "namespace", "n", "", "namespace where the exec command is executed")
 	cmd.Flags().StringVarP(&execFlags.k8sContext, "context", "c", "", "context where the exec command is executed")
 	return cmd

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -28,6 +28,8 @@ import (
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	"github.com/okteto/okteto/pkg/errors"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
@@ -56,13 +58,25 @@ type Options struct {
 	All          bool
 }
 
-func Logs(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
+func Logs(ctx context.Context, k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 	options := &Options{}
 
 	cmd := &cobra.Command{
 		Use:   "logs",
 		Short: "Fetch the logs of your development environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if options.ManifestPath != "" {
+				// check that the manifest file exists
+				if !filesystem.FileExistsWithFilesystem(options.ManifestPath, fs) {
+					return oktetoErrors.ErrManifestPathNotFound
+				}
+
+				// the Okteto manifest flag should specify a file, not a directory
+				if filesystem.IsDir(options.ManifestPath, fs) {
+					return oktetoErrors.ErrManifestPathIsDir
+				}
+			}
+
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
@@ -137,7 +151,7 @@ func Logs(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&options.All, "all", "a", false, "fetch logs from the whole namespace")
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the manifest file")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "the namespace to use to fetch the logs (defaults to the current okteto namespace)")
 	cmd.Flags().StringVarP(&options.Context, "context", "c", "", "the context to use to fetch the logs")
 	cmd.Flags().StringVarP(&options.exclude, "exclude", "e", "", "exclude by service name (regular expression)")

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	modelUtils "github.com/okteto/okteto/pkg/model/utils"
@@ -38,6 +39,7 @@ import (
 	"github.com/okteto/okteto/pkg/repository"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/okteto/okteto/pkg/validator"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 )
@@ -58,7 +60,6 @@ type deployFlags struct {
 	name         string
 	namespace    string
 	file         string
-	filename     string //Deprecated field
 	variables    []string
 	labels       []string
 	timeout      time.Duration
@@ -82,13 +83,24 @@ type DeployOptions struct {
 	ReuseParams  bool
 }
 
-func deploy(ctx context.Context) *cobra.Command {
+func deploy(ctx context.Context, fs afero.Fs) *cobra.Command {
 	flags := &deployFlags{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
 		Short: "Deploy an okteto pipeline",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if flags.file != "" {
+				// check that the manifest file exists
+				if !filesystem.FileExistsWithFilesystem(flags.file, fs) {
+					return oktetoErrors.ErrManifestPathNotFound
+				}
+
+				// the Okteto manifest flag should specify a file, not a directory
+				if filesystem.IsDir(flags.file, fs) {
+					return oktetoErrors.ErrManifestPathIsDir
+				}
+			}
 
 			if err := validator.CheckReservedVariablesNameOption(flags.variables); err != nil {
 				return err
@@ -127,11 +139,7 @@ func deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolVarP(&flags.skipIfExists, "skip-if-exists", "", false, "skip the pipeline deployment if the pipeline already exists in the namespace (defaults to false)")
 	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
 	cmd.Flags().StringArrayVarP(&flags.variables, "var", "v", []string{}, "set a pipeline variable (can be set more than once)")
-	cmd.Flags().StringVarP(&flags.file, "file", "f", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
-	cmd.Flags().StringVarP(&flags.filename, "filename", "", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
-	if err := cmd.Flags().MarkHidden("filename"); err != nil {
-		oktetoLog.Infof("failed to mark 'filename' flag as hidden: %s", err)
-	}
+	cmd.Flags().StringVarP(&flags.file, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "set an environment label (can be set more than once)")
 	cmd.Flags().BoolVar(&flags.reuseParams, "reuse-params", false, "if pipeline exist, reuse same params to redeploy")
 
@@ -425,15 +433,6 @@ func CheckAllResourcesRunning(name string, resourceStatus map[string]string) (bo
 }
 
 func (f deployFlags) toOptions() *DeployOptions {
-	file := f.file
-	if f.filename != "" {
-		oktetoLog.Warning("the 'filename' flag is deprecated and will be removed in a future version. Please consider using 'file' flag")
-		if file == "" {
-			file = f.filename
-		} else {
-			oktetoLog.Warning("flags 'filename' and 'file' can not be used at the same time. 'file' flag will take precedence")
-		}
-	}
 	return &DeployOptions{
 		Branch:       f.branch,
 		Repository:   f.repository,
@@ -442,7 +441,7 @@ func (f deployFlags) toOptions() *DeployOptions {
 		Wait:         f.wait,
 		SkipIfExists: f.skipIfExists,
 		Timeout:      f.timeout,
-		File:         file,
+		File:         f.file,
 		Variables:    f.variables,
 		Labels:       f.labels,
 		ReuseParams:  f.reuseParams,

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -777,25 +777,6 @@ func TestFlagsToOptions(t *testing.T) {
 			expect: &DeployOptions{},
 		},
 		{
-			name: "filename and file",
-			flags: deployFlags{
-				file:     "file",
-				filename: "filename",
-			},
-			expect: &DeployOptions{
-				File: "file",
-			},
-		},
-		{
-			name: "just filename",
-			flags: deployFlags{
-				filename: "filename",
-			},
-			expect: &DeployOptions{
-				File: "filename",
-			},
-		},
-		{
 			name: "all flags ",
 			flags: deployFlags{
 				branch:      "branch",

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -52,13 +53,13 @@ func NewCommand() (*Command, error) {
 }
 
 // Pipeline pipeline management commands
-func Pipeline(ctx context.Context) *cobra.Command {
+func Pipeline(ctx context.Context, fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
 		Short: "Pipeline management commands",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#pipeline"),
 	}
-	cmd.AddCommand(deploy(ctx))
+	cmd.AddCommand(deploy(ctx, fs))
 	cmd.AddCommand(destroy(ctx))
 	cmd.AddCommand(list(ctx))
 	return cmd

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -40,17 +40,16 @@ var (
 )
 
 type DeployOptions struct {
-	branch             string
-	deprecatedFilename string
-	file               string
-	name               string
-	repository         string
-	scope              string
-	sourceUrl          string
-	variables          []string
-	labels             []string
-	timeout            time.Duration
-	wait               bool
+	branch     string
+	file       string
+	name       string
+	repository string
+	scope      string
+	sourceUrl  string
+	variables  []string
+	labels     []string
+	timeout    time.Duration
+	wait       bool
 }
 
 // Deploy Deploy a preview environment
@@ -92,13 +91,9 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
 	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a preview environment variable (can be set more than once)")
 	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", false, "wait until the preview environment deployment finishes (defaults to false)")
-	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "relative path within the repository to the okteto manifest (default to okteto.yaml or .okteto/okteto.yaml)")
+	cmd.Flags().StringVarP(&opts.file, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringArrayVarP(&opts.labels, "label", "", []string{}, "set a preview environment label (can be set more than once)")
 
-	cmd.Flags().StringVarP(&opts.deprecatedFilename, "filename", "", "", "relative path within the repository to the manifest file (default to okteto-pipeline.yaml or .okteto/okteto-pipeline.yaml)")
-	if err := cmd.Flags().MarkHidden("filename"); err != nil {
-		oktetoLog.Infof("failed to hide deprecated flag: %s", err)
-	}
 	return cmd
 }
 

--- a/cmd/preview/deploy_utils_test.go
+++ b/cmd/preview/deploy_utils_test.go
@@ -58,27 +58,6 @@ func Test_optionsSetup(t *testing.T) {
 			},
 		},
 		{
-			name: "success-filename",
-			opts: &DeployOptions{
-				scope:              "personal",
-				repository:         "test-repository",
-				branch:             "test-branch",
-				deprecatedFilename: "filename-old",
-			},
-			expectedFile: "filename-old",
-		},
-		{
-			name: "success-filename-file",
-			opts: &DeployOptions{
-				scope:              "personal",
-				repository:         "test-repository",
-				branch:             "test-branch",
-				deprecatedFilename: "filename-old",
-				file:               "file",
-			},
-			expectedFile: "file",
-		},
-		{
 			name: "get-repository-err",
 			opts: &DeployOptions{
 				scope:  "personal",

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -26,6 +26,7 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/status"
 	"github.com/okteto/okteto/pkg/config"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/filesystem"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -39,7 +40,7 @@ const (
 )
 
 // Status returns the status of the synchronization process
-func Status() *cobra.Command {
+func Status(fs afero.Fs) *cobra.Command {
 	var devPath string
 	var namespace string
 	var k8sContext string
@@ -50,6 +51,18 @@ func Status() *cobra.Command {
 		Short: "Status of the synchronization process",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#status"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if devPath != "" {
+				// check that the manifest file exists
+				if !filesystem.FileExistsWithFilesystem(devPath, fs) {
+					return oktetoErrors.ErrManifestPathNotFound
+				}
+
+				// the Okteto manifest flag should specify a file, not a directory
+				if filesystem.IsDir(devPath, fs) {
+					return oktetoErrors.ErrManifestPathIsDir
+				}
+			}
+
 			if okteto.InDevContainer() {
 				return oktetoErrors.ErrNotInDevContainer
 			}
@@ -109,7 +122,7 @@ func Status() *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVarP(&devPath, "file", "f", utils.DefaultManifest, "path to the manifest file")
+	cmd.Flags().StringVarP(&devPath, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the up command is executing")
 	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the up command is executing")
 	cmd.Flags().BoolVarP(&showInfo, "info", "i", false, "show syncthing links for troubleshooting the synchronization service")

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -90,7 +90,7 @@ type Options struct {
 }
 
 // Up starts a development container
-func Up(at analyticsTrackerInterface, insights buildDeployTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLogger) *cobra.Command {
+func Up(at analyticsTrackerInterface, insights buildDeployTrackerInterface, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 	upOptions := &Options{}
 	cmd := &cobra.Command{
 		Use:   "up service [flags] -- COMMAND [args...]",
@@ -151,6 +151,16 @@ okteto up my-svc -- echo this is a test
 				// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
 				upOptions.ManifestPathFlag = manifestPathFlag
 
+				// check that the manifest file exists
+				if !filesystem.FileExistsWithFilesystem(manifestPathFlag, fs) {
+					return oktetoErrors.ErrManifestPathNotFound
+				}
+
+				// the Okteto manifest flag should specify a file, not a directory
+				if filesystem.IsDir(manifestPathFlag, fs) {
+					return oktetoErrors.ErrManifestPathIsDir
+				}
+
 				// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir
 				uptManifestPath, err := filesystem.UpdateCWDtoManifestPath(upOptions.ManifestPath)
 				if err != nil {
@@ -158,7 +168,7 @@ okteto up my-svc -- echo this is a test
 				}
 				upOptions.ManifestPath = uptManifestPath
 			}
-			oktetoManifest, err := model.GetManifestV2(upOptions.ManifestPath, afero.NewOsFs())
+			oktetoManifest, err := model.GetManifestV2(upOptions.ManifestPath, fs)
 			if err != nil {
 				if !errors.Is(err, discovery.ErrOktetoManifestNotFound) {
 					return err
@@ -222,7 +232,7 @@ okteto up my-svc -- echo this is a test
 				StartTime:         time.Now(),
 				Registry:          registry.NewOktetoRegistry(okteto.Config{}),
 				Options:           upOptions,
-				Fs:                afero.NewOsFs(),
+				Fs:                fs,
 				analyticsTracker:  at,
 				analyticsMeta:     upMeta,
 				K8sClientProvider: okteto.NewK8sClientProviderWithLogger(k8sLogger),
@@ -358,7 +368,7 @@ okteto up my-svc -- echo this is a test
 		},
 	}
 
-	cmd.Flags().StringVarP(&upOptions.ManifestPath, "file", "f", "", "path to the manifest file")
+	cmd.Flags().StringVarP(&upOptions.ManifestPath, "file", "f", utils.DefaultManifest, "path to the Okteto manifest file")
 	cmd.Flags().StringVarP(&upOptions.Namespace, "namespace", "n", "", "namespace where the up command is executed")
 	cmd.Flags().StringVarP(&upOptions.K8sContext, "context", "c", "", "context where the up command is executed")
 	cmd.Flags().StringArrayVarP(&upOptions.Envs, "env", "e", []string{}, "envs to add to the development container")

--- a/main.go
+++ b/main.go
@@ -168,22 +168,22 @@ func main() {
 	root.AddCommand(build.Build(ctx, ioController, at, insights, k8sLogger))
 
 	root.AddCommand(namespace.Namespace(ctx, k8sLogger))
-	root.AddCommand(up.Up(at, insights, ioController, k8sLogger))
-	root.AddCommand(cmd.Down(at, k8sLogger))
-	root.AddCommand(cmd.Status())
-	root.AddCommand(cmd.Doctor(k8sLogger))
+	root.AddCommand(up.Up(at, insights, ioController, k8sLogger, fs))
+	root.AddCommand(cmd.Down(at, k8sLogger, fs))
+	root.AddCommand(cmd.Status(fs))
+	root.AddCommand(cmd.Doctor(k8sLogger, fs))
 	root.AddCommand(exec.NewExec(fs, ioController, k8sClientProvider).Cmd(ctx))
 	root.AddCommand(preview.Preview(ctx))
 	root.AddCommand(cmd.Restart())
 	root.AddCommand(deploy.Deploy(ctx, at, insights, ioController, k8sLogger))
-	root.AddCommand(destroy.Destroy(ctx, at, insights, ioController, k8sLogger))
+	root.AddCommand(destroy.Destroy(ctx, at, insights, ioController, k8sLogger, fs))
 	root.AddCommand(deploy.Endpoints(ctx, k8sLogger))
-	root.AddCommand(logs.Logs(ctx, k8sLogger))
+	root.AddCommand(logs.Logs(ctx, k8sLogger, fs))
 	root.AddCommand(generateFigSpec.NewCmdGenFigSpec())
 	root.AddCommand(remoterun.RemoteRun(ctx, k8sLogger))
 	root.AddCommand(test.Test(ctx, ioController, k8sLogger, at))
 
-	root.AddCommand(pipeline.Pipeline(ctx))
+	root.AddCommand(pipeline.Pipeline(ctx, fs))
 
 	err = root.Execute()
 
@@ -194,7 +194,7 @@ func main() {
 			tmp[0] = unicode.ToUpper(tmp[0])
 			message = string(tmp)
 		}
-		oktetoLog.Fail(message) // TODO: Change to use ioController  when we fully move to ioController
+		oktetoLog.Fail(message) // TODO: Change to use ioController when we fully move to ioController
 		if uErr, ok := err.(oktetoErrors.UserError); ok {
 			if len(uErr.Hint) > 0 {
 				oktetoLog.Hint("    %s", uErr.Hint)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -44,11 +44,6 @@ func (u CommandError) Error() string {
 	return fmt.Sprintf("%s: %s", u.E.Error(), strings.ToLower(u.Reason.Error()))
 }
 
-const (
-	// InvalidDockerfile text error
-	InvalidDockerfile = "invalid Dockerfile"
-)
-
 // NotLoggedError is raised when the user is not logged in okteto
 type NotLoggedError struct {
 	Context string
@@ -211,6 +206,15 @@ var (
 
 	// ErrNamespaceNotFound is raised when the get namespace query returns a namespace not found
 	ErrNamespaceNotFound = errors.New("namespace-not-found")
+
+	ErrManifestPathNotFound = UserError{
+		E:    fmt.Errorf("the Okteto manifest specified does not exist"),
+		Hint: "Check the path to the Okteto manifest file",
+	}
+	ErrManifestPathIsDir = UserError{
+		E:    fmt.Errorf("the Okteto manifest specified is a directory, please specify a file"),
+		Hint: "Check the path to the Okteto manifest file",
+	}
 )
 
 // IsForbidden raised if the Okteto API returns 401

--- a/pkg/filesystem/file.go
+++ b/pkg/filesystem/file.go
@@ -90,6 +90,15 @@ func FileExistsAndNotDir(path string, fs afero.Fs) bool {
 	return !info.IsDir()
 }
 
+// IsDir checks if a path is a dir or not
+func IsDir(path string, fs afero.Fs) bool {
+	info, err := fs.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+
 // GetLastNLines returns the last N lines of a file up to a max amount of bytes
 func GetLastNLines(fs afero.Fs, path string, n int, maxChunkByteSize int64) ([]string, error) {
 	file, err := fs.Open(path)


### PR DESCRIPTION
# Proposed changes

Fixes: [DEV-449](https://okteto.atlassian.net/browse/DEV-449)

With this change we return an error when the `-f` flag is used with a non-existing path or a directory.

## How to validate

Run Okteto CLI commands using the `-f` and observe its behaviour

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
