### PR TITLE
deploy waits by default

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -285,7 +285,7 @@ $ okteto deploy --build=false`,
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")
 	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "force run deploy commands in remote")
 
-	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the development environment is deployed (defaults to false)")
+	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", true, "wait until the development environment is deployed")
 	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
 
 	return cmd

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -186,9 +186,8 @@ func getDeployCmd(oktetoPath string, deployOptions *DeployOptions) *exec.Cmd {
 	if deployOptions.IsRemote {
 		cmd.Args = append(cmd.Args, "--remote")
 	}
-	if deployOptions.Wait {
-		cmd.Args = append(cmd.Args, "--wait")
-	}
+	cmd.Args = append(cmd.Args, fmt.Sprintf("--wait=%t", deployOptions.Wait))
+
 	cmd.Env = os.Environ()
 	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -69,7 +69,9 @@ const (
       retries: 5
       start_period: 30s
   db:
-    image: alpine
+    image: postgres:16.3-alpine3.19
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - data:/data
     labels:
@@ -121,7 +123,9 @@ volumes:
       retries: 5
       start_period: 30s
   db:
-    image: alpine
+    image: postgres:16.3-alpine3.19
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - data:/data
     labels:
@@ -174,7 +178,9 @@ volumes:
       retries: 5
       start_period: 30s
   db:
-    image: alpine
+    image: postgres:16.3-alpine3.19
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - data:/data
     labels:
@@ -243,6 +249,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 		OktetoHome: dir,
 		Token:      token,
 		LogOutput:  "info",
+		Wait:       false,
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
@@ -563,7 +570,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
-// TestDeployPipelineFromCompose tests the following scenario:
+// TestDeployComposeFromOktetoManifest tests the following scenario:
 // - Deploying a compose manifest locally from an okteto manifestv2
 // - The endpoints generated are accessible
 // - Depends on
@@ -595,6 +602,7 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 		OktetoHome: dir,
 		Token:      token,
 		LogOutput:  "info",
+		Wait:       false,
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-443

Deploy will wait by default

## How to validate

1. Deploy a repo containing several services and endpoints
1. Observe the CLI waiting to deploying all services
1. Observe the endpoints being visible at the end


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
