### PR TITLE
Split integration tests into jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,15 +557,12 @@ workflows:
           context: GKE
   lint-build-test:
     when:
-      or:
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - not:
-            equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-        - not:
-            equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-        - not:
-            equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+      not:
+        or:
+          - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+          - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+          - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
 
     jobs:
       - golangci-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - run:
           name: Build all binaries
           command: env VERSION_STRING=$CIRCLE_TAG make -j 3 build-all
@@ -118,7 +121,7 @@ jobs:
   integration-actions:
     executor: golang-ci
     environment:
-      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
@@ -131,8 +134,9 @@ jobs:
       - run:
           name: Run actions integration tests
           command: |
-            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
+            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_TOKEN=${API_STAGING_TOKEN}
             make integration-actions
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -143,7 +147,7 @@ jobs:
   integration-build:
     executor: golang-ci
     environment:
-      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
@@ -158,8 +162,9 @@ jobs:
           command: |
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
-            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
+            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_TOKEN=${API_STAGING_TOKEN}
             make integration-build
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -170,7 +175,7 @@ jobs:
   integration-deploy:
     executor: golang-ci
     environment:
-      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
@@ -186,7 +191,8 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
+            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             make integration-deploy
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -197,7 +203,7 @@ jobs:
   integration-up:
     executor: golang-ci
     environment:
-      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
@@ -212,7 +218,8 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
+            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
@@ -225,7 +232,7 @@ jobs:
   integration-okteto:
     executor: golang-ci
     environment:
-      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
@@ -240,7 +247,8 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
+            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             make integration-okteto
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -265,7 +273,8 @@ jobs:
           name: Run deprecated integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
+            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             make integration-deprecated
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -277,7 +286,7 @@ jobs:
     executor: golang-ci
     resource_class: large
     environment:
-      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
@@ -297,7 +306,7 @@ jobs:
             curl -L "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
             chmod +x /usr/local/bin/kubectl
             cp $(pwd)/artifacts/bin/okteto-Linux-x86_64 /usr/local/bin/okteto
-            /usr/local/bin/okteto login --token ${API_STAGING_TOKEN}
+            okteto context use ${OKTETO_CONTEXT} --token ${API_STAGING_TOKEN}
       - run:
           # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,10 @@ executors:
   golang-ci:
     docker:
       - image: okteto/golang-ci:2.6.2
+    environment:
+      OKTETO_CONTEXT: https://staging.okteto.dev
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
 
 jobs:
   golangci-lint:
@@ -127,10 +131,6 @@ jobs:
 
   integration-actions:
     executor: golang-ci
-    environment:
-      OKTETO_CONTEXT: https://staging.okteto.dev
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
       - when:
@@ -158,10 +158,6 @@ jobs:
 
   integration-build:
     executor: golang-ci
-    environment:
-      OKTETO_CONTEXT: https://staging.okteto.dev
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
       - when:
@@ -191,10 +187,6 @@ jobs:
 
   integration-deploy:
     executor: golang-ci
-    environment:
-      OKTETO_CONTEXT: https://staging.okteto.dev
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
       - when:
@@ -225,10 +217,6 @@ jobs:
 
   integration-up:
     executor: golang-ci
-    environment:
-      OKTETO_CONTEXT: https://staging.okteto.dev
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
       - when:
@@ -260,10 +248,6 @@ jobs:
 
   integration-okteto:
     executor: golang-ci
-    environment:
-      OKTETO_CONTEXT: https://staging.okteto.dev
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
       - when:
@@ -324,10 +308,6 @@ jobs:
 
   test-integration-setup:
     executor: golang-ci
-    environment:
-      OKTETO_CONTEXT: https://staging.okteto.dev
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,7 +354,7 @@ jobs:
             choco install kubernetes-helm -y
       - run:
           name: Run windows unit test-release
-          command: go tests ./...
+          command: go test ./...
       - run:
           # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deprecated
 
-  test-integration-setup:
+  test-e2e-setup:
     executor: golang-ci
     steps:
       - checkout
@@ -288,7 +288,7 @@ jobs:
           command: |
             okteto build --platform "linux/arm64,linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile .
 
-  test-integration-setup-windows:
+  test-e2e-setup-windows:
     executor: win/default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
@@ -547,7 +547,7 @@ workflows:
               ignore: *release-branch-regex
             tags:
               ignore: /.*/
-      - test-integration-setup-windows:
+      - test-e2e-setup-windows:
           requires:
             - build-binaries
           filters:
@@ -556,33 +556,33 @@ workflows:
                 - master
       - integration-build-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
           filters:
             branches:
               only:
                 - master
       - integration-deploy-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
           filters:
             branches:
               only:
                 - master
       - integration-up-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
           filters:
             branches:
               only:
                 - master
       - integration-deprecated-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
           filters:
             branches:
               only:
                 - master
-      - test-integration-setup:
+      - test-e2e-setup:
           requires:
             - build-binaries
           filters:
@@ -591,42 +591,42 @@ workflows:
                 - master
       - integration-build:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
           filters:
             branches:
               only:
                 - master
       - integration-deploy:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
           filters:
             branches:
               only:
                 - master
       - integration-up:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
           filters:
             branches:
               only:
                 - master
       - integration-actions:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
           filters:
             branches:
               only:
                 - master
       - integration-okteto:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
           filters:
             branches:
               only:
                 - master
       - integration-deprecated:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
           filters:
             branches:
               only:
@@ -652,43 +652,46 @@ workflows:
             branches:
               only: master
 
-  # release-branch workflow is triggered when branch is "release-*"
-  # and tag is not empty
+  # release-branch workflow is triggered when branch name is "release-*", ignoring any tag
   release-branch:
     when:
-      and:
-        - matches:
-            pattern: *release-branch-regex
-            value: << pipeline.git.branch >>
-        - not:
-            matches:
-              pattern: /.*/
-              value: << pipeline.git.tag >>
+      matches:
+        pattern: *release-branch-regex
+        value: << parameters.git.branch >>
     jobs:
-      - build-binaries
-      - run-unit-test
-      - run-windows-unit-test
-      - test-integration-setup:
+      - build-binaries:
+          filters:
+            tags:
+              ignore: /.*/
+      - run-unit-test:
+          filters:
+            tags:
+              ignore: /.*/
+      - run-windows-unit-test:
+          filters:
+            tags:
+              ignore: /.*/
+      - test-e2e-setup:
           requires:
             - build-binaries
       - integration-build:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-deploy:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-up:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-actions:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-okteto:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-deprecated:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - release-branch-job:
           requires:
             - build-binaries
@@ -701,7 +704,7 @@ workflows:
             - run-unit-test
             - run-windows-unit-test
 
-  # release-dev is triggered on merge to master
+  # release-dev is a nightly run on master branch
   release-dev:
     when:
       and:
@@ -721,6 +724,7 @@ workflows:
             - build-binaries
             - push-image-tag
 
+  # release workflow is triggered when the tag for release is pushed
   release:
     when:
       not:
@@ -783,91 +787,91 @@ workflows:
       equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
-      - test-integration-setup:
+      - test-e2e-setup:
           requires:
             - build-binaries
       - integration-build:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-deploy:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-up:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-actions:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-okteto:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-deprecated:
           requires:
-            - test-integration-setup
-      - test-integration-setup-windows:
+            - test-e2e-setup
+      - test-e2e-setup-windows:
           requires:
             - build-binaries
       - integration-build-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
       - integration-deploy-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
       - integration-up-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
       - integration-deprecated-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
 
-  # run-integration-unix is triggered by okteto-bot via Github Actions when adding the run-e2e-unix label to the PR
+  # run-e2e-unix is triggered by okteto-bot via Github Actions when adding the run-e2e-unix label to the PR
   # integration test for unix platform are run
-  run-integration-unix:
+  run-e2e-unix:
     when:
       equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
-      - test-integration-setup:
+      - test-e2e-setup:
           requires:
             - build-binaries
       - integration-build:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-deploy:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-up:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-actions:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-okteto:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
       - integration-deprecated:
           requires:
-            - test-integration-setup
+            - test-e2e-setup
 
-  # run-integration-windows is triggered by okteto-bot via Github Actions when adding the run-e2e-windows label to the PR
+  # run-e2e-windows is triggered by okteto-bot via Github Actions when adding the run-e2e-windows label to the PR
   # integration test for windows platform are run
-  run-integration-windows:
+  run-e2e-windows:
     when:
       equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
-      - test-integration-setup-windows:
+      - test-e2e-setup-windows:
           requires:
             - build-binaries
       - integration-build-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
       - integration-deploy-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
       - integration-up-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows
       - integration-deprecated-windows:
           requires:
-            - test-integration-setup-windows
+            - test-e2e-setup-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,10 +312,6 @@ jobs:
             - /go/pkg
       - store_artifacts:
           path: /root/.okteto
-      - persist_to_workspace:
-          root: .okteto
-          paths:
-            - .noanalytics
   test-release:
     executor: golang-ci
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,9 +134,9 @@ jobs:
       - run:
           name: Run actions integration tests
           command: |
-            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-actions
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -162,9 +162,9 @@ jobs:
           command: |
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
-            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-build
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -192,7 +192,7 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
-            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deploy
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -219,7 +219,7 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
-            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
@@ -248,7 +248,7 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
-            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-okteto
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -274,7 +274,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
-            mkdir -p $HOME/.okteto && touch $HOME/.okteto/.noanalytics
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deprecated
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -297,23 +297,14 @@ jobs:
       - attach_workspace:
           at: ./artifacts
       - run:
-          name: Prepare env
-          command: |
-            mkdir -p $HOME/.okteto
-            touch $HOME/.okteto/.noanalytics
-            echo $HOME
-            sudo chown -R $(whoami) /usr/local/bin
-            curl -L "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
-            chmod +x /usr/local/bin/kubectl
-            cp $(pwd)/artifacts/bin/okteto-Linux-x86_64 /usr/local/bin/okteto
-            okteto context use ${OKTETO_CONTEXT} --token ${API_STAGING_TOKEN}
-      - run:
           # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build CLI image
           command: |
-            okteto build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       # - integration-build
       # - integration-deploy
       # - integration-up

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,6 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-            export OKTETO_HOME=$HOME/.okteto
             make integration-actions
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -166,7 +165,6 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-            export OKTETO_HOME=$HOME/.okteto
             make integration-build
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -195,7 +193,6 @@ jobs:
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-            export OKTETO_HOME=$HOME/.okteto
             make integration-deploy
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -223,7 +220,6 @@ jobs:
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-            export OKTETO_HOME=$HOME/.okteto
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
@@ -253,7 +249,6 @@ jobs:
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-            export OKTETO_HOME=$HOME/.okteto
             make integration-okteto
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -280,7 +275,6 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-            export OKTETO_HOME=$HOME/.okteto
             make integration-deprecated
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -736,15 +730,20 @@ workflows:
       - integration-deploy:
           requires:
             - test-integration
+            - integration-build
       - integration-up:
           requires:
             - test-integration
+            - integration-deploy
       - integration-actions:
           requires:
             - test-integration
+            - integration-up
       - integration-okteto:
           requires:
             - test-integration
+            - integration-actions
       - integration-deprecated:
           requires:
             - test-integration
+            - integration-okteto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,8 +560,16 @@ workflows:
           context: GKE
   lint-build-test:
     when:
-      not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+      or:
+        - not:
+            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - not:
+            equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+        - not:
+            equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+        - not:
+            equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+
     jobs:
       - golangci-lint
       - build-binaries:
@@ -831,7 +839,6 @@ workflows:
   run-integration-windows:
     when:
       or:
-        - equal: [true, << pipeline.parameters.TriggerIntegration >>]
         - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
         - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deploy
@@ -218,6 +219,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-up
@@ -247,6 +249,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-okteto
@@ -282,7 +285,7 @@ jobs:
             - ~/.cache/go-build
             - /go/pkg
 
-  test-integration:
+  test-integration-setup:
     executor: golang-ci
     resource_class: large
     environment:
@@ -300,17 +303,11 @@ jobs:
           # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
-          name: Build CLI image
+          name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
           command: |
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-      # - integration-build
-      # - integration-deploy
-      # - integration-up
-      # - integration-actions
-      # - integration-okteto
-      # - integration-deprecated
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
@@ -502,14 +499,13 @@ jobs:
       - run: ./scripts/ci/release-branch.sh
 
 workflows:
+  # upload-static runs on every merge to master
   upload-static:
+    when:
+      equal: ["master", <<pipeline.git.branch>>]
     jobs:
       - upload-static-job:
           context: GKE
-          filters:
-            branches:
-              only:
-                - master
   lint-build-test:
     when:
       not:
@@ -548,9 +544,57 @@ workflows:
               only:
                 - master
                 - /.*(windows|win)/
-      - test-integration:
+      - test-integration-setup:
           requires:
             - build-binaries
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
+      - integration-build:
+          requires:
+            - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
+      - integration-deploy:
+          requires:
+            - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
+      - integration-up:
+          requires:
+            - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
+      - integration-actions:
+          requires:
+            - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
+      - integration-okteto:
+          requires:
+            - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
+      - integration-deprecated:
+          requires:
+            - test-integration-setup
           filters:
             branches:
               only:
@@ -577,42 +621,55 @@ workflows:
             branches:
               only: master
 
+  # release-branch workflow is triggered when branch is "release-*"
+  # and tag is not empty
   release-branch:
+    when:
+      and:
+        - matches:
+            pattern: *release-branch-regex
+            value: << pipeline.git.branch >>
+        - matches:
+            pattern: ^\S+$
+            value: << pipeline.git.tag >>
     jobs:
-      - build-binaries:
-          filters:
-            branches:
-              only: *release-branch-regex
-            tags:
-              ignore: /.*/
-      - run-unit-test:
-          filters:
-            branches:
-              only: *release-branch-regex
-            tags:
-              ignore: /.*/
-      - run-windows-unit-test:
-          filters:
-            branches:
-              only: *release-branch-regex
-            tags:
-              ignore: /.*/
-      - test-integration:
-          filters:
-            branches:
-              only: *release-branch-regex
+      - build-binaries
+      - run-unit-test
+      - run-windows-unit-test
+      - test-integration-setup:
           requires:
             - build-binaries
+      - integration-build:
+          requires:
+            - test-integration-setup
+      - integration-deploy:
+          requires:
+            - test-integration-setup
+      - integration-up:
+          requires:
+            - test-integration-setup
+      - integration-actions:
+          requires:
+            - test-integration-setup
+      - integration-okteto:
+          requires:
+            - test-integration-setup
+      - integration-deprecated:
+          requires:
+            - test-integration-setup
       - release-branch-job:
           requires:
             - build-binaries
-            - test-integration
+            - integration-build
+            - integration-deploy
+            - integration-up
+            - integration-actions
+            - integration-okteto
+            - integration-deprecated
             - run-unit-test
             - run-windows-unit-test
-          filters:
-            branches:
-              only: *release-branch-regex
 
+  # release-dev is triggered on merge to master
   release-dev:
     when:
       and:
@@ -695,50 +752,42 @@ workflows:
       - run-windows-e2e-test:
           requires:
             - build-binaries
-  run-unix-e2e-tests:
-    when:
-      equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-    jobs:
-      - build-binaries
-      - test-integration:
-          requires:
-            - build-binaries
 
   run-e2e-tests:
     when:
       equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
-      - test-integration:
-          requires:
-            - build-binaries
       - run-windows-e2e-test:
           requires:
             - build-binaries
 
   run-integration:
     when:
-      equal: [true, << pipeline.parameters.TriggerIntegration >>]
+      or:
+        - equal: [true, << pipeline.parameters.TriggerIntegration >>]
+        - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+        - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
-      - test-integration:
+      - test-integration-setup:
           requires:
             - build-binaries
       - integration-build:
           requires:
-            - test-integration
+            - test-integration-setup
       - integration-deploy:
           requires:
-            - test-integration
+            - test-integration-setup
       - integration-up:
           requires:
-            - test-integration
+            - test-integration-setup
       - integration-actions:
           requires:
-            - test-integration
+            - test-integration-setup
       - integration-okteto:
           requires:
-            - test-integration
+            - test-integration-setup
       - integration-deprecated:
           requires:
-            - test-integration
+            - test-integration-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,18 +39,6 @@ executors:
     docker:
       - image: okteto/golang-ci:2.6.2
 
-command:
-  save_go_mod_cache:
-    - save_cache:
-        key: v5-pkg-cache-{{ checksum "go.sum" }}
-        paths:
-          - ~/.cache/go-build
-          - /go/pkg/mod
-  restore_go_mod_cache:
-    - restore_cache:
-        keys:
-          - v5-pkg-cache-{{ checksum "go.sum" }}
-
 jobs:
   golangci-lint:
     executor: golang-ci
@@ -72,7 +60,9 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - run:
           name: Build all binaries
           command: env VERSION_STRING=$CIRCLE_TAG make -j 3 build-all
@@ -91,7 +81,9 @@ jobs:
     executor: golang-ci
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - run:
           name: Compile integration tests
           command: make build-integration
@@ -100,7 +92,11 @@ jobs:
           command: |
             make test
             bash <(curl -s https://codecov.io/bash)
-      - run: save_go_mod_cache
+      - save_cache:
+          key: v5-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg/mod
 
       - store_artifacts:
           path: coverage.txt
@@ -132,7 +128,9 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
       - run:
@@ -142,8 +140,6 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-actions
-      - run: save_go_mod_cache
-
 
   integration-build:
     executor: golang-ci
@@ -153,7 +149,9 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: integration-workspace
       - run:
@@ -164,8 +162,6 @@ jobs:
             export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
             export OKTETO_HOME=/integration-workspace/
             make integration-build
-      - run: save_go_mod_cache
-
 
   integration-deploy:
     executor: golang-ci
@@ -175,7 +171,9 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: integration-workspace
       - run:
@@ -187,7 +185,6 @@ jobs:
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             make integration-deploy
-      - run: save_go_mod_cache
 
 
   integration-up:
@@ -198,7 +195,9 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: integration-workspace
       - run:
@@ -211,7 +210,6 @@ jobs:
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
-      - run: save_go_mod_cache
 
 
   integration-okteto:
@@ -222,7 +220,9 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: integration-workspace
       - run:
@@ -233,7 +233,6 @@ jobs:
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             make integration-okteto
-      - run: save_go_mod_cache
 
 
   integration-deprecated:
@@ -244,7 +243,9 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: integration-workspace
       - run:
@@ -253,7 +254,6 @@ jobs:
             export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
             export OKTETO_HOME=/integration-workspace/
             make integration-deprecated
-      - run: save_go_mod_cache
 
   test-integration-setup:
     executor: golang-ci
@@ -263,7 +263,9 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run: restore_go_mod_cache
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
       - run:
@@ -287,9 +289,12 @@ jobs:
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-          command: $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-
-      - run: save_go_mod_cache
+          command: okteto build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+      - save_cache:
+          key: v5-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg/mod
 
   test-release:
     executor: golang-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,9 +721,21 @@ workflows:
       equal: [true, << pipeline.parameters.TriggerIntegration >>]
     jobs:
       - test-integration
-      - integration-build
-      - integration-deploy
-      - integration-up
-      - integration-actions
-      - integration-okteto
-      - integration-deprecated
+      - integration-build:
+          requires:
+            - test-integration
+      - integration-deploy:
+          requires:
+            - test-integration
+      - integration-up:
+          requires:
+            - test-integration
+      - integration-actions:
+          requires:
+            - test-integration
+      - integration-okteto:
+          requires:
+            - test-integration
+      - integration-deprecated:
+          requires:
+            - test-integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,58 +30,12 @@ parameters:
   GHA_Meta:
     type: string
     default: ""
+  TriggerIntegration:
+    type: boolean
+    default: false
 
 orbs:
   win: circleci/windows@5.0.0
-
-commands:
-  integration-actions:
-    steps:
-      - run:
-          name: Run actions integration tests
-          command: make integration-actions
-
-  integration-build:
-    steps:
-      - run:
-          name: Run build integration tests
-          command: |
-            export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
-            export DEPOT_TOKEN=$DEPOT_TOKEN
-            make integration-build
-
-  integration-deploy:
-    steps:
-      - run:
-          name: Run deploy integration tests
-          # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
-          command: |
-            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            make integration-deploy
-
-  integration-up:
-    steps:
-      - run:
-          name: Run up integration tests
-          command: |
-            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            make integration-up
-          environment:
-            OKTETO_SKIP_CLEANUP: "true"
-
-  integration-okteto:
-    steps:
-      - run:
-          name: Run okteto integration tests
-          command: |
-            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            make integration-okteto
-
-  integration-deprecated:
-    steps:
-      - run:
-          name: Run deprecated integration tests
-          command: make integration-deprecated
 
 executors:
   golang-ci:
@@ -160,6 +114,61 @@ jobs:
             go mod download
             go version
             go test ./...
+
+  integration-actions:
+    executor: golang-ci
+    steps:
+      - run:
+          name: Run actions integration tests
+          command: make integration-actions
+
+  integration-build:
+    executor: golang-ci
+    steps:
+      - run:
+          name: Run build integration tests
+          command: |
+            export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
+            export DEPOT_TOKEN=$DEPOT_TOKEN
+            make integration-build
+
+  integration-deploy:
+    executor: golang-ci
+    steps:
+      - run:
+          name: Run deploy integration tests
+          # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
+          command: |
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            make integration-deploy
+
+  integration-up:
+    executor: golang-ci
+    steps:
+      - run:
+          name: Run up integration tests
+          command: |
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            make integration-up
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
+
+  integration-okteto:
+    executor: golang-ci
+    steps:
+      - run:
+          name: Run okteto integration tests
+          command: |
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            make integration-okteto
+
+  integration-deprecated:
+    executor: golang-ci
+    steps:
+      - run:
+          name: Run deprecated integration tests
+          command: make integration-deprecated
+
   test-integration:
     executor: golang-ci
     resource_class: large
@@ -604,3 +613,9 @@ workflows:
       - run-windows-e2e-test:
           requires:
             - build-binaries
+
+  run-integration:
+    when:
+      equal: [true, << pipeline.parameters.TriggerIntegration >>]
+    jobs:
+      - test-integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -720,7 +720,10 @@ workflows:
     when:
       equal: [true, << pipeline.parameters.TriggerIntegration >>]
     jobs:
-      - test-integration
+      - build-binaries
+      - test-integration:
+          requires:
+            - build-binaries
       - integration-build:
           requires:
             - test-integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -660,9 +660,10 @@ workflows:
         - matches:
             pattern: *release-branch-regex
             value: << pipeline.git.branch >>
-        - matches:
-            pattern: ^\S+$
-            value: << pipeline.git.tag >>
+        - not:
+            matches:
+              pattern: /.*/
+              value: << pipeline.git.tag >>
     jobs:
       - build-binaries
       - run-unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,17 +133,30 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: ./integration-workspace
-      - run:
-          name: Run actions integration tests
-          command: |
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
-            make integration-actions
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(e2e)/
+                  value: << pipeline.git.branch >>
+              - matches:
+                  pattern: *release-branch-regex
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v4-pkg-cache-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: ./integration-workspace
+            - run:
+                name: Run actions integration tests
+                command: |
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  make integration-actions
 
   integration-build:
     executor: golang-ci
@@ -153,19 +166,32 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: ./integration-workspace
-      - run:
-          name: Run build integration tests
-          command: |
-            export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
-            export DEPOT_TOKEN=$DEPOT_TOKEN
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
-            make integration-build
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(e2e)/
+                  value: << pipeline.git.branch >>
+              - matches:
+                  pattern: *release-branch-regex
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v4-pkg-cache-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: ./integration-workspace
+            - run:
+                name: Run build integration tests
+                command: |
+                  export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
+                  export DEPOT_TOKEN=$DEPOT_TOKEN
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  make integration-build
 
   integration-deploy:
     executor: golang-ci
@@ -175,21 +201,33 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: ./integration-workspace
-      - run:
-          name: Run deploy integration tests
-          # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
-          command: |
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            make integration-deploy
-
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(e2e)/
+                  value: << pipeline.git.branch >>
+              - matches:
+                  pattern: *release-branch-regex
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v4-pkg-cache-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: ./integration-workspace
+            - run:
+                name: Run deploy integration tests
+                # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
+                command: |
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+                  echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+                  make integration-deploy
 
   integration-up:
     executor: golang-ci
@@ -199,22 +237,34 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: ./integration-workspace
-      - run:
-          name: Run up integration tests
-          command: |
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            make integration-up
-          environment:
-            OKTETO_SKIP_CLEANUP: "true"
-
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(e2e)/
+                  value: << pipeline.git.branch >>
+              - matches:
+                  pattern: *release-branch-regex
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v4-pkg-cache-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: ./integration-workspace
+            - run:
+                name: Run up integration tests
+                command: |
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+                  echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+                  make integration-up
+                environment:
+                  OKTETO_SKIP_CLEANUP: "true"
 
   integration-okteto:
     executor: golang-ci
@@ -224,19 +274,32 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: ./integration-workspace
-      - run:
-          name: Run okteto integration tests
-          command: |
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            make integration-okteto
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(e2e)/
+                  value: << pipeline.git.branch >>
+              - matches:
+                  pattern: *release-branch-regex
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v4-pkg-cache-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: ./integration-workspace
+            - run:
+                name: Run okteto integration tests
+                command: |
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+                  echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+                  make integration-okteto
 
   integration-deprecated:
     executor: golang-ci
@@ -246,17 +309,30 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: ./integration-workspace
-      - run:
-          name: Run deprecated integration tests
-          command: |
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
-            make integration-deprecated
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(e2e)/
+                  value: << pipeline.git.branch >>
+              - matches:
+                  pattern: *release-branch-regex
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v4-pkg-cache-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: ./integration-workspace
+            - run:
+                name: Run deprecated integration tests
+                command: |
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  make integration-deprecated
 
   test-integration-setup:
     executor: golang-ci
@@ -266,37 +342,50 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: ./integration-workspace
-      - run:
-          name: Okteto Setup for integration
-          command: |
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            echo "$CIRCLE_SHA1"
-            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 version
-            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 analytics --disable
-      - persist_to_workspace:
-          root: integration-workspace
-          paths:
-            - .okteto/analytics.json
-            - .okteto/context/config.json
-      - run:
-          # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
-          # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
-          # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
-          name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-          command: |
-            export OKTETO_HOME=$(pwd)/integration-workspace
-            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(e2e)/
+                  value: << pipeline.git.branch >>
+              - matches:
+                  pattern: *release-branch-regex
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v4-pkg-cache-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: ./integration-workspace
+            - run:
+                name: Okteto Setup for integration
+                command: |
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  echo "$CIRCLE_SHA1"
+                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 version
+                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 analytics --disable
+            - persist_to_workspace:
+                root: integration-workspace
+                paths:
+                  - .okteto/analytics.json
+                  - .okteto/context/config.json
+            - run:
+                # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
+                # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
+                # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
+                name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
+                command: |
+                  export OKTETO_HOME=$(pwd)/integration-workspace
+                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            - save_cache:
+                key: v4-pkg-cache-{{ checksum "go.sum" }}
+                paths:
+                  - ~/.cache/go-build
+                  - /go/pkg
 
   test-release:
     executor: golang-ci
@@ -327,26 +416,49 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: .\artifacts
-      - run:
-          # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
-          # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
-          # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
-          name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-          command: |
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
-      - save_cache:
-          key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-          paths:
-            - C:\Users\circleci\AppData\Local\go-build
-            - C:\Users\circleci\go\pkg
-            - C:\Go\pkg
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(windows|win)/
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: .\integration-workspace
+            - run:
+                name: Okteto Setup for integration
+                command: |
+                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  & "$($HOME)\project\integration-workspace\bin\okteto.exe" analytics --disable
+                  & "$($HOME)\project\integration-workspace\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            - persist_to_workspace:
+                root: integration-workspace
+                paths:
+                  - .okteto/analytics.json
+                  - .okteto/context/config.json
+            - run:
+                # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
+                # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
+                # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
+                name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
+                command: |
+                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
+                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  & "$($HOME)\project\integration-workspace\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
+            - save_cache:
+                key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+                paths:
+                  - C:\Users\circleci\AppData\Local\go-build
+                  - C:\Users\circleci\go\pkg
+                  - C:\Go\pkg
   integration-deprecated-windows:
     executor: win/default
     environment:
@@ -355,30 +467,39 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: .\artifacts
-      - run:
-          name: Install kubectl and helm
-          command: |
-            go version
-            choco install kubernetes-cli -y
-            choco install kubernetes-helm -y
-      - run:
-          name: Run deprecated integration tests
-          environment:
-            OKTETO_URL: https://staging.okteto.dev/
-            OKTETO_SKIP_CLEANUP: "true"
-            OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
-          command: |
-            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-            $env:Path+=";$($HOME)\project\artifacts\bin"
-            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-            go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
-            go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(windows|win)/
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: .\integration-workspace
+            - run:
+                name: Install kubectl and helm
+                command: |
+                  go version
+                  choco install kubernetes-cli -y
+                  choco install kubernetes-helm -y
+            - run:
+                name: Run deprecated integration tests
+                environment:
+                  OKTETO_URL: https://staging.okteto.dev/
+                  OKTETO_SKIP_CLEANUP: "true"
+                  OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+                command: |
+                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
+                  go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
 
   integration-build-windows:
     executor: win/default
@@ -388,22 +509,32 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: .\artifacts
-      - run:
-          name: Run build integration tests
-          environment:
-            OKTETO_SKIP_CLEANUP: "true"
-          command: |
-            $env:DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
-            $env:DEPOT_TOKEN=$DEPOT_TOKEN
-            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-            go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(windows|win)/
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: .\integration-workspace
+            - run:
+                name: Run build integration tests
+                environment:
+                  OKTETO_SKIP_CLEANUP: "true"
+                command: |
+                  $env:DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
+                  $env:DEPOT_TOKEN=$DEPOT_TOKEN
+                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
 
   integration-deploy-windows:
     executor: win/default
@@ -413,30 +544,40 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: .\artifacts
-      - run:
-          name: Install kubectl and helm
-          command: |
-            go version
-            choco install kubernetes-cli -y
-            choco install kubernetes-helm -y
-      - run:
-          name: Run deploy integration tests
-          environment:
-            OKTETO_SKIP_CLEANUP: "true"
-          # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
-          command: |
-            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-            $env:Path+=";$($HOME)\project\artifacts\bin"
-            $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
-            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
-            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-            go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(windows|win)/
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: .\integration-workspace
+            - run:
+                name: Install kubectl and helm
+                command: |
+                  go version
+                  choco install kubernetes-cli -y
+                  choco install kubernetes-helm -y
+            - run:
+                name: Run deploy integration tests
+                environment:
+                  OKTETO_SKIP_CLEANUP: "true"
+                # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
+                command: |
+                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
+                  $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
+                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
+
   integration-up-windows:
     executor: win/default
     environment:
@@ -445,31 +586,40 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-      - attach_workspace:
-          at: .\artifacts
-      - run:
-          name: Install kubectl and helm
-          command: |
-            go version
-            choco install kubernetes-cli -y
-            choco install kubernetes-helm -y
-      - run:
-          name: Run up integration tests
-          environment:
-            OKTETO_URL: https://staging.okteto.dev/
-            OKTETO_SKIP_CLEANUP: "true"
-            OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
-          command: |
-            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-            $env:Path+=";$($HOME)\project\artifacts\bin"
-            $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
-            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
-            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-            go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
+      - when:
+          condition:
+            or:
+              - matches:
+                  pattern: /.*(windows|win)/
+                  value: << pipeline.git.branch >>
+              - equal: ["master", << pipeline.git.branch >>]
+              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          steps:
+            - restore_cache:
+                keys:
+                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+            - attach_workspace:
+                at: .\integration-workspace
+            - run:
+                name: Install kubectl and helm
+                command: |
+                  go version
+                  choco install kubernetes-cli -y
+                  choco install kubernetes-helm -y
+            - run:
+                name: Run up integration tests
+                environment:
+                  OKTETO_URL: https://staging.okteto.dev/
+                  OKTETO_SKIP_CLEANUP: "true"
+                  OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+                command: |
+                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
+                  $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
+                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
 
   push-image-tag:
     executor: golang-ci
@@ -547,12 +697,7 @@ workflows:
   lint-build-test:
     when:
       not:
-        or:
-          - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-          - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-          - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - golangci-lint
       - build-binaries:
@@ -582,99 +727,39 @@ workflows:
       - test-integration-setup-windows:
           requires:
             - build-binaries
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(windows|win)/
       - integration-build-windows:
           requires:
             - test-integration-setup-windows
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(windows|win)/
       - integration-deploy-windows:
           requires:
             - test-integration-setup-windows
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(windows|win)/
       - integration-up-windows:
           requires:
             - test-integration-setup-windows
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(windows|win)/
       - integration-deprecated-windows:
           requires:
             - test-integration-setup-windows
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(windows|win)/
       - test-integration-setup:
           requires:
             - build-binaries
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
       - integration-build:
           requires:
             - test-integration-setup
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
       - integration-deploy:
           requires:
             - test-integration-setup
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
       - integration-up:
           requires:
             - test-integration-setup
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
       - integration-actions:
           requires:
             - test-integration-setup
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
       - integration-okteto:
           requires:
             - test-integration-setup
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
       - integration-deprecated:
           requires:
             - test-integration-setup
-          filters:
-            branches:
-              only:
-                - master
-                - /.*(e2e)/
       - test-release:
           context:
             - GKE
@@ -818,54 +903,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
-
-  run-integration-windows:
-    when:
-      or:
-        - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-        - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-    jobs:
-      - build-binaries
-      - test-integration-setup-windows:
-          requires:
-            - build-binaries
-      - integration-build-windows:
-          requires:
-            - test-integration-setup-windows
-      - integration-deploy-windows:
-          requires:
-            - test-integration-setup-windows
-      - integration-up-windows:
-          requires:
-            - test-integration-setup-windows
-      - integration-deprecated-windows:
-          requires:
-            - test-integration-setup-windows
-  run-integration:
-    when:
-      or:
-        - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-        - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-    jobs:
-      - build-binaries
-      - test-integration-setup:
-          requires:
-            - build-binaries
-      - integration-build:
-          requires:
-            - test-integration-setup
-      - integration-deploy:
-          requires:
-            - test-integration-setup
-      - integration-up:
-          requires:
-            - test-integration-setup
-      - integration-actions:
-          requires:
-            - test-integration-setup
-      - integration-okteto:
-          requires:
-            - test-integration-setup
-      - integration-deprecated:
-          requires:
-            - test-integration-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - run:
           name: Build all binaries
           command: env VERSION_STRING=$CIRCLE_TAG make -j 3 build-all
@@ -70,10 +70,10 @@ jobs:
           name: Add version string
           command: env VERSION_STRING=$CIRCLE_TAG make latest
       - save_cache:
-          key: v5-pkg-cache-{{ checksum "go.sum" }}
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
-            - /go/pkg/mod
+            - /go/pkg
       - persist_to_workspace:
           root: .
           paths:
@@ -88,7 +88,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - run:
           name: Compile integration tests
           command: make build-integration
@@ -98,10 +98,10 @@ jobs:
             make test
             bash <(curl -s https://codecov.io/bash)
       - save_cache:
-          key: v5-pkg-cache-{{ checksum "go.sum" }}
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
-            - /go/pkg/mod
+            - /go/pkg
 
       - store_artifacts:
           path: coverage.txt
@@ -135,7 +135,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./integration-workspace
       - run:
@@ -155,7 +155,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./integration-workspace
       - run:
@@ -177,7 +177,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./integration-workspace
       - run:
@@ -201,7 +201,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./integration-workspace
       - run:
@@ -226,7 +226,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./integration-workspace
       - run:
@@ -248,7 +248,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./integration-workspace
       - run:
@@ -268,18 +268,17 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v5-pkg-cache-{{ checksum "go.sum" }}
+            - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./integration-workspace
       - run:
           name: Okteto Setup for integration
           command: |
             export OKTETO_HOME=$(pwd)/integration-workspace
-            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             echo "$CIRCLE_SHA1"
-            okteto version
-            okteto analytics --disable
-            okteto context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 version
+            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 analytics --disable
       - persist_to_workspace:
           root: integration-workspace
           paths:
@@ -290,12 +289,12 @@ jobs:
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-          command: okteto build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+          command: $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       - save_cache:
-          key: v5-pkg-cache-{{ checksum "go.sum" }}
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
-            - /go/pkg/mod
+            - /go/pkg
 
   test-release:
     executor: golang-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,6 @@ jobs:
 
   test-integration-setup:
     executor: golang-ci
-    resource_class: large
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -334,48 +333,57 @@ jobs:
           command: |
             okteto build --platform "linux/arm64,linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile .
 
-  run-windows-e2e-test:
+  test-integration-setup-windows:
     executor: win/default
     environment:
+      OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - run:
-          name: Check Golang version
-          command: go version
       - restore_cache:
           keys:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-      - run:
-          name: Run unit tests
-          command: |
-            go mod download
-            go version
-            go test ./...
-      - run:
-          name: Upgrade kubectl
-          command: choco install kubernetes-cli -y
-      - run:
-          name: Upgrade helm
-          command: choco install kubernetes-helm -y
       - attach_workspace:
           at: .\artifacts
       - run:
-          name: Prepare env
-          environment:
-            OKTETO_URL: https://staging.okteto.dev/
+          name: Setup environment
           command: |
-            new-item $HOME\.okteto -itemtype "directory" -force
-            new-item $HOME\.okteto\.noanalytics -itemtype "file" -value "noanalytics" -force
-            & "$($HOME)\project\artifacts\bin\okteto.exe" login --token $env:API_STAGING_TOKEN
-            & "$($HOME)\project\artifacts\bin\okteto.exe" kubeconfig
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
+      - run:
+          name: Run windows unit test-release
+          command: go tests ./...
       - run:
           # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
-          name: Build CLI image windows
+          name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
           command: |
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" kubeconfig
             & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
+      - save_cache:
+          key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+          paths:
+            - C:\Users\circleci\AppData\Local\go-build
+            - C:\Users\circleci\go\pkg
+            - C:\Go\pkg
+  integration-deprecated-windows:
+    executor: win/default
+    environment:
+      OKTETO_CONTEXT: https://staging.okteto.dev
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
       - run:
           name: Run deprecated integration tests
           environment:
@@ -385,32 +393,75 @@ jobs:
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
             go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
+
+  integration-build-windows:
+    executor: win/default
+    environment:
+      OKTETO_CONTEXT: https://staging.okteto.dev
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
       - run:
           name: Run build integration tests
           environment:
-            OKTETO_URL: https://staging.okteto.dev/
             OKTETO_SKIP_CLEANUP: "true"
-            OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
           command: |
             $env:DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             $env:DEPOT_TOKEN=$DEPOT_TOKEN
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
+
+  integration-deploy-windows:
+    executor: win/default
+    environment:
+      OKTETO_CONTEXT: https://staging.okteto.dev
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
       - run:
           name: Run deploy integration tests
           environment:
-            OKTETO_URL: https://staging.okteto.dev/
             OKTETO_SKIP_CLEANUP: "true"
-            OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
             $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
             $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
+  integration-up-windows:
+    executor: win/default
+    environment:
+      OKTETO_CONTEXT: https://staging.okteto.dev
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
       - run:
           name: Run up integration tests
           environment:
@@ -422,16 +473,9 @@ jobs:
             $env:Path+=";$($HOME)\project\artifacts\bin"
             $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
             $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
-      - store_artifacts:
-          path: C:\Users\circleci\.okteto
-
-      - save_cache:
-          key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-          paths:
-            - C:\Users\circleci\AppData\Local\go-build
-            - C:\Users\circleci\go\pkg
-            - C:\Go\pkg
 
   push-image-tag:
     executor: golang-ci
@@ -536,9 +580,41 @@ workflows:
               ignore: *release-branch-regex
             tags:
               ignore: /.*/
-      - run-windows-e2e-test:
+      - test-integration-setup-windows:
           requires:
             - build-binaries
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
+      - integration-build-windows:
+          requires:
+            - test-integration-setup-windows
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
+      - integration-deploy-windows:
+          requires:
+            - test-integration-setup-windows
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
+      - integration-up-windows:
+          requires:
+            - test-integration-setup-windows
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
+      - integration-deprecated-windows:
+          requires:
+            - test-integration-setup-windows
           filters:
             branches:
               only:
@@ -744,28 +820,32 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
 
-  run-windows-e2e:
-    when:
-      equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-    jobs:
-      - build-binaries
-      - run-windows-e2e-test:
-          requires:
-            - build-binaries
-
-  run-e2e-tests:
-    when:
-      equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-    jobs:
-      - build-binaries
-      - run-windows-e2e-test:
-          requires:
-            - build-binaries
-
-  run-integration:
+  run-integration-windows:
     when:
       or:
         - equal: [true, << pipeline.parameters.TriggerIntegration >>]
+        - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+        - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-binaries
+      - test-integration-setup-windows:
+          requires:
+            - build-binaries
+      - integration-build-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-deploy-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-up-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-deprecated-windows:
+          requires:
+            - test-integration-setup-windows
+  run-integration:
+    when:
+      or:
         - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
         - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
           name: Run actions integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-actions
@@ -163,6 +164,7 @@ jobs:
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-build
@@ -190,6 +192,7 @@ jobs:
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
@@ -217,6 +220,7 @@ jobs:
           name: Run up integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
@@ -246,6 +250,7 @@ jobs:
           name: Run okteto integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
@@ -273,6 +278,7 @@ jobs:
           name: Run deprecated integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deprecated
@@ -303,6 +309,7 @@ jobs:
           name: Build CLI image
           command: |
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            export OKTETO_HOME=$HOME/.okteto
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       # - integration-build
@@ -316,9 +323,6 @@ jobs:
           paths:
             - ~/.cache/go-build
             - /go/pkg
-      - store_artifacts:
-          path: $HOME/.okteto
-          destination: .okteto
   test-release:
     executor: golang-ci
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,11 @@ jobs:
       - run:
           name: Add version string
           command: env VERSION_STRING=$CIRCLE_TAG make latest
+      - save_cache:
+          key: v5-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg/mod
       - persist_to_workspace:
           root: .
           paths:
@@ -132,13 +137,12 @@ jobs:
           keys:
             - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
-          at: ./artifacts
+          at: ./integration-workspace
       - run:
           name: Run actions integration tests
           command: |
-            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             make integration-actions
 
   integration-build:
@@ -153,14 +157,14 @@ jobs:
           keys:
             - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
-          at: integration-workspace
+          at: ./integration-workspace
       - run:
           name: Run build integration tests
           command: |
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
-            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=/integration-workspace/
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             make integration-build
 
   integration-deploy:
@@ -175,13 +179,13 @@ jobs:
           keys:
             - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
-          at: integration-workspace
+          at: ./integration-workspace
       - run:
           name: Run deploy integration tests
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
-            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=/integration-workspace/
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             make integration-deploy
@@ -199,12 +203,12 @@ jobs:
           keys:
             - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
-          at: integration-workspace
+          at: ./integration-workspace
       - run:
           name: Run up integration tests
           command: |
-            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=/integration-workspace/
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             make integration-up
@@ -224,16 +228,15 @@ jobs:
           keys:
             - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
-          at: integration-workspace
+          at: ./integration-workspace
       - run:
           name: Run okteto integration tests
           command: |
-            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=/integration-workspace/
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
             make integration-okteto
-
 
   integration-deprecated:
     executor: golang-ci
@@ -247,12 +250,12 @@ jobs:
           keys:
             - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
-          at: integration-workspace
+          at: ./integration-workspace
       - run:
           name: Run deprecated integration tests
           command: |
-            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=/integration-workspace/
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             make integration-deprecated
 
   test-integration-setup:
@@ -267,13 +270,12 @@ jobs:
           keys:
             - v5-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
-          at: ./artifacts
+          at: ./integration-workspace
       - run:
           name: Okteto Setup for integration
           command: |
-            mkdir -p integration-workspace/bin && export OKTETO_HOME=/integration-workspace
-            cp $(pwd)/artifacts/bin/okteto-Linux-x86_64 /integration-workspace/bin/okteto-Linux-x86_64
-            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
             echo "$CIRCLE_SHA1"
             okteto version
             okteto analytics --disable
@@ -281,7 +283,6 @@ jobs:
       - persist_to_workspace:
           root: integration-workspace
           paths:
-            - bin/okteto-Linux-x86_64
             - .okteto/analytics.json
             - .okteto/context/config.json
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
       - store_artifacts:
           path: coverage.txt
           destination: coverage.txt
+
   run-windows-unit-test:
     executor: win/default
     environment:
@@ -133,212 +134,138 @@ jobs:
     executor: golang-ci
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - matches:
-                  pattern: *release-branch-regex
-                  value: << pipeline.git.branch >>
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v4-pkg-cache-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: ./artifacts
-            - run:
-                name: Run actions integration tests
-                command: |
-                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-                  make integration-actions
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Run actions integration tests
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            make integration-actions
 
   integration-build:
     executor: golang-ci
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - matches:
-                  pattern: *release-branch-regex
-                  value: << pipeline.git.branch >>
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v4-pkg-cache-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: ./artifacts
-            - run:
-                name: Run build integration tests
-                command: |
-                  export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
-                  export DEPOT_TOKEN=$DEPOT_TOKEN
-                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-                  make integration-build
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Run build integration tests
+          command: |
+            export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
+            export DEPOT_TOKEN=$DEPOT_TOKEN
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            make integration-build
 
   integration-deploy:
     executor: golang-ci
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - matches:
-                  pattern: *release-branch-regex
-                  value: << pipeline.git.branch >>
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v4-pkg-cache-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: ./artifacts
-            - run:
-                name: Run deploy integration tests
-                # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
-                command: |
-                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-                  export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-                  echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-                  make integration-deploy
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Run deploy integration tests
+          # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            make integration-deploy
 
   integration-up:
     executor: golang-ci
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - matches:
-                  pattern: *release-branch-regex
-                  value: << pipeline.git.branch >>
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v4-pkg-cache-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: ./artifacts
-            - run:
-                name: Run up integration tests
-                command: |
-                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-                  export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-                  echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-                  make integration-up
-                environment:
-                  OKTETO_SKIP_CLEANUP: "true"
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Run up integration tests
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            make integration-up
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
 
   integration-okteto:
     executor: golang-ci
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - matches:
-                  pattern: *release-branch-regex
-                  value: << pipeline.git.branch >>
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v4-pkg-cache-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: ./artifacts
-            - run:
-                name: Run okteto integration tests
-                command: |
-                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-                  export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-                  echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-                  make integration-okteto
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Run okteto integration tests
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            make integration-okteto
 
   integration-deprecated:
     executor: golang-ci
-    environment:
-      OKTETO_URL: https://staging.okteto.dev/
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - matches:
-                  pattern: *release-branch-regex
-                  value: << pipeline.git.branch >>
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v4-pkg-cache-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: ./artifacts
-            - run:
-                name: Run deprecated integration tests
-                command: |
-                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-                  make integration-deprecated
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Run deprecated integration tests
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            make integration-deprecated
 
   test-integration-setup:
     executor: golang-ci
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - matches:
-                  pattern: *release-branch-regex
-                  value: << pipeline.git.branch >>
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v4-pkg-cache-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: ./artifacts
-            - run:
-                # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
-                # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
-                # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
-                name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-                command: |
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            - save_cache:
-                key: v4-pkg-cache-{{ checksum "go.sum" }}
-                paths:
-                  - ~/.cache/go-build
-                  - /go/pkg
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
+          # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
+          # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
+          name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
+          command: |
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+      - save_cache:
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg
 
   test-release:
     executor: golang-ci
@@ -366,36 +293,28 @@ jobs:
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: .\artifacts
-            - run:
-                # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
-                # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
-                # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
-                name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-                command: |
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
-            - save_cache:
-                key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-                paths:
-                  - C:\Users\circleci\AppData\Local\go-build
-                  - C:\Users\circleci\go\pkg
-                  - C:\Go\pkg
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
+      - run:
+          # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
+          # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
+          # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
+          name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
+          command: |
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
+      - save_cache:
+          key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+          paths:
+            - C:\Users\circleci\AppData\Local\go-build
+            - C:\Users\circleci\go\pkg
+            - C:\Go\pkg
   integration-deprecated-windows:
     executor: win/default
     environment:
@@ -404,37 +323,28 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: .\artifacts
-            - run:
-                name: Install kubectl and helm
-                command: |
-                  go version
-                  choco install kubernetes-cli -y
-                  choco install kubernetes-helm -y
-            - run:
-                name: Run deprecated integration tests
-                environment:
-                  OKTETO_URL: https://staging.okteto.dev/
-                  OKTETO_SKIP_CLEANUP: "true"
-                  OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
-                command: |
-                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\artifacts\bin"
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-                  go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
-                  go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
+      - run:
+          name: Install kubectl and helm
+          command: |
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
+      - run:
+          name: Run deprecated integration tests
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
+          command: |
+            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
+            go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
 
   integration-build-windows:
     executor: win/default
@@ -444,30 +354,23 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: .\artifacts
-            - run:
-                name: Run build integration tests
-                environment:
-                  OKTETO_SKIP_CLEANUP: "true"
-                command: |
-                  $env:DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
-                  $env:DEPOT_TOKEN=$DEPOT_TOKEN
-                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\artifacts\bin"
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-                  go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
+      - run:
+          name: Run build integration tests
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
+          command: |
+            $env:DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
+            $env:DEPOT_TOKEN=$DEPOT_TOKEN
+            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
 
   integration-deploy-windows:
     executor: win/default
@@ -477,37 +380,30 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: .\artifacts
-            - run:
-                name: Install kubectl and helm
-                command: |
-                  go version
-                  choco install kubernetes-cli -y
-                  choco install kubernetes-helm -y
-            - run:
-                name: Run deploy integration tests
-                environment:
-                  OKTETO_SKIP_CLEANUP: "true"
-                # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
-                command: |
-                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\artifacts\bin"
-                  $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
-                  $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-                  go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
+      - run:
+          name: Install kubectl and helm
+          command: |
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
+      - run:
+          name: Run deploy integration tests
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
+          command: |
+            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
+            $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
+            # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
+            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
 
   integration-up-windows:
     executor: win/default
@@ -517,38 +413,29 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - when:
-          condition:
-            or:
-              - equal: ["master", << pipeline.git.branch >>]
-              - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
-              - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-          steps:
-            - restore_cache:
-                keys:
-                  - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
-            - attach_workspace:
-                at: .\artifacts
-            - run:
-                name: Install kubectl and helm
-                command: |
-                  go version
-                  choco install kubernetes-cli -y
-                  choco install kubernetes-helm -y
-            - run:
-                name: Run up integration tests
-                environment:
-                  OKTETO_URL: https://staging.okteto.dev/
-                  OKTETO_SKIP_CLEANUP: "true"
-                  OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
-                command: |
-                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\artifacts\bin"
-                  $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
-                  $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-                  go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
+      - run:
+          name: Install kubectl and helm
+          command: |
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
+      - run:
+          name: Run up integration tests
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
+          command: |
+            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
+            $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
+            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
 
   push-image-tag:
     executor: golang-ci
@@ -623,15 +510,17 @@ workflows:
     jobs:
       - upload-static-job:
           context: GKE
+  # lint-build-test runs on every push to a branch and when merge to master
+  # unit tests are run on every push and integration is run when merging to master
   lint-build-test:
     when:
       not:
         or:
           - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+          # when workflows from GHA are triggered, do not re-trigger this workflow
           - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
           - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
           - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-
     jobs:
       - golangci-lint
       - build-binaries:
@@ -886,13 +775,11 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
 
-  # run-integration is triggered by okteto-bot via Github Actions when adding the e2e labels to the PR
+  # run-integration is triggered by okteto-bot via Github Actions when adding the e2e label to the PR
+  # integration tests are run for both platformas, windows and unix
   run-integration:
     when:
-      or:
-        - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
-        - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
-        - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+      equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
       - build-binaries
       - test-integration-setup:
@@ -916,6 +803,58 @@ workflows:
       - integration-deprecated:
           requires:
             - test-integration-setup
+      - test-integration-setup-windows:
+          requires:
+            - build-binaries
+      - integration-build-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-deploy-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-up-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-deprecated-windows:
+          requires:
+            - test-integration-setup-windows
+
+  # run-integration-unix is triggered by okteto-bot via Github Actions when adding the run-e2e-unix label to the PR
+  # integration test for unix platform are run
+  run-integration-unix:
+    when:
+      equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-binaries
+      - test-integration-setup:
+          requires:
+            - build-binaries
+      - integration-build:
+          requires:
+            - test-integration-setup
+      - integration-deploy:
+          requires:
+            - test-integration-setup
+      - integration-up:
+          requires:
+            - test-integration-setup
+      - integration-actions:
+          requires:
+            - test-integration-setup
+      - integration-okteto:
+          requires:
+            - test-integration-setup
+      - integration-deprecated:
+          requires:
+            - test-integration-setup
+
+  # run-integration-windows is triggered by okteto-bot via Github Actions when adding the run-e2e-windows label to the PR
+  # integration test for windows platform are run
+  run-integration-windows:
+    when:
+      equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-binaries
       - test-integration-setup-windows:
           requires:
             - build-binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,6 @@ parameters:
   GHA_Meta:
     type: string
     default: ""
-  TriggerIntegration:
-    type: boolean
-    default: false
 
 orbs:
   win: circleci/windows@5.0.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,18 @@ executors:
     docker:
       - image: okteto/golang-ci:2.6.2
 
+command:
+  save_go_mod_cache:
+    - save_cache:
+        key: v5-pkg-cache-{{ checksum "go.sum" }}
+        paths:
+          - ~/.cache/go-build
+          - /go/pkg/mod
+  restore_go_mod_cache:
+    - restore_cache:
+        keys:
+          - v5-pkg-cache-{{ checksum "go.sum" }}
+
 jobs:
   golangci-lint:
     executor: golang-ci
@@ -60,9 +72,7 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - run:
           name: Build all binaries
           command: env VERSION_STRING=$CIRCLE_TAG make -j 3 build-all
@@ -76,10 +86,12 @@ jobs:
       - store_artifacts:
           path: bin
           destination: binaries
+
   run-unit-test:
     executor: golang-ci
     steps:
       - checkout
+      - run: restore_go_mod_cache
       - run:
           name: Compile integration tests
           command: make build-integration
@@ -88,11 +100,8 @@ jobs:
           command: |
             make test
             bash <(curl -s https://codecov.io/bash)
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - run: save_go_mod_cache
+
       - store_artifacts:
           path: coverage.txt
           destination: coverage.txt
@@ -123,9 +132,7 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - attach_workspace:
           at: ./artifacts
       - run:
@@ -135,11 +142,8 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-actions
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - run: save_go_mod_cache
+
 
   integration-build:
     executor: golang-ci
@@ -149,25 +153,19 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - attach_workspace:
-          at: ./artifacts
+          at: integration-workspace
       - run:
           name: Run build integration tests
           command: |
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
-            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=/integration-workspace/
             make integration-build
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - run: save_go_mod_cache
+
 
   integration-deploy:
     executor: golang-ci
@@ -177,26 +175,20 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - attach_workspace:
-          at: ./artifacts
+          at: integration-workspace
       - run:
           name: Run deploy integration tests
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
-            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=/integration-workspace/
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deploy
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - run: save_go_mod_cache
+
 
   integration-up:
     executor: golang-ci
@@ -206,27 +198,21 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - attach_workspace:
-          at: ./artifacts
+          at: integration-workspace
       - run:
           name: Run up integration tests
           command: |
-            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=/integration-workspace/
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - run: save_go_mod_cache
+
 
   integration-okteto:
     executor: golang-ci
@@ -236,25 +222,19 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - attach_workspace:
-          at: ./artifacts
+          at: integration-workspace
       - run:
           name: Run okteto integration tests
           command: |
-            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=/integration-workspace/
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-okteto
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - run: save_go_mod_cache
+
 
   integration-deprecated:
     executor: golang-ci
@@ -264,23 +244,16 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - attach_workspace:
-          at: ./artifacts
+          at: integration-workspace
       - run:
           name: Run deprecated integration tests
           command: |
-            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
+            export OKTETO_HOME=/integration-workspace/
             make integration-deprecated
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+      - run: save_go_mod_cache
 
   test-integration-setup:
     executor: golang-ci
@@ -290,25 +263,34 @@ jobs:
       OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - run: restore_go_mod_cache
       - attach_workspace:
           at: ./artifacts
+      - run:
+          name: Okteto Setup for integration
+          command: |
+            mkdir -p integration-workspace/bin && export OKTETO_HOME=/integration-workspace
+            cp $(pwd)/artifacts/bin/okteto-Linux-x86_64 /integration-workspace/bin/okteto-Linux-x86_64
+            export OKTETO_PATH=/integration-workspace/bin/okteto-Linux-x86_64
+            echo "$CIRCLE_SHA1"
+            okteto version
+            okteto analytics --disable
+            okteto context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+      - persist_to_workspace:
+          root: integration-workspace
+          paths:
+            - bin/okteto-Linux-x86_64
+            - .okteto/analytics.json
+            - .okteto/context/config.json
       - run:
           # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-          command: |
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-      - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
-          paths:
-            - ~/.cache/go-build
-            - /go/pkg
+          command: $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+
+      - run: save_go_mod_cache
+
   test-release:
     executor: golang-ci
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,57 +117,155 @@ jobs:
 
   integration-actions:
     executor: golang-ci
+    environment:
+      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
       - run:
           name: Run actions integration tests
-          command: make integration-actions
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            make integration-actions
+      - save_cache:
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg
 
   integration-build:
     executor: golang-ci
+    environment:
+      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
       - run:
           name: Run build integration tests
           command: |
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             make integration-build
+      - save_cache:
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg
 
   integration-deploy:
     executor: golang-ci
+    environment:
+      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
       - run:
           name: Run deploy integration tests
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             make integration-deploy
+      - save_cache:
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg
 
   integration-up:
     executor: golang-ci
+    environment:
+      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
       - run:
           name: Run up integration tests
           command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
+      - save_cache:
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg
 
   integration-okteto:
     executor: golang-ci
+    environment:
+      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
       - run:
           name: Run okteto integration tests
           command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             make integration-okteto
+      - save_cache:
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg
 
   integration-deprecated:
     executor: golang-ci
+    environment:
+      OKTETO_URL: https://staging.okteto.dev/
+      OKTETO_USER: cindylopez
+      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
       - run:
           name: Run deprecated integration tests
-          command: make integration-deprecated
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            make integration-deprecated
+      - save_cache:
+          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go-build
+            - /go/pkg
 
   test-integration:
     executor: golang-ci
@@ -201,12 +299,12 @@ jobs:
           name: Build CLI image
           command: |
             okteto build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-      - integration-build
-      - integration-deploy
-      - integration-up
-      - integration-actions
-      - integration-okteto
-      - integration-deprecated
+      # - integration-build
+      # - integration-deploy
+      # - integration-up
+      # - integration-actions
+      # - integration-okteto
+      # - integration-deprecated
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:
@@ -214,6 +312,10 @@ jobs:
             - /go/pkg
       - store_artifacts:
           path: /root/.okteto
+      - persist_to_workspace:
+          root: .okteto
+          paths:
+            - .noanalytics
   test-release:
     executor: golang-ci
     steps:
@@ -619,3 +721,9 @@ workflows:
       equal: [true, << pipeline.parameters.TriggerIntegration >>]
     jobs:
       - test-integration
+      - integration-build
+      - integration-deploy
+      - integration-up
+      - integration-actions
+      - integration-okteto
+      - integration-deprecated

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,8 +463,8 @@ jobs:
                 command: |
                   $env:DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
                   $env:DEPOT_TOKEN=$DEPOT_TOKEN
-                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\artifacts\bin"
                   & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
                   & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
                   go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,9 +135,9 @@ jobs:
           name: Run actions integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_HOME=$HOME/.okteto
             make integration-actions
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -164,9 +164,9 @@ jobs:
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_HOME=$HOME/.okteto
             make integration-build
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -192,10 +192,10 @@ jobs:
           # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_HOME=$HOME/.okteto
             make integration-deploy
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -220,10 +220,10 @@ jobs:
           name: Run up integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_HOME=$HOME/.okteto
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
@@ -250,10 +250,10 @@ jobs:
           name: Run okteto integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_HOME=$HOME/.okteto
             make integration-okteto
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -278,9 +278,9 @@ jobs:
           name: Run deprecated integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_HOME=$HOME/.okteto
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            export OKTETO_HOME=$HOME/.okteto
             make integration-deprecated
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -309,7 +309,6 @@ jobs:
           name: Build CLI image
           command: |
             export OKTETO_TOKEN=${API_STAGING_TOKEN}
-            export OKTETO_HOME=$HOME/.okteto
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       # - integration-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,12 +147,13 @@ jobs:
                 keys:
                   - v4-pkg-cache-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: ./integration-workspace
+                at: ./artifacts
             - run:
                 name: Run actions integration tests
                 command: |
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
                   make integration-actions
 
   integration-build:
@@ -177,14 +178,15 @@ jobs:
                 keys:
                   - v4-pkg-cache-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: ./integration-workspace
+                at: ./artifacts
             - run:
                 name: Run build integration tests
                 command: |
                   export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
                   export DEPOT_TOKEN=$DEPOT_TOKEN
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
                   make integration-build
 
   integration-deploy:
@@ -209,15 +211,16 @@ jobs:
                 keys:
                   - v4-pkg-cache-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: ./integration-workspace
+                at: ./artifacts
             - run:
                 name: Run deploy integration tests
                 # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
                 command: |
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
                   export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
                   echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
                   make integration-deploy
 
   integration-up:
@@ -242,14 +245,15 @@ jobs:
                 keys:
                   - v4-pkg-cache-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: ./integration-workspace
+                at: ./artifacts
             - run:
                 name: Run up integration tests
                 command: |
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
                   export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
                   echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
                   make integration-up
                 environment:
                   OKTETO_SKIP_CLEANUP: "true"
@@ -276,14 +280,15 @@ jobs:
                 keys:
                   - v4-pkg-cache-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: ./integration-workspace
+                at: ./artifacts
             - run:
                 name: Run okteto integration tests
                 command: |
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
                   export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
                   echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
                   make integration-okteto
 
   integration-deprecated:
@@ -308,12 +313,13 @@ jobs:
                 keys:
                   - v4-pkg-cache-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: ./integration-workspace
+                at: ./artifacts
             - run:
                 name: Run deprecated integration tests
                 command: |
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  export OKTETO_PATH=$(pwd)/integration-workspace/bin/okteto-Linux-x86_64
+                  export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
                   make integration-deprecated
 
   test-integration-setup:
@@ -338,28 +344,16 @@ jobs:
                 keys:
                   - v4-pkg-cache-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: ./integration-workspace
-            - run:
-                name: Okteto Setup for integration
-                command: |
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  echo "$CIRCLE_SHA1"
-                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 version
-                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
-                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 analytics --disable
-            - persist_to_workspace:
-                root: integration-workspace
-                paths:
-                  - .okteto/analytics.json
-                  - .okteto/context/config.json
+                at: ./artifacts
             - run:
                 # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
                 # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
                 # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
                 name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
                 command: |
-                  export OKTETO_HOME=$(pwd)/integration-workspace
-                  $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+                  $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             - save_cache:
                 key: v4-pkg-cache-{{ checksum "go.sum" }}
                 paths:
@@ -406,29 +400,16 @@ jobs:
                 keys:
                   - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: .\integration-workspace
-            - run:
-                name: Okteto Setup for integration
-                command: |
-                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
-                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
-                  & "$($HOME)\project\integration-workspace\bin\okteto.exe" analytics --disable
-                  & "$($HOME)\project\integration-workspace\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
-            - persist_to_workspace:
-                root: integration-workspace
-                paths:
-                  - .okteto/analytics.json
-                  - .okteto/context/config.json
+                at: .\artifacts
             - run:
                 # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
                 # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
                 # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
                 name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
                 command: |
-                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
-                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
-                  & "$($HOME)\project\integration-workspace\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
             - save_cache:
                 key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
                 paths:
@@ -454,7 +435,7 @@ jobs:
                 keys:
                   - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: .\integration-workspace
+                at: .\artifacts
             - run:
                 name: Install kubectl and helm
                 command: |
@@ -468,9 +449,10 @@ jobs:
                   OKTETO_SKIP_CLEANUP: "true"
                   OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
                 command: |
-                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
-                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\artifacts\bin"
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
                   go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
                   go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
 
@@ -493,7 +475,7 @@ jobs:
                 keys:
                   - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: .\integration-workspace
+                at: .\artifacts
             - run:
                 name: Run build integration tests
                 environment:
@@ -503,7 +485,8 @@ jobs:
                   $env:DEPOT_TOKEN=$DEPOT_TOKEN
                   $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
                   $env:Path+=";$($HOME)\project\integration-workspace\bin"
-                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
                   go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
 
   integration-deploy-windows:
@@ -525,7 +508,7 @@ jobs:
                 keys:
                   - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: .\integration-workspace
+                at: .\artifacts
             - run:
                 name: Install kubectl and helm
                 command: |
@@ -538,11 +521,12 @@ jobs:
                   OKTETO_SKIP_CLEANUP: "true"
                 # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
                 command: |
-                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\artifacts\bin"
                   $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
                   $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
-                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
                   go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
 
   integration-up-windows:
@@ -564,7 +548,7 @@ jobs:
                 keys:
                   - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
             - attach_workspace:
-                at: .\integration-workspace
+                at: .\artifacts
             - run:
                 name: Install kubectl and helm
                 command: |
@@ -578,11 +562,12 @@ jobs:
                   OKTETO_SKIP_CLEANUP: "true"
                   OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
                 command: |
-                  $env:OKTETO_PATH="$($HOME)\project\integration-workspace\bin\okteto.exe"
-                  $env:Path+=";$($HOME)\project\integration-workspace\bin"
+                  $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+                  $env:Path+=";$($HOME)\project\artifacts\bin"
                   $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
                   $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
-                  $env:OKTETO_HOME="$($HOME)\project\integration-workspace"
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+                  & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
                   go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
 
   push-image-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
           name: Run actions integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-actions
       - save_cache:
@@ -163,7 +163,7 @@ jobs:
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-build
       - save_cache:
@@ -191,7 +191,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deploy
       - save_cache:
@@ -218,7 +218,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-up
           environment:
@@ -247,7 +247,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
-            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-okteto
       - save_cache:
@@ -273,7 +273,7 @@ jobs:
           name: Run deprecated integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deprecated
       - save_cache:
@@ -302,7 +302,7 @@ jobs:
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build CLI image
           command: |
-            export OKTETO_TOKEN=${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       # - integration-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -697,7 +697,12 @@ workflows:
   lint-build-test:
     when:
       not:
-        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        or:
+          - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+          - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+          - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+          - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+
     jobs:
       - golangci-lint
       - build-binaries:
@@ -727,39 +732,99 @@ workflows:
       - test-integration-setup-windows:
           requires:
             - build-binaries
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
       - integration-build-windows:
           requires:
             - test-integration-setup-windows
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
       - integration-deploy-windows:
           requires:
             - test-integration-setup-windows
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
       - integration-up-windows:
           requires:
             - test-integration-setup-windows
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
       - integration-deprecated-windows:
           requires:
             - test-integration-setup-windows
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(windows|win)/
       - test-integration-setup:
           requires:
             - build-binaries
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - integration-build:
           requires:
             - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - integration-deploy:
           requires:
             - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - integration-up:
           requires:
             - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - integration-actions:
           requires:
             - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - integration-okteto:
           requires:
             - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - integration-deprecated:
           requires:
             - test-integration-setup
+          filters:
+            branches:
+              only:
+                - master
+                - /.*(e2e)/
       - test-release:
           context:
             - GKE
@@ -903,3 +968,49 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
+
+  # run-integration is triggered by okteto-bot via Github Actions when adding the e2e labels to the PR
+  run-integration:
+    when:
+      or:
+        - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
+        - equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
+        - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
+    jobs:
+      - build-binaries
+      - test-integration-setup:
+          requires:
+            - build-binaries
+      - integration-build:
+          requires:
+            - test-integration-setup
+      - integration-deploy:
+          requires:
+            - test-integration-setup
+      - integration-up:
+          requires:
+            - test-integration-setup
+      - integration-actions:
+          requires:
+            - test-integration-setup
+      - integration-okteto:
+          requires:
+            - test-integration-setup
+      - integration-deprecated:
+          requires:
+            - test-integration-setup
+      - test-integration-setup-windows:
+          requires:
+            - build-binaries
+      - integration-build-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-deploy-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-up-windows:
+          requires:
+            - test-integration-setup-windows
+      - integration-deprecated-windows:
+          requires:
+            - test-integration-setup-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,15 +347,6 @@ jobs:
       - attach_workspace:
           at: .\artifacts
       - run:
-          name: Setup environment
-          command: |
-            go version
-            choco install kubernetes-cli -y
-            choco install kubernetes-helm -y
-      - run:
-          name: Run windows unit test-release
-          command: go test ./...
-      - run:
           # As the integration test running the okteto deploy needs the CLI which we are testing, we build the current
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
@@ -363,7 +354,6 @@ jobs:
           command: |
             & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
             & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" kubeconfig
             & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
       - save_cache:
           key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -384,6 +374,12 @@ jobs:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
       - attach_workspace:
           at: .\artifacts
+      - run:
+          name: Install kubectl and helm
+          command: |
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
       - run:
           name: Run deprecated integration tests
           environment:
@@ -437,6 +433,12 @@ jobs:
       - attach_workspace:
           at: .\artifacts
       - run:
+          name: Install kubectl and helm
+          command: |
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
+      - run:
           name: Run deploy integration tests
           environment:
             OKTETO_SKIP_CLEANUP: "true"
@@ -462,6 +464,12 @@ jobs:
             - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
       - attach_workspace:
           at: .\artifacts
+      - run:
+          name: Install kubectl and helm
+          command: |
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
       - run:
           name: Run up integration tests
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ jobs:
       - run:
           name: Run actions integration tests
           command: |
+            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             make integration-actions
       - save_cache:
@@ -157,6 +158,7 @@ jobs:
           command: |
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
+            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             make integration-build
       - save_cache:
@@ -184,6 +186,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
             make integration-deploy
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -209,6 +212,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
             make integration-up
           environment:
             OKTETO_SKIP_CLEANUP: "true"
@@ -236,6 +240,7 @@ jobs:
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
             make integration-okteto
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -260,6 +265,7 @@ jobs:
           name: Run deprecated integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            mkdir -p $HOME/.okteto && cp $(pwd)/artifacts/.okteto $HOME/.okteto
             make integration-deprecated
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
@@ -311,7 +317,8 @@ jobs:
             - ~/.cache/go-build
             - /go/pkg
       - store_artifacts:
-          path: /root/.okteto
+          path: $HOME/.okteto
+          destination: .okteto
   test-release:
     executor: golang-ci
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,9 @@ jobs:
           # CLI to the okteto.dev registry, so it is available for the user running the tests. Then, in the step
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
-          command: $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
+          command: |
+            export OKTETO_HOME=$(pwd)/integration-workspace
+            $(pwd)/integration-workspace/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       - save_cache:
           key: v4-pkg-cache-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,7 +657,7 @@ workflows:
     when:
       matches:
         pattern: *release-branch-regex
-        value: << parameters.git.branch >>
+        value: << pipeline.git.branch >>
     jobs:
       - build-binaries:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -730,20 +730,15 @@ workflows:
       - integration-deploy:
           requires:
             - test-integration
-            - integration-build
       - integration-up:
           requires:
             - test-integration
-            - integration-deploy
       - integration-actions:
           requires:
             - test-integration
-            - integration-up
       - integration-okteto:
           requires:
             - test-integration
-            - integration-actions
       - integration-deprecated:
           requires:
             - test-integration
-            - integration-okteto

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v4-pkg-cache-{{ checksum "go.sum" }}
+            - v1-bin-pkg-cache-{{ checksum "go.sum" }}
       - run:
           name: Build all binaries
           command: env VERSION_STRING=$CIRCLE_TAG make -j 3 build-all
@@ -70,7 +70,7 @@ jobs:
           name: Add version string
           command: env VERSION_STRING=$CIRCLE_TAG make latest
       - save_cache:
-          key: v4-pkg-cache-{{ checksum "go.sum" }}
+          key: v1-bin-pkg-cache-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go-build
             - /go/pkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,9 +137,6 @@ jobs:
           condition:
             or:
               - matches:
-                  pattern: /.*(e2e)/
-                  value: << pipeline.git.branch >>
-              - matches:
                   pattern: *release-branch-regex
                   value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
@@ -169,9 +166,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(e2e)/
-                  value: << pipeline.git.branch >>
               - matches:
                   pattern: *release-branch-regex
                   value: << pipeline.git.branch >>
@@ -205,9 +199,6 @@ jobs:
           condition:
             or:
               - matches:
-                  pattern: /.*(e2e)/
-                  value: << pipeline.git.branch >>
-              - matches:
                   pattern: *release-branch-regex
                   value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
@@ -240,9 +231,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(e2e)/
-                  value: << pipeline.git.branch >>
               - matches:
                   pattern: *release-branch-regex
                   value: << pipeline.git.branch >>
@@ -278,9 +266,6 @@ jobs:
           condition:
             or:
               - matches:
-                  pattern: /.*(e2e)/
-                  value: << pipeline.git.branch >>
-              - matches:
                   pattern: *release-branch-regex
                   value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
@@ -313,9 +298,6 @@ jobs:
           condition:
             or:
               - matches:
-                  pattern: /.*(e2e)/
-                  value: << pipeline.git.branch >>
-              - matches:
                   pattern: *release-branch-regex
                   value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
@@ -345,9 +327,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(e2e)/
-                  value: << pipeline.git.branch >>
               - matches:
                   pattern: *release-branch-regex
                   value: << pipeline.git.branch >>
@@ -419,9 +398,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(windows|win)/
-                  value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
               - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
               - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
@@ -470,9 +446,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(windows|win)/
-                  value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
               - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
               - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
@@ -512,9 +485,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(windows|win)/
-                  value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
               - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
               - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
@@ -547,9 +517,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(windows|win)/
-                  value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
               - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
               - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
@@ -589,9 +556,6 @@ jobs:
       - when:
           condition:
             or:
-              - matches:
-                  pattern: /.*(windows|win)/
-                  value: << pipeline.git.branch >>
               - equal: ["master", << pipeline.git.branch >>]
               - equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
               - equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
@@ -736,7 +700,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(windows|win)/
       - integration-build-windows:
           requires:
             - test-integration-setup-windows
@@ -744,7 +707,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(windows|win)/
       - integration-deploy-windows:
           requires:
             - test-integration-setup-windows
@@ -752,7 +714,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(windows|win)/
       - integration-up-windows:
           requires:
             - test-integration-setup-windows
@@ -760,7 +721,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(windows|win)/
       - integration-deprecated-windows:
           requires:
             - test-integration-setup-windows
@@ -768,7 +728,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(windows|win)/
       - test-integration-setup:
           requires:
             - build-binaries
@@ -776,7 +735,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(e2e)/
       - integration-build:
           requires:
             - test-integration-setup
@@ -784,7 +742,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(e2e)/
       - integration-deploy:
           requires:
             - test-integration-setup
@@ -792,7 +749,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(e2e)/
       - integration-up:
           requires:
             - test-integration-setup
@@ -800,7 +756,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(e2e)/
       - integration-actions:
           requires:
             - test-integration-setup
@@ -808,7 +763,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(e2e)/
       - integration-okteto:
           requires:
             - test-integration-setup
@@ -816,7 +770,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(e2e)/
       - integration-deprecated:
           requires:
             - test-integration-setup
@@ -824,7 +777,6 @@ workflows:
             branches:
               only:
                 - master
-                - /.*(e2e)/
       - test-release:
           context:
             - GKE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
             go version
             go test ./...
 
-  integration-actions:
+  e2e-actions:
     executor: golang-ci
     steps:
       - checkout
@@ -147,7 +147,7 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-actions
 
-  integration-build:
+  e2e-build:
     executor: golang-ci
     steps:
       - checkout
@@ -166,7 +166,7 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-build
 
-  integration-deploy:
+  e2e-deploy:
     executor: golang-ci
     steps:
       - checkout
@@ -186,7 +186,7 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deploy
 
-  integration-up:
+  e2e-up:
     executor: golang-ci
     steps:
       - checkout
@@ -207,7 +207,7 @@ jobs:
           environment:
             OKTETO_SKIP_CLEANUP: "true"
 
-  integration-okteto:
+  e2e-okteto:
     executor: golang-ci
     steps:
       - checkout
@@ -226,7 +226,7 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-okteto
 
-  integration-deprecated:
+  e2e-deprecated:
     executor: golang-ci
     steps:
       - checkout
@@ -315,7 +315,7 @@ jobs:
             - C:\Users\circleci\AppData\Local\go-build
             - C:\Users\circleci\go\pkg
             - C:\Go\pkg
-  integration-deprecated-windows:
+  e2e-deprecated-windows:
     executor: win/default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
@@ -346,7 +346,7 @@ jobs:
             go test github.com/okteto/okteto/integration/deprecated/push -tags="integration" --count=1 -v -timeout 15m
             go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
 
-  integration-build-windows:
+  e2e-build-windows:
     executor: win/default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
@@ -372,7 +372,7 @@ jobs:
             & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
 
-  integration-deploy-windows:
+  e2e-deploy-windows:
     executor: win/default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
@@ -405,7 +405,7 @@ jobs:
             & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
 
-  integration-up-windows:
+  e2e-up-windows:
     executor: win/default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
@@ -511,7 +511,7 @@ workflows:
       - upload-static-job:
           context: GKE
   # lint-build-test runs on every push to a branch and when merge to master
-  # unit tests are run on every push and integration is run when merging to master
+  # unit tests are run on every push and e2e is run when merging to master
   lint-build-test:
     when:
       not:
@@ -554,28 +554,28 @@ workflows:
             branches:
               only:
                 - master
-      - integration-build-windows:
+      - e2e-build-windows:
           requires:
             - test-e2e-setup-windows
           filters:
             branches:
               only:
                 - master
-      - integration-deploy-windows:
+      - e2e-deploy-windows:
           requires:
             - test-e2e-setup-windows
           filters:
             branches:
               only:
                 - master
-      - integration-up-windows:
+      - e2e-up-windows:
           requires:
             - test-e2e-setup-windows
           filters:
             branches:
               only:
                 - master
-      - integration-deprecated-windows:
+      - e2e-deprecated-windows:
           requires:
             - test-e2e-setup-windows
           filters:
@@ -589,42 +589,42 @@ workflows:
             branches:
               only:
                 - master
-      - integration-build:
+      - e2e-build:
           requires:
             - test-e2e-setup
           filters:
             branches:
               only:
                 - master
-      - integration-deploy:
+      - e2e-deploy:
           requires:
             - test-e2e-setup
           filters:
             branches:
               only:
                 - master
-      - integration-up:
+      - e2e-up:
           requires:
             - test-e2e-setup
           filters:
             branches:
               only:
                 - master
-      - integration-actions:
+      - e2e-actions:
           requires:
             - test-e2e-setup
           filters:
             branches:
               only:
                 - master
-      - integration-okteto:
+      - e2e-okteto:
           requires:
             - test-e2e-setup
           filters:
             branches:
               only:
                 - master
-      - integration-deprecated:
+      - e2e-deprecated:
           requires:
             - test-e2e-setup
           filters:
@@ -674,33 +674,33 @@ workflows:
       - test-e2e-setup:
           requires:
             - build-binaries
-      - integration-build:
+      - e2e-build:
           requires:
             - test-e2e-setup
-      - integration-deploy:
+      - e2e-deploy:
           requires:
             - test-e2e-setup
-      - integration-up:
+      - e2e-up:
           requires:
             - test-e2e-setup
-      - integration-actions:
+      - e2e-actions:
           requires:
             - test-e2e-setup
-      - integration-okteto:
+      - e2e-okteto:
           requires:
             - test-e2e-setup
-      - integration-deprecated:
+      - e2e-deprecated:
           requires:
             - test-e2e-setup
       - release-branch-job:
           requires:
             - build-binaries
-            - integration-build
-            - integration-deploy
-            - integration-up
-            - integration-actions
-            - integration-okteto
-            - integration-deprecated
+            - e2e-build
+            - e2e-deploy
+            - e2e-up
+            - e2e-actions
+            - e2e-okteto
+            - e2e-deprecated
             - run-unit-test
             - run-windows-unit-test
 
@@ -780,9 +780,9 @@ workflows:
             tags:
               only: /^\d+\.\d+\.\d+$/
 
-  # run-integration is triggered by okteto-bot via Github Actions when adding the e2e label to the PR
-  # integration tests are run for both platformas, windows and unix
-  run-integration:
+  # run-e2e is triggered by okteto-bot via Github Actions when adding the e2e label to the PR
+  # e2e tests are run for both platformas, windows and unix
+  run-e2e:
     when:
       equal: ["run-e2e", << pipeline.parameters.GHA_Meta >>]
     jobs:
@@ -790,42 +790,42 @@ workflows:
       - test-e2e-setup:
           requires:
             - build-binaries
-      - integration-build:
+      - e2e-build:
           requires:
             - test-e2e-setup
-      - integration-deploy:
+      - e2e-deploy:
           requires:
             - test-e2e-setup
-      - integration-up:
+      - e2e-up:
           requires:
             - test-e2e-setup
-      - integration-actions:
+      - e2e-actions:
           requires:
             - test-e2e-setup
-      - integration-okteto:
+      - e2e-okteto:
           requires:
             - test-e2e-setup
-      - integration-deprecated:
+      - e2e-deprecated:
           requires:
             - test-e2e-setup
       - test-e2e-setup-windows:
           requires:
             - build-binaries
-      - integration-build-windows:
+      - e2e-build-windows:
           requires:
             - test-e2e-setup-windows
-      - integration-deploy-windows:
+      - e2e-deploy-windows:
           requires:
             - test-e2e-setup-windows
-      - integration-up-windows:
+      - e2e-up-windows:
           requires:
             - test-e2e-setup-windows
-      - integration-deprecated-windows:
+      - e2e-deprecated-windows:
           requires:
             - test-e2e-setup-windows
 
   # run-e2e-unix is triggered by okteto-bot via Github Actions when adding the run-e2e-unix label to the PR
-  # integration test for unix platform are run
+  # e2e test for unix platform are run
   run-e2e-unix:
     when:
       equal: ["run-e2e-unix", << pipeline.parameters.GHA_Meta >>]
@@ -834,27 +834,27 @@ workflows:
       - test-e2e-setup:
           requires:
             - build-binaries
-      - integration-build:
+      - e2e-build:
           requires:
             - test-e2e-setup
-      - integration-deploy:
+      - e2e-deploy:
           requires:
             - test-e2e-setup
-      - integration-up:
+      - e2e-up:
           requires:
             - test-e2e-setup
-      - integration-actions:
+      - e2e-actions:
           requires:
             - test-e2e-setup
-      - integration-okteto:
+      - e2e-okteto:
           requires:
             - test-e2e-setup
-      - integration-deprecated:
+      - e2e-deprecated:
           requires:
             - test-e2e-setup
 
   # run-e2e-windows is triggered by okteto-bot via Github Actions when adding the run-e2e-windows label to the PR
-  # integration test for windows platform are run
+  # e2e test for windows platform are run
   run-e2e-windows:
     when:
       equal: ["run-e2e-windows", << pipeline.parameters.GHA_Meta >>]
@@ -863,15 +863,15 @@ workflows:
       - test-e2e-setup-windows:
           requires:
             - build-binaries
-      - integration-build-windows:
+      - e2e-build-windows:
           requires:
             - test-e2e-setup-windows
-      - integration-deploy-windows:
+      - e2e-deploy-windows:
           requires:
             - test-e2e-setup-windows
-      - integration-up-windows:
+      - e2e-up-windows:
           requires:
             - test-e2e-setup-windows
-      - integration-deprecated-windows:
+      - e2e-deprecated-windows:
           requires:
             - test-e2e-setup-windows

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 /.git
 /.github
 /.vscode
+/integration-workspace

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,4 @@
 /.git
 /.github
 /.vscode
-/integration-workspace
+/artifacts


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-507

- remove integration commands, instead run jobs for each of them, this way we can retrigger a job without having to retrigger the whole workflow
- when labels on PRs are used to run integration, the new workflows are triggered without duplicating the `lint-test-build` launched by the push to the branch
- use okteto context instead of deprecated okteto login on integration jobs and okteto analytics --disable instead of creating the file
- reduce binary build time by using exclusive cache key, when building the windows binary the pkg where not saved at the cache key used on that job (reduced 5 minuts)


How to test:
- create new branch from this and make some code changes, push and check workflows
- trigger with `run-e2e` labels (unix and windows) the integration workflows are triggered
- create a branch that ends with win or e2e to check workflows are triggered for integration

