### PR TITLE
add metrics in order to know the usage

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -128,6 +128,7 @@ func Build(ctx context.Context, ioCtrl *io.Controller, at, insights buildTracker
 				}
 			}
 
+			analytics.TrackBuildWithManifestVsDockerfile(builder.IsV1())
 			return builder.Build(ctx, options)
 		},
 	}

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -34,30 +34,31 @@ const (
 	// This is mixpanel's public token, is needed to send analytics to the project
 	mixpanelToken = "92fe782cdffa212d8f03861fbf1ea301"
 
-	manifestHasChangedEvent  = "Manifest Has Changed"
-	downEvent                = "Down"
-	downVolumesEvent         = "DownVolumes"
-	restartEvent             = "Restart Services"
-	statusEvent              = "Status"
-	logsEvent                = "Logs"
-	doctorEvent              = "Doctor"
-	buildEvent               = "Build"
-	buildTransientErrorEvent = "BuildTransientError"
-	destroyEvent             = "Destroy"
-	deployStackEvent         = "Deploy Stack"
-	kubeconfigEvent          = "Kubeconfig"
-	namespaceEvent           = "Namespace"
-	namespaceCreateEvent     = "CreateNamespace"
-	namespaceDeleteEvent     = "DeleteNamespace"
-	previewDeployEvent       = "DeployPreview"
-	previewDestroyEvent      = "DestroyPreview"
-	execEvent                = "Exec"
-	signupEvent              = "Signup"
-	contextEvent             = "Context"
-	disableEvent             = "Disable Analytics"
-	stackNotSupportedField   = "Stack Field Not Supported"
-	buildPullErrorEvent      = "BuildPullError"
-	deleteContexts           = "Contexts Deletion"
+	manifestHasChangedEvent       = "Manifest Has Changed"
+	downEvent                     = "Down"
+	downVolumesEvent              = "DownVolumes"
+	restartEvent                  = "Restart Services"
+	statusEvent                   = "Status"
+	logsEvent                     = "Logs"
+	doctorEvent                   = "Doctor"
+	buildEvent                    = "Build"
+	buildWithManifestVsDockerfile = "BuildWithManifestVsDockerfile"
+	buildTransientErrorEvent      = "BuildTransientError"
+	destroyEvent                  = "Destroy"
+	deployStackEvent              = "Deploy Stack"
+	kubeconfigEvent               = "Kubeconfig"
+	namespaceEvent                = "Namespace"
+	namespaceCreateEvent          = "CreateNamespace"
+	namespaceDeleteEvent          = "DeleteNamespace"
+	previewDeployEvent            = "DeployPreview"
+	previewDestroyEvent           = "DestroyPreview"
+	execEvent                     = "Exec"
+	signupEvent                   = "Signup"
+	contextEvent                  = "Context"
+	disableEvent                  = "Disable Analytics"
+	stackNotSupportedField        = "Stack Field Not Supported"
+	buildPullErrorEvent           = "BuildPullError"
+	deleteContexts                = "Contexts Deletion"
 )
 
 var (
@@ -174,6 +175,14 @@ func TrackDoctor(success bool) {
 
 func trackDisable(success bool) {
 	track(disableEvent, success, nil)
+}
+
+func TrackBuildWithManifestVsDockerfile(isDockerfile bool) {
+	props := map[string]interface{}{
+		"isDockerfile": isDockerfile,
+	}
+	track(buildWithManifestVsDockerfile, true, props)
+
 }
 
 // TrackBuild sends a tracking event to mixpanel when the user builds on remote


### PR DESCRIPTION
# Proposed changes

Fixes DEV-471

- Adds metrics in order to know the usage of the build command with a dockerfile vs an okteto manifest

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
