### PR TITLE
remove global from build command

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -144,7 +144,6 @@ func Build(ctx context.Context, ioCtrl *io.Controller, at, insights buildTracker
 	cmd.Flags().StringArrayVar(&options.Secrets, "secret", nil, "secret files exposed to the build. Format: id=mysecret,src=/local/secret")
 	cmd.Flags().StringVar(&options.Platform, "platform", "", "set platform if server is multi-platform capable")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "namespace against which the image will be consumed. Default is the one defined at okteto context or okteto manifest")
-	cmd.Flags().BoolVarP(&options.BuildToGlobal, "global", "", false, "push the image to the global registry")
 	return cmd
 }
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -246,12 +246,7 @@ func OptsFromBuildInfo(manifestName, svcName string, b *build.Info, o *types.Bui
 	// manifestName can be not sanitized when option name is used at deploy
 	sanitizedName := format.ResourceK8sMetaString(manifestName)
 	if okCtx.IsOktetoCluster() && b.Image == "" {
-		// if flag --global, point to global registry
-		targetRegistry := constants.DevRegistry
-		if o != nil && o.BuildToGlobal {
-			targetRegistry = constants.GlobalRegistry
-		}
-		b.Image = fmt.Sprintf("%s/%s-%s:%s", targetRegistry, sanitizedName, svcName, model.OktetoDefaultImageTag)
+		b.Image = fmt.Sprintf("%s/%s-%s:%s", constants.DevRegistry, sanitizedName, svcName, model.OktetoDefaultImageTag)
 	}
 
 	file := b.Dockerfile

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -50,11 +50,10 @@ type BuildOptions struct {
 	Secrets         []string
 	ExportCache     []string
 	// CommandArgs comes from the user input on the command
-	CommandArgs   []string
-	SshSessions   []BuildSshSession
-	ExtraHosts    []HostMap
-	CacheFrom     []string
-	BuildToGlobal bool
-	NoCache       bool
-	EnableStages  bool
+	CommandArgs  []string
+	SshSessions  []BuildSshSession
+	ExtraHosts   []HostMap
+	CacheFrom    []string
+	NoCache      bool
+	EnableStages bool
 }


### PR DESCRIPTION
# Proposed changes

Fixes DEV-463

- Remove the global flag support for okteto build

## How to validate

1. Run `okteto build --global` and check that is not valid anymore

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
