### PR TITLE
fix: context stateless gettingnot updated values

### DIFF
--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -169,6 +169,15 @@ func (c *Command) RunStateless(ctx context.Context, ctxOptions *Options) (*oktet
 	// Storing previous global namespace gotten after executing c.Run as it is memory, but after reading the
 	// context store from path that is lost
 	globalNamespace := okteto.GetContext().GlobalNamespace
+	builder := okteto.GetContext().Builder
+	cert := okteto.GetContext().Certificate
+	name := okteto.GetContext().Name
+	registry := okteto.GetContext().Registry
+	token := okteto.GetContext().Token
+	user := okteto.GetContext().UserID
+	isInsecure := okteto.GetContext().IsInsecure
+	namespace := okteto.GetContext().Namespace
+	isOkteto := okteto.GetContext().IsOkteto
 
 	oktetoContextStore := okteto.GetContextStoreFromStorePath()
 
@@ -177,8 +186,16 @@ func (c *Command) RunStateless(ctx context.Context, ctxOptions *Options) (*oktet
 	}
 
 	oktetoContextStateless.SetCurrentCfg(cfg)
-	// Setting the global namespace because it is missing after reading again the context from the store path
 	oktetoContextStateless.SetGlobalNamespace(globalNamespace)
+	oktetoContextStateless.SetCurrentBuilder(builder)
+	oktetoContextStateless.SetCurrentCertStr(cert)
+	oktetoContextStateless.SetCurrentName(name)
+	oktetoContextStateless.SetCurrentRegistry(registry)
+	oktetoContextStateless.SetCurrentToken(token)
+	oktetoContextStateless.SetCurrentUser(user)
+	oktetoContextStateless.SetInsecure(isInsecure)
+	oktetoContextStateless.SetNamespace(namespace)
+	oktetoContextStateless.SetOktetoCluster(isOkteto)
 
 	return oktetoContextStateless, nil
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -127,7 +127,7 @@ func GetRegistryConfigFromOktetoConfig(okCtx OktetoContextInterface) *okteto.Con
 		IsOkteto:                    okCtx.IsOktetoCluster(),
 		ContextName:                 okCtx.GetCurrentName(),
 		Namespace:                   okCtx.GetNamespace(),
-		RegistryUrl:                 okCtx.GetCurrentRegister(),
+		RegistryUrl:                 okCtx.GetRegistryURL(),
 		UserId:                      okCtx.GetCurrentUser(),
 		Token:                       okCtx.GetCurrentToken(),
 		GlobalNamespace:             okCtx.GetGlobalNamespace(),
@@ -193,7 +193,7 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 func validateImages(okctx OktetoContextInterface, imageTags string) error {
 	reg := registry.NewOktetoRegistry(GetRegistryConfigFromOktetoConfig(okctx))
 
-	if strings.HasPrefix(imageTags, okctx.GetCurrentRegister()) && strings.Count(imageTags, "/") == 2 {
+	if strings.HasPrefix(imageTags, okctx.GetRegistryURL()) && strings.Count(imageTags, "/") == 2 {
 		return nil
 	}
 	numberOfSlashToBeCorrect := 2

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -141,7 +141,7 @@ func getSolveOpt(buildOptions *types.BuildOptions, okctx OktetoContextInterface,
 			cert:     okctx.GetCurrentCertStr(),
 		}
 
-		ap := newDockerAndOktetoAuthProvider(okctx.GetCurrentRegister(), okctx.GetCurrentUser(), okctx.GetCurrentToken(), apCtx, os.Stderr)
+		ap := newDockerAndOktetoAuthProvider(okctx.GetRegistryURL(), okctx.GetCurrentUser(), okctx.GetCurrentToken(), apCtx, os.Stderr)
 		attachable = append(attachable, ap)
 	} else {
 		dockerCfg := dockerConfig.LoadDefaultConfigFile(os.Stderr)

--- a/pkg/cmd/build/context.go
+++ b/pkg/cmd/build/context.go
@@ -26,7 +26,6 @@ type OktetoContextInterface interface {
 	GetCurrentCfg() *clientcmdapi.Config
 	GetCurrentToken() string
 	GetCurrentUser() string
-	GetCurrentRegister() string
 	ExistsContext() bool
 	IsOktetoCluster() bool
 	IsInsecure() bool

--- a/pkg/okteto/context_stateless.go
+++ b/pkg/okteto/context_stateless.go
@@ -31,7 +31,6 @@ type ContextInterface interface {
 	GetCurrentCertStr() string
 	GetCurrentToken() string
 	GetCurrentUser() string
-	GetCurrentRegister() string
 	ExistsContext() bool
 	IsOktetoCluster() bool
 	IsInsecure() bool
@@ -58,32 +57,52 @@ func (oc *ContextStateless) GetCurrentBuilder() string {
 	return oc.getCurrentOktetoContext().Builder
 }
 
-func (oc *ContextStateless) SetCurrentCfg(cfg *clientcmdapi.Config) {
-	oc.getCurrentOktetoContext().Cfg = cfg
+func (oc *ContextStateless) SetCurrentBuilder(builder string) {
+	oc.getCurrentOktetoContext().Builder = builder
 }
 
 func (oc *ContextStateless) GetCurrentName() string {
 	return oc.getCurrentOktetoContext().Name
 }
 
+func (oc *ContextStateless) SetCurrentName(name string) {
+	oc.getCurrentOktetoContext().Name = name
+}
+
 func (oc *ContextStateless) GetCurrentCertStr() string {
 	return oc.getCurrentOktetoContext().Certificate
+}
+
+func (oc *ContextStateless) SetCurrentCertStr(cert string) {
+	oc.getCurrentOktetoContext().Certificate = cert
 }
 
 func (oc *ContextStateless) GetCurrentToken() string {
 	return oc.getCurrentOktetoContext().Token
 }
 
+func (oc *ContextStateless) SetCurrentToken(token string) {
+	oc.getCurrentOktetoContext().Token = token
+}
+
 func (oc *ContextStateless) GetCurrentUser() string {
 	return oc.getCurrentOktetoContext().UserID
 }
 
-func (oc *ContextStateless) GetCurrentRegister() string {
-	return oc.getCurrentOktetoContext().Registry
+func (oc *ContextStateless) SetCurrentUser(user string) {
+	oc.getCurrentOktetoContext().UserID = user
+}
+
+func (oc *ContextStateless) SetCurrentRegistry(reg string) {
+	oc.getCurrentOktetoContext().Registry = reg
 }
 
 func (oc *ContextStateless) IsOktetoCluster() bool {
 	return oc.getCurrentOktetoContext().IsOkteto
+}
+
+func (oc *ContextStateless) SetOktetoCluster(isOkteto bool) {
+	oc.getCurrentOktetoContext().IsOkteto = isOkteto
 }
 
 func (oc *ContextStateless) ExistsContext() bool {
@@ -94,12 +113,24 @@ func (oc *ContextStateless) IsInsecure() bool {
 	return oc.getCurrentOktetoContext().IsInsecure
 }
 
+func (oc *ContextStateless) SetInsecure(insecure bool) {
+	oc.getCurrentOktetoContext().IsInsecure = insecure
+}
+
 func (oc *ContextStateless) GetCurrentCfg() *clientcmdapi.Config {
 	return oc.getCurrentOktetoContext().Cfg
 }
 
+func (oc *ContextStateless) SetCurrentCfg(cfg *clientcmdapi.Config) {
+	oc.getCurrentOktetoContext().Cfg = cfg
+}
+
 func (oc *ContextStateless) GetNamespace() string {
 	return oc.getCurrentOktetoContext().Namespace
+}
+
+func (oc *ContextStateless) SetNamespace(namespace string) {
+	oc.getCurrentOktetoContext().Namespace = namespace
 }
 
 func (oc *ContextStateless) GetRegistryURL() string {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-233

Now all the fields on the context are updated by the ones in the context command instead of checking the file again

## How to validate

1. Run `okteto context` an select one
1. Set `OKTETO_URL` pointing to another cluster
1. Run `okteto build` and check that is build and pushed to the right cluster

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
