### PR TITLE
preview deploy/ wait by default

### DIFF
--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -90,7 +90,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.sourceUrl, "sourceUrl", "", "", "the URL of the original pull/merge request.")
 	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
 	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a preview environment variable (can be set more than once)")
-	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", false, "wait until the preview environment deployment finishes (defaults to false)")
+	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the preview environment deployment finishes")
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "path to the Okteto manifest file")
 	cmd.Flags().StringArrayVarP(&opts.labels, "label", "", []string{}, "set a preview environment label (can be set more than once)")
 

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -59,6 +59,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 		Use:   "deploy <name>",
 		Short: "Deploy a preview environment",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
+		Example: `To deploy a preview environment without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
+okteto preview deploy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -85,7 +85,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the preview environment gets destroyed (defaults to true)")
+	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the preview environment gets destroyed")
 	return cmd
 }
 

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -59,6 +59,8 @@ func Destroy(ctx context.Context) *cobra.Command {
 		Use:   "destroy <name>",
 		Short: "Destroy a preview environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
+		Example: `To destroy a preview environment without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
+okteto preview destroy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = getExpandedName(args[0])
 


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-444

`okteto preview deploy` will now wait by default.

## How to validate

Use the commands against different okteto samples and validate the behaviour of the Okteto CLI

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
