### PR TITLE
Bump kubectl and other binaries. Fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax = docker/dockerfile:experimental
 
 ARG KUBECTL_VERSION=1.29.7
-ARG HELM_VERSION=3.14.4
-ARG KUSTOMIZE_VERSION=5.4.1
+ARG HELM_VERSION=3.15.3
+ARG KUSTOMIZE_VERSION=5.4.2
 FROM golang:1.22-bookworm as golang-builder
 
 FROM golang-builder as kubectl-builder


### PR DESCRIPTION
Bump kubectl version to fix [CVE-2024-24790](https://github.com/advisories/GHSA-49gw-vxvf-fc2g). This requires a backport to 2.29 and bumping the cli image in the backend to fix the pipeline installer critical CVE