### PR TITLE
feat: validate manifest before executing a command

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -81,6 +81,11 @@ func Doctor(k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 				return err
 			}
 
+			if !okteto.IsOkteto() {
+				if err := manifest.ValidateForCLIOnly(); err != nil {
+					return err
+				}
+			}
 			c, _, err := okteto.GetK8sClientWithLogger(k8sLogger)
 			if err != nil {
 				return err

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -90,6 +90,11 @@ func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger, fs afero.Fs) 
 				return err
 			}
 
+			if !okteto.IsOkteto() {
+				if err := manifest.ValidateForCLIOnly(); err != nil {
+					return err
+				}
+			}
 			c, _, err := okteto.GetK8sClientWithLogger(k8sLogsCtrl)
 			if err != nil {
 				return err

--- a/cmd/exec/cmd.go
+++ b/cmd/exec/cmd.go
@@ -123,6 +123,12 @@ okteto exec my-pod`,
 				return fmt.Errorf("failed to load manifest: %w", err)
 			}
 
+			if !okteto.IsOkteto() {
+				if err := manifest.ValidateForCLIOnly(); err != nil {
+					return err
+				}
+			}
+
 			argParser := oargs.NewDevCommandArgParser(oargs.NewDevModeOnLister(e.k8sClientProvider), e.ioCtrl, true)
 			argsLenAtDash := cmd.ArgsLenAtDash()
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -65,6 +65,12 @@ func Restart(fs afero.Fs) *cobra.Command {
 				return err
 			}
 
+			if !okteto.IsOkteto() {
+				if err := manifest.ValidateForCLIOnly(); err != nil {
+					return err
+				}
+			}
+
 			devName := ""
 			if len(args) == 1 {
 				devName = args[0]

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -79,6 +79,12 @@ func Status(fs afero.Fs) *cobra.Command {
 				return err
 			}
 
+			if !okteto.IsOkteto() {
+				if err := manifest.ValidateForCLIOnly(); err != nil {
+					return err
+				}
+			}
+
 			devName := ""
 			if len(args) == 1 {
 				devName = args[0]

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -179,6 +179,12 @@ okteto up my-svc -- echo this is a test
 				}
 			}
 
+			if !okteto.IsOkteto() {
+				if err := oktetoManifest.ValidateForCLIOnly(); err != nil {
+					return err
+				}
+			}
+
 			upMeta.OktetoContextConfig(time.Since(startOkContextConfig))
 			if okteto.IsOkteto() {
 				create, err := utils.ShouldCreateNamespace(ctx, okteto.GetContext().Namespace)

--- a/pkg/build/manifest_section.go
+++ b/pkg/build/manifest_section.go
@@ -108,3 +108,7 @@ func (b ManifestBuild) toGraph() utils.Graph {
 	}
 	return g
 }
+
+func (b ManifestBuild) IsEmpty() bool {
+	return len(b) == 0
+}

--- a/pkg/build/manifest_section_test.go
+++ b/pkg/build/manifest_section_test.go
@@ -136,3 +136,31 @@ func TestGetSvcsToBuildFromListf(t *testing.T) {
 	result := mb.GetSvcsToBuildFromList(inputList)
 	require.ElementsMatch(t, result, expectedList)
 }
+
+func TestIsEmpty(t *testing.T) {
+	tests := []struct {
+		input    ManifestBuild
+		expected bool
+	}{
+		{
+			input:    ManifestBuild{},
+			expected: true,
+		},
+		{
+			input: ManifestBuild{
+				"testSvc": &Info{
+					DependsOn: DependsOn{
+						"anotherService",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			result := tt.input.IsEmpty()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -162,3 +162,7 @@ func (d *Dependency) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	return nil
 }
+
+func (md ManifestSection) IsEmpty() bool {
+	return len(md) == 0
+}

--- a/pkg/externalresource/external_resource.go
+++ b/pkg/externalresource/external_resource.go
@@ -107,3 +107,7 @@ func (er *ExternalResource) SetURLUsingEnvironFile(name string, dynamicEnvs map[
 
 	return nil
 }
+
+func (es Section) IsEmpty() bool {
+	return len(es) == 0
+}

--- a/pkg/externalresource/external_resource_test.go
+++ b/pkg/externalresource/external_resource_test.go
@@ -255,8 +255,8 @@ func TestExternalResource_SetURLUsingEnvironFile(t *testing.T) {
 }
 func TestSection_IsEmpty(t *testing.T) {
 	tests := []struct {
-		name     string
 		section  Section
+		name     string
 		expected bool
 	}{
 		{

--- a/pkg/externalresource/external_resource_test.go
+++ b/pkg/externalresource/external_resource_test.go
@@ -253,3 +253,31 @@ func TestExternalResource_SetURLUsingEnvironFile(t *testing.T) {
 		})
 	}
 }
+func TestSection_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		section  Section
+		expected bool
+	}{
+		{
+			name:     "empty section",
+			section:  Section{},
+			expected: true,
+		},
+		{
+			name: "non-empty section",
+			section: Section{
+				"external1": &ExternalResource{},
+				"external2": &ExternalResource{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.section.IsEmpty()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1265,7 +1265,7 @@ func (m *Manifest) ValidateForCLIOnly() error {
 	}
 	if len(invalidFields) > 0 {
 		return oktetoErrors.UserError{
-			E:    fmt.Errorf("the following fields are not allowed in this context: %s", strings.Join(invalidFields, ", ")),
+			E:    fmt.Errorf("these features are only supported if you install Okteto in your cluster: %s", strings.Join(invalidFields, ", ")),
 			Hint: "To install Okteto platform on your cluster check: https://www.okteto.com/docs/get-started/install/",
 		}
 	}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1265,7 +1265,7 @@ func (m *Manifest) ValidateForCLIOnly() error {
 	}
 	if len(invalidFields) > 0 {
 		return oktetoErrors.UserError{
-			E:    fmt.Errorf("these features are only supported if you install Okteto in your cluster: %s", strings.Join(invalidFields, ", ")),
+			E:    fmt.Errorf("these features are only supported if you install Okteto in your context: %s", strings.Join(invalidFields, ", ")),
 			Hint: "To install Okteto platform on your cluster check: https://www.okteto.com/docs/get-started/install/",
 		}
 	}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1206,3 +1206,68 @@ func getBuildContextForComposeWithVolumeMounts(m *Manifest) (string, error) {
 
 	return context, nil
 }
+
+func (di DeployInfo) IsEmpty() bool {
+	if len(di.Commands) > 0 {
+		return false
+	}
+	if di.ComposeSection != nil && di.ComposeSection.Stack != nil {
+		return false
+	}
+	if di.Divert != nil {
+		return false
+	}
+	if di.Endpoints != nil {
+		return false
+	}
+	return true
+}
+
+func (di DestroyInfo) IsEmpty() bool {
+	if di.Image != "" {
+		return false
+	}
+	if len(di.Commands) > 0 {
+		return false
+	}
+	return true
+}
+
+func (mt ManifestTests) IsEmpty() bool {
+	return len(mt) == 0
+}
+
+func (m *Manifest) ValidateForCLIOnly() error {
+	invalidFields := []string{}
+	if !(m.Build == nil || m.Build.IsEmpty()) {
+		invalidFields = append(invalidFields, "build")
+	}
+	if !(m.Dependencies == nil || m.Dependencies.IsEmpty()) {
+		invalidFields = append(invalidFields, "dependencies")
+	}
+	if !(m.Deploy == nil || m.Deploy.IsEmpty()) {
+		invalidFields = append(invalidFields, "deploy")
+	}
+	if !(m.Destroy == nil || m.Destroy.IsEmpty()) {
+		invalidFields = append(invalidFields, "destroy")
+	}
+	if !(m.External == nil || m.External.IsEmpty()) {
+		invalidFields = append(invalidFields, "external")
+	}
+	if !(m.Test == nil || m.Test.IsEmpty()) {
+		invalidFields = append(invalidFields, "test")
+	}
+	if m.Icon != "" {
+		invalidFields = append(invalidFields, "icon")
+	}
+	if m.Name != "" {
+		invalidFields = append(invalidFields, "name")
+	}
+	if len(invalidFields) > 0 {
+		return oktetoErrors.UserError{
+			E:    fmt.Errorf("the following fields are not allowed in this context: %s", strings.Join(invalidFields, ", ")),
+			Hint: "To install Okteto platform on your cluster check: https://www.okteto.com/docs/get-started/install/",
+		}
+	}
+	return nil
+}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -1849,3 +1849,219 @@ func TestGetBuildContextForComposeWithVolumeMounts(t *testing.T) {
 		})
 	}
 }
+func TestDeployInfo_IsEmpty(t *testing.T) {
+	tests := []struct {
+		deployInfo DeployInfo
+		isEmpty    bool
+	}{
+		{
+			deployInfo: DeployInfo{
+				Commands: []DeployCommand{
+					{
+						Name:    "Deploy",
+						Command: "echo 'Replace this line with the proper 'helm' or 'kubectl' commands to deploy your development environment'",
+					},
+				},
+			},
+			isEmpty: false,
+		},
+		{
+			deployInfo: DeployInfo{
+				ComposeSection: &ComposeSectionInfo{
+					Stack: &Stack{},
+				},
+			},
+			isEmpty: false,
+		},
+		{
+			deployInfo: DeployInfo{
+				Divert: &DivertDeploy{},
+			},
+			isEmpty: false,
+		},
+		{
+			deployInfo: DeployInfo{
+				Endpoints: EndpointSpec{},
+			},
+			isEmpty: false,
+		},
+		{
+			deployInfo: DeployInfo{},
+			isEmpty:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		isEmpty := tt.deployInfo.IsEmpty()
+		if isEmpty != tt.isEmpty {
+			t.Errorf("expected IsEmpty() to be %v, but got %v", tt.isEmpty, isEmpty)
+		}
+	}
+}
+func TestManifestTests_IsEmpty(t *testing.T) {
+	tests := []struct {
+		tests   ManifestTests
+		isEmpty bool
+	}{
+		{
+			tests:   ManifestTests{},
+			isEmpty: true,
+		},
+		{
+			tests: ManifestTests{
+				"test1": &Test{},
+				"test2": &Test{},
+			},
+			isEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		isEmpty := tt.tests.IsEmpty()
+		if isEmpty != tt.isEmpty {
+			t.Errorf("expected IsEmpty to be %v, but got %v", tt.isEmpty, isEmpty)
+		}
+	}
+}
+
+func TestDestroyInfo_IsEmpty(t *testing.T) {
+	tests := []struct {
+		destroyInfo DestroyInfo
+		isEmpty     bool
+	}{
+		{
+			destroyInfo: DestroyInfo{},
+			isEmpty:     true,
+		},
+		{
+			destroyInfo: DestroyInfo{
+				Image: "image",
+			},
+			isEmpty: false,
+		},
+		{
+			destroyInfo: DestroyInfo{
+				Commands: []DeployCommand{
+					{
+						Name:    "Destroy",
+						Command: "echo 'Replace this line with the proper 'helm' or 'kubectl' commands to destroy your development environment'",
+					},
+				},
+			},
+			isEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		isEmpty := tt.destroyInfo.IsEmpty()
+		if isEmpty != tt.isEmpty {
+			t.Errorf("expected IsEmpty to be %v, but got %v", tt.isEmpty, isEmpty)
+		}
+	}
+}
+
+func TestManifest_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest Manifest
+		isErr    bool
+	}{
+		{
+			name:     "empty manifest",
+			manifest: Manifest{},
+			isErr:    false,
+		},
+		{
+			name: "manifest with test",
+			manifest: Manifest{
+				Test: ManifestTests{
+					"test1": &Test{},
+					"test2": &Test{},
+				},
+			},
+			isErr: true,
+		},
+		{
+			name: "manifest with deploy",
+			manifest: Manifest{
+				Deploy: &DeployInfo{
+					Commands: []DeployCommand{
+						{
+							Name:    "Deploy",
+							Command: "echo 'Replace this line with the proper 'helm' or 'kubectl' commands to deploy your development environment'",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		{
+			name: "manifest with destroy",
+			manifest: Manifest{
+				Destroy: &DestroyInfo{
+					Commands: []DeployCommand{
+						{
+							Name:    "Destroy",
+							Command: "echo 'Replace this line with the proper 'helm' or 'kubectl' commands to destroy your development environment'",
+						},
+					},
+				},
+			},
+			isErr: true,
+		},
+		{
+			name: "manifest with external",
+			manifest: Manifest{
+				External: externalresource.Section{
+					"external1": &externalresource.ExternalResource{},
+				},
+			},
+			isErr: true,
+		},
+		{
+			name: "manifest with dependencies",
+			manifest: Manifest{
+				Dependencies: deps.ManifestSection{
+					"dep1": &deps.Dependency{},
+					"dep2": &deps.Dependency{},
+				},
+			},
+			isErr: true,
+		},
+		{
+			name: "manifest with build",
+			manifest: Manifest{
+				Build: build.ManifestBuild{
+					"service1": &build.Info{},
+					"service2": &build.Info{},
+				},
+			},
+			isErr: true,
+		},
+		{
+			name: "manifest with name",
+			manifest: Manifest{
+				Name: "manifest",
+			},
+			isErr: true,
+		},
+		{
+			name: "manifest with icon",
+			manifest: Manifest{
+				Icon: "icon",
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifest.ValidateForCLIOnly()
+			if tt.isErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-466

- Adds a new function to check if the manifest is valid for okteto CLI only
- Use the function on the commands that are available for CLI only instances

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Use ´okteto context´ to switch to a non okteto instance
1. Run okteto up with any of the non supported fields
1. See error

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
