### PR TITLE
add arg `CacheByName` to remote builds to allow parallel executions

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -112,7 +112,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 	}
 
 	runParams := remote.Params{
-		CacheNamespace: deployOptions.Name,
+		CacheByName: deployOptions.Name,
 		// This is the base image provided by the deploy operation. If it is empty, the runner is the one in charge of
 		// providing the default one
 		BaseImage:                 baseImage,

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -112,6 +112,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 	}
 
 	runParams := remote.Params{
+		CacheNamespace: deployOptions.Name,
 		// This is the base image provided by the deploy operation. If it is empty, the runner is the one in charge of
 		// providing the default one
 		BaseImage:                 baseImage,

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -193,6 +193,7 @@ func TestDeployRemote(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
+		CacheNamespace:      "test",
 		BaseImage:           manifest.Deploy.Image,
 		ManifestPathFlag:    "/path/to/manifest",
 		TemplateName:        templateName,
@@ -253,6 +254,7 @@ func TestDeployRemoteWithError(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
+		CacheNamespace:      "test",
 		BaseImage:           manifest.Deploy.Image,
 		ManifestPathFlag:    "/path/to/manifest",
 		TemplateName:        templateName,

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -193,7 +193,7 @@ func TestDeployRemote(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
-		CacheNamespace:      "test",
+		CacheByName:         "test",
 		BaseImage:           manifest.Deploy.Image,
 		ManifestPathFlag:    "/path/to/manifest",
 		TemplateName:        templateName,
@@ -254,7 +254,7 @@ func TestDeployRemoteWithError(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
-		CacheNamespace:      "test",
+		CacheByName:         "test",
 		BaseImage:           manifest.Deploy.Image,
 		ManifestPathFlag:    "/path/to/manifest",
 		TemplateName:        templateName,

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -113,6 +113,7 @@ func (rd *remoteDestroyCommand) Destroy(ctx context.Context, opts *Options) erro
 	}
 
 	runParams := remote.Params{
+		CacheNamespace:            opts.Name,
 		BaseImage:                 baseImage,
 		ManifestPathFlag:          opts.ManifestPathFlag,
 		TemplateName:              templateName,

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -113,7 +113,7 @@ func (rd *remoteDestroyCommand) Destroy(ctx context.Context, opts *Options) erro
 	}
 
 	runParams := remote.Params{
-		CacheNamespace:            opts.Name,
+		CacheByName:               opts.Name,
 		BaseImage:                 baseImage,
 		ManifestPathFlag:          opts.ManifestPathFlag,
 		TemplateName:              templateName,

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -128,6 +128,7 @@ func TestDestroyRemote(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
+		CacheNamespace:   "test",
 		BaseImage:        manifest.Destroy.Image,
 		ManifestPathFlag: "/path/to/manifest",
 		TemplateName:     templateName,
@@ -177,6 +178,7 @@ func TestDestroyRemoteWithError(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
+		CacheNamespace:   "test",
 		BaseImage:        manifest.Destroy.Image,
 		ManifestPathFlag: "/path/to/manifest",
 		TemplateName:     templateName,

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -128,7 +128,7 @@ func TestDestroyRemote(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
-		CacheNamespace:   "test",
+		CacheByName:      "test",
 		BaseImage:        manifest.Destroy.Image,
 		ManifestPathFlag: "/path/to/manifest",
 		TemplateName:     templateName,
@@ -178,7 +178,7 @@ func TestDestroyRemoteWithError(t *testing.T) {
 	}
 
 	expectedParams := &remote.Params{
-		CacheNamespace:   "test",
+		CacheByName:      "test",
 		BaseImage:        manifest.Destroy.Image,
 		ManifestPathFlag: "/path/to/manifest",
 		TemplateName:     templateName,

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -331,7 +331,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			return analytics.TestMetadata{}, fmt.Errorf("failed to create ignore rules for %s: %w", name, err)
 		}
 		params := &remote.Params{
-			CacheNamespace:      name,
+			CacheByName:         name,
 			BaseImage:           test.Image,
 			ManifestPathFlag:    options.ManifestPathFlag,
 			TemplateName:        "dockerfile",

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -331,6 +331,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			return analytics.TestMetadata{}, fmt.Errorf("failed to create ignore rules for %s: %w", name, err)
 		}
 		params := &remote.Params{
+			CacheNamespace:      name,
 			BaseImage:           test.Image,
 			ManifestPathFlag:    options.ManifestPathFlag,
 			TemplateName:        "dockerfile",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -66,8 +66,11 @@ const (
 	// OktetoInternalServerNameEnvVar defines the internal server name for --remote
 	OktetoInternalServerNameEnvVar = "INTERNAL_SERVER_NAME"
 
-	// OktetoInvalidateCacheEnvVar defines a ramdom number to invalidate the "--remote" cache
+	// OktetoInvalidateCacheEnvVar defines a random number to invalidate the "--remote" cache
 	OktetoInvalidateCacheEnvVar = "OKTETO_INVALIDATE_CACHE"
+
+	// OktetoCacheNamespaceEnvVar defines a unique name for each build to avoid conflicts in the cache when running parallel builds
+	OktetoCacheNamespaceEnvVar = "OKTETO_CACHE_NAMESPACE"
 
 	// OktetoDeployRemoteImage defines okteto cli image used for deploy an environment remotely
 	OktetoDeployRemoteImage = "OKTETO_REMOTE_CLI_IMAGE"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -69,8 +69,8 @@ const (
 	// OktetoInvalidateCacheEnvVar defines a random number to invalidate the "--remote" cache
 	OktetoInvalidateCacheEnvVar = "OKTETO_INVALIDATE_CACHE"
 
-	// OktetoCacheNamespaceEnvVar defines a unique name for each build to avoid conflicts in the cache when running parallel builds
-	OktetoCacheNamespaceEnvVar = "OKTETO_CACHE_NAMESPACE"
+	// OktetoCacheByNameEnvVar defines a unique name for each build to avoid conflicts in the cache when running parallel builds
+	OktetoCacheByNameEnvVar = "OKTETO_CACHE_BY_NAME"
 
 	// OktetoDeployRemoteImage defines okteto cli image used for deploy an environment remotely
 	OktetoDeployRemoteImage = "OKTETO_REMOTE_CLI_IMAGE"

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -93,7 +93,7 @@ ENV {{$key}} {{$val}}
 ARG {{ .GitCommitArgName }}
 ARG {{ .GitBranchArgName }}
 ARG {{ .InvalidateCacheArgName }}
-ARG {{ .CacheNamespaceArgName }}
+ARG {{ .CacheByNameArgName }}
 
 RUN echo "${{ .InvalidateCacheArgName }}" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
@@ -154,8 +154,8 @@ type Params struct {
 	// to a random value which essentially means no-cache. Setting this to a
 	// static or known value will reuse the build cache
 	CacheInvalidationKey string
-	// CacheNamespace is used to allow multiple builds to run concurrently without interfering with each other cache
-	CacheNamespace string
+	// CacheByName is used to allow multiple builds to run concurrently without interfering with each other cache
+	CacheByName    string
 	TemplateName   string
 	DockerfileName string
 	KnownHostsPath string
@@ -200,7 +200,7 @@ type dockerfileTemplateProperties struct {
 	GitCommitArgName         string
 	GitBranchArgName         string
 	InvalidateCacheArgName   string
-	CacheNamespaceArgName    string
+	CacheByNameArgName       string
 	CommandFlags             string
 	OktetoDeployable         string
 	GitHubRepositoryArgName  string
@@ -320,7 +320,7 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		fmt.Sprintf("%s=%s", constants.OktetoGitBranchEnvVar, os.Getenv(constants.OktetoGitBranchEnvVar)),
 		fmt.Sprintf("%s=%s", constants.OktetoTlsCertBase64EnvVar, base64.StdEncoding.EncodeToString(sc.Certificate)),
 		fmt.Sprintf("%s=%s", constants.OktetoInvalidateCacheEnvVar, cacheKey),
-		fmt.Sprintf("%s=%s", constants.OktetoCacheNamespaceEnvVar, params.CacheNamespace),
+		fmt.Sprintf("%s=%s", constants.OktetoCacheByNameEnvVar, params.CacheByName),
 		fmt.Sprintf("%s=%s", constants.OktetoDeployableEnvVar, base64.StdEncoding.EncodeToString(b)),
 		fmt.Sprintf("%s=%s", model.GithubRepositoryEnvVar, os.Getenv(model.GithubRepositoryEnvVar)),
 		fmt.Sprintf("%s=%s", model.OktetoRegistryURLEnvVar, os.Getenv(model.OktetoRegistryURLEnvVar)),
@@ -411,7 +411,7 @@ func (r *Runner) createDockerfile(tmpDir string, params *Params) (string, error)
 		GitCommitArgName:         constants.OktetoGitCommitEnvVar,
 		GitBranchArgName:         constants.OktetoGitBranchEnvVar,
 		InvalidateCacheArgName:   constants.OktetoInvalidateCacheEnvVar,
-		CacheNamespaceArgName:    constants.OktetoCacheNamespaceEnvVar,
+		CacheByNameArgName:       constants.OktetoCacheByNameEnvVar,
 		CommandFlags:             strings.Join(params.CommandFlags, " "),
 		OktetoDeployable:         constants.OktetoDeployableEnvVar,
 		GitHubRepositoryArgName:  model.GithubRepositoryEnvVar,

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -323,6 +323,7 @@ func TestCreateDockerfile(t *testing.T) {
 			name: "with dockerignore",
 			config: config{
 				params: &Params{
+					CacheNamespace:      "test",
 					BaseImage:           "test-image",
 					Manifest:            fakeManifest,
 					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
@@ -378,6 +379,7 @@ ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME dependency_user
 ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
+ARG OKTETO_CACHE_NAMESPACE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
@@ -465,6 +467,7 @@ ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME dependency_user
 ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
+ARG OKTETO_CACHE_NAMESPACE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -323,7 +323,7 @@ func TestCreateDockerfile(t *testing.T) {
 			name: "with dockerignore",
 			config: config{
 				params: &Params{
-					CacheNamespace:      "test",
+					CacheByName:         "test",
 					BaseImage:           "test-image",
 					Manifest:            fakeManifest,
 					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
@@ -379,7 +379,7 @@ ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME dependency_user
 ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
-ARG OKTETO_CACHE_NAMESPACE
+ARG OKTETO_CACHE_BY_NAME
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
@@ -467,7 +467,7 @@ ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME dependency_user
 ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
-ARG OKTETO_CACHE_NAMESPACE
+ARG OKTETO_CACHE_BY_NAME
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-522

This change is required to allow `okteto test` to run in parallel. At the moment if a user runs multiple tests in parallel, they are running in sequence, waiting for each to complete. After investigating, the root cause seems to be related to:

> Docker uses a build cache to speed up builds. If both builds are trying to access or modify the same cache layers, Docker might serialize the builds to prevent conflicts.

We're adding a new arg, to allow running each test in parallel.

Disclaimer: this change also affect `deploy` and `destroy` and it will invalidate the cache of existing projects built, even if they are re-built for the same commit etc. The other approach that I've considered is to add this argument only for `okteto test`, we can easily do that, but I think it goes against our current approach of keeping everything aligned as much as possible, otherwise the template starts to become a hell of conditionals. 

## How to validate

1. Use https://github.com/okteto/go-getting-started
2. Add the following to the `okteto.yml`
```yaml
test:
  sleep1:
    commands:
      - echo starting...
      - sleep 60
  sleep2:
    commands:
      - echo starting...
      - sleep 60
  sleep3:
    commands:
      - echo starting...
      - sleep 60
```
3. Run `okteto test sleep1`, `okteto test sleep2` and `okteto test sleep3` in 3 terminals at the same time
4. Observe how the test start without having the others to finish
5. Repeat the same with the latest stable Okteto CLI `2.29.1` and observe that in this case, each test will wait until another one has finished before starting.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
