### PR TITLE
DEV-494: Handling an special error from the registry when an image digest is malformed

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	cryptoRand "crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -205,7 +206,8 @@ func main() {
 			message = string(tmp)
 		}
 		oktetoLog.Fail(message) // TODO: Change to use ioController  when we fully move to ioController
-		if uErr, ok := err.(oktetoErrors.UserError); ok {
+		var uErr oktetoErrors.UserError
+		if errors.As(err, &uErr) {
 			if len(uErr.Hint) > 0 {
 				oktetoLog.Hint("    %s", uErr.Hint)
 			}

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -515,7 +515,7 @@ func Test_GetDescriptor(t *testing.T) {
 			},
 		},
 		{
-			name: "not found for being invalide",
+			name: "not found for being invalid",
 			input: input{
 				image: "okteto/test:latest",
 			},

--- a/pkg/registry/client_test.go
+++ b/pkg/registry/client_test.go
@@ -514,6 +514,29 @@ func Test_GetDescriptor(t *testing.T) {
 				err:        oktetoErrors.ErrNotFound,
 			},
 		},
+		{
+			name: "not found for being invalide",
+			input: input{
+				image: "okteto/test:latest",
+			},
+			expected: expected{
+				descriptor: nil,
+				err: oktetoErrors.UserError{
+					E:    fmt.Errorf("malformed image digest"),
+					Hint: "Image 'okteto/test:latest' seems malformed. Please run 'okteto build --no-cache' to rebuild your image",
+				},
+			},
+			getConfig: getConfig{
+				descriptor: nil,
+				err: &transport.Error{
+					Errors: []transport.Diagnostic{
+						{
+							Code: manifestUnknownForBeingInvalidErrorCode,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-494

Handle in a different way an specific error from the registry when the image digest is malformed. In that case, if you build without cache the affected image, it would fix the issue,  so we return a custom error with a user hint to suggest them to build the image with `--no-cache`.

This is a new error we are adding in our registry fork, so it shouldn't impact on existing flows. We would keep returning an error but with a suggestion that might fix the issue

## How to validate

You need to force the scenario of a malformed revision for an image digest and trying to build that image. I have shared internally a video on how to reproduce the issue

