### PR TITLE
fix: deploy remote falback to dockerignore instead of skipping it

### DIFF
--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -51,6 +51,9 @@ func (i *Ignore) Rules(sections ...string) ([]string, error) {
 		}
 		rules = append(rules, slice...)
 	}
+	if len(rules) == 0 {
+		rules = append(rules, "# Okteto docker ignore")
+	}
 	return rules, nil
 }
 

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -51,9 +51,6 @@ func (i *Ignore) Rules(sections ...string) ([]string, error) {
 		}
 		rules = append(rules, slice...)
 	}
-	if len(rules) == 0 {
-		rules = append(rules, "# Okteto docker ignore")
-	}
 	return rules, nil
 }
 

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -205,13 +205,13 @@ func TestRules(t *testing.T) {
 			backend
 			`,
 			section:  []string{"nonexistent"},
-			expected: []string{"# Okteto docker ignore"},
+			expected: nil,
 		},
 		{
 			name:     "empty_section",
 			input:    ``,
 			section:  []string{RootSection},
-			expected: []string{"# Okteto docker ignore"},
+			expected: nil,
 		},
 	}
 

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -115,6 +115,11 @@ func TestIgnore(t *testing.T) {
 				"test.frontend": {str: "\nbackend\n\n\n\n", files: []string{"backend"}},
 			},
 		},
+		{
+			name:     "empty",
+			input:    ``,
+			expected: map[string]exp{},
+		},
 	}
 
 	for _, tc := range tt {
@@ -150,4 +155,72 @@ backend
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, f, []string{".git", "chart", "backend"})
 
+}
+
+func TestRules(t *testing.T) {
+	tt := []struct {
+		name        string
+		section     []string
+		input       string
+		expectedErr bool
+		expected    []string
+	}{
+		{
+			name: "single_section",
+			input: `
+			.git
+			`,
+			section:  []string{RootSection},
+			expected: []string{".git"},
+		},
+		{
+			name: "multiple_sections",
+			input: `
+			.git
+			[deploy]
+			integration
+			[destroy]
+			frontend/*
+			backend
+			[test]
+			chart
+			[test.frontend]
+			backend
+			`,
+			section:  []string{"deploy", "destroy", "test"},
+			expected: []string{"integration", "frontend/*", "backend", "chart"},
+		},
+		{
+			name: "nonexistent_section",
+			input: `
+			.git
+			[deploy]
+			integration
+			[destroy]
+			frontend/*
+			backend
+			[test]
+			chart
+			[test.frontend]
+			backend
+			`,
+			section:  []string{"nonexistent"},
+			expected: []string{"# Okteto docker ignore"},
+		},
+		{
+			name:     "empty_section",
+			input:    ``,
+			section:  []string{RootSection},
+			expected: []string{"# Okteto docker ignore"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ig := NewFromReader(strings.NewReader(tc.input))
+			f, err := ig.Rules(tc.section...)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, f, tc.expected)
+		})
+	}
 }

--- a/pkg/ignore/ignore_test.go
+++ b/pkg/ignore/ignore_test.go
@@ -160,10 +160,10 @@ backend
 func TestRules(t *testing.T) {
 	tt := []struct {
 		name        string
-		section     []string
 		input       string
-		expectedErr bool
+		section     []string
 		expected    []string
+		expectedErr bool
 	}{
 		{
 			name: "single_section",

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -513,7 +513,9 @@ func createDockerignoreFileWithFilesystem(cwd, tmpDir string, rules []string, us
 		dockerignoreContent = append(dockerignoreContent, []byte(rule)...)
 		dockerignoreContent = append(dockerignoreContent, []byte("\n")...)
 	}
-
+	if len(dockerignoreContent) == 0 {
+		dockerignoreContent = []byte("# Okteto docker ignore\n")
+	}
 	return afero.WriteFile(fs, filename, dockerignoreContent, 0600)
 }
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -764,7 +764,7 @@ func TestCreateDockerignoreFileWithFilesystem(t *testing.T) {
 		{
 			name:            "without dockerignore",
 			config:          config{},
-			expectedContent: "",
+			expectedContent: "# Okteto docker ignore\n",
 			useDeployIgnore: true,
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-523

- Creates a temporal .oktetiognore to not fallback to the one in the user context.
- If .oktetoignore exists we skip this step


## How to validate

1. With the following `okteto.yml`:
```yaml
deploy:
  commands:
    - name: test
      command: pwd; ls -la
```
2. Add the following `.dockerignore`:
```yaml
okteto.yml
```
3. Run `okteto deploy --remote` and check that `okteto.yml` appears 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
