### PR TITLE
DEV-520: Scan image on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ jobs:
       - run: *okteto-login
       - run: *docker-login
       - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG" "linux/amd64,linux/arm64"
-      - run: trivy image okteto/okteto:$CIRCLE_TAG
+      - run: trivy image --no-progress okteto/okteto:$CIRCLE_TAG
 
   push-image-latest:
     executor: golang-ci
@@ -341,7 +341,7 @@ jobs:
       - run: *okteto-login
       - run: *docker-login
       - run: ./scripts/ci/push-image.sh latest "linux/amd64"
-      - run: trivy image okteto/okteto:latest
+      - run: trivy image --no-progress okteto/okteto:latest
 
   upload-static-job:
     executor: golang-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.5.0
+      - image: okteto/golang-ci:2.6.2
 
 jobs:
   golangci-lint:
@@ -332,6 +332,7 @@ jobs:
       - run: *okteto-login
       - run: *docker-login
       - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG" "linux/amd64,linux/arm64"
+      - run: trivy image okteto/okteto:$CIRCLE_TAG
 
   push-image-latest:
     executor: golang-ci
@@ -340,6 +341,7 @@ jobs:
       - run: *okteto-login
       - run: *docker-login
       - run: ./scripts/ci/push-image.sh latest "linux/amd64"
+      - run: trivy image okteto/okteto:latest
 
   upload-static-job:
     executor: golang-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ jobs:
       - checkout
       - run: *okteto-login
       - run: *docker-login
-      - run: trivy image okteto/okteto:$CIRCLE_TAG
+      - run: trivy image okteto/okteto:$CIRCLE_SHA1
 
   upload-static-job:
     executor: golang-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,6 +343,14 @@ jobs:
       - run: ./scripts/ci/push-image.sh latest "linux/amd64"
       - run: trivy image okteto/okteto:latest
 
+  scan-image-test:
+    executor: golang-ci
+    steps:
+      - checkout
+      - run: *okteto-login
+      - run: *docker-login
+      - run: trivy image okteto/okteto:$CIRCLE_TAG
+
   upload-static-job:
     executor: golang-ci
     steps:
@@ -391,6 +399,14 @@ jobs:
       - run: ./scripts/ci/release-branch.sh
 
 workflows:
+  scan-test:
+    jobs:
+      - scan-image-test:
+          context: Product-okteto-dev
+          filters:
+            branches:
+              only:
+                - ifbyol/scan-image-on-release
   upload-static:
     jobs:
       - upload-static-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -343,14 +343,6 @@ jobs:
       - run: ./scripts/ci/push-image.sh latest "linux/amd64"
       - run: trivy image okteto/okteto:latest
 
-  scan-image-test:
-    executor: golang-ci
-    steps:
-      - checkout
-      - run: *okteto-login
-      - run: *docker-login
-      - run: trivy image okteto/okteto:$CIRCLE_SHA1
-
   upload-static-job:
     executor: golang-ci
     steps:
@@ -399,14 +391,6 @@ jobs:
       - run: ./scripts/ci/release-branch.sh
 
 workflows:
-  scan-test:
-    jobs:
-      - scan-image-test:
-          context: Product-okteto-dev
-          filters:
-            branches:
-              only:
-                - ifbyol/scan-image-on-release
   upload-static:
     jobs:
       - upload-static-job:


### PR DESCRIPTION
Fixes DEV-520

Scan CLI built image on the two workflows we execute. `push-image-latest` and `push-image`. The first one is done every time there is a merge in master and the second one every time we release the CLI

There is not an easy way of validating it apart of running the script locally or add a custom workflow. In my case, I added a simple workflow that executed successfully and another one failing. This is the commit where the test workflow is defined: https://github.com/okteto/okteto/commit/382f50dab12e849bb69163b4e0f2148530710442

