### PR TITLE
remove cache for test

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -353,12 +353,6 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			UseRootUser:                 true,
 		}
 
-		if !options.NoCache {
-			// this value can be anything really.
-			// By keeping it constant we skip cache invalidation
-			params.CacheInvalidationKey = "const"
-		}
-
 		ioCtrl.Out().Infof("Executing test container '%s'", name)
 		if err := runner.Run(ctx, params); err != nil {
 			return metadata, err

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -351,6 +351,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			IgnoreRules:                 testIgnoreRules,
 			Artifacts:                   test.Artifacts,
 			UseRootUser:                 true,
+			NoCache:                     options.NoCache,
 		}
 
 		ioCtrl.Out().Infof("Executing test container '%s'", name)

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -149,14 +149,10 @@ type Params struct {
 	DependenciesEnvVars map[string]string
 	Manifest            *model.Manifest
 	Command             string
-	// CacheInvalidationKey is the value use to invalidate the cache. Defaults
-	// to a random value which essentially means no-cache. Setting this to a
-	// static or known value will reuse the build cache
-	CacheInvalidationKey string
-	TemplateName         string
-	DockerfileName       string
-	KnownHostsPath       string
-	BaseImage            string
+	TemplateName        string
+	DockerfileName      string
+	KnownHostsPath      string
+	BaseImage           string
 	// ContextAbsolutePathOverride is the absolute path for the build context. Optional.
 	// If this values is not defined it will default to the folder location of the
 	// okteto manifest which is resolved through params.ManifestPathFlag
@@ -278,14 +274,11 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		return err
 	}
 
-	cacheKey := params.CacheInvalidationKey
-	if cacheKey == "" {
-		randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000000))
-		if err != nil {
-			return err
-		}
-		cacheKey = strconv.Itoa(int(randomNumber.Int64()))
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return err
 	}
+	cacheKey := strconv.Itoa(int(randomNumber.Int64()))
 
 	b, err := yaml.Marshal(params.Deployable)
 	if err != nil {

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -160,6 +160,7 @@ type Params struct {
 	ManifestPathFlag            string
 	Deployable                  deployable.Entity
 	CommandFlags                []string
+	NoCache                     bool
 	Caches                      []string
 	// IgnoreRules are the ignoring rules added to this build execution.
 	// Rules follow the .dockerignore syntax as defined in:
@@ -297,7 +298,7 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		outputMode = buildCmd.DeployOutputModeOnBuild
 	}
 
-	buildOptions := buildCmd.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{OutputMode: outputMode})
+	buildOptions := buildCmd.OptsFromBuildInfoForRemoteDeploy(buildInfo, &types.BuildOptions{OutputMode: outputMode, NoCache: params.NoCache})
 	buildOptions.Manifest = params.Manifest
 	buildOptions.BuildArgs = append(
 		buildOptions.BuildArgs,

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -160,7 +160,6 @@ type Params struct {
 	ManifestPathFlag            string
 	Deployable                  deployable.Entity
 	CommandFlags                []string
-	NoCache                     bool
 	Caches                      []string
 	// IgnoreRules are the ignoring rules added to this build execution.
 	// Rules follow the .dockerignore syntax as defined in:
@@ -176,6 +175,8 @@ type Params struct {
 
 	// UseRootUser is a flag to indicate if the user should be root
 	UseRootUser bool
+
+	NoCache bool
 }
 
 // dockerfileTemplateProperties internal struct with the information needed by the Dockerfile template


### PR DESCRIPTION
# Proposed changes

Fixes DEV-536

Removes the cache for okteto test. It allows to execute the same test several times in parallel

## How to validate

1. Using the following `okteto.yml`:
```yaml
test:
  sleep1:
    commands:
      - echo starting...
      - sleep 60
```
2. Execute `okteto test` in different terminals and check that all of them run

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
