### PR TITLE
fix: add extra hosts in okteot test

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -351,6 +351,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			IgnoreRules:                 testIgnoreRules,
 			Artifacts:                   test.Artifacts,
 			UseRootUser:                 true,
+			Hosts:                       test.Hosts,
 		}
 
 		if !options.NoCache {

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -214,7 +214,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.Sync":                 {"folders", "rescanInterval", "compression", "verbose"},
 				"model.Timeout":              {"default", "resources"},
 				"model.VolumeSpec":           {"labels", "annotations", "size", "class"},
-				"model.Test":                 {"image", "context", "commands", "depends_on", "caches", "artifacts"},
+				"model.Test":                 {"image", "context", "commands", "depends_on", "caches", "artifacts", "hosts"},
 			},
 		},
 	}

--- a/pkg/model/test.go
+++ b/pkg/model/test.go
@@ -114,6 +114,7 @@ func (t *TestCommand) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func (h *Host) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	numberOfHostFields := 2
 	var hostnameIP string
 	err := unmarshal(&hostnameIP)
 	if err == nil {
@@ -121,8 +122,8 @@ func (h *Host) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if err != nil {
 			return err
 		}
-		splittedHostNameIP := strings.SplitN(hostnameIPExpanded, ":", 2)
-		if len(splittedHostNameIP) != 2 {
+		splittedHostNameIP := strings.SplitN(hostnameIPExpanded, ":", numberOfHostFields)
+		if len(splittedHostNameIP) != numberOfHostFields {
 			return fmt.Errorf("%w: '%s'", ErrHostMalformed, hostnameIP)
 		}
 		*h = Host{

--- a/pkg/model/test_test.go
+++ b/pkg/model/test_test.go
@@ -1,0 +1,123 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v3"
+)
+
+func TestHostUnmarshalYAML(t *testing.T) {
+	t.Setenv("IP", "192.179.1.1")
+	tests := []struct {
+		name          string
+		bytes         []byte
+		expectedError error
+		expectedHost  Host
+	}{
+		{
+			name:  "ipv4",
+			bytes: []byte("main.example.com:192.168.1.100"),
+			expectedHost: Host{
+				Hostname: "main.example.com",
+				IP:       "192.168.1.100",
+			},
+		},
+		{
+			name:  "ipv4 with expansion",
+			bytes: []byte("main.example.com:${IP}"),
+			expectedHost: Host{
+				Hostname: "main.example.com",
+				IP:       "192.179.1.1",
+			},
+		},
+		{
+			name:          "ipv4 with expansion to non-existent env var",
+			bytes:         []byte("main.example.com:${NON_EXISTENT}"),
+			expectedError: ErrInvalidIp,
+		},
+		{
+			name:  "ipv6",
+			bytes: []byte("main.example.com:::1"),
+			expectedHost: Host{
+				Hostname: "main.example.com",
+				IP:       "::1",
+			},
+		},
+		{
+			name:          "malformed - no ip",
+			bytes:         []byte("main.example.com:"),
+			expectedError: ErrInvalidHostName,
+		},
+		{
+			name:          "malformed - no hostname",
+			bytes:         []byte(":192.168.1.1"),
+			expectedError: ErrInvalidHostName,
+		},
+		{
+			name:          "malformed - no separator",
+			bytes:         []byte("main.example.com192.168.1.1"),
+			expectedError: ErrHostMalformed,
+		},
+		{
+			name:          "extended without ip",
+			bytes:         []byte("hostname: main.example.com"),
+			expectedError: ErrInvalidIp,
+		},
+		{
+			name:          "extended without hostname",
+			bytes:         []byte("ip: 192.168.1.1"),
+			expectedError: ErrInvalidHostName,
+		},
+		{
+			name: "extended",
+			bytes: []byte(`hostname: main.example.com
+ip: 192.168.1.1`),
+			expectedHost: Host{
+				Hostname: "main.example.com",
+				IP:       "192.168.1.1",
+			},
+		},
+		{
+			name: "extended with expansion",
+			bytes: []byte(`hostname: main.example.com
+ip: ${IP}`),
+			expectedHost: Host{
+				Hostname: "main.example.com",
+				IP:       "192.179.1.1",
+			},
+		},
+		{
+			name: "extended with expansion to non-existent env var",
+			bytes: []byte(`hostname: main.example.com
+ip: ${NON_EXISTENT}`),
+			expectedError: ErrInvalidIp,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var host Host
+			err := yaml.Unmarshal(tt.bytes, &host)
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedHost, host)
+			}
+		})
+	}
+}

--- a/pkg/model/test_test.go
+++ b/pkg/model/test_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Okteto Authors
+// Copyright 2024 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,10 +23,10 @@ import (
 func TestHostUnmarshalYAML(t *testing.T) {
 	t.Setenv("IP", "192.179.1.1")
 	tests := []struct {
-		name          string
-		bytes         []byte
 		expectedError error
 		expectedHost  Host
+		name          string
+		bytes         []byte
 	}{
 		{
 			name:  "ipv4",

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -165,6 +165,7 @@ type Params struct {
 	Deployable                  deployable.Entity
 	CommandFlags                []string
 	Caches                      []string
+	Hosts                       []model.Host
 	// IgnoreRules are the ignoring rules added to this build execution.
 	// Rules follow the .dockerignore syntax as defined in:
 	// https://docs.docker.com/build/building/context/#syntax
@@ -338,6 +339,8 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 			buildOptions.ExtraHosts = getExtraHosts(registryUrl, subdomain, ip, *sc)
 		}
 	}
+
+	buildOptions.ExtraHosts = addDefinedHosts(buildOptions.ExtraHosts, params.Hosts)
 
 	sshSock := os.Getenv(r.sshAuthSockEnvvar)
 	if sshSock == "" {
@@ -554,6 +557,13 @@ func getExtraHosts(registryURL, subdomain, ip string, metadata types.ClusterMeta
 		extraHosts = append(extraHosts, types.HostMap{Hostname: metadata.PublicDomain, IP: ip})
 	}
 
+	return extraHosts
+}
+
+func addDefinedHosts(extraHosts []types.HostMap, definedHosts []model.Host) []types.HostMap {
+	for _, host := range definedHosts {
+		extraHosts = append(extraHosts, types.HostMap{Hostname: host.Hostname, IP: host.IP})
+	}
 	return extraHosts
 }
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -594,9 +594,10 @@ func TestGetExtraHosts(t *testing.T) {
 	ip := "1.2.3.4"
 
 	var tests = []struct {
-		name     string
-		expected []types.HostMap
-		metadata types.ClusterMetadata
+		name         string
+		expected     []types.HostMap
+		definedHosts []model.Host
+		metadata     types.ClusterMetadata
 	}{
 		{
 			name:     "no metadata information",
@@ -621,6 +622,27 @@ func TestGetExtraHosts(t *testing.T) {
 			name: "with public domain",
 			metadata: types.ClusterMetadata{
 				PublicDomain: "publicdomain.dev.okteto.net",
+			},
+			expected: []types.HostMap{
+				{Hostname: registryURL, IP: ip},
+				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+				{Hostname: "publicdomain.dev.okteto.net", IP: ip},
+			},
+		},
+		{
+			name: "with defined hosts",
+			metadata: types.ClusterMetadata{
+				PublicDomain: "publicdomain.dev.okteto.net",
+			},
+			definedHosts: []model.Host{
+				{
+					Hostname: "test.dev.okteto.net",
+					IP:       ip,
+				},
+				{
+					Hostname: "test2.dev.okteto.net",
+					IP:       ip,
+				},
 			},
 			expected: []types.HostMap{
 				{Hostname: registryURL, IP: ip},

--- a/pkg/types/build.go
+++ b/pkg/types/build.go
@@ -13,9 +13,7 @@
 
 package types
 
-import (
-	"github.com/okteto/okteto/pkg/model"
-)
+import "github.com/okteto/okteto/pkg/model"
 
 // BuildSshSession is a reference to an ssh session which translates to a
 // --mount=ssh,id={id} argument in a buildkit run.


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-537

Add the hosts syntax to the test section:
```yaml
# Normal syntax
test:
   e2e:
      commands:
      - cat /etc/hosts
      hosts:
      - "*.my-domain.com:${MY_IP}"
```

And 
```yaml
# Extended syntax
test:
   e2e:
      commands:
      - cat /etc/hosts
      hosts:
      - hostname: .my-domain.com
         ip: ${MY_IP}"
```


## How to validate

1. Using the following manifest:
```yaml
# Normal syntax
test:
   e2e:
      commands:
      - cat /etc/hosts
      hosts:
      - "*.my-domain.com:${MY_IP}"
```
2. Export the variable `MY_IP` to a ip like `1.1.1.1`
3. Run `okteto test --no-cache`
4. Check that the host is added to `/etc/hosts`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
