### PR TITLE
[Backport 2.29] deploy remote falback to dockerignore instead of skipping it (#4406)

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -511,7 +511,9 @@ func createDockerignoreFileWithFilesystem(cwd, tmpDir string, rules []string, us
 		dockerignoreContent = append(dockerignoreContent, []byte(rule)...)
 		dockerignoreContent = append(dockerignoreContent, []byte("\n")...)
 	}
-
+	if len(dockerignoreContent) == 0 {
+		dockerignoreContent = []byte("# Okteto docker ignore\n")
+	}
 	return afero.WriteFile(fs, filename, dockerignoreContent, 0600)
 }
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -786,7 +786,7 @@ func TestCreateDockerignoreFileWithFilesystem(t *testing.T) {
 		{
 			name:            "without dockerignore",
 			config:          config{},
-			expectedContent: "",
+			expectedContent: "# Okteto docker ignore\n",
 			useDeployIgnore: true,
 		},
 		{


### PR DESCRIPTION
* fix: deploy remote falback to dockerignore instead of skipping it

Signed-off-by: Javier Lopez <javier@okteto.com>

* fix: field alingment

Signed-off-by: Javier Lopez <javier@okteto.com>

* move to the remote

Signed-off-by: Javier Lopez <javier@okteto.com>

* fix: unit test

Signed-off-by: Javier Lopez <javier@okteto.com>

---------

Signed-off-by: Javier Lopez <javier@okteto.com>
(cherry picked from commit 63d446a9bf06d89e34506911db8d6308858a7e85)
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Backports #4406 to release 2.29

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
