### PR TITLE
feat: refactor syntax for lifecycle

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -237,14 +237,54 @@ func TranslateLifecycle(c *apiv1.Container, l *model.Lifecycle) {
 	if l == nil {
 		return
 	}
-	if c.Lifecycle == nil {
+	setPostStart(c, l)
+	setPreStop(c, l)
+	if c.Lifecycle != nil && c.Lifecycle.PostStart == nil && c.Lifecycle.PreStop == nil {
+		c.Lifecycle = nil
+	}
+}
+
+func setPostStart(c *apiv1.Container, l *model.Lifecycle) {
+	if l.PostStart == nil {
 		return
 	}
-	if !l.PostStart {
-		c.Lifecycle.PostStart = nil
+	if c.Lifecycle == nil {
+		c.Lifecycle = &apiv1.Lifecycle{}
 	}
-	if !l.PostStart {
+	if !l.PostStart.Enabled {
 		c.Lifecycle.PostStart = nil
+		return
+	}
+	if len(l.PostStart.Command.Values) == 0 {
+		return
+	}
+
+	c.Lifecycle.PostStart = &apiv1.LifecycleHandler{
+		Exec: &apiv1.ExecAction{
+			Command: l.PostStart.Command.Values,
+		},
+	}
+}
+
+func setPreStop(c *apiv1.Container, l *model.Lifecycle) {
+	if l.PreStop == nil {
+		return
+	}
+	if c.Lifecycle == nil {
+		c.Lifecycle = &apiv1.Lifecycle{}
+	}
+	if !l.PreStop.Enabled {
+		c.Lifecycle.PreStop = nil
+		return
+	}
+	if len(l.PreStop.Command.Values) == 0 {
+		return
+	}
+
+	c.Lifecycle.PreStop = &apiv1.LifecycleHandler{
+		Exec: &apiv1.ExecAction{
+			Command: l.PreStop.Command.Values,
+		},
 	}
 }
 

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -2144,10 +2144,10 @@ func Test_getDevName(t *testing.T) {
 
 func TestTranslateLifecycle(t *testing.T) {
 	tests := []struct {
-		name            string
 		actualContainer *apiv1.Container
 		devLifecycle    *model.Lifecycle
 		expected        *apiv1.Container
+		name            string
 	}{
 		{
 			name: "both-lifecycle-handlers-enabled",

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -208,8 +208,14 @@ type Probes struct {
 
 // Lifecycle defines the lifecycle for containers
 type Lifecycle struct {
-	PostStart bool `json:"postStart,omitempty" yaml:"postStart,omitempty"`
-	PostStop  bool `json:"postStop,omitempty" yaml:"postStop,omitempty"`
+	PostStart *LifecycleHandler `json:"postStart,omitempty" yaml:"postStart,omitempty"`
+	PreStop   *LifecycleHandler `json:"preStop,omitempty" yaml:"preStop,omitempty"`
+}
+
+// LifecycleHandler defines a handler for lifecycle events
+type LifecycleHandler struct {
+	Enabled bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Command Command `json:"command,omitempty" yaml:"command,omitempty"`
 }
 
 // ResourceList is a set of (resource name, quantity) pairs.

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -214,8 +214,8 @@ type Lifecycle struct {
 
 // LifecycleHandler defines a handler for lifecycle events
 type LifecycleHandler struct {
-	Enabled bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 	Command Command `json:"command,omitempty" yaml:"command,omitempty"`
+	Enabled bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 }
 
 // ResourceList is a set of (resource name, quantity) pairs.

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -1208,7 +1208,7 @@ func Test_validateForExtraFields(t *testing.T) {
 			name: "lifecycle",
 			value: `lifecycle:
                postStart: false
-               postStop: true`,
+               preStop: true`,
 		},
 		{
 			name: "securityContext",

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -200,7 +200,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.HTTPHealtcheck":       {"path", "port"},
 				"model.HealthCheck":          {"http", "test", "interval", "timeout", "retries", "start_period", "disable", "x-okteto-liveness", "x-okteto-readiness"},
 				"model.InitContainer":        {"resources", "image"},
-				"model.Lifecycle":            {"postStart", "postStop"},
+				"model.Lifecycle":            {"postStart", "preStop"},
 				"model.Manifest":             {"name", "icon", "dev", "build", "deploy", "destroy", "dependencies", "external", "forward", "test"},
 				"model.Metadata":             {"labels", "annotations"},
 				"model.PersistentVolumeInfo": {"storageClass", "size", "enabled"},

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -360,9 +360,9 @@ func TestProbesMarshalling(t *testing.T) {
 
 func TestLifecycleMarshalling(t *testing.T) {
 	tests := []struct {
+		lifecycle Lifecycle
 		name      string
 		expected  string
-		lifecycle Lifecycle
 	}{
 		{
 			name: "true-and-false",

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -365,27 +365,48 @@ func TestLifecycleMarshalling(t *testing.T) {
 		lifecycle Lifecycle
 	}{
 		{
-			name:      "true-and-false",
-			lifecycle: Lifecycle{PostStart: true},
-			expected:  "postStart: true\n",
+			name: "true-and-false",
+			lifecycle: Lifecycle{
+				PostStart: &LifecycleHandler{
+					Enabled: true,
+				},
+			},
+			expected: "postStart: true\n",
 		},
 		{
-			name:      "all-lifecycle-true",
-			lifecycle: Lifecycle{PostStart: true, PostStop: true},
-			expected:  "true\n",
+			name: "all-lifecycle-true",
+			lifecycle: Lifecycle{
+				PostStart: &LifecycleHandler{
+					Enabled: true,
+				},
+				PreStop: &LifecycleHandler{
+					Enabled: true,
+				},
+			},
+			expected: "postStart: true\npreStop: true\n",
+		},
+		{
+			name: "full",
+			lifecycle: Lifecycle{
+				PostStart: &LifecycleHandler{
+					Enabled: true,
+					Command: Command{Values: []string{"yarn", "start"}},
+				},
+				PreStop: &LifecycleHandler{
+					Enabled: true,
+					Command: Command{Values: []string{"yarn", "stop"}},
+				},
+			},
+			expected: "postStart:\n  enabled: true\n  command:\n  - yarn\n  - start\npreStop:\n  enabled: true\n  command:\n  - yarn\n  - stop\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			marshalled, err := yaml.Marshal(tt.lifecycle)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(marshalled))
 
-			if string(marshalled) != tt.expected {
-				t.Errorf("didn't marshal correctly. Actual %s, Expected %s", marshalled, tt.expected)
-			}
 		})
 	}
 }
@@ -1111,6 +1132,10 @@ dev:
 								},
 							},
 						},
+						Lifecycle: &Lifecycle{
+							PostStart: nil,
+							PreStop:   nil,
+						},
 						Forward:         []forward.Forward{},
 						Selector:        Selector{},
 						ImagePullPolicy: v1.PullAlways,
@@ -1125,10 +1150,6 @@ dev:
 							Liveness:  false,
 							Readiness: false,
 							Startup:   false,
-						},
-						Lifecycle: &Lifecycle{
-							PostStart: false,
-							PostStop:  false,
 						},
 						SecurityContext: &SecurityContext{
 							RunAsUser:    pointer.Int64(0),
@@ -1180,8 +1201,8 @@ dev:
 							Startup:   false,
 						},
 						Lifecycle: &Lifecycle{
-							PostStart: false,
-							PostStop:  false,
+							PostStart: nil,
+							PreStop:   nil,
 						},
 						SecurityContext: &SecurityContext{
 							RunAsUser:    pointer.Int64(0),
@@ -1240,6 +1261,10 @@ dev:
 								},
 							},
 						},
+						Lifecycle: &Lifecycle{
+							PostStart: nil,
+							PreStop:   nil,
+						},
 						Forward:         []forward.Forward{},
 						Selector:        Selector{},
 						ImagePullPolicy: v1.PullAlways,
@@ -1254,10 +1279,6 @@ dev:
 							Liveness:  false,
 							Readiness: false,
 							Startup:   false,
-						},
-						Lifecycle: &Lifecycle{
-							PostStart: false,
-							PostStop:  false,
 						},
 						SecurityContext: &SecurityContext{
 							RunAsUser:    pointer.Int64(0),
@@ -1333,8 +1354,8 @@ dev:
 							Startup:   false,
 						},
 						Lifecycle: &Lifecycle{
-							PostStart: false,
-							PostStop:  false,
+							PostStart: nil,
+							PreStop:   nil,
 						},
 						SecurityContext: &SecurityContext{
 							RunAsUser:    pointer.Int64(0),
@@ -1356,8 +1377,8 @@ dev:
 									Startup:   false,
 								},
 								Lifecycle: &Lifecycle{
-									PostStart: false,
-									PostStop:  false,
+									PostStart: nil,
+									PreStop:   nil,
 								},
 								SecurityContext: &SecurityContext{
 									RunAsUser:    pointer.Int64(0),
@@ -1456,8 +1477,8 @@ dev:
 							Startup:   false,
 						},
 						Lifecycle: &Lifecycle{
-							PostStart: false,
-							PostStop:  false,
+							PostStart: nil,
+							PreStop:   nil,
 						},
 						SecurityContext: &SecurityContext{
 							RunAsUser:    pointer.Int64(0),
@@ -1536,8 +1557,8 @@ dev:
 							Startup:   false,
 						},
 						Lifecycle: &Lifecycle{
-							PostStart: false,
-							PostStop:  false,
+							PostStart: nil,
+							PreStop:   nil,
 						},
 						SecurityContext: &SecurityContext{
 							RunAsUser:    pointer.Int64(0),
@@ -1590,8 +1611,8 @@ dev:
 							Startup:   false,
 						},
 						Lifecycle: &Lifecycle{
-							PostStart: false,
-							PostStop:  false,
+							PostStart: nil,
+							PreStop:   nil,
 						},
 						SecurityContext: &SecurityContext{
 							RunAsUser:    pointer.Int64(0),

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -397,7 +397,7 @@ func TestLifecycleMarshalling(t *testing.T) {
 					Command: Command{Values: []string{"yarn", "stop"}},
 				},
 			},
-			expected: "postStart:\n  enabled: true\n  command:\n  - yarn\n  - start\npreStop:\n  enabled: true\n  command:\n  - yarn\n  - stop\n",
+			expected: "postStart:\n  command:\n  - yarn\n  - start\n  enabled: true\npreStop:\n  command:\n  - yarn\n  - stop\n  enabled: true\n",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-521

Refactor the syntax for lidecycle to overwrite the container commands.
Supports the following syntax:
```yaml
lifecycle:
  postStart:
    enabled: true
    command:
    - echo
    - Hello
  preStop:
    enabled: true
    command:
    - echo
    - bye 
```

## How to validate

1. Create the following `k8s.yml`
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: lifecycle-demo-deployment
spec:
  replicas: 1
  selector:
    matchLabels:
      app: lifecycle-demo
  template:
    metadata:
      labels:
        app: lifecycle-demo
    spec:
      containers:
      - name: lifecycle-container
        image: nginx
        lifecycle:
          postStart:
            exec:
              command: ["/bin/sh", "-c", "echo 'Container is starting' >> /var/log/lifecycle.log"]
          preStop:
            exec:
              command: ["/bin/sh", "-c", "echo 'Container is stopping' >> /var/log/lifecycle.log"]
        volumeMounts:
        - name: lifecycle-volume
          mountPath: /var/log
      volumes:
      - name: lifecycle-volume
        emptyDir: {}
```
2. Create the following `okteto.yml`:
```yaml
deploy:
  - kubectl apply -f k8s.yml
dev:
  lifecycle-demo-deployment:
    sync:
    - .:/src/app
    workdir: /src/app
    lifecycle:
      postStart:
        enabled: true
        command:
        - echo
        - hello
      preStop:
        enabled: true
        command:
        - echo
        - bye
```
3. Run `okteto up` and check that the new deployment has the lifecycle commands attached to the container 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
