### PR TITLE
feat: add last okteto up branch on cmap

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -47,6 +47,8 @@ const (
 
 	// devBranchTrackingIntervalEnvVar sets the tracking interval for branch trackin (if enabled) using OKTETO_DEV_BRANCH_TRACKING_INTERVAL
 	devBranchTrackingIntervalEnvVar = "OKTETO_DEV_BRANCH_TRACKING_INTERVAL"
+
+	defaultTrackingInterval = 5 * time.Minute
 )
 
 func (up *upContext) activate() error {
@@ -592,7 +594,7 @@ func (up *upContext) TrackLatestBranchOnDevContainer(ctx context.Context) {
 	}
 	r := repository.NewRepository(gitRepo)
 
-	devBranchTrackingInterval := env.LoadTimeOrDefault(devBranchTrackingIntervalEnvVar, 5*time.Minute)
+	devBranchTrackingInterval := env.LoadTimeOrDefault(devBranchTrackingIntervalEnvVar, defaultTrackingInterval)
 	c, _, err := up.K8sClientProvider.Provide(okteto.GetContext().Cfg)
 	if err != nil {
 		oktetoLog.Infof("error getting k8s client: %s", err.Error())

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -53,7 +53,7 @@ const (
 	actionLockField = "actionLock"
 	actionNameField = "actionName"
 	variablesField  = "variables"
-	latestUpBranch  = "latestUpBranch"
+	devBranchField  = "dev-branch"
 	PhasesField     = "phases"
 
 	actionDefaultName = "cli"
@@ -238,12 +238,12 @@ func UpdateLatestUpBranch(ctx context.Context, name, namespace, branch string, c
 	if err != nil {
 		return err
 	}
-	val := cmap.Data[latestUpBranch]
+	val := cmap.Data[devBranchField]
 	if val == branch {
 		oktetoLog.Infof("latestUpBranch already set to %s", branch)
 		return nil
 	}
-	cmap.Data[latestUpBranch] = branch
+	cmap.Data[devBranchField] = branch
 	return configmaps.Deploy(ctx, cmap, cmap.Namespace, c)
 }
 

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -232,13 +232,13 @@ func TranslatePipelineName(name string) string {
 	return fmt.Sprintf("%s%s", ConfigmapNamePrefix, format.ResourceK8sMetaString(name))
 }
 
-// AddPhaseDuration adds a new phase to the configmap with the duration in seconds
+// UpdateLatestUpBranch adds a new phase to the configmap with the duration in seconds
 func UpdateLatestUpBranch(ctx context.Context, name, namespace, branch string, c kubernetes.Interface) error {
 	cmap, err := configmaps.Get(ctx, TranslatePipelineName(name), namespace, c)
 	if err != nil {
 		return err
 	}
-	val, _ := cmap.Data[latestUpBranch]
+	val := cmap.Data[latestUpBranch]
 	if val == branch {
 		oktetoLog.Infof("latestUpBranch already set to %s", branch)
 		return nil

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/a8m/envsubst"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -109,6 +110,21 @@ func LoadBoolean(k string) bool {
 	h, err := strconv.ParseBool(v)
 	if err != nil {
 		oktetoLog.Yellow("'%s' is not a valid value for environment variable %s", v, k)
+	}
+
+	return h
+}
+
+func LoadTimeOrDefault(k string, defaultValue time.Duration) time.Duration {
+	v := os.Getenv(k)
+	if v == "" {
+		return defaultValue
+	}
+
+	h, err := time.ParseDuration(v)
+	if err != nil {
+		oktetoLog.Yellow("'%s' is not a valid value for environment variable %s", v, k)
+		return defaultValue
 	}
 
 	return h

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -15,6 +15,7 @@ package env
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
@@ -292,6 +293,51 @@ func TestLoadBooleanOrDefault(t *testing.T) {
 			t.Setenv(tc.EnvKey, tc.EnvValue)
 			result := LoadBooleanOrDefault(tc.EnvKey, tc.DefaultValue)
 			assert.Equal(t, tc.ExpectedResult, result)
+		})
+	}
+}
+func TestLoadTimeOrDefault(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockKey        string
+		mockValue      string
+		defaultValue   time.Duration
+		expectedResult time.Duration
+	}{
+		{
+			name:           "empty key",
+			defaultValue:   5 * time.Second,
+			expectedResult: 5 * time.Second,
+		},
+		{
+			name:           "empty value",
+			mockKey:        "NON_EXISTING_VAR_UNIT_TEST",
+			defaultValue:   10 * time.Second,
+			expectedResult: 10 * time.Second,
+		},
+		{
+			name:           "valid duration",
+			mockKey:        "VAR_UNIT_TEST",
+			mockValue:      "5s",
+			defaultValue:   10 * time.Second,
+			expectedResult: 5 * time.Second,
+		},
+		{
+			name:           "invalid duration",
+			mockKey:        "VAR_UNIT_TEST",
+			mockValue:      "invalid",
+			defaultValue:   10 * time.Second,
+			expectedResult: 10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mockKey != "" {
+				t.Setenv(tt.mockKey, tt.mockValue)
+			}
+			got := LoadTimeOrDefault(tt.mockKey, tt.defaultValue)
+			assert.Equal(t, tt.expectedResult, got)
 		})
 	}
 }

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -61,6 +61,18 @@ type cleanStatus struct {
 	isClean bool
 }
 
+func (r gitRepoController) getCurrentBranch() (string, error) {
+	repo, err := r.repoGetter.get(r.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
+	return head.Name().Short(), nil
+}
+
 func (r gitRepoController) calculateIsClean(ctx context.Context) (bool, error) {
 	repo, err := r.repoGetter.get(r.path)
 	if err != nil {

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -37,6 +37,7 @@ type repositoryInterface interface {
 	GetLatestDirSHA(string) (string, error)
 	GetDiffHash(string) (string, error)
 	getRepoURL() (string, error)
+	getCurrentBranch() (string, error)
 }
 
 type repositoryURL struct {
@@ -93,6 +94,10 @@ func (r Repository) IsClean() (bool, error) {
 // GetSHA returns the last commit sha of the repository
 func (r Repository) GetSHA() (string, error) {
 	return r.control.getSHA()
+}
+
+func (r Repository) GetCurrentBranch() (string, error) {
+	return r.control.getCurrentBranch()
 }
 
 // IsEqual checks if another repository is the same from the one calling the function


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

FixesDEV-496

This PR introduces a new feature for tracking the latest branch on development containers. This feature is disabled for okteto manifest that don't have a deploy section (they don't create a configmap) or manifest without git repository (they don't have a branch to track)

Key changes include:

- A new method TrackLatestBranchOnDevContainer is added to continuously track and update the current branch in the development container.
- Two new environment variables have been introduced:
  - `OKTETO_ENABLE_DEV_BRANCH_TRACKING: Enables or disables the branch tracking. Defaults to false
  - `OKTETO_DEV_BRANCH_TRACKING_INTERVAL: Sets the interval for checking the current branch. Defaults to 5 min
- Added LoadTimeOrDefault in pkg/env/env.go for parsing environment variables as time durations.
- Creates a new field in the configmap `latestUpBranch`storing the latest up branch that we know


## How to validate

1. Run `export OKTETO_ENABLE_DEV_BRANCH_TRACKING=true`
1. Run okteto up on any manifest that does a deploy and it's a git repository
1. Check the configmap by running `kubectl get configmap okteto-git-{NAME} -oyaml`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
