### PR TITLE
account for groups in repo urls in dependencies

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -23,6 +23,7 @@ import (
 	"github.com/a8m/envsubst/parse"
 	giturls "github.com/chainguard-dev/git-urls"
 	"github.com/okteto/okteto/pkg/env"
+	"github.com/okteto/okteto/pkg/model/utils"
 )
 
 // ManifestSection represents the map of dependencies at a manifest
@@ -130,10 +131,7 @@ func (md *ManifestSection) UnmarshalYAML(unmarshal func(interface{}) error) erro
 			if err != nil {
 				return err
 			}
-			name, err := getRepoNameFromGitURL(r)
-			if err != nil {
-				return err
-			}
+			name := utils.TranslateURLToName(r.String())
 			rawMd[name] = &Dependency{
 				Repository: r.String(),
 			}

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -129,6 +129,20 @@ func Test_ManifestDependencies_UnmarshalYAML(t *testing.T) {
 			},
 		},
 		{
+			name: "deserialized successfully from array with repo with groups",
+			yaml: []byte(`
+- https://gitlab.com/okteto24/samples/nested/movies-frontend
+- https://gitlab.com/okteto24/samples/nested/movies-api`),
+			expected: ManifestSection{
+				"movies-api": &Dependency{
+					Repository: "https://gitlab.com/okteto24/samples/nested/movies-api",
+				},
+				"movies-frontend": &Dependency{
+					Repository: "https://gitlab.com/okteto24/samples/nested/movies-frontend",
+				},
+			},
+		},
+		{
 			name: "deserialized successfully as map",
 			yaml: []byte(`
 frontend:


### PR DESCRIPTION
To be able to successfully deploy dependencies from gitlab repos with subgroups we need to properly read the **name** of the dev environment. Right now, we read the second part of the repo url but in gitlab there's nested groups that can have an arbitrary number of paths.

Currently,  deploying the following `okteto.yml` deploys a single dev env `samples`:

```yaml
dependencies:
  - https://gitlab.com/okteto24/samples/nested/go-getting-started
  - https://gitlab.com/okteto24/samples/nested/go-getting-started
```

After this change both environments should be deployed.

To validate:

```bash
git clone git@gitlab.com:okteto24/samples/nested/multirepo.git
cd multirepo
okteto deploy
```

From master a single `samples` is deploy. Using a build with this change should deploy both



