### PR TITLE
Update windows executors to pinned version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,9 @@ jobs:
           destination: coverage.txt
 
   run-windows-unit-test:
-    executor: win/default
+    executor:
+      name: win/default
+      version: default
     environment:
       OKTETO_USER: cindylopez
     steps:
@@ -289,7 +291,9 @@ jobs:
             okteto build --platform "linux/arm64,linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile .
 
   test-e2e-setup-windows:
-    executor: win/default
+    executor:
+      name: win/default
+      version: default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -316,7 +320,9 @@ jobs:
             - C:\Users\circleci\go\pkg
             - C:\Go\pkg
   e2e-deprecated-windows:
-    executor: win/default
+    executor:
+      name: win/default
+      version: default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -347,7 +353,9 @@ jobs:
             go test github.com/okteto/okteto/integration/deprecated/stack -tags="integration" --count=1 -v -timeout 15m
 
   e2e-build-windows:
-    executor: win/default
+    executor:
+      name: win/default
+      version: default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -373,7 +381,9 @@ jobs:
             go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
 
   e2e-deploy-windows:
-    executor: win/default
+    executor:
+      name: win/default
+      version: default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -406,7 +416,9 @@ jobs:
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
 
   e2e-up-windows:
-    executor: win/default
+    executor:
+      name: win/default
+      version: default
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
     executor:
       name: win/default
       version: default
-      size: windows.medium
+      size: medium
     environment:
       OKTETO_USER: cindylopez
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,7 @@ jobs:
   e2e-deprecated-windows:
     executor:
       name: win/server-2022
-      version: current
+      version: 2024.04.1
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ parameters:
     default: ""
 
 orbs:
+  # https://circleci.com/developer/orbs/orb/circleci/windows#usage-run_windows_2022
+  # https://circleci.com/developer/machine/image/windows-server-2022-gui
   win: circleci/windows@5.0.0
 
 executors:
@@ -113,9 +115,9 @@ jobs:
 
   run-windows-unit-test:
     executor:
-      name: win/default
-      version: default
-      size: medium
+      # https://circleci.com/developer/machine/image/windows-server-2022-gui
+      name: win/server-2022
+      version: 2024.04.1
     environment:
       OKTETO_USER: cindylopez
     steps:
@@ -293,8 +295,8 @@ jobs:
 
   test-e2e-setup-windows:
     executor:
-      name: win/default
-      version: default
+      name: win/server-2022
+      version: 2024.04.1
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -322,8 +324,8 @@ jobs:
             - C:\Go\pkg
   e2e-deprecated-windows:
     executor:
-      name: win/default
-      version: default
+      name: win/server-2022
+      version: current
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -355,8 +357,8 @@ jobs:
 
   e2e-build-windows:
     executor:
-      name: win/default
-      version: default
+      name: win/server-2022
+      version: 2024.04.1
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -383,8 +385,8 @@ jobs:
 
   e2e-deploy-windows:
     executor:
-      name: win/default
-      version: default
+      name: win/server-2022
+      version: 2024.04.1
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez
@@ -418,8 +420,8 @@ jobs:
 
   e2e-up-windows:
     executor:
-      name: win/default
-      version: default
+      name: win/server-2022
+      version: 2024.04.1
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
     executor:
       name: win/default
       version: default
+      size: windows.medium
     environment:
       OKTETO_USER: cindylopez
     steps:


### PR DESCRIPTION
# Proposed changes
https://okteto.atlassian.net/browse/DEV-533
Update CircleCI windows orb settings based on docs.

CircleCI notified that the current orb we are using is using an image which will be deprecated in the following weeks.
According to the docs the "default" image is not availble yet... So this PR pins the version of the executor used, instead of "default" which uses "serever-2022", we pin this version, and also the version of the image inside the orb, instead of "current" use the latests tag available "2024.4.1"

Update guide: https://support.circleci.com/hc/en-us/articles/23614965074459-2024-Image-Deprecations-and-Brownouts-Android-Linux-VM-Remote-Docker-Windows
(tried to just add version: default to image but pipeline would not work)

Docs on orb: https://circleci.com/developer/orbs/orb/circleci/windows#usage-run_windows_2022
Docs on windowns images: https://circleci.com/developer/machine/image/windows-server-2022-gui