### PR TITLE
Return success when destroy/delete preview/namespace and err is not found

### DIFF
--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -74,7 +74,7 @@ func (nc *Command) ExecuteDeleteNamespace(ctx context.Context, namespace string,
 	// trigger namespace deletion
 	if err := nc.okClient.Namespaces().Delete(ctx, namespace); err != nil {
 		if oktetoErrors.IsNotFound(err) {
-			oktetoLog.Success("Namespace '%s' not found", namespace)
+			oktetoLog.Information("Namespace '%s' not found", namespace)
 			return nil
 		}
 		return fmt.Errorf("%w: %w", errFailedDeleteNamespace, err)

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -73,6 +73,10 @@ func (nc *Command) ExecuteDeleteNamespace(ctx context.Context, namespace string,
 
 	// trigger namespace deletion
 	if err := nc.okClient.Namespaces().Delete(ctx, namespace); err != nil {
+		if oktetoErrors.IsNotFound(err) {
+			oktetoLog.Success("Namespace '%s' not found", namespace)
+			return nil
+		}
 		return fmt.Errorf("%w: %w", errFailedDeleteNamespace, err)
 	}
 

--- a/cmd/namespace/delete_test.go
+++ b/cmd/namespace/delete_test.go
@@ -88,7 +88,7 @@ func Test_deleteNamespace(t *testing.T) {
 			toDeleteNs:                      "test-non-existing",
 			initialNamespacesAtOktetoClient: initNamespaces,
 			finalNs:                         currentNamespace,
-			err:                             errFailedDeleteNamespace,
+			err:                             nil,
 			fakeOkClient: &client.FakeOktetoClient{
 				Namespace:       client.NewFakeNamespaceClient(initNamespaces, nil),
 				Users:           client.NewFakeUsersClient(usr),

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -98,7 +98,7 @@ func (c destroyPreviewCommand) executeDestroyPreview(ctx context.Context, opts *
 
 	if err := c.okClient.Previews().Destroy(ctx, opts.name); err != nil {
 		if oktetoErrors.IsNotFound(err) {
-			oktetoLog.Success("Preview environment '%s' not found.", opts.name)
+			oktetoLog.Information("Preview environment '%s' not found.", opts.name)
 			return nil
 		}
 		return fmt.Errorf("failed to destroy preview environment: %w", err)

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -97,6 +97,10 @@ func (c destroyPreviewCommand) executeDestroyPreview(ctx context.Context, opts *
 	defer oktetoLog.StopSpinner()
 
 	if err := c.okClient.Previews().Destroy(ctx, opts.name); err != nil {
+		if oktetoErrors.IsNotFound(err) {
+			oktetoLog.Success("Preview environment '%s' not found.", opts.name)
+			return nil
+		}
 		return fmt.Errorf("failed to destroy preview environment: %w", err)
 	}
 

--- a/cmd/preview/destroy_test.go
+++ b/cmd/preview/destroy_test.go
@@ -15,6 +15,7 @@ package preview
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/okteto/okteto/internal/test/client"
@@ -51,6 +52,33 @@ func TestExecuteDestroyPreviewWithErrorDestroying(t *testing.T) {
 	require.Equal(t, 0, previewResponse.DestroySuccessCount)
 }
 
+// TestExecuteDestroyPreviewWithNotFoundPreviewErrorDestroying tests the case when the preview is not found
+// not return an error
+func TestExecuteDestroyPreviewWithNotFoundPreviewErrorDestroying(t *testing.T) {
+	ctx := context.Background()
+	opts := &DestroyOptions{
+		name: "test-preview",
+		wait: true,
+	}
+	previewResponse := client.FakePreviewResponse{
+		ErrDestroyPreview: fmt.Errorf("preview-not-found"),
+	}
+	command := destroyPreviewCommand{
+		okClient: &client.FakeOktetoClient{
+			Preview: client.NewFakePreviewClient(
+				&previewResponse,
+			),
+			StreamClient: client.NewFakeStreamClient(&client.FakeStreamResponse{}),
+		},
+		k8sClient: fake.NewSimpleClientset(),
+	}
+
+	err := command.executeDestroyPreview(ctx, opts)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, previewResponse.DestroySuccessCount)
+}
+
 func TestExecuteDestroyPreviewWithoutError(t *testing.T) {
 	ctx := context.Background()
 	opts := &DestroyOptions{
@@ -71,7 +99,7 @@ func TestExecuteDestroyPreviewWithoutError(t *testing.T) {
 	err := command.executeDestroyPreview(ctx, opts)
 
 	require.NoError(t, err)
-	require.Equal(t, 1, previewResponse.DestroySuccessCount)
+	require.Equal(t, 0, previewResponse.DestroySuccessCount)
 }
 
 func TestExecuteDestroyPreviewWithoutWait(t *testing.T) {

--- a/cmd/preview/destroy_test.go
+++ b/cmd/preview/destroy_test.go
@@ -76,7 +76,7 @@ func TestExecuteDestroyPreviewWithNotFoundPreviewErrorDestroying(t *testing.T) {
 	err := command.executeDestroyPreview(ctx, opts)
 
 	require.NoError(t, err)
-	require.Equal(t, 1, previewResponse.DestroySuccessCount)
+	require.Equal(t, 0, previewResponse.DestroySuccessCount)
 }
 
 func TestExecuteDestroyPreviewWithoutError(t *testing.T) {
@@ -99,7 +99,7 @@ func TestExecuteDestroyPreviewWithoutError(t *testing.T) {
 	err := command.executeDestroyPreview(ctx, opts)
 
 	require.NoError(t, err)
-	require.Equal(t, 0, previewResponse.DestroySuccessCount)
+	require.Equal(t, 1, previewResponse.DestroySuccessCount)
 }
 
 func TestExecuteDestroyPreviewWithoutWait(t *testing.T) {


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-516

Proposed changes are to return a ~success~ information message when the err from delete client is `not-found`

Screenshot
![Screenshot 2024-08-19 at 07 55 59](https://github.com/user-attachments/assets/0e4efa2e-5357-439e-8750-68e34c91fdec)

