### PR TITLE
Prevent logs to be written from registry credential

### DIFF
--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -138,7 +138,7 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 
 // Run executes the kubetoken command
 func (kc *Cmd) Run(ctx context.Context, flags Flags) error {
-	oktetoLog.SetOutputFormat("silent")
+	oktetoLog.SetOutputFormat(oktetoLog.SilentFormat)
 	err := newPreReqValidator(
 		withCtxName(flags.Context),
 		withNamespace(flags.Namespace),

--- a/main.go
+++ b/main.go
@@ -94,12 +94,8 @@ func main() {
 	ioController.Logger().SetLevel(io.WarnLevel)
 	oktetoLog.Init(logrus.WarnLevel) // TODO: Remove when we fully move to ioController
 	if registrytoken.IsRegistryCredentialHelperCommand(os.Args) {
-		oktetoLog.SetOutput(os.Stderr)          // TODO: Remove when we fully move to ioController
-		oktetoLog.SetLevel(oktetoLog.InfoLevel) // TODO: Remove when we fully move to ioController
-		oktetoLog.SetOutputFormat("silent")
-
-		ioController.Logger().SetLevel(io.InfoLevel)
-		ioController.SetOutputFormat(io.JSONFormat)
+		oktetoLog.SetOutputFormat(io.SilentFormat)
+		ioController.SetOutputFormat(io.SilentFormat)
 	}
 
 	var logLevel string

--- a/main.go
+++ b/main.go
@@ -94,9 +94,9 @@ func main() {
 	ioController.Logger().SetLevel(io.WarnLevel)
 	oktetoLog.Init(logrus.WarnLevel) // TODO: Remove when we fully move to ioController
 	if registrytoken.IsRegistryCredentialHelperCommand(os.Args) {
-		oktetoLog.SetOutput(os.Stderr)                  // TODO: Remove when we fully move to ioController
-		oktetoLog.SetLevel(oktetoLog.InfoLevel)         // TODO: Remove when we fully move to ioController
-		oktetoLog.SetOutputFormat(oktetoLog.JSONFormat) // TODO: Remove when we fully move to ioController
+		oktetoLog.SetOutput(os.Stderr)          // TODO: Remove when we fully move to ioController
+		oktetoLog.SetLevel(oktetoLog.InfoLevel) // TODO: Remove when we fully move to ioController
+		oktetoLog.SetOutputFormat("silent")
 
 		ioController.Logger().SetLevel(io.InfoLevel)
 		ioController.SetOutputFormat(io.JSONFormat)

--- a/pkg/log/io/logger.go
+++ b/pkg/log/io/logger.go
@@ -26,6 +26,9 @@ const (
 	// JSONFormat represents a json logger
 	JSONFormat string = "json"
 
+	// SilentFormat represents a silent logger
+	SilentFormat string = "silent"
+
 	// DebugLevel is the debug level
 	DebugLevel = "debug"
 
@@ -129,6 +132,8 @@ func (ol *oktetoLogger) SetOutputFormat(output string) {
 	switch output {
 	case JSONFormat:
 		ol.logrusFormatter = newLogrusJSONFormatter()
+	case SilentFormat:
+		ol.logrusFormatter = newLogrusSilentFormatter()
 	default:
 		ol.logrusFormatter = &logrus.TextFormatter{}
 	}

--- a/pkg/log/io/logrus.go
+++ b/pkg/log/io/logrus.go
@@ -69,3 +69,16 @@ func (f *logrusJSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	messageJSON = []byte(string(messageJSON) + "\n")
 	return messageJSON, nil
 }
+
+// logrusSilentFormatter is a logrus formatter that doesn't print anything
+type logrusSilentFormatter struct{}
+
+// newLogrusSilentFormatter creates a new logrusSilentFormatter
+func newLogrusSilentFormatter() *logrusSilentFormatter {
+	return &logrusSilentFormatter{}
+}
+
+// Format returns nil to avoid printing logs
+func (f *logrusSilentFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return nil, nil
+}

--- a/pkg/log/io/logrus.go
+++ b/pkg/log/io/logrus.go
@@ -49,6 +49,7 @@ func (f *logrusJSONFormatter) SetStage(stage string) {
 func (f *logrusJSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	level := strings.ToLower(entry.Level.String())
 
+	// err empty stage still appears beacuse the format for controller is json, we dont have a silce format for io controller
 	if f.stage == "" {
 		return nil, errEmptyStage
 	}


### PR DESCRIPTION
# Proposed changes

https://okteto.atlassian.net/browse/DEV-286

- Create a Silent Formatter for logs to silence the logs, this prevents the JSON formatter to throw the error of empty stange
- Use silent format for oktetoLog implementation, this prevents the logs of info to be shown


Tested:

- Added my DockerHub credentials to my dev, tun the command and see the output
Docs on this https://www.okteto.com/docs/admin/registry-credentials/dockerhub/

```
❯ echo https://index.docker.io/v1/ | ok registrytoken get
{"ServerURL":"https://index.docker.io/v1/","Username":"<username>","Secret":"<token>"}
```

