### PR TITLE
DEV-575: Fix UpdateEnvs function to allow variable values with '='

### DIFF
--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -167,9 +167,9 @@ func UpdateEnvs(ctx context.Context, name, namespace string, envs []string, c ku
 
 	if cmap != nil {
 		envsToSet := make(map[string]string, len(envs))
+		envFormatParts := 2
 		for _, env := range envs {
-			result := strings.Split(env, "=")
-			envFormatParts := 2
+			result := strings.SplitN(env, "=", envFormatParts)
 			if len(result) != envFormatParts {
 				return fmt.Errorf("invalid env format: '%s'", env)
 			}
@@ -408,8 +408,8 @@ func removeSensitiveDataFromGitURL(gitURL string) string {
 
 func translateVariables(variables []string) string {
 	var v []types.DeployVariable
+	maxVariableFormatParts := 2
 	for _, item := range variables {
-		maxVariableFormatParts := 2
 		splitV := strings.SplitN(item, "=", maxVariableFormatParts)
 		if len(splitV) != maxVariableFormatParts {
 			continue

--- a/pkg/cmd/pipeline/translate_test.go
+++ b/pkg/cmd/pipeline/translate_test.go
@@ -99,6 +99,7 @@ func Test_updateEnvsWithoutError(t *testing.T) {
 	envs := []string{
 		"ONE=value",
 		"TWO=values",
+		"URL=https://okteto.com?okteto=rocks",
 	}
 
 	err := UpdateEnvs(ctx, "test", namespace, envs, fakeClient)

--- a/pkg/deployable/deploy.go
+++ b/pkg/deployable/deploy.go
@@ -320,6 +320,8 @@ func (r *DeployRunner) runCommandsSection(ctx context.Context, params DeployPara
 	}
 	err = r.ConfigMapHandler.UpdateEnvsFromCommands(ctx, params.Name, params.Namespace, params.Variables)
 	if err != nil {
+		oktetoLog.SetStage(oktetoLog.UnexpectedErrorStage)
+		oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error persisting OKTETO_ENV: %s", err.Error())
 		return fmt.Errorf("could not update config map with environment variables: %w", err)
 	}
 

--- a/pkg/log/json.go
+++ b/pkg/log/json.go
@@ -24,6 +24,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// UnexpectedErrorStage stage to be used in the staged logs when there is an unexpected error
+	UnexpectedErrorStage = "Internal server error"
+)
+
 // JSONWriter writes into a JSON terminal
 type JSONWriter struct {
 	out  *logrus.Logger
@@ -195,7 +200,7 @@ func (w *JSONWriter) Fail(format string, args ...interface{}) {
 	msg := fmt.Sprintf("%s %s", errorSymbol, fmt.Sprintf(format, args...))
 	if msg != "" {
 		if log.stage == "" {
-			log.stage = "Internal server error"
+			log.stage = UnexpectedErrorStage
 		}
 		msg = convertToJSON(ErrorLevel, log.stage, msg)
 		if msg != "" {


### PR DESCRIPTION
# Proposed changes

Fixes DEV-575

We had a regression in the last release when deploying something remotely and a variable with a `=` in the value is stored in `OKTETO_ENV`

The simplest reproduction scenario is having a manifest like this one:

```
deploy:
  remote: true
  commands:
    - echo "URL=https://okteto.docs?okteto=rocks" >> $OKTETO_ENV
```

If you execute `okteto deploy`, it succeeds in `2.29.x` version, but it fails on `2.30.x`. The error returned is `Error building image '': build failed: failed to solve: process "/bin/sh -c mkdir -p $HOME/.ssh && echo \"UserKnownHostsFile=/run/secrets/known_hosts\" >> $HOME/.ssh/config &&   /okteto/bin/okteto remote-run deploy --log-output=json --server-name=\"$INTERNAL_SERVER_NAME\" --name \"test-okteto-env\"" did not complete successfully: exit code: 1` which is not really helpful.

The reason is because since `2.30.x`, remote executions also update the configmap to store the `OKTETO_ENV` and enters into the function `UpdateEnvs`, which is the one failing.

Apart from fixing that scenario, this PR also address:
* Fixing also the local execution when the variable had `=`. This was like that several versions. In this case, the error returned was something more useful, but now, it doesn't fail
* Added some code to return a more clear error if there is some issue updating the `OKTETO_ENV` at the end of the execution. In that way, we return a clear error why it has failed.

<img width="956" alt="Screenshot 2024-08-13 at 10 40 28" src="https://github.com/user-attachments/assets/069b81f4-12a0-4bdb-aa80-dd9537baef85">


## How to validate

Check the manifest described in the description and:

1. Execute `okteto deploy` on `2.30`. You would see how it fails with the error mentioned above.
2. Use this branch and execute it again. You will see how it doesn't fail anymore and the variables are properly stored in the configmap under the key `dependencyEnvs`


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines