### PR TITLE
fix: syncthing restarts with relay enabled

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -37,8 +37,7 @@ const (
 
 	// syncthing
 	oktetoSyncSecretVolume = "okteto-sync-secret" // skipcq GSC-G101  not a secret
-	oktetoSyncDataVolume   = "okteto-sync-data"
-	oktetoDevSecretVolume  = "okteto-dev-secret" // skipcq GSC-G101  not a secret
+	oktetoDevSecretVolume  = "okteto-dev-secret"  // skipcq GSC-G101  not a secret
 	oktetoSecretTemplate   = "okteto-%s"
 )
 
@@ -332,10 +331,6 @@ func TranslateVolumeMounts(c *apiv1.Container, rule *model.TranslationRule) {
 			MountPath: "/var/syncthing/secret/",
 			ReadOnly:  true,
 		},
-		apiv1.VolumeMount{
-			Name:      oktetoSyncDataVolume,
-			MountPath: "/var/syncthing/data/",
-		},
 	)
 
 	if len(rule.Secrets) > 0 {
@@ -577,15 +572,6 @@ func isOktetoSyncSecretVolumePresent(spec *apiv1.PodSpec) bool {
 	return false
 }
 
-func isOktetoSyncDataVolumePresent(spec *apiv1.PodSpec) bool {
-	for _, v := range spec.Volumes {
-		if v.Name == oktetoSyncDataVolume {
-			return true
-		}
-	}
-	return false
-}
-
 // TranslateOktetoSyncthingVolumes translates the syncthing secret container of a pod
 func TranslateOktetoSyncthingVolumes(spec *apiv1.PodSpec, name string) {
 	if spec.Volumes == nil {
@@ -623,15 +609,6 @@ func TranslateOktetoSyncthingVolumes(spec *apiv1.PodSpec, name string) {
 		syncthingVolumes = append(syncthingVolumes, v)
 	}
 
-	if !isOktetoSyncDataVolumePresent(spec) {
-		v := apiv1.Volume{
-			Name: oktetoSyncDataVolume,
-			VolumeSource: apiv1.VolumeSource{
-				EmptyDir: &apiv1.EmptyDirVolumeSource{},
-			},
-		}
-		syncthingVolumes = append(syncthingVolumes, v)
-	}
 	spec.Volumes = append(spec.Volumes, syncthingVolumes...)
 }
 

--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -329,12 +329,12 @@ func TranslateVolumeMounts(c *apiv1.Container, rule *model.TranslationRule) {
 		c.VolumeMounts,
 		apiv1.VolumeMount{
 			Name:      oktetoSyncSecretVolume,
-			MountPath: "/var/syncthing/secret",
+			MountPath: "/var/syncthing/secret/",
 			ReadOnly:  true,
 		},
 		apiv1.VolumeMount{
 			Name:      oktetoSyncDataVolume,
-			MountPath: "/var/syncthing/data",
+			MountPath: "/var/syncthing/data/",
 		},
 	)
 

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -190,6 +190,12 @@ services:
 				},
 			},
 			{
+				Name: oktetoSyncDataVolume,
+				VolumeSource: apiv1.VolumeSource{
+					EmptyDir: &apiv1.EmptyDirVolumeSource{},
+				},
+			},
+			{
 				Name: dev1.GetVolumeName(),
 				VolumeSource: apiv1.VolumeSource{
 					PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
@@ -355,8 +361,12 @@ services:
 					},
 					{
 						Name:      oktetoSyncSecretVolume,
-						ReadOnly:  false,
+						ReadOnly:  true,
 						MountPath: "/var/syncthing/secret/",
+					},
+					{
+						Name:      oktetoSyncDataVolume,
+						MountPath: "/var/syncthing/data/",
 					},
 					{
 						Name:      oktetoDevSecretVolume,
@@ -901,6 +911,12 @@ persistentVolume:
 				},
 			},
 			{
+				Name: oktetoSyncDataVolume,
+				VolumeSource: apiv1.VolumeSource{
+					EmptyDir: &apiv1.EmptyDirVolumeSource{},
+				},
+			},
+			{
 				Name: dev.GetVolumeName(),
 				VolumeSource: apiv1.VolumeSource{
 					EmptyDir: &apiv1.EmptyDirVolumeSource{},
@@ -960,8 +976,12 @@ persistentVolume:
 					},
 					{
 						Name:      oktetoSyncSecretVolume,
-						ReadOnly:  false,
+						ReadOnly:  true,
 						MountPath: "/var/syncthing/secret/",
+					},
+					{
+						Name:      oktetoSyncDataVolume,
+						MountPath: "/var/syncthing/data/",
 					},
 					{
 						Name:      OktetoBinName,
@@ -1603,6 +1623,12 @@ services:
 				},
 			},
 			{
+				Name: oktetoSyncDataVolume,
+				VolumeSource: apiv1.VolumeSource{
+					EmptyDir: &apiv1.EmptyDirVolumeSource{},
+				},
+			},
+			{
 				Name: dev1.GetVolumeName(),
 				VolumeSource: apiv1.VolumeSource{
 					PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
@@ -1768,8 +1794,12 @@ services:
 					},
 					{
 						Name:      oktetoSyncSecretVolume,
-						ReadOnly:  false,
+						ReadOnly:  true,
 						MountPath: "/var/syncthing/secret/",
+					},
+					{
+						Name:      oktetoSyncDataVolume,
+						MountPath: "/var/syncthing/data/",
 					},
 					{
 						Name:      oktetoDevSecretVolume,

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -190,12 +190,6 @@ services:
 				},
 			},
 			{
-				Name: oktetoSyncDataVolume,
-				VolumeSource: apiv1.VolumeSource{
-					EmptyDir: &apiv1.EmptyDirVolumeSource{},
-				},
-			},
-			{
 				Name: dev1.GetVolumeName(),
 				VolumeSource: apiv1.VolumeSource{
 					PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
@@ -363,10 +357,6 @@ services:
 						Name:      oktetoSyncSecretVolume,
 						ReadOnly:  true,
 						MountPath: "/var/syncthing/secret/",
-					},
-					{
-						Name:      oktetoSyncDataVolume,
-						MountPath: "/var/syncthing/data/",
 					},
 					{
 						Name:      oktetoDevSecretVolume,
@@ -911,12 +901,6 @@ persistentVolume:
 				},
 			},
 			{
-				Name: oktetoSyncDataVolume,
-				VolumeSource: apiv1.VolumeSource{
-					EmptyDir: &apiv1.EmptyDirVolumeSource{},
-				},
-			},
-			{
 				Name: dev.GetVolumeName(),
 				VolumeSource: apiv1.VolumeSource{
 					EmptyDir: &apiv1.EmptyDirVolumeSource{},
@@ -978,10 +962,6 @@ persistentVolume:
 						Name:      oktetoSyncSecretVolume,
 						ReadOnly:  true,
 						MountPath: "/var/syncthing/secret/",
-					},
-					{
-						Name:      oktetoSyncDataVolume,
-						MountPath: "/var/syncthing/data/",
 					},
 					{
 						Name:      OktetoBinName,
@@ -1623,12 +1603,6 @@ services:
 				},
 			},
 			{
-				Name: oktetoSyncDataVolume,
-				VolumeSource: apiv1.VolumeSource{
-					EmptyDir: &apiv1.EmptyDirVolumeSource{},
-				},
-			},
-			{
 				Name: dev1.GetVolumeName(),
 				VolumeSource: apiv1.VolumeSource{
 					PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
@@ -1796,10 +1770,6 @@ services:
 						Name:      oktetoSyncSecretVolume,
 						ReadOnly:  true,
 						MountPath: "/var/syncthing/secret/",
-					},
-					{
-						Name:      oktetoSyncDataVolume,
-						MountPath: "/var/syncthing/data/",
 					},
 					{
 						Name:      oktetoDevSecretVolume,

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	// OktetoBinImageTag image tag with okteto internal binaries
-	OktetoBinImageTag = "jlopezbarb/bin-image:1.6.0"
+	OktetoBinImageTag = "jlopezbarb/bin:1.6.0"
 
 	errBadName = fmt.Errorf("Invalid name: must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character")
 

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	// OktetoBinImageTag image tag with okteto internal binaries
-	OktetoBinImageTag = "okteto/bin:1.5.0"
+	OktetoBinImageTag = "jlopezbarb/bin-image:1.6.0"
 
 	errBadName = fmt.Errorf("Invalid name: must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character")
 

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	// OktetoBinImageTag image tag with okteto internal binaries
-	OktetoBinImageTag = "jlopezbarb/bin:1.6.0"
+	OktetoBinImageTag = "okteto/bin:1.6.0"
 
 	errBadName = fmt.Errorf("Invalid name: must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character")
 

--- a/pkg/syncthing/install.go
+++ b/pkg/syncthing/install.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	syncthingVersion          = "1.27.6"
+	syncthingVersion          = "1.27.10"
 	syncthingVersionStringNew = 3
 	syncthingVersionStringOld = 2
 )


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes #DEV-395


- Adds a new volume as a source of truth for the syncthing config which is separated from the syncthing data
- Bump okteto binary to use these new volumes


Depends on:
- https://github.com/okteto/supervisor/pull/15
- https://github.com/okteto/bin-image/pull/12

## How to validate

1. Run okteto up 
1. Remove /var/syncthing/config.xml
1. Kill syncthing process 
1. Check that the /var/syncthing/config.xml is regenerated with the relay enabled to false

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
