### PR TITLE
remove unused func getRepoNameFromGitURL in pkg/deps

### DIFF
--- a/pkg/deps/deps.go
+++ b/pkg/deps/deps.go
@@ -15,9 +15,7 @@ package deps
 
 import (
 	"fmt"
-	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/a8m/envsubst/parse"
@@ -110,14 +108,6 @@ func (d *Dependency) ExpandVars(variables []string) error {
 	d.Variables = expandedVariables
 
 	return nil
-}
-
-func getRepoNameFromGitURL(repo *url.URL) (string, error) {
-	repoPath := strings.Split(strings.TrimPrefix(repo.Path, "/"), "/")
-	if len(repoPath) < 2 || repoPath[1] == "" {
-		return "", fmt.Errorf("dependency has invalid repository url: %s", repo.String())
-	}
-	return strings.ReplaceAll(repoPath[1], ".git", ""), nil
 }
 
 // UnmarshalYAML Implements the Unmarshaler interface of the yaml pkg.

--- a/pkg/deps/deps_test.go
+++ b/pkg/deps/deps_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	giturls "github.com/chainguard-dev/git-urls"
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -182,73 +181,6 @@ frontend:
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, deps)
 			}
-		})
-	}
-}
-
-func Test_getRepoNameFromGitURL(t *testing.T) {
-	tests := []struct {
-		name     string
-		repoUrl  string
-		expected string
-		wantErr  bool
-	}{
-		{
-			name:     "https url with trailing slash",
-			repoUrl:  "https://git-server.com/org/repo/",
-			expected: "repo",
-		},
-		{
-			name:     "https url",
-			repoUrl:  "https://git-server.com/org/repo",
-			expected: "repo",
-		},
-		{
-			name:     "https url with git extension",
-			repoUrl:  "https://git-server.com/org/repo.git",
-			expected: "repo",
-		},
-		{
-			name:     "ssh url",
-			repoUrl:  "git@git-server.com:org/repo.git",
-			expected: "repo",
-		},
-		{
-			name:     "ssh url without .git",
-			repoUrl:  "git@git-server.com:org/repo",
-			expected: "repo",
-		},
-		{
-			name:     "missing repo name",
-			repoUrl:  "https//git-server/org",
-			expected: "",
-			wantErr:  true,
-		},
-		{
-			name:     "invalid url",
-			repoUrl:  "foo//foo/foo",
-			expected: "",
-			wantErr:  true,
-		},
-		{
-			name:     "empty",
-			repoUrl:  "foo",
-			expected: "",
-			wantErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			url, err := giturls.Parse(tt.repoUrl)
-			assert.NoError(t, err)
-			result, err := getRepoNameFromGitURL(url)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
In a [previous PR](https://github.com/okteto/okteto/pull/4416/files#diff-68d2867a9cb66aed53abf9d12bc5b49da18c1fd41f7500e139ceb733d743ab93L133) we removed the only usage of the func `getRepoNameFromGitURL` which now is unused. Randomly caught while reviewing other PRs. 
