### PR TITLE
fix smartbuild nested scenario

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -93,6 +93,13 @@ func NewBuilder(builder buildCmd.OktetoBuilderInterface, registry oktetoRegistry
 	if err != nil {
 		ioCtrl.Logger().Infof("could not get working dir: %s", err)
 	}
+	topLevelGitDir, err := repository.FindTopLevelGitDir(wd)
+	if err != nil {
+		ioCtrl.Logger().Infof("could not get top level git dir: %s", err)
+	}
+	if topLevelGitDir != "" {
+		wd = topLevelGitDir
+	}
 	gitRepo := repository.NewRepository(wd)
 	config := getConfigStateless(registry, gitRepo, ioCtrl.Logger(), okCtx.IsOktetoCluster())
 


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-587

Smart Builds in `okteto build` fail when the manifest is located in a nested directory compared to the `.git`.

## How to validate

1. Setup the scenario
```
cd $(mktemp -d)
git init .
mkdir okteto
mkdir okteto/data
echo "test" > okteto/data/config.yaml
```
2. create the following `./okteto/okteto.yml` 
```
build:
  debugger:
    context: debugger

deploy:
  - okteto deploy -f docker-compose.yaml
```
3. create the following `./okteto/docker-compose.yaml`
```
services:
  demo:
    image: ${OKTETO_BUILD_DEBUGGER_IMAGE}
    volumes:
      - ./data/config.yml:/config.yml
```
4. run `okteto build` from the `okteto` folder and observe the warning `Smart builds cannot access git metadata, building image "demo"...`. Running it from the root folder would work.
5. try with the build from this branch and notice the warning is gone

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
