### PR TITLE
feat: Add env vars wit prefix OKTETO_ENV 

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -585,6 +585,9 @@ func getOktetoPrefixEnvVars(environ []string) map[string]string {
 	envFormatParts := 2
 	for _, v := range environ {
 		result := strings.SplitN(v, "=", envFormatParts)
+		if len(result) != envFormatParts {
+			continue
+		}
 		key := result[0]
 		if strings.HasPrefix(key, "OKTETO_") {
 			value := result[1]

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -140,10 +140,10 @@ type Runner struct {
 	builder              Builder
 	oktetoClientProvider OktetoClientProvider
 	ioCtrl               *io.Controller
+	getEnviron           func() []string
 	// sshAuthSockEnvvar is the default for SSH_AUTH_SOCK. Provided mostly for testing
 	sshAuthSockEnvvar  string
 	useInternalNetwork bool
-	getEnviron         func() []string
 }
 
 // Params struct to pass the necessary parameters to create the Dockerfile

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -582,9 +582,13 @@ func GetOriginalCWD(workingDirectoryCtrl filesystem.WorkingDirectoryInterface, m
 
 func getOktetoPrefixEnvVars(environ []string) map[string]string {
 	prefixEnvVars := make(map[string]string)
+	envFormatParts := 2
 	for _, v := range environ {
-		if strings.HasPrefix(v, "OKTETO_") {
-			prefixEnvVars[strings.Split(v, "=")[0]] = strings.Split(v, "=")[1]
+		result := strings.SplitN(v, "=", envFormatParts)
+		key := result[0]
+		if strings.HasPrefix(key, "OKTETO_") {
+			value := result[1]
+			prefixEnvVars[key] = value
 		}
 	}
 	return prefixEnvVars

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -838,14 +838,17 @@ func TestCreateDockerignoreFileWithFilesystem(t *testing.T) {
 
 func TestGetOktetoPrefixEnvVars(t *testing.T) {
 	expectedEnvVars := map[string]string{
-		"OKTETO_ENV_VAR_1": "value1",
-		"OKTETO_ENV_VAR_2": "value2",
+		"OKTETO_ENV_VAR_1":                        "value1",
+		"OKTETO_ENV_VAR_2":                        "value2",
+		"OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED": "MYVALUEWITHEQUAL=INVALUE",
 	}
 
 	environ := []string{
 		"OKTETO_ENV_VAR_1=value1",
 		"OKTETO_ENV_VAR_2=value2",
 		"NON_OKTETO_ENV_VAR=value3",
+		"OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED=MYVALUEWITHEQUAL=INVALUE",
+		"OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED",
 	}
 
 	prefixEnvVars := getOktetoPrefixEnvVars(environ)

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -851,8 +851,6 @@ func TestGetOktetoPrefixEnvVars(t *testing.T) {
 	prefixEnvVars := getOktetoPrefixEnvVars(environ)
 
 	for key, value := range expectedEnvVars {
-		if prefixEnvVars[key] != value {
-			t.Errorf("Expected value for environment variable %s is %s, but got %s", key, value, prefixEnvVars[key])
-		}
+		assert.Equal(t, value, prefixEnvVars[key])
 	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes DEV-580

Adds all the possible feature flags to the deploy on remote

## How to validate

1. Using the following `okteto.yml`:
```yaml
deploy:
  - echo $OKTETO_FEATURE_FLAG
```
2. Run `export OKTETO_FEATURE_FLAG=true`
3. Run `okteto deploy --remote` and check that the value is the correct one

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
