### PR TITLE
Fixed typo in a feature flag to enable dev branch tracking on okteto up

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -42,8 +42,11 @@ import (
 )
 
 const (
+	// oldEnableDevBranchTrackingEnvVar enables or disables the dev branch tracking by the env var OKTETO_TRACK_DEV_BANCH_ENABLED
+	oldEnableDevBranchTrackingEnvVar = "OKTETO_TRACK_DEV_BANCH_ENABLED"
+
 	// enableDevBranchTrackingEnvVar enables or disables the dev branch tracking by the env var OKTETO_TRACK_DEV_BANCH_ENABLED
-	enableDevBranchTrackingEnvVar = "OKTETO_TRACK_DEV_BANCH_ENABLED"
+	enableDevBranchTrackingEnvVar = "OKTETO_TRACK_DEV_BRANCH_ENABLED"
 
 	// devBranchTrackingIntervalEnvVar sets the tracking interval for branch trackin (if enabled) using OKTETO_TRACK_DEV_BRANCH_INTERVAL
 	devBranchTrackingIntervalEnvVar = "OKTETO_TRACK_DEV_BRANCH_INTERVAL"
@@ -577,18 +580,18 @@ func (up *upContext) waitUntilAppIsAwaken(ctx context.Context, app apps.App) err
 
 // TrackLatestBranchOnDevContainer tracks the latest branch on the dev container
 func TrackLatestBranchOnDevContainer(ctx context.Context, manifest *model.Manifest, manifestPathFlag string, clientProvider okteto.K8sClientProvider) {
-	if !env.LoadBoolean(enableDevBranchTrackingEnvVar) {
+	if !env.LoadBoolean(oldEnableDevBranchTrackingEnvVar) && !env.LoadBoolean(enableDevBranchTrackingEnvVar) {
 		oktetoLog.Infof("branch tracking is disabled")
 		return
 	}
 
-	// if the manfiest deploy is empty we can't update the configmap because it doesn't exist
+	// if the manifest deploy is empty we can't update the configmap because it doesn't exist
 	if manifest.Deploy == nil {
 		oktetoLog.Infof("no deploy section found in the manifest")
 		return
 	}
 
-	gitRepo, err := repository.FindTopLevelGitDir((manifestPathFlag))
+	gitRepo, err := repository.FindTopLevelGitDir(manifestPathFlag)
 	if err != nil {
 		oktetoLog.Infof("error finding git repository: %s", err.Error())
 		return

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -42,7 +42,8 @@ import (
 )
 
 const (
-	// oldEnableDevBranchTrackingEnvVar enables or disables the dev branch tracking by the env var OKTETO_TRACK_DEV_BANCH_ENABLED
+	// oldEnableDevBranchTrackingEnvVar enables or disables the dev branch tracking by the env var OKTETO_TRACK_DEV_BANCH_ENABLED.
+	// This was a typo but keeping it to reduce friction with customers that are already using it. It will go away eventually
 	oldEnableDevBranchTrackingEnvVar = "OKTETO_TRACK_DEV_BANCH_ENABLED"
 
 	// enableDevBranchTrackingEnvVar enables or disables the dev branch tracking by the env var OKTETO_TRACK_DEV_BANCH_ENABLED


### PR DESCRIPTION
# Proposed changes

Raised by a customer, we had a typo in the feature flag env var. As they are already using the old one, we keep considering it to reduce friction with them, but eventually it would go away.

