### PR TITLE
feat: Update contextCMD.Run() arguments to include K8sContext

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -191,7 +191,7 @@ $ okteto deploy --build=false`,
 				return err
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Namespace: options.Namespace}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Namespace: options.Namespace, Context: options.K8sContext}); err != nil {
 				return err
 			}
 

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -109,7 +109,7 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 
 			// false for 'json' and 'md' to avoid breaking their syntax
 			showCtxHeader := options.Output == ""
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: options.Namespace, Show: showCtxHeader}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: options.Namespace, Context: options.K8sContext, Show: showCtxHeader}); err != nil {
 				return err
 			}
 

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -58,6 +58,7 @@ type deployFlags struct {
 	branch       string
 	repository   string
 	name         string
+	k8sContext   string
 	namespace    string
 	file         string
 	variables    []string
@@ -110,6 +111,7 @@ okteto pipeline deploy --wait=false`,
 
 			ctxOptions := &contextCMD.Options{
 				Namespace: flags.namespace,
+				Context:   flags.k8sContext,
 				Show:      true,
 			}
 			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
@@ -134,6 +136,7 @@ okteto pipeline deploy --wait=false`,
 	}
 
 	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "context where the development environment was deployed")
 	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace where the pipeline is deployed (defaults to the current namespace)")
 	cmd.Flags().StringVarP(&flags.repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
 	cmd.Flags().StringVarP(&flags.branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -35,6 +35,7 @@ import (
 // destroyFlags represents the user input for a pipeline destroy command
 type destroyFlags struct {
 	name           string
+	k8sContext     string
 	namespace      string
 	wait           bool
 	destroyVolumes bool
@@ -62,6 +63,7 @@ okteto pipeline destroy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctxOptions := &contextCMD.Options{
 				Namespace: flags.namespace,
+				Context:   flags.k8sContext,
 				Show:      true,
 			}
 			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
@@ -82,6 +84,7 @@ okteto pipeline destroy --wait=false`,
 	}
 
 	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "context where the development environment was deployed")
 	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace where the pipeline is destroyed (defaults to the current namespace)")
 	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the pipeline finishes")
 	cmd.Flags().BoolVarP(&flags.destroyVolumes, "volumes", "v", false, "destroy persistent volumes created by the pipeline (defaults to false)")

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -42,6 +42,7 @@ var (
 type DeployOptions struct {
 	branch     string
 	file       string
+	k8sContext string
 	name       string
 	repository string
 	scope      string
@@ -71,7 +72,7 @@ okteto preview deploy --wait=false`,
 				return err
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Context: opts.k8sContext}); err != nil {
 				return err
 			}
 
@@ -86,6 +87,7 @@ okteto preview deploy --wait=false`,
 			return previewCmd.ExecuteDeployPreview(ctx, opts)
 		},
 	}
+	cmd.Flags().StringVarP(&opts.k8sContext, "context", "c", "", "context where the development environment was deployed")
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
 	cmd.Flags().StringVarP(&opts.repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
 	cmd.Flags().StringVarP(&opts.scope, "scope", "s", "global", "the scope of preview environment to create. Accepted values are ['personal', 'global']")

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -48,8 +48,9 @@ func newDestroyPreviewCommand(okClient types.OktetoInterface, k8sClient kubernet
 }
 
 type DestroyOptions struct {
-	name string
-	wait bool
+	name       string
+	k8sContext string
+	wait       bool
 }
 
 // Destroy destroy a preview
@@ -64,7 +65,7 @@ okteto preview destroy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = getExpandedName(args[0])
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Context: opts.k8sContext}); err != nil {
 				return err
 			}
 
@@ -87,6 +88,7 @@ okteto preview destroy --wait=false`,
 			return err
 		},
 	}
+	cmd.Flags().StringVarP(&opts.k8sContext, "context", "c", "", "context where the development environment was deployed")
 	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the preview environment gets destroyed")
 	return cmd
 }

--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -33,6 +33,7 @@ import (
 // Endpoints show all the endpoints of a preview environment
 func Endpoints(ctx context.Context) *cobra.Command {
 	var output string
+	var k8sContext string
 
 	cmd := &cobra.Command{
 		Use:   "endpoints <name>",
@@ -46,7 +47,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 				oktetoLog.SetOutput(jsonContextBuffer)
 			}
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: previewName}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Namespace: previewName, Context: k8sContext}); err != nil {
 				return err
 			}
 
@@ -68,6 +69,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the development environment was deployed")
 	cmd.Flags().StringVarP(&output, "output", "o", "", "output format. One of: ['json', 'md']")
 
 	return cmd

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -35,8 +35,10 @@ var (
 
 // listFlags are the flags available for list commands
 type listFlags struct {
-	output string
-	labels []string
+	output     string
+	k8sContext string
+	namespace  string
+	labels     []string
 }
 
 type previewOutput struct {
@@ -65,7 +67,10 @@ func List(ctx context.Context) *cobra.Command {
 		Use:   "list",
 		Short: "List all preview environments",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctxOptions := &contextCMD.Options{}
+			ctxOptions := &contextCMD.Options{
+				Namespace: flags.namespace,
+				Context:   flags.k8sContext,
+			}
 
 			if flags.output == "" {
 				ctxOptions.Show = true
@@ -87,6 +92,9 @@ func List(ctx context.Context) *cobra.Command {
 			return listCmd.run(ctx)
 		},
 	}
+
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "context where the development environment was deployed")
+	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace where the pipeline is deployed (defaults to the current namespace)")
 	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize preview environments using labels (multiple --label flags accepted)")
 	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "output format. One of: ['json', 'yaml']")
 

--- a/cmd/preview/sleep.go
+++ b/cmd/preview/sleep.go
@@ -27,13 +27,14 @@ import (
 
 // Sleep sleeps a preview environment
 func Sleep(ctx context.Context) *cobra.Command {
+	var k8sContext string
 	cmd := &cobra.Command{
 		Use:   "sleep <name>",
 		Short: "Sleeps a preview environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prToSleep := args[0]
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Context: k8sContext}); err != nil {
 				return err
 			}
 
@@ -49,6 +50,7 @@ func Sleep(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the development environment was deployed")
 	return cmd
 }
 

--- a/cmd/preview/wake.go
+++ b/cmd/preview/wake.go
@@ -27,13 +27,14 @@ import (
 
 // Wake wakes a preview environment
 func Wake(ctx context.Context) *cobra.Command {
+	var k8sContext string
 	cmd := &cobra.Command{
 		Use:   "wake <name>",
 		Short: "Wakes a preview environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prToWake := args[0]
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Context: k8sContext}); err != nil {
 				return err
 			}
 
@@ -49,6 +50,7 @@ func Wake(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the development environment was deployed")
 	return cmd
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -69,7 +69,7 @@ func Status(fs afero.Fs) *cobra.Command {
 
 			ctx := context.Background()
 
-			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Namespace: namespace}); err != nil {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Namespace: namespace, Context: k8sContext}); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-453

- We were not using k8sContext that were in the flags on certain commands. This PR add to them

## How to validate

You'll need three different contexts. The one you're pointing to, the one in the `.env` file and the one passed as argument.

1. Create the file `.env` with the following content:
```.env
OKTETO_NAMESPACE=Another namespace that you are pointing
OKTETO_CONTEXT=One different to the one you're pointing to
```
2. On any folder with a repo run the following commands:
`okteto deploy --namespace anotherOne --context thirdContext`: You should be able to see that the command is executed in the context/namespace defined by the flags
`okteto deploy`: You should be able to see the message that the context and namespace are initialised by the environment variables and executed in the context/namespace defined in the `.env` file
Remove the `.env` file and run again `okteto deploy`. Check that you are running on the current context


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
