### PR TITLE
Add context store validation

### DIFF
--- a/cmd/build/basic/build_test.go
+++ b/cmd/build/basic/build_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -33,6 +34,15 @@ type fakeBuildRunner struct {
 func (f *fakeBuildRunner) Run(ctx context.Context, buildOptions *types.BuildOptions, ioCtrl *io.Controller) error {
 	args := f.Called(ctx, buildOptions, ioCtrl)
 	return args.Error(0)
+}
+func TestMain(m *testing.M) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
+	os.Exit(m.Run())
 }
 
 func TestBuildWithErrorFromDockerfile(t *testing.T) {

--- a/cmd/build/v1/build_test.go
+++ b/cmd/build/v1/build_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -38,6 +39,12 @@ func (f *fakeBuildRunner) Run(ctx context.Context, buildOptions *types.BuildOpti
 func TestBuildWithErrorFromDockerfile(t *testing.T) {
 	ctx := context.Background()
 
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
 	buildRunner := &fakeBuildRunner{}
 	bc := NewBuilder(buildRunner, io.NewIOController())
 	dir, err := createDockerfile(t)
@@ -67,6 +74,12 @@ func TestBuildWithErrorFromDockerfile(t *testing.T) {
 
 func TestBuildWithErrorFromImageExpansion(t *testing.T) {
 	ctx := context.Background()
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
 
 	buildRunner := &fakeBuildRunner{}
 	bc := NewBuilder(buildRunner, io.NewIOController())
@@ -89,6 +102,12 @@ func TestBuildWithErrorFromImageExpansion(t *testing.T) {
 
 func TestBuildWithNoErrorFromDockerfile(t *testing.T) {
 	ctx := context.Background()
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
 
 	buildRunner := &fakeBuildRunner{}
 	bc := NewBuilder(buildRunner, io.NewIOController())
@@ -120,6 +139,12 @@ func TestBuildWithNoErrorFromDockerfile(t *testing.T) {
 func TestBuildWithNoErrorFromDockerfileAndNoTag(t *testing.T) {
 	ctx := context.Background()
 
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
 	buildRunner := &fakeBuildRunner{}
 	bc := NewBuilder(buildRunner, io.NewIOController())
 	dir, err := createDockerfile(t)

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -177,6 +177,16 @@ func NewFakeBuilder(builder buildCmd.OktetoBuilderInterface, registry oktetoRegi
 	}
 }
 
+func TestMain(m *testing.M) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
+	os.Exit(m.Run())
+}
+
 func TestValidateOptions(t *testing.T) {
 	var tests = []struct {
 		buildSection build.ManifestBuild

--- a/cmd/kubetoken/kubetoken_test.go
+++ b/cmd/kubetoken/kubetoken_test.go
@@ -15,6 +15,7 @@ package kubetoken
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
@@ -51,6 +52,16 @@ type fakeCtxCmdRunner struct {
 
 func (f fakeCtxCmdRunner) Run(ctx context.Context, ctxOptions *contextCMD.Options) error {
 	return f.err
+}
+
+func TestMain(m *testing.M) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
+	os.Exit(m.Run())
 }
 
 func TestKubetoken(t *testing.T) {

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -15,6 +15,7 @@ package istio
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -27,6 +28,16 @@ import (
 	istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestMain(m *testing.M) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {},
+		},
+		CurrentContext: "test",
+	}
+	os.Exit(m.Run())
+}
 
 func Test_translateDivertVirtualService(t *testing.T) {
 	tests := []struct {

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -261,7 +261,24 @@ func GetContextStoreFromStorePath() *ContextStore {
 		oktetoLog.Errorf("error decoding okteto contexts: %v", err)
 		oktetoLog.Fatalf(oktetoErrors.ErrCorruptedOktetoContexts, config.GetOktetoContextFolder())
 	}
+	if err := validateContextStore(ctxStore); err != nil {
+		oktetoLog.Errorf("error validating okteto contexts: %v", err)
+		oktetoLog.Fatalf(oktetoErrors.ErrCorruptedOktetoContexts, config.GetOktetoContextFolder())
+	}
 	return ctxStore
+}
+
+func validateContextStore(ctxStore *ContextStore) error {
+	if ctxStore.Contexts == nil {
+		return fmt.Errorf("contexts cannot be nil")
+	}
+	if ctxStore.CurrentContext == "" {
+		return fmt.Errorf("current-context is empty")
+	}
+	if _, ok := ctxStore.Contexts[ctxStore.CurrentContext]; !ok {
+		return fmt.Errorf("current-context '%s' not found in contexts", ctxStore.CurrentContext)
+	}
+	return nil
 }
 
 func GetContext() *Context {

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -275,7 +276,7 @@ func TestGetContextStoreFromStorePath(t *testing.T) {
 		_ = fs.RemoveAll(tempDir)
 	}()
 
-	content := `{"contexts": {}, "current-context": ""}`
+	content := `{"contexts": {"test":{}}, "current-context": "test"}`
 	_, err = file.WriteString(content)
 	require.NoError(t, err)
 
@@ -284,7 +285,77 @@ func TestGetContextStoreFromStorePath(t *testing.T) {
 	store := GetContextStoreFromStorePath()
 
 	expected := &ContextStore{
-		Contexts: make(map[string]*Context),
+		Contexts: map[string]*Context{
+			"test": {},
+		},
+		CurrentContext: "test",
 	}
 	require.EqualValues(t, expected, store)
+}
+
+func TestValidateContextStore(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctxStore    *ContextStore
+		expectedErr bool
+		expectedMsg string
+	}{
+		{
+			name: "Valid ContextStore",
+			ctxStore: &ContextStore{
+				Contexts: map[string]*Context{
+					"context1": {},
+					"context2": {},
+				},
+				CurrentContext: "context1",
+			},
+			expectedErr: false,
+			expectedMsg: "",
+		},
+		{
+			name: "Nil Contexts",
+			ctxStore: &ContextStore{
+				Contexts:       nil,
+				CurrentContext: "context1",
+			},
+			expectedErr: true,
+			expectedMsg: "contexts cannot be nil",
+		},
+		{
+			name: "Empty CurrentContext",
+			ctxStore: &ContextStore{
+				Contexts: map[string]*Context{
+					"context1": {},
+					"context2": {},
+				},
+				CurrentContext: "",
+			},
+			expectedErr: true,
+			expectedMsg: "current-context is empty",
+		},
+		{
+			name: "CurrentContext not in Contexts",
+			ctxStore: &ContextStore{
+				Contexts: map[string]*Context{
+					"context1": {},
+					"context2": {},
+				},
+				CurrentContext: "context3",
+			},
+			expectedErr: true,
+			expectedMsg: "current-context 'context3' not found in contexts",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateContextStore(tt.ctxStore)
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.expectedMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-339

This pull request adds validation to the context store to ensure that it is not nil, that the current context is not empty, and that the current context exists in the list of contexts. This helps prevent errors and ensures the integrity of the context store.

- Add okteto.CurrentStore to the tests that were relying in the file itself

## How to validate

1. Using the following config.json:
```json
{
	"current-context": "https://product.okteto.dev"
}
```
2. Run `okteto deploy` on any repo and see error

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
