### PR TITLE
feat: Add extractImageTagFromPullAccessDeniedError function

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -143,6 +143,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		oktetoLog.SetStage("remote deploy")
 		var userErr oktetoErrors.UserError
 		if errors.As(err, &userErr) {
+			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error deploying application: %s", userErr.Error())
 			return userErr
 		}
 		return fmt.Errorf("error deploying application: %w", err)

--- a/pkg/cmd/build/errors.go
+++ b/pkg/cmd/build/errors.go
@@ -35,12 +35,12 @@ func getErrorMessage(err error, tag string) error {
 	switch {
 	case isLoggedIntoRegistryButDontHavePermissions(err):
 		err = oktetoErrors.UserError{
-			E:    fmt.Errorf("error building image '%s': You are not authorized to push image '%s'", tag, imageTag),
+			E:    fmt.Errorf("failed to push image '%s': You are not authorized to push image '%s'", tag, imageTag),
 			Hint: fmt.Sprintf("Please log in into the registry '%s' with a user with push permissions to '%s' or use another image.", imageRegistry, imageTag),
 		}
 	case isNotLoggedIntoRegistry(err):
 		err = oktetoErrors.UserError{
-			E:    fmt.Errorf("error building image '%s': You are not authorized to push image '%s'", tag, imageTag),
+			E:    fmt.Errorf("failed to push image '%s': You are not authorized to push image '%s'", tag, imageTag),
 			Hint: fmt.Sprintf("Log in into the registry '%s' and verify that you have permissions to push the image '%s'.", imageRegistry, imageTag),
 		}
 	case isBuildkitServiceUnavailable(err):
@@ -53,7 +53,7 @@ func getErrorMessage(err error, tag string) error {
 			imageTag = extractImageTagFromPullAccessDeniedError(err)
 		}
 		err = oktetoErrors.UserError{
-			E:    fmt.Errorf("error building image: failed to pull image '%s'. The repository is not accessible or it does not exist", imageTag),
+			E:    fmt.Errorf("failed to pull image '%s'. The repository is not accessible or it does not exist", imageTag),
 			Hint: fmt.Sprintf("Please verify the name of the image '%s' to make sure it exists.", imageTag),
 		}
 	default:

--- a/pkg/cmd/build/errors_test.go
+++ b/pkg/cmd/build/errors_test.go
@@ -41,7 +41,7 @@ func Test_getErrorMessage(t *testing.T) {
 			err:  errors.New("insufficient_scope: authorization failed"),
 			tag:  imageTag,
 			expected: oktetoErrors.UserError{
-				E:    fmt.Errorf("error building image '%s': You are not authorized to push image '%s'", imageTag, imageTag),
+				E:    fmt.Errorf("failed to push image '%s': You are not authorized to push image '%s'", imageTag, imageTag),
 				Hint: fmt.Sprintf("Please log in into the registry '%s' with a user with push permissions to '%s' or use another image.", "docker.io", imageTag),
 			},
 		},
@@ -50,7 +50,7 @@ func Test_getErrorMessage(t *testing.T) {
 			err:  errors.New("failed to authorize: failed to fetch anonymous token"),
 			tag:  imageTag,
 			expected: oktetoErrors.UserError{
-				E:    fmt.Errorf("error building image '%s': You are not authorized to push image '%s'", imageTag, imageTag),
+				E:    fmt.Errorf("failed to push image '%s': You are not authorized to push image '%s'", imageTag, imageTag),
 				Hint: fmt.Sprintf("Log in into the registry '%s' and verify that you have permissions to push the image '%s'.", "docker.io", imageTag),
 			},
 		},
@@ -95,7 +95,7 @@ func Test_getErrorMessage(t *testing.T) {
 			err:  errors.New("pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed"),
 			tag:  imageTag,
 			expected: oktetoErrors.UserError{
-				E:    fmt.Errorf("error building image: failed to pull image '%s'. The repository is not accessible or it does not exist", imageTag),
+				E:    fmt.Errorf("failed to pull image '%s'. The repository is not accessible or it does not exist", imageTag),
 				Hint: fmt.Sprintf("Please verify the name of the image '%s' to make sure it exists.", imageTag),
 			},
 		},

--- a/pkg/cmd/build/errors_test.go
+++ b/pkg/cmd/build/errors_test.go
@@ -200,3 +200,38 @@ func Test_isTransientError(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractImageTagFromPullAccessDeniedError(t *testing.T) {
+	tests := []struct {
+		err      error
+		expected string
+	}{
+		{
+			err:      errors.New("pull access denied"),
+			expected: "",
+		},
+		{
+			err:      errors.New("failed to solve: registry/myimage: pull access denied, repository does not exist or may require authorizatio"),
+			expected: "registry/myimage",
+		},
+		{
+			err:      errors.New("failed to solve: myimage: pull access denied, repository does not exist or may require authorizatio"),
+			expected: "myimage",
+		},
+		{
+			err:      errors.New("failed to solve: okteto.dev/myimage: pull access denied, repository does not exist or may require authorizatio"),
+			expected: "okteto.dev/myimage",
+		},
+		{
+			err:      errors.New("failed to solve: myregistry.com/my-namespace/myimage: pull access denied, repository does not exist or may require authorizatio"),
+			expected: "myregistry.com/my-namespace/myimage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.err.Error(), func(t *testing.T) {
+			got := extractImageTagFromPullAccessDeniedError(tt.err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION

# Proposed changes

Fixes DEV-407

If there is no tagImage we get the name of the image that is failing from the error message. We need to use a regex because the grpc error is not exported and can't be used as an error. This has the problem that if something change we'd need to change but it's the only way to do it right now

This commit adds a new function `extractImageTagFromPullAccessDeniedError` to the `errors.go` file. This function extracts the image tag from the error message when a pull access is denied. It uses a regular expression to find the image tag and returns it. This function is used in the `getErrorMessage` function to provide a more informative error message when pulling an inaccessible or non-existent image.

| **Before**                                   | **After**                |
|----------------------------------------------|--------------------------|
| <img width="846" alt="Screenshot 2024-09-06 at 12 35 06" src="https://github.com/user-attachments/assets/9e40c2f5-49ea-44ba-b6d4-854cd4042b72"> | <img width="903" alt="Screenshot 2024-09-06 at 12 35 25" src="https://github.com/user-attachments/assets/5d6590b4-0dbe-4a17-a8fb-bfe7f7ce4b41"> |


## How to validate

1. On any repo with a deploy section, add deploy.image and set it to a non existent image
1. See error

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
