### PR TITLE
fix(remote): :bug: multiline preparation on dockerfile

### DIFF
--- a/cmd/registrytoken/install.go
+++ b/cmd/registrytoken/install.go
@@ -24,6 +24,7 @@ import (
 
 type InstallOptions struct {
 	Overwrite bool
+	filename  string
 }
 
 func Install() *cobra.Command {
@@ -49,6 +50,7 @@ func Install() *cobra.Command {
 			}
 
 			conf.CredentialsStore = "okteto"
+			conf.Filename = options.filename
 
 			if err := conf.Save(); err != nil {
 				return errors.Wrapf(err, "couldn't save docker config file at %q", confDir)
@@ -61,5 +63,6 @@ func Install() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&options.Overwrite, "force", "", false, "force overwrite existing credential store")
+	cmd.Flags().StringVarP(&options.filename, "filename", "f", "", "filename to store the credentials")
 	return cmd
 }

--- a/cmd/registrytoken/install.go
+++ b/cmd/registrytoken/install.go
@@ -50,7 +50,9 @@ func Install() *cobra.Command {
 			}
 
 			conf.CredentialsStore = "okteto"
-			conf.Filename = options.filename
+			if options.filename != "" {
+				conf.Filename = options.filename
+			}
 
 			if err := conf.Save(); err != nil {
 				return errors.Wrapf(err, "couldn't save docker config file at %q", confDir)

--- a/cmd/registrytoken/install.go
+++ b/cmd/registrytoken/install.go
@@ -34,7 +34,6 @@ func Install() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			confDir := config.Dir()
 			conf, err := config.Load(confDir)
-			oktetoLog.SetStage("install registry credential helper")
 			if err != nil {
 				return errors.Wrapf(err, "couldn't load docker config file from %q", confDir)
 			}

--- a/cmd/registrytoken/install.go
+++ b/cmd/registrytoken/install.go
@@ -34,6 +34,7 @@ func Install() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			confDir := config.Dir()
 			conf, err := config.Load(confDir)
+			oktetoLog.SetStage("install registry credential helper")
 			if err != nil {
 				return errors.Wrapf(err, "couldn't load docker config file from %q", confDir)
 			}

--- a/cmd/registrytoken/install.go
+++ b/cmd/registrytoken/install.go
@@ -24,7 +24,6 @@ import (
 
 type InstallOptions struct {
 	Overwrite bool
-	filename  string
 }
 
 func Install() *cobra.Command {
@@ -50,9 +49,6 @@ func Install() *cobra.Command {
 			}
 
 			conf.CredentialsStore = "okteto"
-			if options.filename != "" {
-				conf.Filename = options.filename
-			}
 
 			if err := conf.Save(); err != nil {
 				return errors.Wrapf(err, "couldn't save docker config file at %q", confDir)
@@ -65,6 +61,5 @@ func Install() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&options.Overwrite, "force", "", false, "force overwrite existing credential store")
-	cmd.Flags().StringVarP(&options.filename, "filename", "f", "", "filename to store the credentials")
 	return cmd
 }

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -35,7 +35,7 @@ deploy:
 deploy:
   image: aquasec/trivy:latest
   commands:
-    - trivy -q image alpine:3.14`
+    - trivy -q image --skip-db-update alpine:3.14`
 )
 
 // TestDeployInDeployRemote test the scenario where an okteto deploy is run inside an okteto deploy in remote

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -35,7 +35,6 @@ deploy:
 deploy:
   image: aquasec/trivy:latest
   commands:
-    - printenv
     - trivy -q image --light alpine:3.14`
 )
 

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -63,7 +63,6 @@ func TestDeployInDeployRemote(t *testing.T) {
 		Namespace:  testNamespace,
 		OktetoHome: dir,
 		Token:      token,
-		LogLevel:   "debug",
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -35,7 +35,8 @@ deploy:
 deploy:
   image: aquasec/trivy:latest
   commands:
-    - trivy -q image --skip-db-update alpine:3.14`
+    - printenv
+    - trivy -q image --light alpine:3.14`
 )
 
 // TestDeployInDeployRemote test the scenario where an okteto deploy is run inside an okteto deploy in remote

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -62,6 +62,7 @@ func TestDeployInDeployRemote(t *testing.T) {
 		Namespace:  testNamespace,
 		OktetoHome: dir,
 		Token:      token,
+		LogLevel:   "debug",
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -62,7 +62,6 @@ func TestDeployInDeployRemote(t *testing.T) {
 		Namespace:  testNamespace,
 		OktetoHome: dir,
 		Token:      token,
-		LogLevel:   "debug",
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 

--- a/integration/deploy/deploy_test.go
+++ b/integration/deploy/deploy_test.go
@@ -58,6 +58,7 @@ func TestMain(m *testing.M) {
 		log.Printf("kubectl is not in the path: %s", err)
 		os.Exit(1)
 	}
+	os.Setenv("OKTETO_MULTILINE_LOCAL_VAR", "value1\nvalue2\nvalue3")
 
 	token = integration.GetToken()
 	exitCode := m.Run()

--- a/integration/deploy/remote_test.go
+++ b/integration/deploy/remote_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
-	"github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/require"
 )
@@ -57,8 +56,6 @@ func TestDeployRemoteWithBuildCommand(t *testing.T) {
 	require.NoError(t, createOktetoManifest(dir, deployRemoteWithBuildCommandManifestContent))
 	require.NoError(t, createAppDockerfile(dir))
 
-	t.Setenv(build.DepotTokenEnvVar, "fakeToken")
-	t.Setenv(build.DepotProjectEnvVar, "fakeProject")
 	deployOptions := &commands.DeployOptions{
 		Workdir:    dir,
 		Namespace:  testNamespace,

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -97,7 +97,7 @@ ARG {{ .GitBranchArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
 RUN echo "${{ .InvalidateCacheArgName }}" > /etc/.oktetocachekey
-RUN okteto registrytoken install --force --file /okteto/bin/docker-credential-okteto --log-output=json
+RUN okteto registrytoken install --force --log-output=json
 
 {{ range $key, $val := .OktetoExecutionEnvVars}}
 ENV {{$key}}={{$val}}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -63,9 +63,7 @@ USER 0
 ENV PATH="${PATH}:/okteto/bin"
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
-{{range $key, $val := .OktetoPrefixEnvVars }}
-ARG {{$key}}={{$val}}
-{{end}}
+
 ENV {{ .RemoteDeployEnvVar }} true
 ARG {{ .NamespaceArgName }}
 ARG {{ .ContextArgName }}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -97,7 +97,7 @@ ARG {{ .GitBranchArgName }}
 ARG {{ .InvalidateCacheArgName }}
 
 RUN echo "${{ .InvalidateCacheArgName }}" > /etc/.oktetocachekey
-RUN okteto registrytoken install --force --log-output=json
+RUN okteto registrytoken install --force --file /okteto/bin/docker-credential-okteto --log-output=json
 
 {{ range $key, $val := .OktetoExecutionEnvVars}}
 ENV {{$key}}={{$val}}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -591,6 +591,7 @@ func getOktetoPrefixEnvVars(environ []string) map[string]string {
 	bannedOktetoEnvVars := map[string]bool{
 		"OKTETO_HOME":   true,
 		"OKTETO_FOLDER": true,
+		"OKTETO_PATH":   true,
 	}
 	prefixEnvVars := make(map[string]string)
 	envFormatParts := 2

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -590,6 +590,10 @@ func GetOriginalCWD(workingDirectoryCtrl filesystem.WorkingDirectoryInterface, m
 }
 
 func getOktetoPrefixEnvVars(environ []string) map[string]string {
+	bannedOktetoEnvVars := map[string]bool{
+		"OKTETO_HOME":   true,
+		"OKTETO_FOLDER": true,
+	}
 	prefixEnvVars := make(map[string]string)
 	envFormatParts := 2
 	for _, v := range environ {
@@ -598,6 +602,9 @@ func getOktetoPrefixEnvVars(environ []string) map[string]string {
 			continue
 		}
 		key := result[0]
+		if bannedOktetoEnvVars[key] {
+			continue
+		}
 		if strings.HasPrefix(key, "OKTETO_") {
 			value := result[1]
 			prefixEnvVars[key] = value

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -393,7 +393,7 @@ ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
-RUN okteto registrytoken install --force --file /okteto/bin/docker-credential-okteto --log-output=json
+RUN okteto registrytoken install --force --log-output=json
 
 
 ENV A="A"
@@ -484,7 +484,7 @@ ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
-RUN okteto registrytoken install --force --file /okteto/bin/docker-credential-okteto --log-output=json
+RUN okteto registrytoken install --force --log-output=json
 
 
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -393,7 +393,7 @@ ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
-RUN okteto registrytoken install --force --log-output=json
+RUN okteto registrytoken install --force --file /okteto/bin/docker-credential-okteto --log-output=json
 
 
 ENV A="A"
@@ -484,7 +484,7 @@ ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
-RUN okteto registrytoken install --force --log-output=json
+RUN okteto registrytoken install --force --file /okteto/bin/docker-credential-okteto --log-output=json
 
 
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -377,15 +377,15 @@ COPY . /okteto/src
 WORKDIR /okteto/src
 
 
-ENV OKTETO_BUILD_SVC2_IMAGE TWO_VALUE
+ENV OKTETO_BUILD_SVC2_IMAGE="TWO_VALUE"
 
-ENV OKTETO_BUIL_SVC_IMAGE ONE_VALUE
+ENV OKTETO_BUIL_SVC_IMAGE="ONE_VALUE"
 
 
 
-ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD dependency_pass
+ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD="dependency_pass"
 
-ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME dependency_user
+ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME="dependency_user"
 
 
 ARG OKTETO_GIT_COMMIT
@@ -396,7 +396,7 @@ RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
 
-ENV A A
+ENV A="A"
 
 
 RUN \
@@ -468,15 +468,15 @@ COPY . /okteto/src
 WORKDIR /okteto/src
 
 
-ENV OKTETO_BUILD_SVC2_IMAGE TWO_VALUE
+ENV OKTETO_BUILD_SVC2_IMAGE="TWO_VALUE"
 
-ENV OKTETO_BUIL_SVC_IMAGE ONE_VALUE
+ENV OKTETO_BUIL_SVC_IMAGE="ONE_VALUE"
 
 
 
-ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD dependency_pass
+ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD="dependency_pass"
 
-ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME dependency_user
+ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME="dependency_user"
 
 
 ARG OKTETO_GIT_COMMIT
@@ -862,5 +862,46 @@ func TestGetOktetoPrefixEnvVars(t *testing.T) {
 
 	for key, value := range expectedEnvVars {
 		assert.Equal(t, value, prefixEnvVars[key])
+	}
+}
+
+func TestFormatEnvVarValueForDocker(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single line",
+			input:    "value",
+			expected: "\"value\"",
+		},
+		{
+			name:     "multiple lines",
+			input:    "line1\nline2\nline3",
+			expected: "\"line1\\nline2\\nline3\"",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "\"\"",
+		},
+		{
+			name:     "single newline",
+			input:    "\n",
+			expected: "\"\\n\"",
+		},
+		{
+			name:     "trailing newline",
+			input:    "line1\nline2\n",
+			expected: "\"line1\\nline2\\n\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatEnvVarValueForDocker(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes # (issue)

- Use the specific syntax that docker uses for allowing multiline env vars or args.
- Add to all the e2e tests an env var that is multiline in order to test that it doesn't break

## How to validate

1. With the following okteto.yml
```yaml
deploy:
  - echo $OKTETO_MULTILINE
```
2. Run `export OKTETO_MULTILINE="This is splitted in
two lines"`
3. Run `okteto deploy` and check that is working

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
