### PR TITLE
Update cobra help message to be aligned with out official docs

### DIFF
--- a/cmd/analytics.go
+++ b/cmd/analytics.go
@@ -35,7 +35,7 @@ func Analytics() *cobra.Command {
 			return enableAnalytics()
 		},
 	}
-	cmd.Flags().BoolVarP(&disable, "disable", "d", false, "disable analytics")
+	cmd.Flags().BoolVarP(&disable, "disable", "d", false, "disable analytic collection")
 	return cmd
 }
 

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -98,8 +98,8 @@ const (
 func Build(ctx context.Context, ioCtrl *io.Controller, at, insights buildTrackerInterface, k8slogger *io.K8sLogger) *cobra.Command {
 	options := &types.BuildOptions{}
 	cmd := &cobra.Command{
-		Use:   "build [service...]",
-		Short: "Build and push the images defined in the 'build' section of your okteto manifest",
+		Use:   "build [image...]",
+		Short: "Build and push the images defined in the 'build' section of your Okteto Manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options.CommandArgs = args
 			// The context must be loaded before reading manifest. Otherwise,
@@ -138,18 +138,18 @@ func Build(ctx context.Context, ioCtrl *io.Controller, at, insights buildTracker
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the build command is executed")
-	cmd.Flags().StringVarP(&options.File, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&options.Tag, "tag", "t", "", "name and optionally a tag in the 'name:tag' format (it is automatically pushed)")
-	cmd.Flags().StringVarP(&options.Target, "target", "", "", "set the target build stage to build")
+	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&options.File, "file", "f", "", "the path to the Okteto Manifest or Dockerfile")
+	cmd.Flags().StringVarP(&options.Tag, "tag", "t", "", "tag name to be pushed (optional)")
+	cmd.Flags().StringVarP(&options.Target, "target", "", "", "target build stage to build (optional)")
 	cmd.Flags().BoolVarP(&options.NoCache, "no-cache", "", false, "do not use cache when building the image")
-	cmd.Flags().StringArrayVar(&options.CacheFrom, "cache-from", nil, "cache source images")
-	cmd.Flags().StringArrayVar(&options.ExportCache, "export-cache", nil, "export cache images")
+	cmd.Flags().StringArrayVar(&options.CacheFrom, "cache-from", nil, "list of cache source images (optional)")
+	cmd.Flags().StringArrayVar(&options.ExportCache, "export-cache", nil, "image tag for exported cache when build (optional)s")
 	cmd.Flags().StringVarP(&options.OutputMode, "progress", "", string(TTYFormat), "show plain/tty build output")
-	cmd.Flags().StringArrayVar(&options.BuildArgs, "build-arg", nil, "set build-time variables")
+	cmd.Flags().StringArrayVar(&options.BuildArgs, "build-arg", nil, "set build-time variables (optional)")
 	cmd.Flags().StringArrayVar(&options.Secrets, "secret", nil, "secret files exposed to the build. Format: id=mysecret,src=/local/secret")
-	cmd.Flags().StringVar(&options.Platform, "platform", "", "set platform if server is multi-platform capable")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "namespace against which the image will be consumed. Default is the one defined at okteto context or okteto manifest")
+	cmd.Flags().StringVar(&options.Platform, "platform", "", "specify which platform to build the container image for (optional)")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	return cmd
 }
 

--- a/cmd/context/context.go
+++ b/cmd/context/context.go
@@ -27,17 +27,18 @@ func Context() *cobra.Command {
 		Use:     "context",
 		Aliases: []string{"ctx"},
 		Args:    utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#context"),
-		Short:   "Set the default context",
-		Long: `Set the default context
+		Short:   "Set the default Okteto Context",
+		Long: `Set the default Okteto Context.
 
-A context is a group of cluster access parameters. Each context contains a Kubernetes cluster, a user, and a namespace.
-The current context is the default cluster/namespace for any Okteto CLI command.
+An Okteto Context is a group of cluster access parameters.
+Each context contains a Kubernetes cluster, a user, and a namespace.
+The current Okteto Context is the default cluster/namespace for any Okteto CLI command.
 
-To set your default context, run the ` + "`okteto context`" + ` command:
+To set your default Okteto Context, run the ` + "`okteto context`" + ` command:
 
     $ okteto context
 
-This will prompt you to select one of your existing contexts or to create a new one.
+This will prompt you to select one of your existing Okteto Contexts or to create a new one.
 `,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			okteto.SetInsecureSkipTLSVerifyPolicy(ctxOptions.InsecureSkipTlsVerify)
@@ -49,9 +50,9 @@ This will prompt you to select one of your existing contexts or to create a new 
 	cmd.AddCommand(List())
 	cmd.AddCommand(DeleteCMD())
 
-	cmd.PersistentFlags().BoolVarP(&ctxOptions.InsecureSkipTlsVerify, "insecure-skip-tls-verify", "", false, " If enabled, the server's certificate will not be checked for validity. This will make your connections insecure")
-	cmd.Flags().StringVarP(&ctxOptions.Token, "token", "t", "", "API token for authentication")
-	cmd.Flags().StringVarP(&ctxOptions.Namespace, "namespace", "n", "", "namespace of your okteto context")
+	cmd.PersistentFlags().BoolVarP(&ctxOptions.InsecureSkipTlsVerify, "insecure-skip-tls-verify", "", false, "skip validation of server's certificates")
+	cmd.Flags().StringVarP(&ctxOptions.Token, "token", "t", "", "API token for authentication. Use this when scripting or if you don't want to use browser-based authentication")
+	cmd.Flags().StringVarP(&ctxOptions.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	cmd.Flags().BoolVarP(&ctxOptions.OnlyOkteto, "okteto", "", false, "only shows okteto context options")
 	if err := cmd.Flags().MarkHidden("okteto"); err != nil {
 		oktetoLog.Infof("failed to mark 'okteto' flag as hidden: %s", err)

--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -30,7 +30,7 @@ func DeleteCMD() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Args:  utils.MinimumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#delete"),
-		Short: "Delete one or more contexts",
+		Short: "Delete one or more Okteto Contexts",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			for idx, arg := range args {
 				args[idx] = okteto.AddSchema(arg)
@@ -73,7 +73,7 @@ func Delete(okCtxs []string) error {
 					validOptions = append(validOptions, k)
 				}
 			}
-			errs = multierror.Append(errs, fmt.Errorf("'%s' context doesn't exist.", okCtx))
+			errs = multierror.Append(errs, fmt.Errorf("'%s' context doesn't exist", okCtx))
 		}
 	}
 

--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -34,7 +34,7 @@ func List() *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Args:    utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#list"),
-		Short:   "List available contexts",
+		Short:   "List available Okteto Contexts",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			if err := NewContextCommand().Run(ctx, &Options{raiseNotCtxError: true}); err != nil {

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -32,7 +32,7 @@ func Show() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#show"),
-		Short: "Print the current context",
+		Short: "Print the current Okteto Context",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -78,7 +78,7 @@ This will prompt you to select one of your existing Okteto Contexts or to create
 	}
 
 	cmd.Flags().StringVarP(&ctxOptions.Token, "token", "t", "", "API token for authentication. Use this when scripting or if you don't want to use browser-based authentication")
-	cmd.Flags().StringVarP(&ctxOptions.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespacet")
+	cmd.Flags().StringVarP(&ctxOptions.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	cmd.Flags().BoolVarP(&ctxOptions.OnlyOkteto, "okteto", "", false, "only shows okteto context options")
 	if err := cmd.Flags().MarkHidden("okteto"); err != nil {
 		oktetoLog.Infof("failed to mark 'okteto' flag as hidden: %s", err)

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -43,25 +43,18 @@ func Use() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "use [<url>|Kubernetes context]",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#use"),
-		Short: "Set the default context",
-		Long: `Set the default context
+		Short: "Set the default Okteto Context",
+		Long: `Set the default Okteto Context.
 
-A context is a group of cluster access parameters. Each context contains a Kubernetes cluster, a user, and a namespace.
-The current context is the default cluster/namespace for any Okteto CLI command.
+An Okteto Context is a group of cluster access parameters.
+Each context contains a Kubernetes cluster, a user, and a namespace.
+The current Okteto Context is the default cluster/namespace for any Okteto CLI command.
 
-To set your default context, run the ` + "`okteto context use`" + ` command:
+To set your default Okteto Context, run the ` + "`okteto context`" + ` command:
 
-    $ okteto context use
+    $ okteto context
 
-This will prompt you to select one of your existing contexts or to create a new one.
-
-You can also specify an Okteto URL:
-
-    $ okteto context use https://okteto.example.com
-
-Or a Kubernetes context:
-
-    $ okteto context use kubernetes_context_name
+This will prompt you to select one of your existing Okteto Contexts or to create a new one.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -84,8 +77,8 @@ Or a Kubernetes context:
 		},
 	}
 
-	cmd.Flags().StringVarP(&ctxOptions.Token, "token", "t", "", "API token for authentication")
-	cmd.Flags().StringVarP(&ctxOptions.Namespace, "namespace", "n", "", "namespace of your okteto context")
+	cmd.Flags().StringVarP(&ctxOptions.Token, "token", "t", "", "API token for authentication. Use this when scripting or if you don't want to use browser-based authentication")
+	cmd.Flags().StringVarP(&ctxOptions.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespacet")
 	cmd.Flags().BoolVarP(&ctxOptions.OnlyOkteto, "okteto", "", false, "only shows okteto context options")
 	if err := cmd.Flags().MarkHidden("okteto"); err != nil {
 		oktetoLog.Infof("failed to mark 'okteto' flag as hidden: %s", err)

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -162,7 +162,7 @@ func Deploy(ctx context.Context, at AnalyticsTrackerInterface, insightsTracker b
 	options := &Options{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
-		Short: "Execute the list of commands specified in the 'deploy' section of your okteto manifest",
+		Short: "Deploy your Development Environment by running the commands specified in the 'deploy' section of your Okteto Manifest",
 		Example: `# Execute okteto deploy
 $ okteto deploy
 
@@ -171,7 +171,7 @@ $ okteto deploy --remote
 
 
 # Execute okteto deploy skipping the build
-$ okteto deploy --build=false`,
+$ okteto deploy --no-build=true`,
 		Args: utils.NoArgsAccepted(""),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// validate cmd options
@@ -278,18 +278,18 @@ $ okteto deploy --build=false`,
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
-	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
-	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable (can be set more than once)")
-	cmd.Flags().BoolVarP(&options.NoBuild, "no-build", "", false, "enable/disable building images")
-	cmd.Flags().BoolVarP(&options.Dependencies, "dependencies", "", false, "deploy the dependencies from manifest")
-	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")
-	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "force run deploy commands in remote")
+	cmd.Flags().StringVar(&options.Name, "name", "", "the name of the Development Environment")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable for the deploy commands (can be set more than once)")
+	cmd.Flags().BoolVarP(&options.NoBuild, "no-build", "", false, "skips the re-build of images")
+	cmd.Flags().BoolVarP(&options.Dependencies, "dependencies", "", false, "force deployment of repositories in the 'dependencies' section")
+	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute the command using the container's default shell instead of bash")
+	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "run the deploy commands using Remote Execution")
 
-	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", true, "wait until the development environment is deployed")
-	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
+	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", true, "wait until the deployment finishes")
+	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the duration to wait for the deployment to complete")
 
 	return cmd
 }

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -87,7 +87,7 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 	fs := afero.NewOsFs()
 	cmd := &cobra.Command{
 		Use:   "endpoints",
-		Short: "Show endpoints for an environment",
+		Short: "List the public endpoints of your Development Environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.ManifestPath != "" {
 				workdir := filesystem.GetWorkdirFromManifestPath(options.ManifestPath)
@@ -155,10 +155,10 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 			return eg.showEndpoints(ctx, options)
 		},
 	}
-	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment is deployed")
-	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment is deployed")
+	cmd.Flags().StringVar(&options.Name, "name", "", "the name of the Development Environment")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "overwrite the current Okteto Context")
 
 	cmd.Flags().StringVarP(&options.Output, "output", "o", "", "output format. One of: ['json', 'md']")
 

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -137,9 +137,13 @@ func Destroy(ctx context.Context, at analyticsTrackerInterface, insights buildTr
 
 	cmd := &cobra.Command{
 		Use:   "destroy",
-		Short: `Destroy everything created by the 'okteto deploy' command`,
-		Long:  `Destroy everything created by the 'okteto deploy' command. You can also include a 'destroy' section in your okteto manifest with a list of custom commands to be executed on destroy`,
-		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#destroy"),
+		Short: `Destroy your Development Environment`,
+		Long: `Destroy your Development Environment.
+
+It automatically destroys all the Kubernetes resources created by okteto deploy.
+If you need to destroy external resources (like s3 buckets or other Cloud resources), use the 'destroy' section.
+`,
+		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.ManifestPath != "" {
 				// if path is absolute, its transformed to rel from root
@@ -257,15 +261,15 @@ func Destroy(ctx context.Context, at analyticsTrackerInterface, insights buildTr
 		},
 	}
 
-	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the Okteto manifest file")
+	cmd.Flags().StringVar(&options.Name, "name", "", "the name of the Development Environment")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "the path to the Okteto Manifest")
 	cmd.Flags().BoolVarP(&options.DestroyVolumes, "volumes", "v", false, "remove persistent volumes")
 	cmd.Flags().BoolVarP(&options.DestroyDependencies, "dependencies", "d", false, "destroy dependencies")
 	cmd.Flags().BoolVar(&options.ForceDestroy, "force-destroy", false, "forces the development environment to be destroyed even if there is an error executing the custom destroy commands defined in the manifest")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrites the namespace where the development environment was deployed")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrite the namespace where the development environment was deployed")
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment was deployed")
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute commands without bash")
-	cmd.Flags().BoolVarP(&options.DestroyAll, "all", "", false, "destroy everything in the namespace")
+	cmd.Flags().BoolVarP(&options.DestroyAll, "all", "", false, "destroy all Development Environments, excluding resources annotated with dev.okteto.com/policy: keep")
 	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "force run destroy commands in remote")
 
 	return cmd

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -43,8 +43,8 @@ type doctorOptions struct {
 func Doctor(k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 	doctorOpts := &doctorOptions{}
 	cmd := &cobra.Command{
-		Use:   "doctor [service]",
-		Short: "Generate a zip file with the okteto logs",
+		Use:   "doctor [devContainer]",
+		Short: "Generate a doctor file with all the information relevant for troubleshooting an issue. Use it when filing an issue or asking the Okteto community for help",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#doctor"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Info("starting doctor command")
@@ -114,8 +114,8 @@ func Doctor(k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVarP(&doctorOpts.DevPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&doctorOpts.Namespace, "namespace", "n", "", "namespace where the up command was executing")
-	cmd.Flags().StringVarP(&doctorOpts.K8sContext, "context", "c", "", "context where the up command was executing")
+	cmd.Flags().StringVarP(&doctorOpts.DevPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&doctorOpts.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&doctorOpts.K8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	return cmd
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -48,8 +48,8 @@ func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger, fs afero.Fs) 
 	var all bool
 
 	cmd := &cobra.Command{
-		Use:   "down [service]",
-		Short: "Deactivate your development container",
+		Use:   "down [devContainer]",
+		Short: "Deactivate your Development Container, stops the file synchronization service, and restores your previous deployment configuration",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#down"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -158,10 +158,10 @@ func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger, fs afero.Fs) 
 		},
 	}
 
-	cmd.Flags().StringVarP(&devPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().BoolVarP(&rm, "volumes", "v", false, "remove persistent volume")
-	cmd.Flags().BoolVarP(&all, "all", "A", false, "deactivate all running dev containers")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the down command is executed")
-	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the down command is executed")
+	cmd.Flags().StringVarP(&devPath, "file", "f", "", "the path to the Okteto manifest")
+	cmd.Flags().BoolVarP(&rm, "volumes", "v", false, "remove persistent volumes where your local folder is synched on remote")
+	cmd.Flags().BoolVarP(&all, "all", "A", false, "deactivate all running Development Containers")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	return cmd
 }

--- a/cmd/exec/cmd.go
+++ b/cmd/exec/cmd.go
@@ -84,17 +84,14 @@ func (e *Exec) Cmd(ctx context.Context) *cobra.Command {
 	execFlags := &execFlags{}
 
 	cmd := &cobra.Command{
-		Use:                   "exec service [flags] -- COMMAND [args...]",
+		Use:                   "exec [devContainer] [flags] -- COMMAND [args...]",
 		DisableFlagsInUseLine: true,
-		Short:                 "Execute a command in your development container",
-		Long: `Executes the provided command or the default shell inside a running pod.
-This command allows you to run tools or perform operations directly on a dev environment that is already running.
-For more information on managing pods, refer to the okteto documentation: https://www.okteto.com/docs/`,
-		Example: `# Run the 'echo this is a test' command inside the pod named 'my-pod'
-okteto exec my-pod -- echo this is a test
+		Short:                 "Execute a command inside your Development Container",
+		Example: `# Run the 'echo this is a test' command inside the Development Container 'api'
+okteto exec api -- echo this is a test
 
-# Get an interactive shell session inside the pod named 'my-pod'
-okteto exec my-pod`,
+# Get an interactive shell session inside the Development Container 'api'
+okteto exec api -- bash`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if execFlags.manifestPath != "" {
 				// check that the manifest file exists
@@ -146,9 +143,9 @@ okteto exec my-pod`,
 			return e.Run(ctx, argsResult, manifest.Dev[argsResult.DevName], okteto.GetContext().Namespace)
 		},
 	}
-	cmd.Flags().StringVarP(&execFlags.manifestPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&execFlags.namespace, "namespace", "n", "", "namespace where the exec command is executed")
-	cmd.Flags().StringVarP(&execFlags.k8sContext, "context", "c", "", "context where the exec command is executed")
+	cmd.Flags().StringVarP(&execFlags.manifestPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&execFlags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&execFlags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	return cmd
 }
 

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -118,8 +118,8 @@ func (kc *Cmd) Cmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "kubetoken",
-		Short: "Print Kubernetes cluster credentials in ExecCredential format.",
-		Long: `Print Kubernetes cluster credentials in ExecCredential format.
+		Short: "Print Kubernetes cluster credentials in ExecCredential format",
+		Long: `Print Kubernetes cluster credentials in ExecCredential format
 You can find more information on 'ExecCredential' and 'client side authentication' at (https://kubernetes.io/docs/reference/config-api/client-authentication.v1/) and  https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins`,
 		Hidden: true,
 		Args:   cobra.NoArgs,
@@ -132,8 +132,8 @@ You can find more information on 'ExecCredential' and 'client side authenticatio
 			return kc.Run(ctx, flags)
 		},
 	}
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "okteto context's namespace")
-	cmd.Flags().StringVarP(&contextName, "context", "c", "", "okteto context's name")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrites the current Okteto Namespace")
+	cmd.Flags().StringVarP(&contextName, "context", "c", "", "overwrites the current Okteto Context")
 	return cmd
 }
 

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -63,7 +63,7 @@ func Logs(ctx context.Context, k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:   "logs",
-		Short: "Fetch the logs of your development environment",
+		Short: "Fetch the logs of your Development Environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if options.ManifestPath != "" {
 				// check that the manifest file exists
@@ -155,14 +155,14 @@ func Logs(ctx context.Context, k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Comm
 	}
 
 	cmd.Flags().BoolVarP(&options.All, "all", "a", false, "fetch logs from the whole namespace")
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "the namespace to use to fetch the logs (defaults to the current okteto namespace)")
-	cmd.Flags().StringVarP(&options.Context, "context", "c", "", "the context to use to fetch the logs")
-	cmd.Flags().StringVarP(&options.exclude, "exclude", "e", "", "exclude by service name (regular expression)")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&options.Context, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&options.exclude, "exclude", "e", "", "exclude by container name (regular expression)")
 	cmd.Flags().DurationVarP(&options.Since, "since", "s", defaultSinceOptionHoursValue*time.Hour, "return logs newer than a relative duration like 5s, 2m, or 3h")
 	cmd.Flags().Int64Var(&options.Tail, "tail", defaultTailOptionValue, "the number of lines from the end of the logs to show")
 	cmd.Flags().BoolVarP(&options.Timestamps, "timestamps", "t", false, "print timestamps")
-	cmd.Flags().StringVar(&options.Name, "name", "", "development environment name")
+	cmd.Flags().StringVar(&options.Name, "name", "", "the name of the Development Environment")
 
 	return cmd
 }

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -42,7 +42,7 @@ func Create(ctx context.Context) *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "create <name>",
-		Short: "Create a namespace",
+		Short: "Create an Okteto Namespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
@@ -64,8 +64,8 @@ func Create(ctx context.Context) *cobra.Command {
 		Args: utils.ExactArgsAccepted(1, ""),
 	}
 
-	options.Members = cmd.Flags().StringArrayP("members", "m", []string{}, "members of the namespace, it can the username or email")
-	cmd.Flags().BoolVarP(&options.SetCurrentNs, "use", "", true, "use the newly created namespace as the current namespace")
+	options.Members = cmd.Flags().StringArrayP("members", "m", []string{}, "members of the Okteto Namespace, it can by username or email")
+	cmd.Flags().BoolVarP(&options.SetCurrentNs, "use", "", true, "use the newly created Okteto Namespace as the current namespace")
 	return cmd
 }
 

--- a/cmd/namespace/delete.go
+++ b/cmd/namespace/delete.go
@@ -38,7 +38,7 @@ import (
 func Delete(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <name>",
-		Short: "Delete a namespace",
+		Short: "Delete an Okteto Namespace",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -30,7 +30,7 @@ import (
 func List(ctx context.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:     "list",
-		Short:   "List namespaces managed by Okteto in your current context",
+		Short:   "List your Okteto Namespaces",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -59,12 +59,12 @@ func Namespace(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 	options := &UseOptions{}
 	cmd := &cobra.Command{
 		Use:     "namespace",
-		Short:   "Configure the current namespace of the okteto context",
+		Short:   "Configure the default namespace of the Okteto Context",
 		Aliases: []string{"ns"},
 		Args:    utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#namespace"),
 		RunE:    Use(ctx).RunE,
 	}
-	cmd.Flags().BoolVarP(&options.personal, "personal", "", false, "Load personal account")
+	cmd.Flags().BoolVarP(&options.personal, "personal", "", false, "Load personal namespace")
 
 	cmd.AddCommand(Use(ctx))
 	cmd.AddCommand(List(ctx))

--- a/cmd/namespace/use.go
+++ b/cmd/namespace/use.go
@@ -40,7 +40,7 @@ func Use(ctx context.Context) *cobra.Command {
 	options := &UseOptions{}
 	cmd := &cobra.Command{
 		Use:     "use [namespace]",
-		Short:   "Configure the current namespace of the okteto context",
+		Short:   "Configure the default namespace of the Okteto Context",
 		Aliases: []string{"ns"},
 		Args:    utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#use-1"),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -67,7 +67,7 @@ func Use(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().BoolVarP(&options.personal, "personal", "", false, "Load personal account")
+	cmd.Flags().BoolVarP(&options.personal, "personal", "", false, "Load personal namespace")
 
 	return cmd
 }

--- a/cmd/namespace/wake.go
+++ b/cmd/namespace/wake.go
@@ -28,7 +28,7 @@ import (
 func Wake(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wake <name>",
-		Short: "Wakes a namespace",
+		Short: "Wakes an Okteto Namespace. By default, it wakes the default namespace in the Okteto Context",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			nsToWake := okteto.GetContext().Namespace

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -88,7 +88,7 @@ func deploy(ctx context.Context, fs afero.Fs) *cobra.Command {
 	flags := &deployFlags{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
-		Short: "Deploy an okteto pipeline",
+		Short: "Runs a job in the cluster that clones a repository and executes okteto deploy on it",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
 		Example: `To run the deploy without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
 okteto pipeline deploy --wait=false`,
@@ -135,18 +135,18 @@ okteto pipeline deploy --wait=false`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
-	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "context where the development environment was deployed")
-	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace where the pipeline is deployed (defaults to the current namespace)")
-	cmd.Flags().StringVarP(&flags.repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
-	cmd.Flags().StringVarP(&flags.branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
-	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the pipeline finishes")
-	cmd.Flags().BoolVarP(&flags.skipIfExists, "skip-if-exists", "", false, "skip the pipeline deployment if the pipeline already exists in the namespace (defaults to false)")
-	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h")
-	cmd.Flags().StringArrayVarP(&flags.variables, "var", "v", []string{}, "set a pipeline variable (can be set more than once)")
-	cmd.Flags().StringVarP(&flags.file, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "set an environment label (can be set more than once)")
-	cmd.Flags().BoolVar(&flags.reuseParams, "reuse-params", false, "if pipeline exist, reuse same params to redeploy")
+	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "the name of the Development Environment")
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&flags.repository, "repository", "r", "", "the repository to deploy (defaults to your current repository)")
+	cmd.Flags().StringVarP(&flags.branch, "branch", "b", "", "the branch to deploy (defaults to your current branch)")
+	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the deployment finishes")
+	cmd.Flags().BoolVarP(&flags.skipIfExists, "skip-if-exists", "", false, "skip the deployment if the Development Environment already exists")
+	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for the deployment, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h")
+	cmd.Flags().StringArrayVarP(&flags.variables, "var", "v", []string{}, "set a variable to be injected in the deploy commands (can be set more than once)")
+	cmd.Flags().StringVarP(&flags.file, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize Development Environments using labels (multiple --label flags accepted)")
+	cmd.Flags().BoolVar(&flags.reuseParams, "reuse-params", false, "if the Development Environment exists, reuse same parameters to redeploy")
 
 	return cmd
 }

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -56,7 +56,7 @@ func destroy(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "destroy",
-		Short: "Destroy an okteto pipeline",
+		Short: "Runs a job in the cluster that clones a repository and executes okteto destroy on it.",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#destroy-1"),
 		Example: `To run the destroy without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
 okteto pipeline destroy --wait=false`,
@@ -83,12 +83,12 @@ okteto pipeline destroy --wait=false`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "name of the pipeline (defaults to the git config name)")
-	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "context where the development environment was deployed")
-	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace where the pipeline is destroyed (defaults to the current namespace)")
-	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the pipeline finishes")
-	cmd.Flags().BoolVarP(&flags.destroyVolumes, "volumes", "v", false, "destroy persistent volumes created by the pipeline (defaults to false)")
-	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h")
+	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "the name of the Development Environment")
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the Development Environment is destroyed")
+	cmd.Flags().BoolVarP(&flags.destroyVolumes, "volumes", "v", false, "destroy persistent volumes created by the Development Environment")
+	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the duration to wait for the Development Environment to be destroyed. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h")
 	return cmd
 }
 

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -67,7 +67,7 @@ func list(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&flags.context, "context", "c", "", "overwrite the current Okteto Context")
-	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize Development Environments using labels (multiple --label flags accepted)	")
+	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize Development Environments using labels (multiple --label flags accepted)")
 	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "output format. One of: ['json', 'yaml']")
 	return cmd

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -59,16 +59,16 @@ func list(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all okteto pipelines",
+		Short: "List all your Development Environments in the current Okteto Namespace",
 		Args:  utils.NoArgsAccepted(""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pipelineListCommandHandler(ctx, flags, contextCMD.NewContextCommand().Run)
 		},
 	}
 
-	cmd.Flags().StringVarP(&flags.context, "context", "c", "", "context where the pipelines are deployed (defaults to the current context)")
-	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize dev environments using labels (multiple --label flags accepted)")
-	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace where the pipelines are deployed (defaults to the current namespace)")
+	cmd.Flags().StringVarP(&flags.context, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize Development Environments using labels (multiple --label flags accepted)	")
+	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "output format. One of: ['json', 'yaml']")
 	return cmd
 }

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -56,7 +56,7 @@ func NewCommand() (*Command, error) {
 func Pipeline(ctx context.Context, fs afero.Fs) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
-		Short: "Pipeline management commands",
+		Short: "Development Environments management commands",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#pipeline"),
 	}
 	cmd.AddCommand(deploy(ctx, fs))

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -58,7 +58,7 @@ func Deploy(ctx context.Context) *cobra.Command {
 	opts := &DeployOptions{}
 	cmd := &cobra.Command{
 		Use:   "deploy <name>",
-		Short: "Deploy a preview environment",
+		Short: "Deploy a Preview Environment",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
 		Example: `To deploy a preview environment without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
 okteto preview deploy --wait=false`,
@@ -87,16 +87,16 @@ okteto preview deploy --wait=false`,
 			return previewCmd.ExecuteDeployPreview(ctx, opts)
 		},
 	}
-	cmd.Flags().StringVarP(&opts.k8sContext, "context", "c", "", "context where the development environment was deployed")
-	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "the branch to deploy (defaults to the current branch)")
-	cmd.Flags().StringVarP(&opts.repository, "repository", "r", "", "the repository to deploy (defaults to the current repository)")
-	cmd.Flags().StringVarP(&opts.scope, "scope", "s", "global", "the scope of preview environment to create. Accepted values are ['personal', 'global']")
+	cmd.Flags().StringVarP(&opts.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "the branch to deploy (defaults to your current branch)")
+	cmd.Flags().StringVarP(&opts.repository, "repository", "r", "", "the repository to deploy (defaults to your current repository)")
+	cmd.Flags().StringVarP(&opts.scope, "scope", "s", "global", "the scope of Preview Environment to create. Accepted values are ['personal', 'global']")
 	cmd.Flags().StringVarP(&opts.sourceUrl, "sourceUrl", "", "", "the URL of the original pull/merge request.")
-	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
-	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a preview environment variable (can be set more than once)")
-	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the preview environment deployment finishes")
-	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringArrayVarP(&opts.labels, "label", "", []string{}, "set a preview environment label (can be set more than once)")
+	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", fiveMinutes, "the duration to wait for the deployment to complete. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h")
+	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a variable to be injected in the deploy commands (can be set more than once)")
+	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the deployment finishes")
+	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringArrayVarP(&opts.labels, "label", "", []string{}, "tag and organize Preview Environments using labels (multiple --label flags accepted)")
 
 	return cmd
 }

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -58,9 +58,9 @@ func Destroy(ctx context.Context) *cobra.Command {
 	opts := &DestroyOptions{}
 	cmd := &cobra.Command{
 		Use:   "destroy <name>",
-		Short: "Destroy a preview environment",
+		Short: "Destroy a Preview Environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
-		Example: `To destroy a preview environment without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
+		Example: `To destroy a Preview Environment without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
 okteto preview destroy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = getExpandedName(args[0])
@@ -88,8 +88,8 @@ okteto preview destroy --wait=false`,
 			return err
 		},
 	}
-	cmd.Flags().StringVarP(&opts.k8sContext, "context", "c", "", "context where the development environment was deployed")
-	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the preview environment gets destroyed")
+	cmd.Flags().StringVarP(&opts.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the Preview Environment destruction finishes")
 	return cmd
 }
 

--- a/cmd/preview/endpoints.go
+++ b/cmd/preview/endpoints.go
@@ -37,7 +37,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "endpoints <name>",
-		Short: "Show endpoints for a preview environment",
+		Short: "List the endpoints of a Preview Environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			previewName := args[0]
@@ -69,7 +69,7 @@ func Endpoints(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the development environment was deployed")
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	cmd.Flags().StringVarP(&output, "output", "o", "", "output format. One of: ['json', 'md']")
 
 	return cmd

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -65,7 +65,7 @@ func List(ctx context.Context) *cobra.Command {
 	flags := &listFlags{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all your Preview Environments",
+		Short: "List all Preview Environments",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctxOptions := &contextCMD.Options{
 				Namespace: flags.namespace,

--- a/cmd/preview/list.go
+++ b/cmd/preview/list.go
@@ -65,7 +65,7 @@ func List(ctx context.Context) *cobra.Command {
 	flags := &listFlags{}
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List all preview environments",
+		Short: "List all your Preview Environments",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctxOptions := &contextCMD.Options{
 				Namespace: flags.namespace,
@@ -93,9 +93,9 @@ func List(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "context where the development environment was deployed")
-	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace where the pipeline is deployed (defaults to the current namespace)")
-	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize preview environments using labels (multiple --label flags accepted)")
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrites the current Okteto Namespace")
+	cmd.Flags().StringArrayVarP(&flags.labels, "label", "", []string{}, "tag and organize Preview Environments using labels (multiple --label flags accepted)")
 	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "output format. One of: ['json', 'yaml']")
 
 	return cmd

--- a/cmd/preview/preview.go
+++ b/cmd/preview/preview.go
@@ -40,7 +40,7 @@ func NewCommand() (*Command, error) {
 func Preview(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "preview",
-		Short: "Preview environment management commands",
+		Short: "Preview Environment management commands",
 	}
 
 	cmd.AddCommand(Deploy(ctx))

--- a/cmd/preview/sleep.go
+++ b/cmd/preview/sleep.go
@@ -30,7 +30,7 @@ func Sleep(ctx context.Context) *cobra.Command {
 	var k8sContext string
 	cmd := &cobra.Command{
 		Use:   "sleep <name>",
-		Short: "Sleeps a preview environment",
+		Short: "Sleep a Preview Environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prToSleep := args[0]
@@ -50,7 +50,7 @@ func Sleep(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the development environment was deployed")
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	return cmd
 }
 

--- a/cmd/preview/wake.go
+++ b/cmd/preview/wake.go
@@ -30,7 +30,7 @@ func Wake(ctx context.Context) *cobra.Command {
 	var k8sContext string
 	cmd := &cobra.Command{
 		Use:   "wake <name>",
-		Short: "Wakes a preview environment",
+		Short: "Wake a preview environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			prToWake := args[0]
@@ -50,7 +50,7 @@ func Wake(ctx context.Context) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the development environment was deployed")
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	return cmd
 }
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -40,8 +40,8 @@ func Restart(fs afero.Fs) *cobra.Command {
 	var devPath string
 
 	cmd := &cobra.Command{
-		Use:    "restart [service]",
-		Short:  "Restart the deployments listed in the services field of a development container",
+		Use:    "restart [devContainer]",
+		Short:  "Restarts the containers corresponding to the 'services' section for a given Development Container",
 		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#restart"),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -107,9 +107,9 @@ func Restart(fs afero.Fs) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&devPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the restart command is executed")
-	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the restart command is executed")
+	cmd.Flags().StringVarP(&devPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 
 	return cmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -48,7 +48,7 @@ func Status(fs afero.Fs) *cobra.Command {
 	var watch bool
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Status of the synchronization process",
+		Short: "Status of the file synchronization process for a given Development Container",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#status"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if devPath != "" {
@@ -128,9 +128,9 @@ func Status(fs afero.Fs) *cobra.Command {
 			return err
 		},
 	}
-	cmd.Flags().StringVarP(&devPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "namespace where the up command is executing")
-	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "context where the up command is executing")
+	cmd.Flags().StringVarP(&devPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	cmd.Flags().BoolVarP(&showInfo, "info", "i", false, "show syncthing links for troubleshooting the synchronization service")
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "watch for changes")
 	return cmd

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -73,7 +73,7 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 	options := &Options{}
 	cmd := &cobra.Command{
 		Use:   "test",
-		Short: "Run unit and e2e tests defined in your okteto manifest. More information available here: https://www.okteto.com/docs/reference/okteto-cli/#test",
+		Short: "Run tests using Remote Execution",
 		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
 
 			if err := validator.CheckReservedVariablesNameOption(options.Variables); err != nil {
@@ -106,14 +106,14 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 		},
 	}
 
-	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "Overwrites the namespace where the development environment is deployed")
-	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "Context where the development environment is deployed")
-	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "Set a variable (can be set more than once)")
-	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "The length of time to wait for completion, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h ")
-	cmd.Flags().StringVar(&options.Name, "name", "", "Name of the development environment name to be deployed")
-	cmd.Flags().BoolVar(&options.Deploy, "deploy", false, "Always deploy the dev environment. If it's already deployed it will be redeployed")
-	cmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "Do not use cache for running tests")
+	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "the path to the Okteto Manifest")
+	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringArrayVarP(&options.Variables, "var", "v", []string{}, "set a variable to be injected in the test commands (can be set more than once)")
+	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the duration to wait for the Test Container to run. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h")
+	cmd.Flags().StringVar(&options.Name, "name", "", "the name of the Development Environment")
+	cmd.Flags().BoolVar(&options.Deploy, "deploy", false, "Force execution of the commands in the 'deploy' section")
+	cmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "by default, the caches of a Test Container are reused between executions")
 
 	return cmd
 }

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -374,7 +374,7 @@ okteto up api -- echo this is a test
 		},
 	}
 
-	cmd.Flags().StringVarP(&upOptions.ManifestPath, "file", "f", "", "thepath to the Okteto Manifest")
+	cmd.Flags().StringVarP(&upOptions.ManifestPath, "file", "f", "", "the path to the Okteto Manifest")
 	cmd.Flags().StringVarP(&upOptions.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	cmd.Flags().StringVarP(&upOptions.K8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	cmd.Flags().StringArrayVarP(&upOptions.Envs, "env", "e", []string{}, "set environment variable in the Development Container")

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -94,12 +94,12 @@ func Up(at analyticsTrackerInterface, insights buildDeployTrackerInterface, ioCt
 	upOptions := &Options{}
 	cmd := &cobra.Command{
 		Use:   "up service [flags] -- COMMAND [args...]",
-		Short: "Deploy your development environment",
-		Example: `  # okteto up deploying the development environment defined in the okteto manifest
-okteto up my-svc --deploy -- echo this is a test
+		Short: "Activate a Development Container",
+		Example: `# 'okteto up' re-deploying the Development Environment defined in the Okteto Manifest
+okteto up api --deploy
 
-# okteto up replacing the command defined in the okteto manifest
-okteto up my-svc -- echo this is a test
+# 'okteto up' replacing the command defined in the Okteto Manifest
+okteto up api -- echo this is a test
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if okteto.InDevContainer() {
@@ -374,17 +374,17 @@ okteto up my-svc -- echo this is a test
 		},
 	}
 
-	cmd.Flags().StringVarP(&upOptions.ManifestPath, "file", "f", "", "path to the Okteto manifest file")
-	cmd.Flags().StringVarP(&upOptions.Namespace, "namespace", "n", "", "namespace where the up command is executed")
-	cmd.Flags().StringVarP(&upOptions.K8sContext, "context", "c", "", "context where the up command is executed")
-	cmd.Flags().StringArrayVarP(&upOptions.Envs, "env", "e", []string{}, "envs to add to the development container")
-	cmd.Flags().IntVarP(&upOptions.Remote, "remote", "r", 0, "configures remote execution on the specified port")
-	cmd.Flags().BoolVarP(&upOptions.Deploy, "deploy", "d", false, "Force execution of the commands in the 'deploy' section of the okteto manifest (defaults to 'false')")
-	cmd.Flags().BoolVarP(&upOptions.ForcePull, "pull", "", false, "force dev image pull")
+	cmd.Flags().StringVarP(&upOptions.ManifestPath, "file", "f", "", "thepath to the Okteto Manifest")
+	cmd.Flags().StringVarP(&upOptions.Namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
+	cmd.Flags().StringVarP(&upOptions.K8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringArrayVarP(&upOptions.Envs, "env", "e", []string{}, "set environment variable in the Development Container")
+	cmd.Flags().IntVarP(&upOptions.Remote, "remote", "r", 0, "exposes the SSH server in a given port")
+	cmd.Flags().BoolVarP(&upOptions.Deploy, "deploy", "d", false, "force the redeployment of your Development Environment")
+	cmd.Flags().BoolVarP(&upOptions.ForcePull, "pull", "", false, "force the Development Container image to be pulled")
 	if err := cmd.Flags().MarkHidden("pull"); err != nil {
 		oktetoLog.Infof("failed to mark 'pull' flag as hidden: %s", err)
 	}
-	cmd.Flags().BoolVarP(&upOptions.Reset, "reset", "", false, "reset the file synchronization database")
+	cmd.Flags().BoolVarP(&upOptions.Reset, "reset", "", false, "resets the file synchronization service. Use it if the file synchronization service stops working")
 	return cmd
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,7 +28,7 @@ import (
 func Version() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "View the version of the okteto binary",
+		Short: "Show the current installed Okteto CLI binary version",
 		Args:  utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#version"),
 		RunE:  Show().RunE,
 	}
@@ -41,7 +41,7 @@ func Version() *cobra.Command {
 func Update() *cobra.Command {
 	return &cobra.Command{
 		Use:   "update",
-		Short: "Update Okteto CLI version",
+		Short: "Show information about how to update the Okteto CLI binary",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			currentVersion, err := semver.NewVersion(config.VersionString)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -111,8 +111,8 @@ func main() {
 
 	root := &cobra.Command{
 		Use:           fmt.Sprintf("%s COMMAND [ARG...]", config.GetBinaryName()),
-		Short:         "Okteto - Remote Development Environments powered by Kubernetes",
-		Long:          "Okteto - Remote Development Environments powered by Kubernetes",
+		Short:         "The Okteto Command Line Interface is a unified tool to manage Development Environments",
+		Long:          "The Okteto Command Line Interface is a unified tool to manage Development Environments",
 		SilenceErrors: true,
 		PersistentPreRun: func(ccmd *cobra.Command, args []string) {
 			ccmd.SilenceUsage = true

--- a/pkg/syncthing/completion.go
+++ b/pkg/syncthing/completion.go
@@ -169,7 +169,7 @@ func (wfc *waitForCompletion) isCompleted() bool {
 		}
 	}
 	if !wfc.sy.IsAllOverwritten() {
-		oktetoLog.Info("synced completed, but overwrite not sent, retrying...")
+		oktetoLog.Info("synced completed, but overwrites not sent, retrying...")
 		return false
 	}
 	return true

--- a/pkg/syncthing/completion.go
+++ b/pkg/syncthing/completion.go
@@ -169,7 +169,7 @@ func (wfc *waitForCompletion) isCompleted() bool {
 		}
 	}
 	if !wfc.sy.IsAllOverwritten() {
-		oktetoLog.Info("synced completed, but overwrites not sent, retrying...")
+		oktetoLog.Info("synced completed, but overwrite not sent, retrying...")
 		return false
 	}
 	return true

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -432,7 +432,7 @@ func (s *Syncthing) Ping(ctx context.Context, local bool) bool {
 	return false
 }
 
-// Overwrite overwrites local changes to the remote syncthing
+// Overwrite overwrite local changes to the remote syncthing
 func (s *Syncthing) Overwrite(ctx context.Context) error {
 	for _, folder := range s.Folders {
 		oktetoLog.Infof("overriding local changes to the remote syncthing path=%s", folder.LocalPath)

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -432,7 +432,7 @@ func (s *Syncthing) Ping(ctx context.Context, local bool) bool {
 	return false
 }
 
-// Overwrite overwrite local changes to the remote syncthing
+// Overwrite overwrites local changes to the remote syncthing
 func (s *Syncthing) Overwrite(ctx context.Context) error {
 	for _, folder := range s.Folders {
 		oktetoLog.Infof("overriding local changes to the remote syncthing path=%s", folder.LocalPath)


### PR DESCRIPTION
While working on our CLI 3.0 official docs, I realized we are using different terminology than in our cobra help messages.

This PR standardized to use the same terminology than in our docs, and unify the text messages too