### PR TITLE
revert default wait flag values

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -288,7 +288,7 @@ $ okteto deploy --no-build=true`,
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute the command using the container's default shell instead of bash")
 	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "run the deploy commands using Remote Execution")
 
-	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the deployment finishes")
+	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the deployment finishes and pods are healthy")
 	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the duration to wait for the deployment to complete")
 
 	return cmd

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -288,7 +288,7 @@ $ okteto deploy --no-build=true`,
 	cmd.Flags().BoolVarP(&options.RunWithoutBash, "no-bash", "", false, "execute the command using the container's default shell instead of bash")
 	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "run the deploy commands using Remote Execution")
 
-	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", true, "wait until the deployment finishes")
+	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the deployment finishes")
 	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the duration to wait for the deployment to complete")
 
 	return cmd

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -90,8 +90,8 @@ func deploy(ctx context.Context, fs afero.Fs) *cobra.Command {
 		Use:   "deploy",
 		Short: "Runs a job in the cluster that clones a repository and executes okteto deploy on it",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
-		Example: `To run the deploy and have the Okteto CLI wait for its completion, use the '--wait' flag:
-okteto pipeline deploy --wait`,
+		Example: `To run the deploy without the Okteto CLI wait for its completion, use the '--wait=false' flag:
+okteto pipeline deploy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flags.file != "" {
 				// check that the manifest file exists
@@ -140,7 +140,7 @@ okteto pipeline deploy --wait`,
 	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	cmd.Flags().StringVarP(&flags.repository, "repository", "r", "", "the repository to deploy (defaults to your current repository)")
 	cmd.Flags().StringVarP(&flags.branch, "branch", "b", "", "the branch to deploy (defaults to your current branch)")
-	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", false, "wait until the deployment finishes")
+	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the deployment finishes")
 	cmd.Flags().BoolVarP(&flags.skipIfExists, "skip-if-exists", "", false, "skip the deployment if the Development Environment already exists")
 	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for the deployment, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h")
 	cmd.Flags().StringArrayVarP(&flags.variables, "var", "v", []string{}, "set a variable to be injected in the deploy commands (can be set more than once)")

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -140,7 +140,7 @@ okteto pipeline deploy --wait=false`,
 	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
 	cmd.Flags().StringVarP(&flags.repository, "repository", "r", "", "the repository to deploy (defaults to your current repository)")
 	cmd.Flags().StringVarP(&flags.branch, "branch", "b", "", "the branch to deploy (defaults to your current branch)")
-	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the deployment finishes")
+	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", false, "wait until the deployment finishes")
 	cmd.Flags().BoolVarP(&flags.skipIfExists, "skip-if-exists", "", false, "skip the deployment if the Development Environment already exists")
 	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the length of time to wait for the deployment, zero means never. Any other values should contain a corresponding time unit e.g. 1s, 2m, 3h")
 	cmd.Flags().StringArrayVarP(&flags.variables, "var", "v", []string{}, "set a variable to be injected in the deploy commands (can be set more than once)")

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -90,8 +90,8 @@ func deploy(ctx context.Context, fs afero.Fs) *cobra.Command {
 		Use:   "deploy",
 		Short: "Runs a job in the cluster that clones a repository and executes okteto deploy on it",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#deploy-1"),
-		Example: `To run the deploy without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
-okteto pipeline deploy --wait=false`,
+		Example: `To run the deploy and have the Okteto CLI wait for its completion, use the '--wait' flag:
+okteto pipeline deploy --wait`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flags.file != "" {
 				// check that the manifest file exists

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -86,7 +86,7 @@ okteto pipeline destroy --wait=false`,
 	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "the name of the Development Environment")
 	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
-	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the Development Environment is destroyed")
+	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", false, "wait until the Development Environment is destroyed")
 	cmd.Flags().BoolVarP(&flags.destroyVolumes, "volumes", "v", false, "destroy persistent volumes created by the Development Environment")
 	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the duration to wait for the Development Environment to be destroyed. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h")
 	return cmd

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -58,8 +58,8 @@ func destroy(ctx context.Context) *cobra.Command {
 		Use:   "destroy",
 		Short: "Runs a job in the cluster that clones a repository and executes okteto destroy on it.",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#destroy-1"),
-		Example: `To run the destroy and have the Okteto CLI wait for its completion, use the '--wait' flag:
-okteto pipeline destroy --wait`,
+		Example: `To run the destroy without the Okteto CLI wait for its completion, use the '--wait=false' flag:
+okteto pipeline destroy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctxOptions := &contextCMD.Options{
 				Namespace: flags.namespace,
@@ -86,7 +86,7 @@ okteto pipeline destroy --wait`,
 	cmd.Flags().StringVarP(&flags.name, "name", "p", "", "the name of the Development Environment")
 	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
 	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "overwrite the current Okteto Namespace")
-	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", false, "wait until the Development Environment is destroyed")
+	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the Development Environment is destroyed")
 	cmd.Flags().BoolVarP(&flags.destroyVolumes, "volumes", "v", false, "destroy persistent volumes created by the Development Environment")
 	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", fiveMinutes, "the duration to wait for the Development Environment to be destroyed. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h")
 	return cmd

--- a/cmd/pipeline/destroy.go
+++ b/cmd/pipeline/destroy.go
@@ -58,8 +58,8 @@ func destroy(ctx context.Context) *cobra.Command {
 		Use:   "destroy",
 		Short: "Runs a job in the cluster that clones a repository and executes okteto destroy on it.",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#destroy-1"),
-		Example: `To run the destroy without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
-okteto pipeline destroy --wait=false`,
+		Example: `To run the destroy and have the Okteto CLI wait for its completion, use the '--wait' flag:
+okteto pipeline destroy --wait`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctxOptions := &contextCMD.Options{
 				Namespace: flags.namespace,

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -60,8 +60,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 		Use:   "deploy <name>",
 		Short: "Deploy a Preview Environment",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
-		Example: `To deploy a preview environment and have the Okteto CLI wait for its completion, use the '--wait' flag:
-okteto preview deploy --wait`,
+		Example: `To deploy a preview environment without the Okteto CLI wait for its completion, use the '--wait=false' flag:
+okteto preview deploy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -94,7 +94,7 @@ okteto preview deploy --wait`,
 	cmd.Flags().StringVarP(&opts.sourceUrl, "sourceUrl", "", "", "the URL of the original pull/merge request.")
 	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", fiveMinutes, "the duration to wait for the deployment to complete. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h")
 	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a variable to be injected in the deploy commands (can be set more than once)")
-	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", false, "wait until the deployment finishes")
+	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the deployment finishes")
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "the path to the Okteto Manifest")
 	cmd.Flags().StringArrayVarP(&opts.labels, "label", "", []string{}, "tag and organize Preview Environments using labels (multiple --label flags accepted)")
 

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -94,7 +94,7 @@ okteto preview deploy --wait=false`,
 	cmd.Flags().StringVarP(&opts.sourceUrl, "sourceUrl", "", "", "the URL of the original pull/merge request.")
 	cmd.Flags().DurationVarP(&opts.timeout, "timeout", "t", fiveMinutes, "the duration to wait for the deployment to complete. Any value should contain a corresponding time unit e.g. 1s, 2m, 3h")
 	cmd.Flags().StringArrayVarP(&opts.variables, "var", "v", []string{}, "set a variable to be injected in the deploy commands (can be set more than once)")
-	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", true, "wait until the deployment finishes")
+	cmd.Flags().BoolVarP(&opts.wait, "wait", "w", false, "wait until the deployment finishes")
 	cmd.Flags().StringVarP(&opts.file, "file", "f", "", "the path to the Okteto Manifest")
 	cmd.Flags().StringArrayVarP(&opts.labels, "label", "", []string{}, "tag and organize Preview Environments using labels (multiple --label flags accepted)")
 

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -60,8 +60,8 @@ func Deploy(ctx context.Context) *cobra.Command {
 		Use:   "deploy <name>",
 		Short: "Deploy a Preview Environment",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
-		Example: `To deploy a preview environment without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
-okteto preview deploy --wait=false`,
+		Example: `To deploy a preview environment and have the Okteto CLI wait for its completion, use the '--wait' flag:
+okteto preview deploy --wait`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -60,7 +60,7 @@ func Destroy(ctx context.Context) *cobra.Command {
 		Use:   "destroy <name>",
 		Short: "Destroy a Preview Environment",
 		Args:  utils.ExactArgsAccepted(1, ""),
-		Example: `To destroy a Preview Environment without the Okteto CLI waiting for its completion, use the '--wait=false' flag:
+		Example: `To destroy a Preview Environment without the Okteto CLI wait for its completion, use the '--wait=false' flag:
 okteto preview destroy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.name = getExpandedName(args[0])


### PR DESCRIPTION
# Proposed changes

Fixes: DEV-662

In this PR we're reverting the default value for the `--wait` flag of `okteto deploy`. In the 3.0 we wanted to change it to `true`, however, we've noticed that some DevX is not quite there and we'll come back to this later on.

## How to validate

- Try runing the commands involved

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
