### PR TITLE
Support okteto volume access mode, volume mode, labels and annotations

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -24,7 +24,6 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	apiv1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -100,7 +99,6 @@ func (tr *Translation) translate() error {
 		}
 
 		tr.DevApp.TemplateObjectMeta().Labels[model.DetachedDevLabel] = tr.getDevName()
-		TranslatePodAffinity(tr.DevApp.PodSpec(), tr.MainDev.Name)
 	}
 
 	tr.DevApp.PodSpec().TerminationGracePeriodSeconds = pointer.Int64(0)
@@ -158,30 +156,6 @@ func (tr *Translation) DevModeOff() error {
 // TranslateDevTolerations sets the user provided toleretions
 func TranslateDevTolerations(spec *apiv1.PodSpec, tolerations []apiv1.Toleration) {
 	spec.Tolerations = append(spec.Tolerations, tolerations...)
-}
-
-// TranslatePodAffinity translates the affinity of pod to be all on the same node
-func TranslatePodAffinity(spec *apiv1.PodSpec, name string) {
-	if spec.Affinity == nil {
-		spec.Affinity = &apiv1.Affinity{}
-	}
-	if spec.Affinity.PodAffinity == nil {
-		spec.Affinity.PodAffinity = &apiv1.PodAffinity{}
-	}
-	if spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-		spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = []apiv1.PodAffinityTerm{}
-	}
-	spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
-		spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
-		apiv1.PodAffinityTerm{
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					model.InteractiveDevLabel: name,
-				},
-			},
-			TopologyKey: "kubernetes.io/hostname",
-		},
-	)
 }
 
 // TranslateDevContainer translates a dev container

--- a/pkg/k8s/volumes/crud.go
+++ b/pkg/k8s/volumes/crud.go
@@ -155,6 +155,25 @@ func checkPVCValues(pvc *apiv1.PersistentVolumeClaim, dev *model.Dev, devPath st
 			)
 		}
 	}
+
+	if len(pvc.Spec.AccessModes) == 1 && dev.PersistentVolumeAccessMode() != pvc.Spec.AccessModes[0] {
+		return fmt.Errorf(
+			"okteto volume access-mode is '%s' instead of '%s'. Run '%s' and try again",
+			pvc.Spec.AccessModes[0],
+			dev.PersistentVolumeAccessMode(),
+			utils.GetDownCommand(devPath),
+		)
+	}
+
+	if pvc.Spec.VolumeMode != nil && dev.PersistentVolumeMode() != *pvc.Spec.VolumeMode {
+		return fmt.Errorf(
+			"okteto volume mode is '%s' instead of '%s'. Run '%s' and try again",
+			*pvc.Spec.VolumeMode,
+			dev.PersistentVolumeMode(),
+			utils.GetDownCommand(devPath),
+		)
+	}
+
 	return nil
 
 }

--- a/pkg/k8s/volumes/crud_test.go
+++ b/pkg/k8s/volumes/crud_test.go
@@ -31,6 +31,7 @@ import (
 
 func Test_checkPVCValues(t *testing.T) {
 	className := "class"
+	blockVolumeMode := apiv1.PersistentVolumeBlock
 	var tests = []struct {
 		pvc       *apiv1.PersistentVolumeClaim
 		dev       *model.Dev
@@ -115,7 +116,6 @@ func Test_checkPVCValues(t *testing.T) {
 			},
 			wantError: true,
 		},
-
 		{
 			name: "pvc-with-less-storage-size",
 			pvc: &apiv1.PersistentVolumeClaim{
@@ -152,6 +152,93 @@ func Test_checkPVCValues(t *testing.T) {
 				PersistentVolumeInfo: &model.PersistentVolumeInfo{
 					Size:         "20Gi",
 					StorageClass: "wrong-class",
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "pvc-with-same-access-mode",
+			pvc: &apiv1.PersistentVolumeClaim{
+				Spec: apiv1.PersistentVolumeClaimSpec{
+					StorageClassName: &className,
+					AccessModes:      []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteMany},
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							"storage": resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+			dev: &model.Dev{
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Size:         "10Gi",
+					StorageClass: "class",
+					AccessMode:   apiv1.ReadWriteMany,
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "pvc-with-different-access-mode",
+			pvc: &apiv1.PersistentVolumeClaim{
+				Spec: apiv1.PersistentVolumeClaimSpec{
+					StorageClassName: &className,
+					AccessModes:      []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteMany},
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							"storage": resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+			dev: &model.Dev{
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Size:         "10Gi",
+					StorageClass: "class",
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "pvc-with-same-volume-mode",
+			pvc: &apiv1.PersistentVolumeClaim{
+				Spec: apiv1.PersistentVolumeClaimSpec{
+					StorageClassName: &className,
+					VolumeMode:       &blockVolumeMode,
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							"storage": resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+			dev: &model.Dev{
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Size:         "10Gi",
+					StorageClass: "class",
+					VolumeMode:   blockVolumeMode,
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "pvc-with-different-access-mode",
+			pvc: &apiv1.PersistentVolumeClaim{
+				Spec: apiv1.PersistentVolumeClaimSpec{
+					StorageClassName: &className,
+					VolumeMode:       &blockVolumeMode,
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							"storage": resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+			dev: &model.Dev{
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Size:         "10Gi",
+					StorageClass: "class",
+					VolumeMode:   apiv1.PersistentVolumeFilesystem,
 				},
 			},
 			wantError: true,

--- a/pkg/k8s/volumes/translate.go
+++ b/pkg/k8s/volumes/translate.go
@@ -22,15 +22,22 @@ import (
 )
 
 func translate(dev *model.Dev) *apiv1.PersistentVolumeClaim {
+	volumeMode := dev.PersistentVolumeMode()
+	labels := map[string]string{
+		constants.DevLabel: "true",
+	}
+	for k, v := range dev.PersistentVolumeLabels() {
+		labels[k] = v
+	}
 	pvc := &apiv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: dev.GetVolumeName(),
-			Labels: map[string]string{
-				constants.DevLabel: "true",
-			},
+			Name:        dev.GetVolumeName(),
+			Labels:      labels,
+			Annotations: dev.PersistentVolumeAnnotations(),
 		},
 		Spec: apiv1.PersistentVolumeClaimSpec{
-			AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOnce},
+			AccessModes: []apiv1.PersistentVolumeAccessMode{dev.PersistentVolumeAccessMode()},
+			VolumeMode:  &volumeMode,
 			Resources: apiv1.ResourceRequirements{
 				Requests: apiv1.ResourceList{
 					"storage": resource.MustParse(dev.PersistentVolumeSize()),

--- a/pkg/k8s/volumes/translate_test.go
+++ b/pkg/k8s/volumes/translate_test.go
@@ -1,0 +1,106 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package volumes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/model"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_translate(t *testing.T) {
+	filesystemVolumeMode := apiv1.PersistentVolumeFilesystem
+	blockVolumeMode := apiv1.PersistentVolumeBlock
+	storageClass := "okteto-sc"
+	var tests = []struct {
+		name string
+		dev  *model.Dev
+		want *apiv1.PersistentVolumeClaim
+	}{
+		{
+			name: "default",
+			dev: &model.Dev{
+				Name: "test",
+			},
+			want: &apiv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-okteto",
+					Labels: map[string]string{
+						constants.DevLabel: "true",
+					},
+				},
+				Spec: apiv1.PersistentVolumeClaimSpec{
+					AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOnce},
+					VolumeMode:  &filesystemVolumeMode,
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							"storage": resource.MustParse("5Gi"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "custom",
+			dev: &model.Dev{
+				Name: "test",
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Enabled:      true,
+					Labels:       map[string]string{"l1": "v1"},
+					Annotations:  map[string]string{"a1": "v1"},
+					AccessMode:   apiv1.ReadWriteMany,
+					VolumeMode:   apiv1.PersistentVolumeBlock,
+					Size:         "20Gi",
+					StorageClass: storageClass,
+				},
+			},
+			want: &apiv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-okteto",
+					Annotations: map[string]string{
+						"a1": "v1",
+					},
+					Labels: map[string]string{
+						"l1":               "v1",
+						constants.DevLabel: "true",
+					},
+				},
+				Spec: apiv1.PersistentVolumeClaimSpec{
+					AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteMany},
+					VolumeMode:  &blockVolumeMode,
+					Resources: apiv1.ResourceRequirements{
+						Requests: apiv1.ResourceList{
+							"storage": resource.MustParse("20Gi"),
+						},
+					},
+					StorageClassName: &storageClass,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := translate(tt.dev)
+			if !reflect.DeepEqual(result, tt.want) {
+				t.Errorf("wrong PVC generation in test '%s': '%v' vs '%v'", tt.name, result, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/k8s/volumes/translate_test.go
+++ b/pkg/k8s/volumes/translate_test.go
@@ -29,9 +29,9 @@ func Test_translate(t *testing.T) {
 	blockVolumeMode := apiv1.PersistentVolumeBlock
 	storageClass := "okteto-sc"
 	var tests = []struct {
-		name string
-		dev  *model.Dev
 		want *apiv1.PersistentVolumeClaim
+		dev  *model.Dev
+		name string
 	}{
 		{
 			name: "default",

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -140,13 +140,13 @@ type ExternalVolume struct {
 
 // PersistentVolumeInfo info about the persistent volume
 type PersistentVolumeInfo struct {
-	AccessMode   apiv1.PersistentVolumeAccessMode `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
 	Annotations  Annotations                      `json:"annotations,omitempty" yaml:"annotations,omitempty"`
-	Enabled      bool                             `json:"enabled,omitempty" yaml:"enabled"`
 	Labels       Labels                           `json:"labels,omitempty" yaml:"labels,omitempty"`
+	AccessMode   apiv1.PersistentVolumeAccessMode `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
 	Size         string                           `json:"size,omitempty" yaml:"size,omitempty"`
 	StorageClass string                           `json:"storageClass,omitempty" yaml:"storageClass,omitempty"`
 	VolumeMode   apiv1.PersistentVolumeMode       `json:"volumeMode,omitempty" yaml:"volumeMode,omitempty"`
+	Enabled      bool                             `json:"enabled,omitempty" yaml:"enabled"`
 }
 
 // InitContainer represents the initial container

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -203,7 +203,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.Lifecycle":            {"postStart", "preStop"},
 				"model.Manifest":             {"name", "icon", "dev", "build", "deploy", "destroy", "dependencies", "external", "forward", "test"},
 				"model.Metadata":             {"labels", "annotations"},
-				"model.PersistentVolumeInfo": {"storageClass", "size", "enabled"},
+				"model.PersistentVolumeInfo": {"accessMode", "volumeMode", "annotations", "labels", "storageClass", "size", "enabled"},
 				"model.Probes":               {"liveness", "readiness", "startup"},
 				"model.ResourceRequirements": {"limits", "requests"},
 				"model.SecurityContext":      {"runAsUser", "runAsGroup", "fsGroup", "capabilities", "runAsNonRoot", "allowPrivilegeEscalation"},

--- a/pkg/model/volumes.go
+++ b/pkg/model/volumes.go
@@ -20,6 +20,7 @@ import (
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
+	apiv1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -164,6 +165,44 @@ func (dev *Dev) PersistentVolumeEnabled() bool {
 		return true
 	}
 	return dev.PersistentVolumeInfo.Enabled
+}
+
+// PersistentVolumeAccessMode returns the persistent volume accessMode
+func (dev *Dev) PersistentVolumeAccessMode() apiv1.PersistentVolumeAccessMode {
+	if dev.PersistentVolumeInfo == nil {
+		return apiv1.ReadWriteOnce
+	}
+	if dev.PersistentVolumeInfo.AccessMode == "" {
+		return apiv1.ReadWriteOnce
+	}
+	return dev.PersistentVolumeInfo.AccessMode
+}
+
+// PersistentVolumeMode returns the persistent volume volumeMode
+func (dev *Dev) PersistentVolumeMode() apiv1.PersistentVolumeMode {
+	if dev.PersistentVolumeInfo == nil {
+		return apiv1.PersistentVolumeFilesystem
+	}
+	if dev.PersistentVolumeInfo.VolumeMode == "" {
+		return apiv1.PersistentVolumeFilesystem
+	}
+	return dev.PersistentVolumeInfo.VolumeMode
+}
+
+// PersistentVolumeAnnotations returns the persistent volume annotations
+func (dev *Dev) PersistentVolumeAnnotations() Annotations {
+	if dev.PersistentVolumeInfo == nil {
+		return nil
+	}
+	return dev.PersistentVolumeInfo.Annotations
+}
+
+// PersistentVolumeLabels returns the persistent volume labels
+func (dev *Dev) PersistentVolumeLabels() Labels {
+	if dev.PersistentVolumeInfo == nil {
+		return nil
+	}
+	return dev.PersistentVolumeInfo.Labels
 }
 
 // PersistentVolumeSize returns the persistent volume size

--- a/pkg/model/volumes_test.go
+++ b/pkg/model/volumes_test.go
@@ -20,6 +20,7 @@ import (
 
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/sirupsen/logrus"
+	apiv1 "k8s.io/api/core/v1"
 )
 
 func TestDev_translateDeprecatedVolumeFields(t *testing.T) {
@@ -815,6 +816,194 @@ func Test_validateVolumes(t *testing.T) {
 				if err != nil && !tt.wantErr {
 					t.Errorf("'%s' got unexpected error: %s", tt.name, err.Error())
 				}
+			}
+		})
+	}
+}
+
+func Test_PersistentVolumeEnabled(t *testing.T) {
+	var tests = []struct {
+		name string
+		dev  *Dev
+		want bool
+	}{
+		{
+			name: "nil",
+			dev:  &Dev{},
+			want: true,
+		},
+		{
+			name: "enabled",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{Enabled: true}},
+			want: true,
+		},
+		{
+			name: "disabled",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{Enabled: false}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dev.PersistentVolumeEnabled()
+			if result != tt.want {
+				t.Errorf("'%s' did get an expected result '%t' vs '%t'", tt.name, tt.want, result)
+			}
+		})
+	}
+}
+
+func Test_PersistentVolumeAccessMode(t *testing.T) {
+	var tests = []struct {
+		name string
+		dev  *Dev
+		want apiv1.PersistentVolumeAccessMode
+	}{
+		{
+			name: "nil",
+			dev:  &Dev{},
+			want: apiv1.ReadWriteOnce,
+		},
+		{
+			name: "empty",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{}},
+			want: apiv1.ReadWriteOnce,
+		},
+		{
+			name: "access-mode",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{AccessMode: apiv1.ReadWriteMany}},
+			want: apiv1.ReadWriteMany,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dev.PersistentVolumeAccessMode()
+			if result != tt.want {
+				t.Errorf("'%s' did get an expected result '%s' vs '%s'", tt.name, tt.want, result)
+			}
+		})
+	}
+}
+
+func Test_PersistentVolumeMode(t *testing.T) {
+	var tests = []struct {
+		name string
+		dev  *Dev
+		want apiv1.PersistentVolumeMode
+	}{
+		{
+			name: "nil",
+			dev:  &Dev{},
+			want: apiv1.PersistentVolumeFilesystem,
+		},
+		{
+			name: "empty",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{}},
+			want: apiv1.PersistentVolumeFilesystem,
+		},
+		{
+			name: "volume-mode",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{VolumeMode: apiv1.PersistentVolumeBlock}},
+			want: apiv1.PersistentVolumeBlock,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dev.PersistentVolumeMode()
+			if result != tt.want {
+				t.Errorf("'%s' did get an expected result '%s' vs '%s'", tt.name, tt.want, result)
+			}
+		})
+	}
+}
+
+func Test_PersistentVolumeAnnotations(t *testing.T) {
+	var tests = []struct {
+		name string
+		dev  *Dev
+		want Annotations
+	}{
+		{
+			name: "nil",
+			dev:  &Dev{},
+			want: nil,
+		},
+		{
+			name: "annotations",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{Annotations: Annotations{"a1": "v1"}}},
+			want: Annotations{"a1": "v1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dev.PersistentVolumeAnnotations()
+			if !reflect.DeepEqual(result, tt.want) {
+				t.Errorf("'%s' did get an expected result '%v' vs '%v'", tt.name, tt.want, result)
+			}
+		})
+	}
+}
+
+func Test_PersistentVolumeLabels(t *testing.T) {
+	var tests = []struct {
+		name string
+		dev  *Dev
+		want Labels
+	}{
+		{
+			name: "nil",
+			dev:  &Dev{},
+			want: nil,
+		},
+		{
+			name: "labels",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{Labels: Labels{"a1": "v1"}}},
+			want: Labels{"a1": "v1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dev.PersistentVolumeLabels()
+			if !reflect.DeepEqual(result, tt.want) {
+				t.Errorf("'%s' did get an expected result '%v' vs '%v'", tt.name, tt.want, result)
+			}
+		})
+	}
+}
+
+func Test_PersistentVolumeSize(t *testing.T) {
+	var tests = []struct {
+		name string
+		dev  *Dev
+		want string
+	}{
+		{
+			name: "nil",
+			dev:  &Dev{},
+			want: defaultVolumeSize,
+		},
+		{
+			name: "empty",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{}},
+			want: defaultVolumeSize,
+		},
+		{
+			name: "size",
+			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{Size: "15Gi"}},
+			want: "15Gi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dev.PersistentVolumeSize()
+			if result != tt.want {
+				t.Errorf("'%s' did get an expected result '%s' vs '%s'", tt.name, tt.want, result)
 			}
 		})
 	}

--- a/pkg/model/volumes_test.go
+++ b/pkg/model/volumes_test.go
@@ -823,8 +823,8 @@ func Test_validateVolumes(t *testing.T) {
 
 func Test_PersistentVolumeEnabled(t *testing.T) {
 	var tests = []struct {
-		name string
 		dev  *Dev
+		name string
 		want bool
 	}{
 		{
@@ -922,9 +922,9 @@ func Test_PersistentVolumeMode(t *testing.T) {
 
 func Test_PersistentVolumeAnnotations(t *testing.T) {
 	var tests = []struct {
-		name string
 		dev  *Dev
 		want Annotations
+		name string
 	}{
 		{
 			name: "nil",
@@ -950,9 +950,9 @@ func Test_PersistentVolumeAnnotations(t *testing.T) {
 
 func Test_PersistentVolumeLabels(t *testing.T) {
 	var tests = []struct {
-		name string
 		dev  *Dev
 		want Labels
+		name string
 	}{
 		{
 			name: "nil",


### PR DESCRIPTION
# Proposed changes

By adding support to labels, annotations, access mode and volume node, users have more flexibility to customize the creation of the okteto persistent volume.
For example, this allows the creation of EFS volumes to be shared across nodes when using [services](https://www.okteto.com/docs/reference/okteto-manifest/#services-object-optional).
