### PR TITLE
Add X-Okteto-CLI-Version version to requests

### DIFF
--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -525,8 +525,8 @@ func GetServerNameOverride() string {
 }
 
 type VersionedTransport struct {
-	Version string
 	http.RoundTripper
+	Version string
 }
 
 func (t *VersionedTransport) RoundTrip(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
There seem to be a lot of different http clients that are being used. This seems to cover all the cases but it needs review