### PR TITLE
PROD-218: Add a timeout flag to okteto preview destroy command

### DIFF
--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -169,7 +169,7 @@ func (c destroyPreviewCommand) waitForPreviewDestroyed(ctx context.Context, prev
 	for {
 		select {
 		case <-to.C:
-			return fmt.Errorf("%w: preview %s, time %s. Timeout can be increased using --timeout flag", errDestroyPreviewTimeout, preview, timeout.String())
+			return fmt.Errorf("%w: preview %s timed out after %s. Timeout can be increased using the '--timeout' flag", errDestroyPreviewTimeout, preview, timeout.String())
 		case <-ticker.C:
 			ns, err := c.k8sClient.CoreV1().Namespaces().Get(ctx, preview, metav1.GetOptions{})
 			if err != nil {

--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -169,7 +169,7 @@ func (c destroyPreviewCommand) waitForPreviewDestroyed(ctx context.Context, prev
 	for {
 		select {
 		case <-to.C:
-			return fmt.Errorf("%w: preview %s, time %s. Timeout can be increase using --timeout flag", errDestroyPreviewTimeout, preview, timeout.String())
+			return fmt.Errorf("%w: preview %s, time %s. Timeout can be increased using --timeout flag", errDestroyPreviewTimeout, preview, timeout.String())
 		case <-ticker.C:
 			ns, err := c.k8sClient.CoreV1().Namespaces().Get(ctx, preview, metav1.GetOptions{})
 			if err != nil {

--- a/cmd/preview/destroy_test.go
+++ b/cmd/preview/destroy_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/okteto/okteto/internal/test/client"
 	"github.com/okteto/okteto/pkg/constants"
@@ -82,8 +83,9 @@ func TestExecuteDestroyPreviewWithNotFoundPreviewErrorDestroying(t *testing.T) {
 func TestExecuteDestroyPreviewWithoutError(t *testing.T) {
 	ctx := context.Background()
 	opts := &DestroyOptions{
-		name: "test-preview",
-		wait: true,
+		name:    "test-preview",
+		wait:    true,
+		timeout: 5 * time.Minute,
 	}
 	var previewResponse client.FakePreviewResponse
 	command := destroyPreviewCommand{
@@ -128,8 +130,9 @@ func TestExecuteDestroyPreviewWithoutWait(t *testing.T) {
 func TestExecuteDestroyPreviewWithFailedJob(t *testing.T) {
 	ctx := context.Background()
 	opts := &DestroyOptions{
-		name: "test-preview",
-		wait: true,
+		name:    "test-preview",
+		wait:    true,
+		timeout: 5 * time.Minute,
 	}
 	var previewResponse client.FakePreviewResponse
 	ns := v1.Namespace{

--- a/cmd/preview/destroy_test.go
+++ b/cmd/preview/destroy_test.go
@@ -163,8 +163,9 @@ func TestExecuteDestroyPreviewWithErrorStreaming(t *testing.T) {
 	ctx := context.Background()
 	var previewResponse client.FakePreviewResponse
 	opts := &DestroyOptions{
-		name: "test-preview",
-		wait: true,
+		name:    "test-preview",
+		wait:    true,
+		timeout: 5 * time.Minute,
 	}
 	command := destroyPreviewCommand{
 		okClient: &client.FakeOktetoClient{


### PR DESCRIPTION
# Proposed changes

Fixes PROD-218

This PR adds a `timeout` flag to the `okteto preview destroy` command. The command, when the flag `wait` was set to `true`, it was already waiting for the preview to be destroyed, but it was waiting a hardcoded time of 5 minutes. With this new flag, users can configure the time to wait in case the preview can take long time to be destroyed.

I also changed the message displayed when the timeout happens to encourage the usage of `--timeout` flag to increase the timeout. This is how it looks like

<img width="819" alt="Screenshot 2024-09-20 at 17 27 22" src="https://github.com/user-attachments/assets/27158398-2b8e-400b-aac4-8c52c7aded24">

@codyjlandstrom @pchico83 How do you see it? I just added the last sentence, but I think we could improve it

## How to validate

1. Deploy a preview environment
2. Destroy it specifying a custom timeout. Specify a very short timeout if you want to see the experience when it fails.
3. Ensure also that the timeout doesn't have any effect when the flag `--wait` is set to `true`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

