### PR TITLE
Host "busybox" in the "okteto" DockerHub organization

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -25,6 +25,7 @@ import (
 	buildv2 "github.com/okteto/okteto/cmd/build/v2"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/build"
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/format"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -338,7 +339,7 @@ func getAddPermissionsInitContainer(svcName string, svc *model.Service) apiv1.Co
 	initContainerCommand, initContainerVolumeMounts := getInitContainerCommandAndVolumeMounts(*svc)
 	initContainer := apiv1.Container{
 		Name:         fmt.Sprintf("init-%s", svcName),
-		Image:        "busybox",
+		Image:        constants.OktetoBusyboxImage,
 		Command:      initContainerCommand,
 		VolumeMounts: initContainerVolumeMounts,
 	}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/pkg/build"
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/stretchr/testify/assert"
@@ -279,7 +280,7 @@ func Test_translateStatefulSet(t *testing.T) {
 	}
 	initContainer := apiv1.Container{
 		Name:    fmt.Sprintf("init-%s", "svcName"),
-		Image:   "busybox",
+		Image:   constants.OktetoBusyboxImage,
 		Command: []string{"sh", "-c", "chmod 777 /data"},
 		VolumeMounts: []apiv1.VolumeMount{
 			{
@@ -634,7 +635,7 @@ func Test_translateJobWithVolumes(t *testing.T) {
 	}
 	initContainer := apiv1.Container{
 		Name:    fmt.Sprintf("init-%s", "svcName"),
-		Image:   "busybox",
+		Image:   constants.OktetoBusyboxImage,
 		Command: []string{"sh", "-c", "chmod 777 /data"},
 		VolumeMounts: []apiv1.VolumeMount{
 			{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -75,6 +75,9 @@ const (
 	// OktetoPipelineRunnerImage defines image to use for remote deployments if empty
 	OktetoPipelineRunnerImage = "okteto/pipeline-runner:1.0.2"
 
+	// OktetoBusyboxImage defines image to use for stacks and hybrid
+	OktetoBusyboxImage = "okteto/busybox:latest"
+
 	// OktetoEnvFile defines the name for okteto env file
 	OktetoEnvFile = "OKTETO_ENV"
 

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -762,7 +762,7 @@ func (d *Dev) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return fmt.Errorf("dev workdir is not a dir")
 		}
 		dev.Workdir = localDir
-		dev.Image = "busybox"
+		dev.Image = constants.OktetoBusyboxImage
 
 	} else {
 		dev.Mode = constants.OktetoSyncModeFieldValue

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1808,7 +1808,7 @@ reverse:
 						Local:  8080,
 					},
 				},
-				Image:     "busybox",
+				Image:     constants.OktetoBusyboxImage,
 				Secrets:   []Secret{},
 				Probes:    &Probes{},
 				Lifecycle: &Lifecycle{},
@@ -1972,7 +1972,7 @@ forward:
 				Command: Command{
 					Values: []string{"sh"},
 				},
-				Image:     "busybox",
+				Image:     constants.OktetoBusyboxImage,
 				Secrets:   []Secret{},
 				Probes:    &Probes{},
 				Lifecycle: &Lifecycle{},


### PR DESCRIPTION
# Proposed changes

Host `busybox` image in `okteto/busybox:latest` to avoid pull rate limits.

Fixes # (issue)

`busybox` is affected by DockerHub rate limits.

## How to validate

Deploy https://github.com/okteto/compose-getting-started and check it works