### PR TITLE
Refactor authProvider to prioritize local registry credentials

### DIFF
--- a/pkg/cmd/build/authprovider.go
+++ b/pkg/cmd/build/authprovider.go
@@ -156,7 +156,7 @@ func (ap *authProvider) Credentials(ctx context.Context, req *auth.CredentialsRe
 	}
 
 	areCredentialsValid := func(creds *auth.CredentialsResponse) bool {
-		return creds.Username != "" && creds.Secret != ""
+		return creds != nil && creds.Username != "" && creds.Secret != ""
 	}
 
 	// Return local credentials if prioritizing local and valid, otherwise Okteto credentials if valid, fallback to local
@@ -173,6 +173,7 @@ func (ap *authProvider) getLocalCredentials(req *auth.CredentialsRequest) (*auth
 			oktetoLog.Infof("could not access %s defined in %s", ap.config.CredentialsStore, ap.config.Filename)
 			return &auth.CredentialsResponse{}, nil
 		}
+		return nil, err
 	}
 
 	if ac.IdentityToken != "" {

--- a/pkg/cmd/build/authprovider_test.go
+++ b/pkg/cmd/build/authprovider_test.go
@@ -214,8 +214,8 @@ func TestCredentials(t *testing.T) {
 			localCredentials:  true,
 			oktetoCredentials: false,
 			expected: &auth.CredentialsResponse{
-				Username: "",
-				Secret:   "",
+				Username: "local",
+				Secret:   "local",
 			},
 		},
 		{
@@ -270,8 +270,8 @@ func TestCredentials(t *testing.T) {
 			localCredentials:  true,
 			oktetoCredentials: false,
 			expected: &auth.CredentialsResponse{
-				Username: "",
-				Secret:   "",
+				Username: "local",
+				Secret:   "local",
 			},
 		},
 		{
@@ -334,7 +334,7 @@ func TestCredentials(t *testing.T) {
 				authContext: &fakeContext{},
 			}
 			if tc.envVarSet {
-				t.Setenv(oktetoLocalRegistryStoreEnabledEnvVarKey, tc.envVarValue)
+				t.Setenv(oktetoLocalRegistryStorePriorityEnabledEnvVarKey, tc.envVarValue)
 			}
 
 			if tc.localCredentials {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	oktetoLocalRegistryStoreEnabledEnvVarKey = "OKTETO_LOCAL_REGISTRY_STORE_ENABLED"
+	oktetoLocalRegistryStorePriorityEnabledEnvVarKey = "OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED"
 
 	// This is defined in our registry fork, be aware of it if changing it
 	manifestUnknownForBeingInvalidErrorCode = "MANIFEST_UNKNOWN_FOR_BEING_INVALID"
@@ -209,7 +209,7 @@ func (c client) getAuthentication(ref name.Reference) remote.Option {
 		authn.DefaultKeychain,
 		authn.NewKeychainFromHelper(inlineHelper(c.config.GetExternalRegistryCredentials)),
 	)
-	if !env.LoadBooleanOrDefault(oktetoLocalRegistryStoreEnabledEnvVarKey, false) {
+	if !env.LoadBooleanOrDefault(oktetoLocalRegistryStorePriorityEnabledEnvVarKey, false) {
 		kc = authn.NewMultiKeychain(
 			authn.NewKeychainFromHelper(inlineHelper(c.config.GetExternalRegistryCredentials)),
 			authn.DefaultKeychain,


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-680

- Rename variable from OKTETO_LOCAL_REGISTRY_STORE_ENABLED to OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED
- Now we are going to retrieve always local and okteto credentials but will prioritise okteto one if the env var is unset or false


## How to validate

1. Add a registry credentials that you already have in local from the UI
1. Run `okteto build -t registry/repo/image:latest` and check that you are using the one from okteto
1. Set OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED to true
1. Run again `okteto build -t registry/repo/image:latest` and check that you are using the one from local

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
