### PR TITLE
remove remote deploy CTA on vanilla

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -261,14 +261,14 @@ okteto up api -- echo this is a test
 				return fmt.Errorf("failed to load k8s client: %w", err)
 			}
 
-			if upOptions.Deploy || !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Namespace, k8sClient) {
+			if okteto.GetContext().IsOkteto && upOptions.Deploy || !pipeline.IsDeployed(ctx, up.Manifest.Name, up.Namespace, k8sClient) {
 				err := up.deployApp(ctx, ioCtrl, k8sLogger)
 
 				// only allow error.ErrManifestFoundButNoDeployAndDependenciesCommands to go forward - autocreate property will deploy the app
 				if err != nil && !errors.Is(err, oktetoErrors.ErrManifestFoundButNoDeployAndDependenciesCommands) {
 					return err
 				}
-			} else if !upOptions.Deploy && pipeline.IsDeployed(ctx, up.Manifest.Name, okteto.GetContext().Namespace, k8sClient) {
+			} else if okteto.GetContext().IsOkteto && !upOptions.Deploy && pipeline.IsDeployed(ctx, up.Manifest.Name, okteto.GetContext().Namespace, k8sClient) {
 				oktetoLog.Information("'%s' was already deployed. To redeploy run 'okteto deploy' or 'okteto up --deploy'", up.Manifest.Name)
 			}
 


### PR DESCRIPTION
# Proposed changes

Fixes #DEV-682

We were showing a message before that should not appear on vanilla cluster:
<img width="682" alt="Screenshot 2024-09-23 at 13 08 17" src="https://github.com/user-attachments/assets/79b951c9-8b26-481a-8a5d-7aa14acc9f63">
We have removed the CTA on vanilla clusters
<img width="475" alt="Screenshot 2024-09-23 at 13 08 24" src="https://github.com/user-attachments/assets/5f94e64a-74d4-4c91-b6ec-30b2fc296756">

## How to validate

1. On a vanilla cluster run `okteto up` and check that no CTA is appearing

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
