### PR TITLE
Document test command to accept multiple test names as arguments

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -72,7 +72,7 @@ type builder interface {
 func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at *analytics.Tracker) *cobra.Command {
 	options := &Options{}
 	cmd := &cobra.Command{
-		Use:   "test",
+		Use:   "test [testName...]",
 		Short: "Run tests using Remote Execution",
 		RunE: func(cmd *cobra.Command, servicesToTest []string) error {
 


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Add documentation on `okteto test --help` to show that the user can introduce more than one testName.

## How to validate

1. Run `okteto test --help` and check that the Use have the  testName as arguments
1.
1.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
