### PR TITLE
Fix checking for pod sandbox creation error

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -436,7 +436,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
     More information about configuring your persistent volume at https://okteto.com/docs/reference/okteto-manifest/#persistentvolume-object-optional`, utils.GetDownCommand(up.Options.ManifestPathFlag)),
 					}
 				}
-				if e.Type == "Warning" && strings.Contains(e.Message, "container veth name provided (eth0) already exists") {
+				if e.Type == "Warning" && strings.Contains(e.Message, "container veth name") && strings.Contains(e.Message, "already exists") {
 					oktetoLog.Infof("pod event: %s:%s:%s", e.Reason, e.Type, e.Message)
 					continue
 				}


### PR DESCRIPTION
Looks like the message we check for pod sandboxes errors was changed in Kubernetes 1.30, which results in a very flaky of `okteto up` with statefulsets.

I updated the check to work with the old and the new message.

BAckporting to reduce flakiness in the 3.0 release branch.