### PR TITLE
refactor (release): refactor the actions release script to match the …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,13 +413,22 @@ jobs:
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --no-progress okteto/okteto:$CIRCLE_TAG
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --no-progress okteto/bin:latest
 
+  push-image-dev:
+    executor: golang-ci
+    steps:
+      - checkout
+      - run: *okteto-login
+      - run: *docker-login
+      - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG",dev "linux/amd64,linux/arm64"
+      - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --no-progress okteto/okteto:dev
+
   push-image-master:
     executor: golang-ci
     steps:
       - checkout
       - run: *okteto-login
       - run: *docker-login
-      - run: ./scripts/ci/push-image.sh master "linux/amd64,linux/arm64"
+      - run: ./scripts/ci/push-image.sh "master" "linux/amd64,linux/arm64"
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --no-progress okteto/okteto:master
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --no-progress okteto/bin:latest
 
@@ -664,7 +673,7 @@ workflows:
       - build-binaries
       - run-unit-test
       - run-windows-unit-test
-      - push-image-tag:
+      - push-image-dev:
           context: Product-okteto-dev
           requires:
             - build-binaries
@@ -672,7 +681,7 @@ workflows:
           context: GKE
           requires:
             - build-binaries
-            - push-image-tag
+            - push-image-dev
 
   # release workflow is triggered when the tag for release is pushed
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,7 +413,7 @@ jobs:
       - run: trivy image --no-progress okteto/okteto:$CIRCLE_TAG
       - run: trivy image --no-progress okteto/bin:latest
 
-  push-image-latest:
+  push-image-master:
     executor: golang-ci
     steps:
       - checkout
@@ -608,7 +608,7 @@ workflows:
               ignore:
                 - master
                 - *release-branch-regex
-      - push-image-latest:
+      - push-image-master:
           context: Product-okteto-dev
           requires:
             - build-binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,8 +419,8 @@ jobs:
       - checkout
       - run: *okteto-login
       - run: *docker-login
-      - run: ./scripts/ci/push-image.sh latest "linux/amd64"
-      - run: trivy image --no-progress okteto/okteto:latest
+      - run: ./scripts/ci/push-image.sh master "linux/amd64,linux/arm64"
+      - run: trivy image --no-progress okteto/okteto:master
       - run: trivy image --no-progress okteto/bin:latest
 
   upload-static-job:

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -17,29 +17,68 @@
         # PLATFORMS is the arch's we want to release
         PLATFORMS="${2}"
 
+        echo "DEBUG: RELEASE_TAG: ${RELEASE_TAG}"
+        echo "DEBUG: PLATFORMS: ${PLATFORMS}"
+
         if [ -z "$RELEASE_TAG" ]; then
                 commit=$(git rev-parse --short HEAD)
                 RELEASE_TAG="$commit"
+                echo "DEBUG: RELEASE_TAG was empty. Using git commit: ${RELEASE_TAG}"
         fi
 
+        IFS=',' read -ra TAGS_ARRAY <<< "$RELEASE_TAG"
+        echo "DEBUG: Splitting RELEASE_TAG into TAGS_ARRAY:"
+        for tag in "${TAGS_ARRAY[@]}"; do
+                echo "  DEBUG: Tag: ${tag}"
+        done
 
-        beta_prerel_regex="^beta\.[0-9]+"
-        prerel="$(semver get prerel "${RELEASE_TAG}" || true)"
-        version="$(semver get release "${RELEASE_TAG}" || true)"
-        tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev"
+        # The first tag is the version for the build
+        VERSION_STRING="${TAGS_ARRAY[0]}"
 
-        # if release tag is  not empty, push the stable image
-        if [ -n "$RELEASE_TAG" ]; then
-                echo "prerel: ${prerel}"
-                echo "version ${version}"
-                if [[ $prerel =~ $beta_prerel_regex ]]; then
-                        tags="${tags},okteto/okteto:beta"
+        tags_array=()
+        beta_added=false
+        stable_added=false
+        for tag in "${TAGS_ARRAY[@]}"; do
+                echo "DEBUG: Processing tag: ${tag}"        
+                prerel="$(semver get prerel "${tag}" || true)"
+                version="$(semver get release "${tag}" || true)"
+                echo "  DEBUG: prerel: ${prerel}"
+                echo "  DEBUG: version: ${version}"
+
+                tags_array+=("jlopezbarb/okteto:${tag}")
+                echo "  DEBUG: Added tag to tags_array: jlopezbarb/okteto:${tag}"
+                echo "  DEBUG: tags_array so far: ${tags_array[@]}"
+
+                if [ -n "$prerel" ]; then
+                        if [ "$beta_added" = false ]; then
+                                tags_array+=("jlopezbarb/okteto:beta")
+                                beta_added=true
+                                echo "  DEBUG: Added beta tag to tags_array"
+                        else
+                                echo "  DEBUG: Beta tag already added, skipping"
+                        fi
                 elif [ -n "$version" ]; then
-                        tags="${tags},okteto/okteto:stable,okteto/okteto:latest"
+                        # It's a stable version because it has $version and it's not a prerrelease
+                        if [ "$stable_added" = false ]; then
+                                tags_array+=("jlopezbarb/okteto:stable" "jlopezbarb/okteto:latest")
+                                stable_added=true
+                                echo "  DEBUG: Added stable and latest tags to tags_array"
+                        else
+                                echo "  DEBUG: Stable and latest tags already added, skipping"
+                        fi
+                else
+                        # We don't push to dev because it's done just at the nightlies
+                        echo "  DEBUG: Tag ${tag} is a dev tag"
                 fi
-        fi
+        done
+        
+        tags=$(IFS=','; echo "${tags_array[*]}")
+
+        echo "DEBUG: Final tags string: ${tags}"
 
         echo "Pushing ${tags} to Docker Hub"
-        okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${RELEASE_TAG}" -t "${tags}" -f Dockerfile .
+        echo "DEBUG: Executing command:"
+        echo "okteto build --platform \"${PLATFORMS}\" --build-arg VERSION_STRING=\"${VERSION_STRING}\" -t \"${tags}\" -f Dockerfile . --progress=plain"
 
+        okteto build --platform "${PLATFORMS}" --build-arg VERSION_STRING="${VERSION_STRING}" -t "${tags}" -f Dockerfile . --progress=plain
 ); }

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -26,7 +26,7 @@
         beta_prerel_regex="^beta\.[0-9]+"
         prerel="$(semver get prerel "${RELEASE_TAG}" || true)"
         version="$(semver get release "${RELEASE_TAG}" || true)"
-        tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev"
+        tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev,okteto/okteto:master"
 
         # if release tag is  not empty, push the stable image
         if [ -n "$RELEASE_TAG" ]; then

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -45,13 +45,13 @@
                 echo "  DEBUG: prerel: ${prerel}"
                 echo "  DEBUG: version: ${version}"
 
-                tags_array+=("jlopezbarb/okteto:${tag}")
-                echo "  DEBUG: Added tag to tags_array: jlopezbarb/okteto:${tag}"
+                tags_array+=("okteto/okteto:${tag}")
+                echo "  DEBUG: Added tag to tags_array: okteto/okteto:${tag}"
                 echo "  DEBUG: tags_array so far: ${tags_array[@]}"
 
                 if [ -n "$prerel" ]; then
                         if [ "$beta_added" = false ]; then
-                                tags_array+=("jlopezbarb/okteto:beta")
+                                tags_array+=("okteto/okteto:beta")
                                 beta_added=true
                                 echo "  DEBUG: Added beta tag to tags_array"
                         else
@@ -60,7 +60,7 @@
                 elif [ -n "$version" ]; then
                         # It's a stable version because it has $version and it's not a prerrelease
                         if [ "$stable_added" = false ]; then
-                                tags_array+=("jlopezbarb/okteto:stable" "jlopezbarb/okteto:latest")
+                                tags_array+=("okteto/okteto:stable" "okteto/okteto:latest")
                                 stable_added=true
                                 echo "  DEBUG: Added stable and latest tags to tags_array"
                         else

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -26,7 +26,7 @@
         beta_prerel_regex="^beta\.[0-9]+"
         prerel="$(semver get prerel "${RELEASE_TAG}" || true)"
         version="$(semver get release "${RELEASE_TAG}" || true)"
-        tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev,okteto/okteto:master"
+        tags="okteto/okteto:${RELEASE_TAG},okteto/okteto:dev"
 
         # if release tag is  not empty, push the stable image
         if [ -n "$RELEASE_TAG" ]; then
@@ -35,7 +35,7 @@
                 if [[ $prerel =~ $beta_prerel_regex ]]; then
                         tags="${tags},okteto/okteto:beta"
                 elif [ -n "$version" ]; then
-                        tags="${tags},okteto/okteto:stable"
+                        tags="${tags},okteto/okteto:stable,okteto/okteto:latest"
                 fi
         fi
 

--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -1,139 +1,227 @@
 #!/usr/bin/env bash
 
-# release-github-actions.sh takes care of create a github action release that
-# matches a stable CLI release.
-# It does so by creating a git tag in each of the action repos and updating the
-# tip of LTS branches if necessary.
-# Github Actions can be consumed through LTS branches or "latest". These
-# branches are created for major releases and kept up to date with the latest
-# changes.
+# release-github-actions.sh - Automates the release of GitHub Actions to match a stable CLI release.
+# It modifies the Dockerfile, updates tags and branches as per the specified release version.
 
-# run in a subshell
-{ (
-        set -e # make any error fail the script
-        set -u # make unbound variables fail the script
+set -euo pipefail
 
-        # SC2039: In POSIX sh, set option pipefail is undefined
-        # shellcheck disable=SC2039
-        set -o pipefail # make any pipe error fail the script
+# Function to display usage information
+usage() {
+    echo "Usage: $0 [--dry-run] <RELEASE_TAG>"
+    exit 1
+}
 
-        # RELEASE_TAG is the release tag that we want to release
-        RELEASE_TAG="${1:-""}"
+# Check for required commands
+required_commands=("semver" "gsutil" "git")
+for cmd in "${required_commands[@]}"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "Error: Required command '$cmd' not found."
+        exit 1
+    fi
+done
 
-        # REPO_OWNER is the owner of the repo (okteto)
-        REPO_OWNER="okteto"
+# Check if GITHUB_TOKEN is set
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "Error: GITHUB_TOKEN environment variable is not set."
+    exit 1
+fi
 
-        if [ "$RELEASE_TAG" = "" ]; then
-                echo "RELEASE_TAG not provided"
-                exit 1
-        fi
+# Parse arguments
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=true
+    shift
+fi
 
-        if ! semver validate "${RELEASE_TAG}" >/dev/null 2>&1; then
-                echo "${RELEASE_TAG} is not a valid semver format"
-                exit 1
-        fi
+RELEASE_TAG="${1:-}"
 
-        PREREL="$(semver get prerel "${RELEASE_TAG}")"
-        MAJOR_VERSION="$(semver get major "${RELEASE_TAG}")"
-        LTS_BRANCH="v${MAJOR_VERSION}"
+if [[ -z "$RELEASE_TAG" ]]; then
+    usage
+fi
 
-        # stable release
-        if [ -n "$PREREL" ]; then
-                echo "Current version ${RELEASE_TAG} is not a stable semver release"
-                exit 1
-        fi
+REPO_OWNER="${REPO_OWNER:-okteto}"
 
-        VERSIONS_BUCKET_FILENAME="downloads.okteto.com/cli/stable/versions"
+echo "========================================"
+echo "Running with dry-run: ${DRY_RUN}"
+echo "Releasing GitHub Actions for version: ${RELEASE_TAG}"
+echo "========================================"
 
-        VERSIONS_FILE=$(mktemp)
-        gsutil cat "gs://${VERSIONS_BUCKET_FILENAME}" >"$VERSIONS_FILE"
-        echo "Current version list for stable channel (showing latest 10):"
-        tail -n 10 "$VERSIONS_FILE"
+# Validate RELEASE_TAG
+if ! semver validate "$RELEASE_TAG" >/dev/null 2>&1; then
+    echo "Error: '$RELEASE_TAG' is not a valid semantic version."
+    exit 1
+fi
 
-        if ! grep -qFx "${RELEASE_TAG}" "${VERSIONS_FILE}"; then
-                echo "RELEASE_TAG: ${RELEASE_TAG} not included in the versions from https://${VERSIONS_BUCKET_FILENAME}"
-                exit 1
-        fi
+PREREL=$(semver get prerel "$RELEASE_TAG")
+MAJOR_VERSION=$(semver get major "$RELEASE_TAG")
+MINOR_VERSION=$(semver get minor "$RELEASE_TAG")
+MAJOR_TAG="v${MAJOR_VERSION}"
+MINOR_TAG="v${MAJOR_VERSION}.${MINOR_VERSION}"
+RELEASE_BRANCH="release-${MAJOR_VERSION}.${MINOR_VERSION}"
 
-        repos=(
-                delete-namespace
-                build
-                destroy-preview
-                deploy-preview
-                deploy-stack
-                namespace
-                pipeline
-                push
-                create-namespace
-                destroy-pipeline
-                login
-                destroy-stack
-                apply
-                context
-                test
-        )
+echo "Pre-release: $PREREL"
+echo "Major version: $MAJOR_VERSION"
+echo "Minor version: $MINOR_VERSION"
+echo "Major tag: $MAJOR_TAG"
+echo "Minor tag: $MINOR_TAG"
+echo "Release branch: $RELEASE_BRANCH"
+echo "========================================"
 
-        for repo in "${repos[@]}"; do
-                echo "Releasing ${REPO_OWNER}/$repo"
-                git clone "git@github.com:${REPO_OWNER}/${repo}.git"
-                pushd "$repo"
-                git config user.name "okteto"
-                git config user.email "ci@okteto.com"
+# Ensure it's a stable release
+if [[ -n "$PREREL" ]]; then
+    echo "Error: '$RELEASE_TAG' is not a stable release."
+    exit 1
+fi
 
-                if git tag --list | grep -qFx "$RELEASE_TAG"; then
-                        echo "$RELEASE_TAG already exists"
-                        exit 1
+VERSIONS_BUCKET_FILENAME="downloads.okteto.com/cli/stable/versions"
+VERSIONS_FILE=$(mktemp)
+trap 'rm -f "$VERSIONS_FILE"' EXIT
+
+# Fetch versions from GCS
+if ! gsutil cat "gs://${VERSIONS_BUCKET_FILENAME}" >"$VERSIONS_FILE"; then
+    echo "Error: Failed to fetch versions from gs://${VERSIONS_BUCKET_FILENAME}"
+    exit 1
+fi
+
+echo "========================================"
+echo "Current stable versions (latest 10):"
+tail -n 10 "$VERSIONS_FILE"
+echo "========================================"
+
+if ! grep -qFx "$RELEASE_TAG" "$VERSIONS_FILE"; then
+    echo "Error: RELEASE_TAG '$RELEASE_TAG' not found in versions list."
+    exit 1
+fi
+
+repos=(
+    delete-namespace
+    build
+    destroy-preview
+    deploy-preview
+    namespace
+    pipeline
+    create-namespace
+    destroy-pipeline
+    apply
+    context
+    test
+)
+
+for repo in "${repos[@]}"; do
+    echo "----------------------------------------"
+    echo "Processing repository: ${REPO_OWNER}/${repo}"
+    REPO_DIR=$(mktemp -d)
+    # Ensure cleanup of the temporary directory
+    trap 'rm -rf "$REPO_DIR"' EXIT
+
+    git clone "git@github.com:${REPO_OWNER}/${repo}.git" "$REPO_DIR"
+    pushd "$REPO_DIR" >/dev/null
+
+    git config user.name "okteto"
+    git config user.email "ci@okteto.com"
+
+    git checkout main
+
+    # Get the current highest tag in main branch
+    current_tag=$(git tag --list --sort=-v:refname | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$" | head -n1 || echo "0.0.0")
+
+    echo "Current tag in repository '$repo': $current_tag"
+
+    semver_diff=$(semver compare "${RELEASE_TAG}" "${current_tag}")
+    if [ "${semver_diff}" -le 0 ]; then
+        echo "RELEASE_TAG '$RELEASE_TAG' is not newer than current tag '$current_tag'. Skipping repository."
+        popd >/dev/null
+        rm -rf "$REPO_DIR"
+        continue
+    fi
+
+    # Modify Dockerfile
+    if [[ -f Dockerfile ]]; then
+        echo "Updating Dockerfile to use okteto/okteto:${RELEASE_TAG}"
+        sed -i.bak -E 's|(FROM okteto/okteto:)[^ ]*|\1'"${RELEASE_TAG}"'|g' Dockerfile
+        rm Dockerfile.bak
+        
+        echo "Dockerfile changes:"
+        git --no-pager diff Dockerfile
+
+        git add Dockerfile 
+        git commit -m "Release ${RELEASE_TAG}" || echo "No changes to commit in repository '$repo'."
+    else
+        echo "Warning: Dockerfile not found in repository '$repo'. Skipping Dockerfile update."
+    fi
+
+    # Create an annotated tag for RELEASE_TAG
+    echo "Creating tag ${RELEASE_TAG}"
+    if [ "$DRY_RUN" = false ]; then
+        git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_TAG}"
+    else
+        echo "Dry run: Skipping tag creation for ${RELEASE_TAG}"
+    fi
+
+    # Function to update tags if RELEASE_TAG is greater
+    update_tag_if_greater() {
+        local TAG_NAME=$1
+        if git rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
+            current_tag_version=$(git describe --tags "${TAG_NAME}" --abbrev=0 --match "*.*.*" 2>/dev/null || echo "0.0.0")
+            diff=$(semver compare "${RELEASE_TAG}" "${current_tag_version}")
+            if [ "${diff}" -gt 0 ]; then
+                echo "Moving tag ${TAG_NAME} to new release ${RELEASE_TAG}"
+                if [ "$DRY_RUN" = false ]; then
+                    git tag -f "${TAG_NAME}" "${RELEASE_TAG}"
+                else
+                    echo "Dry run: Skipping moving tag ${TAG_NAME}"
                 fi
+            else
+                echo "Existing ${TAG_NAME} tag points to an equal or newer version. Skipping."
+            fi
+        else
+            echo "Creating tag ${TAG_NAME} for release ${RELEASE_TAG}"
+            if [ "$DRY_RUN" = false ]; then
+                git tag "${TAG_NAME}" "${RELEASE_TAG}"
+            else
+                echo "Dry run: Skipping creating tag ${TAG_NAME}"
+            fi
+        fi
+    }
 
-                # checkout the list branch. Create it if it doesn't exist
-                git checkout "${LTS_BRANCH}" 2>/dev/null || git checkout -b "${LTS_BRANCH}"
+    # Update MAJOR_TAG
+    update_tag_if_greater "${MAJOR_TAG}"
 
-                # get the latest tag from the lts branch
-                current_tag="$(git describe --tags --abbrev=0 --match "*.*.*" || echo "0.0.0")"
-                diff="$(semver compare "${current_tag}" "$RELEASE_TAG")"
+    # Update MINOR_TAG
+    update_tag_if_greater "${MINOR_TAG}"
 
-                # RELEASE_TAG must be a newer release
-                if [ "${diff}" != "-1" ]; then
-                        echo "RELEASE_TAG ${RELEASE_TAG} is older than the current tag: ${current_tag}"
-                        exit 0
-                fi
+    # Create release branch
+    if git rev-parse --verify --quiet "${RELEASE_BRANCH}"; then
+        echo "Release branch ${RELEASE_BRANCH} already exists. Skipping branch creation."
+    else
+        echo "Creating release branch ${RELEASE_BRANCH}"
+        if [ "$DRY_RUN" = false ]; then
+            git branch "${RELEASE_BRANCH}" "${RELEASE_TAG}"
+        else
+            echo "Dry run: Skipping creation of release branch ${RELEASE_BRANCH}"
+        fi
+    fi
 
-                # NOTE: these sed commands will not work in OS X and will require `brew install gnu-sed` and updating the PATH
-                sed -i -E 's_FROM\ okteto\/okteto\:latest_FROM\ okteto\/okteto\:'"$RELEASE_TAG"'_' Dockerfile
-                sed -i -E 's_FROM\ okteto\/okteto\:[[:digit:]]*\.[[:digit:]]*\.[[:digit:]]*_FROM\ okteto\/okteto\:'"$RELEASE_TAG"'_' Dockerfile
-                git add Dockerfile
-                git commit -m "release ${RELEASE_TAG}"
+    # Update 'latest' and 'stable' tags if RELEASE_TAG is greater
+    update_tag_if_greater "latest"
+    update_tag_if_greater "stable"
 
-                echo "Pushing LTS branch ${LTS_BRANCH}"
-                git push "git@github.com:${REPO_OWNER}/${repo}.git" "${LTS_BRANCH}"
+    # Push changes
+    if [ "$DRY_RUN" = false ]; then
+        echo "Pushing commits, branches, and tags to remote for repository '$repo'"
+        git push "git@github.com:${REPO_OWNER}/${repo}.git" main
+        git push "git@github.com:${REPO_OWNER}/${repo}.git" "${RELEASE_BRANCH}"
+        git push --tags --force
+    else
+        echo "Dry run: Skipping pushing commits, branches, and tags"
+    fi
 
-                echo "Creating release for tag ${RELEASE_TAG}"
-                ghr \
-                        -debug \
-                        -name "${RELEASE_TAG}" \
-                        -token "$GITHUB_TOKEN" \
-                        -recreate \
-                        -replace \
-                        -commitish "$(git rev-parse "${LTS_BRANCH}")" \
-                        "$RELEASE_TAG"
+    popd >/dev/null
+    rm -rf "$REPO_DIR"
+    echo "Finished processing repository: ${REPO_OWNER}/${repo}"
+    echo "----------------------------------------"
+done
 
-                # After updating the LTS branch, if the current release is the latest known
-                # release, update latest
-                latest="$(tail -n1 "${VERSIONS_FILE}")"
-                if [ "${latest}" = "${RELEASE_TAG}" ]; then
-                        echo "Updating latest tag"
-                        ghr \
-                                -debug \
-                                -name "latest@${RELEASE_TAG}" \
-                                -token "$GITHUB_TOKEN" \
-                                -recreate \
-                                -replace \
-                                -commitish "$(git rev-parse "${LTS_BRANCH}")" \
-                                latest
-                fi
-
-                popd
-                rm -rf "$repo"
-        done
-
-); }
+echo "========================================"
+echo "Release process completed."
+echo "========================================"

--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -161,8 +161,15 @@ for repo in "${repos[@]}"; do
     # Function to update tags if RELEASE_TAG is greater
     update_tag_if_greater() {
         local TAG_NAME=$1
+        # Check if the tag TAG_NAME exists in the Git repository
         if git rev-parse "${TAG_NAME}" >/dev/null 2>&1; then
+            # If TAG_NAME exists, retrieve the semantic version associated with it
+            # Note: We are not using TAG_NAME directly for comparison
+            # Instead, we find the version tag that TAG_NAME points to
             current_tag_version=$(git describe --tags "${TAG_NAME}" --abbrev=0 --match "*.*.*" 2>/dev/null || echo "0.0.0")
+            
+            # Compare the new RELEASE_TAG with the current_tag_version
+            # This comparison determines if RELEASE_TAG is newer than the version TAG_NAME points to
             diff=$(semver compare "${RELEASE_TAG}" "${current_tag_version}")
             if [ "${diff}" -gt 0 ]; then
                 echo "Moving tag ${TAG_NAME} to new release ${RELEASE_TAG}"


### PR DESCRIPTION
…new release process

# Proposed changes

Fixes DEV-435


This PR introduces a comprehensive script to automate the release process of our GitHub Actions in alignment with stable Okteto CLI releases. The script is designed to:

- Modify the `Dockerfile` in each Action repository to use the specified Okteto CLI version.
- Create or update tags (`vMAJOR`, `vMAJOR.MINOR`, `latest`, `stable`) based on the new release.
- Create a release branch (`release-MAJOR.MINOR`) for targeted fixes without affecting the main branch.
- Include a `--dry-run` option to safely test the release process without making any changes.
- Enhance debugging in case the script fails whenever we execute it 

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1.Ensure the GITHUB_TOKEN environment variable is set and has the necessary permissions to push commits and tags and Install all required commands: `semver`, `gsutil`, `git`
1. Comment the following lines:
```sh
if ! grep -qFx "$RELEASE_TAG" "$VERSIONS_FILE"; then
    echo "Error: RELEASE_TAG '$RELEASE_TAG' not found in versions list."
    exit 1
fi
```
3. Run the script: `scripts/ci/new-release-github-actions.sh --dry-run 3.0.0` and check the output

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
