### PR TITLE
revert pipeline and preview file check

### DIFF
--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -31,7 +31,6 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	modelUtils "github.com/okteto/okteto/pkg/model/utils"
@@ -39,7 +38,6 @@ import (
 	"github.com/okteto/okteto/pkg/repository"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/okteto/okteto/pkg/validator"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 )
@@ -84,7 +82,7 @@ type DeployOptions struct {
 	ReuseParams  bool
 }
 
-func deploy(ctx context.Context, fs afero.Fs) *cobra.Command {
+func deploy(ctx context.Context) *cobra.Command {
 	flags := &deployFlags{}
 	cmd := &cobra.Command{
 		Use:   "deploy",
@@ -93,17 +91,6 @@ func deploy(ctx context.Context, fs afero.Fs) *cobra.Command {
 		Example: `To run the deploy without the Okteto CLI wait for its completion, use the '--wait=false' flag:
 okteto pipeline deploy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if flags.file != "" {
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(flags.file, fs) {
-					return oktetoErrors.ErrManifestPathNotFound
-				}
-
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(flags.file, fs) {
-					return oktetoErrors.ErrManifestPathIsDir
-				}
-			}
 
 			if err := validator.CheckReservedVariablesNameOption(flags.variables); err != nil {
 				return err

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -19,7 +19,6 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -53,13 +52,13 @@ func NewCommand() (*Command, error) {
 }
 
 // Pipeline pipeline management commands
-func Pipeline(ctx context.Context, fs afero.Fs) *cobra.Command {
+func Pipeline(ctx context.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
 		Short: "Development Environments management commands",
 		Args:  utils.NoArgsAccepted("https://www.okteto.com/docs/reference/okteto-cli/#pipeline"),
 	}
-	cmd.AddCommand(deploy(ctx, fs))
+	cmd.AddCommand(deploy(ctx))
 	cmd.AddCommand(destroy(ctx))
 	cmd.AddCommand(list(ctx))
 	return cmd

--- a/cmd/preview/deploy_utils.go
+++ b/cmd/preview/deploy_utils.go
@@ -21,13 +21,10 @@ import (
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/env"
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/filesystem"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	modelUtils "github.com/okteto/okteto/pkg/model/utils"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/validator"
-	"github.com/spf13/afero"
 )
 
 var (
@@ -43,19 +40,6 @@ func optionsSetup(cwd string, opts *DeployOptions, args []string) error {
 		opts.name = getRandomName(opts.scope)
 	} else {
 		opts.name = getExpandedName(args[0])
-	}
-
-	if opts.file != "" {
-		fs := afero.NewOsFs()
-		// check that the manifest file exists
-		if !filesystem.FileExistsWithFilesystem(opts.file, fs) {
-			return oktetoErrors.ErrManifestPathNotFound
-		}
-
-		// the Okteto manifest flag should specify a file, not a directory
-		if filesystem.IsDir(opts.file, fs) {
-			return oktetoErrors.ErrManifestPathIsDir
-		}
 	}
 
 	var err error

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 	root.AddCommand(remoterun.RemoteRun(ctx, k8sLogger))
 	root.AddCommand(test.Test(ctx, ioController, k8sLogger, at))
 
-	root.AddCommand(pipeline.Pipeline(ctx, fs))
+	root.AddCommand(pipeline.Pipeline(ctx))
 
 	err = root.Execute()
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-697

Revert pipeline and preview file check.
We were checking for the `-f` flag in the pipeline and preview commands

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Run `okteto pipeline deploy -f okteto.yml`
1. Run `okteto preview deploy -f okteto.yml`
1.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
