### PR TITLE
check abs with abs

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -367,6 +367,10 @@ func extractFromContextAndDockerfile(context, dockerfile, svcName string, getWd 
 		return joinPath
 	}
 
+	if !filepath.IsAbs(joinPath) {
+		joinPath = filepath.Join(wd, joinPath)
+	}
+
 	if joinPath != filepath.Join(wd, filepath.Clean(dockerfile)) && filesystem.FileExistsAndNotDir(dockerfile, fs) {
 		oktetoLog.Warning(fmt.Sprintf(doubleDockerfileWarning, svcName, context, dockerfile))
 	}

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -535,7 +535,7 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			name:            "one dockerfile in root no warning",
 			svcName:         "t5",
 			dockerfile:      "Dockerfile",
-			fileExpected:    "/Dockerfile",
+			fileExpected:    filepath.Clean("/Dockerfile"),
 			optionalContext: ".",
 			getWd: func() (string, error) {
 				return filepath.Clean("/"), nil
@@ -547,7 +547,7 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			name:            "dockerfile in root, not showing 2 dockerfiles warning",
 			svcName:         "t6",
 			dockerfile:      "./Dockerfile",
-			fileExpected:    "/Dockerfile",
+			fileExpected:    filepath.Clean("/Dockerfile"),
 			optionalContext: ".",
 			getWd: func() (string, error) {
 				return filepath.Clean("/"), nil

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -492,9 +492,9 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			svcName:    "t1",
 			dockerfile: filepath.Join(contextPath, "Dockerfile"),
 			getWd: func() (string, error) {
-				return "/", nil
+				return filepath.Clean("/"), nil
 			},
-			fileExpected:       filepath.Clean(filepath.Join("/", contextPath, "Dockerfile")),
+			fileExpected:       filepath.Clean(filepath.Join(filepath.Clean("/"), contextPath, "Dockerfile")),
 			dockerfilesCreated: nil,
 			expectedError:      "",
 		},
@@ -503,7 +503,7 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			svcName:    "t2",
 			dockerfile: "Dockerfile",
 			getWd: func() (string, error) {
-				return "/", nil
+				return filepath.Clean("/"), nil
 			},
 			fileExpected:       filepath.Clean("Dockerfile"),
 			dockerfilesCreated: []string{"Dockerfile"},
@@ -514,9 +514,9 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			svcName:    "t3",
 			dockerfile: "Dockerfile",
 			getWd: func() (string, error) {
-				return "/", nil
+				return filepath.Clean("/"), nil
 			},
-			fileExpected:       filepath.Clean(filepath.Join("/", buildName, "Dockerfile")),
+			fileExpected:       filepath.Clean(filepath.Join(filepath.Clean("/"), buildName, "Dockerfile")),
 			dockerfilesCreated: []string{"Dockerfile", filepath.Join(buildName, "Dockerfile")},
 			expectedError:      fmt.Sprintf(doubleDockerfileWarning, "t3", buildName, "Dockerfile"),
 		},
@@ -525,9 +525,9 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			svcName:    "t4",
 			dockerfile: "Dockerfile",
 			getWd: func() (string, error) {
-				return "/", nil
+				return filepath.Clean("/"), nil
 			},
-			fileExpected:       filepath.Clean(filepath.Join("/", buildName, "Dockerfile")),
+			fileExpected:       filepath.Clean(filepath.Join(filepath.Clean("/"), buildName, "Dockerfile")),
 			dockerfilesCreated: []string{filepath.Join(buildName, "Dockerfile")},
 			expectedError:      "",
 		},
@@ -538,7 +538,7 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			fileExpected:    "/Dockerfile",
 			optionalContext: ".",
 			getWd: func() (string, error) {
-				return "/", nil
+				return filepath.Clean("/"), nil
 			},
 			dockerfilesCreated: []string{"Dockerfile"},
 			expectedError:      "",
@@ -550,7 +550,7 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			fileExpected:    "/Dockerfile",
 			optionalContext: ".",
 			getWd: func() (string, error) {
-				return "/", nil
+				return filepath.Clean("/"), nil
 			},
 			dockerfilesCreated: []string{"Dockerfile"},
 			expectedError:      "",
@@ -562,7 +562,7 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			fileExpected:    filepath.Clean("/Dockerfile"),
 			optionalContext: ".",
 			getWd: func() (string, error) {
-				return "/", nil
+				return filepath.Clean("/"), nil
 			},
 			dockerfilesCreated: []string{"Dockerfile"},
 			expectedError:      "",

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -494,7 +494,7 @@ func TestExtractFromContextAndDockerfile(t *testing.T) {
 			getWd: func() (string, error) {
 				return filepath.Clean("/"), nil
 			},
-			fileExpected:       filepath.Clean(filepath.Join(filepath.Clean("/"), contextPath, "Dockerfile")),
+			fileExpected:       filepath.Clean(filepath.Join(contextPath, "Dockerfile")),
 			dockerfilesCreated: nil,
 			expectedError:      "",
 		},


### PR DESCRIPTION
# Proposed changes

Fixes DEV-695

We were checking a relative path with an absolute path.
With this change we compare both paths as absolute paths

## How to validate

1. With the following `okteto.yml`
```yaml
build:
  service:
    context: .
    dockerfile: Dockerfile
```
2. And the following `Dockerfile`
``` Dockerfile
FROM alpine
```
3. From the previous folder run `okteto build -f folder/okteto.yml`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
