### PR TITLE
Refactor getStackServicesToDeploy function to handle multiple Compose…

### DIFF
--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -93,10 +93,18 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 func getStackServicesToDeploy(ctx context.Context, composeSectionInfo *model.ComposeSectionInfo, c kubernetes.Interface) ([]string, error) {
 	svcs := []string{}
 
-	for _, composeInfo := range composeSectionInfo.ComposesInfo {
-		svcs = append(svcs, composeInfo.ServicesToDeploy...)
-	}
 	if len(composeSectionInfo.ComposesInfo) > 0 {
+		servicesToDeploy := 0
+		for _, composeInfo := range composeSectionInfo.ComposesInfo {
+			svcs = append(svcs, composeInfo.ServicesToDeploy...)
+			servicesToDeploy += len(composeInfo.ServicesToDeploy)
+		}
+		if servicesToDeploy == 0 {
+			for service := range composeSectionInfo.Stack.Services {
+				svcs = append(svcs, service)
+			}
+			return svcs, nil
+		}
 		if err := stack.ValidateDefinedServices(composeSectionInfo.Stack, svcs); err != nil {
 			return []string{}, err
 		}

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -15,7 +15,6 @@ package deploy
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"os"
 
@@ -102,7 +101,8 @@ func getStackServicesToDeploy(ctx context.Context, composeSectionInfo *model.Com
 	if servicesToDeploy == 0 {
 		svcs = []string{}
 		if composeSectionInfo.Stack == nil {
-			return nil, fmt.Errorf("no services to deploy")
+			oktetoLog.Warning("There is no stack defined in the manifest")
+			return svcs, nil
 		}
 		for service := range composeSectionInfo.Stack.Services {
 			svcs = append(svcs, service)

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -101,7 +101,7 @@ func getStackServicesToDeploy(ctx context.Context, composeSectionInfo *model.Com
 	if servicesToDeploy == 0 {
 		svcs = []string{}
 		if composeSectionInfo.Stack == nil {
-			oktetoLog.Warning("There is no stack defined in the manifest")
+			oktetoLog.Info("There is no stack defined in the manifest")
 			return svcs, nil
 		}
 		for service := range composeSectionInfo.Stack.Services {

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -93,23 +93,24 @@ func setDeployOptionsValuesFromManifest(ctx context.Context, deployOptions *Opti
 func getStackServicesToDeploy(ctx context.Context, composeSectionInfo *model.ComposeSectionInfo, c kubernetes.Interface) ([]string, error) {
 	svcs := []string{}
 
-	if len(composeSectionInfo.ComposesInfo) > 0 {
-		servicesToDeploy := 0
-		for _, composeInfo := range composeSectionInfo.ComposesInfo {
-			svcs = append(svcs, composeInfo.ServicesToDeploy...)
-			servicesToDeploy += len(composeInfo.ServicesToDeploy)
-		}
-		if servicesToDeploy == 0 {
-			for service := range composeSectionInfo.Stack.Services {
-				svcs = append(svcs, service)
-			}
-			return svcs, nil
-		}
-		if err := stack.ValidateDefinedServices(composeSectionInfo.Stack, svcs); err != nil {
-			return []string{}, err
-		}
-		svcs = stack.AddDependentServicesIfNotPresent(ctx, composeSectionInfo.Stack, svcs, c)
+	servicesToDeploy := 0
+	for _, composeInfo := range composeSectionInfo.ComposesInfo {
+		svcs = append(svcs, composeInfo.ServicesToDeploy...)
+		servicesToDeploy += len(composeInfo.ServicesToDeploy)
 	}
+	if servicesToDeploy == 0 {
+		svcs = []string{}
+		for service := range composeSectionInfo.Stack.Services {
+			svcs = append(svcs, service)
+		}
+		return svcs, nil
+	}
+
+	if err := stack.ValidateDefinedServices(composeSectionInfo.Stack, svcs); err != nil {
+		return []string{}, err
+	}
+	svcs = stack.AddDependentServicesIfNotPresent(ctx, composeSectionInfo.Stack, svcs, c)
+
 	return svcs, nil
 }
 

--- a/cmd/deploy/command_configuration.go
+++ b/cmd/deploy/command_configuration.go
@@ -15,6 +15,7 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 
@@ -100,6 +101,9 @@ func getStackServicesToDeploy(ctx context.Context, composeSectionInfo *model.Com
 	}
 	if servicesToDeploy == 0 {
 		svcs = []string{}
+		if composeSectionInfo.Stack == nil {
+			return nil, fmt.Errorf("no services to deploy")
+		}
 		for service := range composeSectionInfo.Stack.Services {
 			svcs = append(svcs, service)
 		}

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -173,7 +173,7 @@ func Test_getStackServicesToDeploy(t *testing.T) {
 			expected: []string{"service1", "service2", "service3", "service4"},
 		},
 		{
-			name: "MultipleComposeInfo",
+			name: "MultipleComposeInfo with non existent service",
 			composeSectionInfo: &model.ComposeSectionInfo{
 				ComposesInfo: []model.ComposeInfo{
 					{
@@ -205,10 +205,10 @@ func Test_getStackServicesToDeploy(t *testing.T) {
 				ComposesInfo: []model.ComposeInfo{},
 				Stack:        stack,
 			},
-			expected: []string{},
+			expected: []string{"service1", "service2", "service3", "service4"},
 		},
 		{
-			name: "MultipleComposeInfo",
+			name: "only one docker compose",
 			composeSectionInfo: &model.ComposeSectionInfo{
 				ComposesInfo: []model.ComposeInfo{
 					{

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -207,6 +207,18 @@ func Test_getStackServicesToDeploy(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			name: "MultipleComposeInfo",
+			composeSectionInfo: &model.ComposeSectionInfo{
+				ComposesInfo: []model.ComposeInfo{
+					{
+						File: "docker-compose.yml",
+					},
+				},
+				Stack: stack,
+			},
+			expected: []string{"service1", "service2", "service3", "service4"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -216,7 +228,7 @@ func Test_getStackServicesToDeploy(t *testing.T) {
 
 			svcs, _ := getStackServicesToDeploy(ctx, tt.composeSectionInfo, c)
 
-			assert.Equal(t, tt.expected, svcs)
+			assert.ElementsMatch(t, tt.expected, svcs)
 
 		})
 	}


### PR DESCRIPTION
…Info objects

The getStackServicesToDeploy function in command_configuration.go has been refactored to handle multiple ComposeInfo objects. Previously, it only processed the first ComposeInfo object and ignored the rest. Now, it correctly appends the services to deploy from all ComposeInfo objects and validates the defined services accordingly.

This change ensures that all services specified in the ComposeInfo objects are included in the deployment process.

Fixes DEV-692

# Proposed changes

When we removed the services to deploy from flags we updated the services toDeploy from the compose file but were not checking one of the conditions if run from a okteto manifest

## How to validate

1. With the following `okteto.yml`
```yaml
deploy:
  compose: compose.yml
```
2. Deploy using `okteto deploy`
3. Check that there is no error

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
