### PR TITLE
Remove context and namespace from manifestRaw

### DIFF
--- a/cmd/context/utils_test.go
+++ b/cmd/context/utils_test.go
@@ -39,8 +39,6 @@ func Test_GetManifestV2(t *testing.T) {
 			file:        "file",
 			expectedErr: false,
 			manifestYAML: []byte(`
-namespace: test-namespace
-context: manifest-context
 build:
   service:
     image: defined-tag-image
@@ -91,6 +89,24 @@ dependencies:
 		},
 		{
 			name:        "manifest-path-not-found",
+			expectedErr: true,
+		},
+		{
+			name: "manifest-context-not-valid",
+			file: "file",
+			manifestYAML: []byte(`
+context: value
+deploy:
+  - echo "deploy"`),
+			expectedErr: true,
+		},
+		{
+			name: "manifest-namespace-not-valid",
+			file: "file",
+			manifestYAML: []byte(`
+namespace: value
+deploy:
+  - echo "deploy"`),
 			expectedErr: true,
 		},
 	}

--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -782,8 +782,6 @@ type manifestRaw struct {
 	Dependencies  deps.ManifestSection     `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 	External      externalresource.Section `json:"external,omitempty" yaml:"external,omitempty"`
 	Name          string                   `json:"name,omitempty" yaml:"name,omitempty"`
-	Namespace     string                   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Context       string                   `json:"context,omitempty" yaml:"context,omitempty"`
 	Icon          string                   `json:"icon,omitempty" yaml:"icon,omitempty"`
 	GlobalForward []forward.GlobalForward  `json:"forward,omitempty" yaml:"forward,omitempty"`
 }

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -1054,8 +1054,6 @@ services:
 		{
 			name: "manifest with namespace and context",
 			manifest: []byte(`
-namespace: test
-context: context-to-use
 deploy:
 - okteto stack deploy`),
 			expected: &Manifest{


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-698

When having a manifest with `context` and `namespace` fields on root these were ignored and should throw an error as the fields are no longer available at the manifest 3.0

## How to validate

Using a repo with an invalid manifest, build the binary and run any command (build, deploy, etc)
The context or namespace at the manifest should not be used
The CLI shoud throw an error

```
❯ ok deploy
 i  Using <namespace> @ <context> as context
 x  Your okteto manifest is not valid, please check the following errors:
     - line 1: field 'context' is not a property of the okteto manifest
    Check out the okteto manifest docs at: https://www.okteto.com/docs/reference/okteto-manifest
❯ ok deploy
 i  Using <namespace> @ <context> as context
 x  Your okteto manifest is not valid, please check the following errors:
     - line 1: field 'namespace' is not a property of the okteto manifest
    Check out the okteto manifest docs at: https://www.okteto.com/docs/reference/okteto-manifest
```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines


