### PR TITLE
refactor: remove context and namespace from Stack

### DIFF
--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -42,8 +42,6 @@ const (
 type StackRaw struct {
 	Version   string                     `yaml:"version,omitempty"`
 	Name      string                     `yaml:"name"`
-	Namespace string                     `yaml:"namespace,omitempty"`
-	Context   string                     `yaml:"context,omitempty"`
 	Services  map[string]*ServiceRaw     `yaml:"services,omitempty"`
 	Endpoints EndpointSpec               `yaml:"endpoints,omitempty"`
 	Volumes   map[string]*VolumeTopLevel `yaml:"volumes,omitempty"`
@@ -280,9 +278,6 @@ func (s *Stack) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 	s.Name = stackRaw.Name
-
-	s.Namespace = stackRaw.Namespace
-	s.Context = stackRaw.Context
 
 	s.Endpoints = stackRaw.Endpoints
 


### PR DESCRIPTION
Working on https://github.com/okteto/okteto/pull/4488 spotted Stack still had context and namespace

This PR removes Context and Namespace input from the compose or stack file. With this change when running.
When using the fields on the stack manifest an error will ocurr.


```
❯ ok deploy
 i  Using - @ - as context
 x  Invalid compose manifest: The following fields are not supported.
    - context
    - namespace
    More information is available here: https://okteto.com/docs/reference/docker-compose/
```