### PR TITLE
DEV-690: Use right build context path to get the right diff and sha in git operations for Smart Builds

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -111,7 +111,7 @@ func NewBuilder(builder buildCmd.OktetoBuilderInterface, registry oktetoRegistry
 		buildEnvironments: buildEnvs,
 		Config:            config,
 		ioCtrl:            ioCtrl,
-		smartBuildCtrl:    smartbuild.NewSmartBuildCtrl(gitRepo, registry, config.fs, ioCtrl),
+		smartBuildCtrl:    smartbuild.NewSmartBuildCtrl(gitRepo, registry, config.fs, ioCtrl, wdCtrl),
 		oktetoContext:     okCtx,
 		k8sLogger:         k8sLogger,
 		onBuildFinish:     onBuildFinish,
@@ -154,7 +154,7 @@ func NewBuilderFromScratch(ioCtrl *io.Controller, onBuildFinish []OnBuildFinish)
 		buildEnvironments: buildEnvs,
 		Config:            config,
 		ioCtrl:            ioCtrl,
-		smartBuildCtrl:    smartbuild.NewSmartBuildCtrl(gitRepo, reg, config.fs, ioCtrl),
+		smartBuildCtrl:    smartbuild.NewSmartBuildCtrl(gitRepo, reg, config.fs, ioCtrl, wdCtrl),
 		oktetoContext:     okCtx,
 
 		onBuildFinish: onBuildFinish,

--- a/cmd/build/v2/build_test.go
+++ b/cmd/build/v2/build_test.go
@@ -73,6 +73,12 @@ var fakeManifest *model.Manifest = &model.Manifest{
 	},
 }
 
+type fakeWorkingDirGetter struct{}
+
+func (f fakeWorkingDirGetter) Get() (string, error) {
+	return "", nil
+}
+
 type fakeRegistry struct {
 	registry          map[string]fakeImage
 	errAddImageByName error
@@ -160,7 +166,7 @@ func NewFakeBuilder(builder buildCmd.OktetoBuilderInterface, registry oktetoRegi
 		},
 		Config:         cfg,
 		ioCtrl:         io.NewIOController(),
-		smartBuildCtrl: smartbuild.NewSmartBuildCtrl(fakeConfigRepo{}, registry, afero.NewMemMapFs(), io.NewIOController()),
+		smartBuildCtrl: smartbuild.NewSmartBuildCtrl(fakeConfigRepo{}, registry, afero.NewMemMapFs(), io.NewIOController(), fakeWorkingDirGetter{}),
 		oktetoContext: &okteto.ContextStateless{
 			Store: &okteto.ContextStore{
 				Contexts: map[string]*okteto.Context{

--- a/cmd/build/v2/smartbuild/hasher.go
+++ b/cmd/build/v2/smartbuild/hasher.go
@@ -44,11 +44,12 @@ type serviceHasher struct {
 
 	fs afero.Fs
 
+	wdGetter osWorkingDirGetter
+
 	serviceShaCache map[string]string
 
 	getCurrentTimestampNano func() int64
 	projectCommit           string
-	wdGetter                osWorkingDirGetter
 
 	// lock is a mutex to provide thread safety
 	lock sync.RWMutex

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -14,228 +14,228 @@
 package smartbuild
 
 import (
-    "errors"
-    "path/filepath"
-    "testing"
+	"errors"
+	"path/filepath"
+	"testing"
 
-    "github.com/okteto/okteto/pkg/build"
-    "github.com/spf13/afero"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/mock"
+	"github.com/okteto/okteto/pkg/build"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type fakeWorkingDirGetter struct {
-    err        error
-    workingDir string
+	err        error
+	workingDir string
 }
 
 func (f fakeWorkingDirGetter) Get() (string, error) {
-    if f.err != nil {
-        return "", f.err
-    }
-    return f.workingDir, nil
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.workingDir, nil
 }
 
 type mockConfigRepo struct {
-    mock.Mock
+	mock.Mock
 }
 
 func (m *mockConfigRepo) GetSHA() (string, error) {
-    args := m.Called()
-    return args.Get(0).(string), args.Error(1)
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
 }
 func (m *mockConfigRepo) GetLatestDirSHA(dir string) (string, error) {
-    args := m.Called(dir)
-    return args.String(0), args.Error(1)
+	args := m.Called(dir)
+	return args.String(0), args.Error(1)
 }
 func (m *mockConfigRepo) GetDiffHash(dir string) (string, error) {
-    args := m.Called(dir)
-    return args.String(0), args.Error(1)
+	args := m.Called(dir)
+	return args.String(0), args.Error(1)
 }
 
 func TestServiceHasher_HashProjectCommit(t *testing.T) {
-    fakeErr := errors.New("fake error")
-    tests := []struct {
-        repoCtrl     repositoryCommitRetriever
-        expectedErr  error
-        name         string
-        expectedHash string
-    }{
-        {
-            name: "success",
-            repoCtrl: fakeConfigRepo{
-                sha: "testsha",
-            },
-            expectedHash: "832d66070268d5a47860e9bd4402f504a1c0fe8d0c2dc1ecf814af610de72f0e",
-            expectedErr:  nil,
-        },
-        {
-            name: "error",
-            repoCtrl: fakeConfigRepo{
-                err: fakeErr,
-            },
-            expectedHash: "",
-            expectedErr:  fakeErr,
-        },
-    }
+	fakeErr := errors.New("fake error")
+	tests := []struct {
+		repoCtrl     repositoryCommitRetriever
+		expectedErr  error
+		name         string
+		expectedHash string
+	}{
+		{
+			name: "success",
+			repoCtrl: fakeConfigRepo{
+				sha: "testsha",
+			},
+			expectedHash: "832d66070268d5a47860e9bd4402f504a1c0fe8d0c2dc1ecf814af610de72f0e",
+			expectedErr:  nil,
+		},
+		{
+			name: "error",
+			repoCtrl: fakeConfigRepo{
+				err: fakeErr,
+			},
+			expectedHash: "",
+			expectedErr:  fakeErr,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            wdGetter := fakeWorkingDirGetter{}
-            sh := newServiceHasher(tt.repoCtrl, afero.NewMemMapFs(), wdGetter)
-            hash, err := sh.hashProjectCommit(&build.Info{})
-            assert.Equal(t, tt.expectedHash, hash)
-            assert.ErrorIs(t, err, tt.expectedErr)
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wdGetter := fakeWorkingDirGetter{}
+			sh := newServiceHasher(tt.repoCtrl, afero.NewMemMapFs(), wdGetter)
+			hash, err := sh.hashProjectCommit(&build.Info{})
+			assert.Equal(t, tt.expectedHash, hash)
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
-    serviceName := "fake-service"
-    tests := []struct {
-        name                 string
-        wdGetter             *fakeWorkingDirGetter
-        context              string
-        dirSHA               string
-        errSHA               error
-        diffHash             string
-        errHash              error
-        expectedBuildContext string
-        expectedHash         string
-    }{
-        {
-            name: "withErrorGettingShaAndDiffHash",
-            wdGetter: &fakeWorkingDirGetter{
-                workingDir: "/tmp/test-okteto/working-dir",
-            },
-            context:              "test",
-            dirSHA:               "",
-            errSHA:               assert.AnError,
-            diffHash:             "",
-            errHash:              assert.AnError,
-            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
-            expectedHash:         "70d446809d8ec0a5c83cd8c74a24b757524e26c85ccd8f8101f40ed3f51275ea",
-        },
-        {
-            name: "withErrorGettingSha",
-            wdGetter: &fakeWorkingDirGetter{
-                workingDir: "/tmp/test-okteto/working-dir",
-            },
-            context:              "test",
-            dirSHA:               "",
-            errSHA:               assert.AnError,
-            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-            errHash:              nil,
-            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
-            expectedHash:         "52f2fa59c20ab2b747ba019f6835d62c0cf76712261966b859e34957c4804578",
-        },
-        {
-            name: "withErrorGettingDiffHash",
-            wdGetter: &fakeWorkingDirGetter{
-                workingDir: "/tmp/test-okteto/working-dir",
-            },
-            context:              "test",
-            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-            errSHA:               nil,
-            diffHash:             "",
-            errHash:              assert.AnError,
-            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
-            expectedHash:         "52b47d89a34e4ed991d415b72b3359ebc1d3204bab998ef94f1bec390dc4f0e0",
-        },
-        {
-            name: "withoutErrorWithRelativePathOnContext",
-            wdGetter: &fakeWorkingDirGetter{
-                workingDir: "/tmp/test-okteto/working-dir",
-            },
-            context:              "test/service-a",
-            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-            errSHA:               nil,
-            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-            errHash:              nil,
-            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test/service-a"),
-            expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
-        },
-        {
-            name: "withoutErrorWithAbsolutePathOnContext",
-            wdGetter: &fakeWorkingDirGetter{
-                workingDir: "/tmp/test-okteto/working-dir",
-            },
-            context:              "/tmp/test-case/absolute-path/test/service-a",
-            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-            errSHA:               nil,
-            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-            errHash:              nil,
-            expectedBuildContext: filepath.Clean("/tmp/test-case/absolute-path/test/service-a"),
-            expectedHash:         "c5de9669d6ad49db99a4a6415e61a378f98eb756fed8e0dc37fdf876436fcac4",
-        },
-        {
-            name: "withoutErrorWithEmptyContext",
-            wdGetter: &fakeWorkingDirGetter{
-                workingDir: "/tmp/test-okteto/working-dir",
-            },
-            context:              "",
-            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-            errSHA:               nil,
-            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-            errHash:              nil,
-            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
-            expectedHash:         "63facbf3f5dede6119682e69dc444fa154d066a8449524a91862f8ada0e96d0f",
-        },
-        {
-            name: "withErrorGettingWorkingDirectoryWithRelativeContext",
-            wdGetter: &fakeWorkingDirGetter{
-                err: assert.AnError,
-            },
-            context:              "test/service-a",
-            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-            errSHA:               nil,
-            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-            errHash:              nil,
-            expectedBuildContext: filepath.Clean("test/service-a"),
-            expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
-        },
-        {
-            name: "withErrorGettingWorkingDirectoryWithAbsoluteContext",
-            wdGetter: &fakeWorkingDirGetter{
-                err: assert.AnError,
-            },
-            context:              "/tmp/test-okteto/working-dir",
-            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-            errSHA:               nil,
-            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-            errHash:              nil,
-            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
-            expectedHash:         "0eb548056aa376058d70623c8fd687d57493b1de7093f57102f70a68eeba86de",
-        },
-    }
+	serviceName := "fake-service"
+	tests := []struct {
+		name                 string
+		wdGetter             *fakeWorkingDirGetter
+		context              string
+		dirSHA               string
+		errSHA               error
+		diffHash             string
+		errHash              error
+		expectedBuildContext string
+		expectedHash         string
+	}{
+		{
+			name: "withErrorGettingShaAndDiffHash",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "test",
+			dirSHA:               "",
+			errSHA:               assert.AnError,
+			diffHash:             "",
+			errHash:              assert.AnError,
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+			expectedHash:         "70d446809d8ec0a5c83cd8c74a24b757524e26c85ccd8f8101f40ed3f51275ea",
+		},
+		{
+			name: "withErrorGettingSha",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "test",
+			dirSHA:               "",
+			errSHA:               assert.AnError,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+			expectedHash:         "52f2fa59c20ab2b747ba019f6835d62c0cf76712261966b859e34957c4804578",
+		},
+		{
+			name: "withErrorGettingDiffHash",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "test",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "",
+			errHash:              assert.AnError,
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+			expectedHash:         "52b47d89a34e4ed991d415b72b3359ebc1d3204bab998ef94f1bec390dc4f0e0",
+		},
+		{
+			name: "withoutErrorWithRelativePathOnContext",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "test/service-a",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test/service-a"),
+			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
+		},
+		{
+			name: "withoutErrorWithAbsolutePathOnContext",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "/tmp/test-case/absolute-path/test/service-a",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: filepath.Clean("/tmp/test-case/absolute-path/test/service-a"),
+			expectedHash:         "c5de9669d6ad49db99a4a6415e61a378f98eb756fed8e0dc37fdf876436fcac4",
+		},
+		{
+			name: "withoutErrorWithEmptyContext",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
+			expectedHash:         "63facbf3f5dede6119682e69dc444fa154d066a8449524a91862f8ada0e96d0f",
+		},
+		{
+			name: "withErrorGettingWorkingDirectoryWithRelativeContext",
+			wdGetter: &fakeWorkingDirGetter{
+				err: assert.AnError,
+			},
+			context:              "test/service-a",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: filepath.Clean("test/service-a"),
+			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
+		},
+		{
+			name: "withErrorGettingWorkingDirectoryWithAbsoluteContext",
+			wdGetter: &fakeWorkingDirGetter{
+				err: assert.AnError,
+			},
+			context:              "/tmp/test-okteto/working-dir",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
+			expectedHash:         "0eb548056aa376058d70623c8fd687d57493b1de7093f57102f70a68eeba86de",
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            repoController := &mockConfigRepo{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoController := &mockConfigRepo{}
 
-            buildInfo := &build.Info{
-                Context: tt.context,
-            }
+			buildInfo := &build.Info{
+				Context: tt.context,
+			}
 
-            sh := &serviceHasher{
-                gitRepoCtrl: repoController,
-                fs:          afero.NewMemMapFs(),
-                getCurrentTimestampNano: func() int64 {
-                    return int64(12312345252)
-                },
-                serviceShaCache: map[string]string{},
-                wdGetter:        tt.wdGetter,
-            }
+			sh := &serviceHasher{
+				gitRepoCtrl: repoController,
+				fs:          afero.NewMemMapFs(),
+				getCurrentTimestampNano: func() int64 {
+					return int64(12312345252)
+				},
+				serviceShaCache: map[string]string{},
+				wdGetter:        tt.wdGetter,
+			}
 
-            repoController.On("GetLatestDirSHA", tt.expectedBuildContext).Return(tt.dirSHA, tt.errSHA)
+			repoController.On("GetLatestDirSHA", tt.expectedBuildContext).Return(tt.dirSHA, tt.errSHA)
 
-            repoController.On("GetDiffHash", tt.expectedBuildContext).Return(tt.diffHash, tt.errHash)
+			repoController.On("GetDiffHash", tt.expectedBuildContext).Return(tt.diffHash, tt.errHash)
 
-            hash := sh.hashWithBuildContext(buildInfo, serviceName)
+			hash := sh.hashWithBuildContext(buildInfo, serviceName)
 
-            assert.Equal(t, tt.expectedHash, hash)
+			assert.Equal(t, tt.expectedHash, hash)
 
-            repoController.AssertExpectations(t)
-        })
-    }
+			repoController.AssertExpectations(t)
+		})
+	}
 }

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -15,7 +15,6 @@ package smartbuild
 
 import (
 	"errors"
-	"path/filepath"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/build"
@@ -113,7 +112,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               assert.AnError,
 			diffHash:             "",
 			errHash:              assert.AnError,
-			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
 			expectedHash:         "70d446809d8ec0a5c83cd8c74a24b757524e26c85ccd8f8101f40ed3f51275ea",
 		},
 		{
@@ -126,7 +125,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               assert.AnError,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
 			expectedHash:         "52f2fa59c20ab2b747ba019f6835d62c0cf76712261966b859e34957c4804578",
 		},
 		{
@@ -139,7 +138,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "",
 			errHash:              assert.AnError,
-			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
 			expectedHash:         "52b47d89a34e4ed991d415b72b3359ebc1d3204bab998ef94f1bec390dc4f0e0",
 		},
 		{
@@ -152,7 +151,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test/service-a"),
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test/service-a",
 			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
 		},
 		{
@@ -160,13 +159,13 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			wdGetter: &fakeWorkingDirGetter{
 				workingDir: "/tmp/test-okteto/working-dir",
 			},
-			context:              "/tmp/test-case/absolute-path/test/service-a",
+			context:              "//tmp/test-case/absolute-path/test/service-a",
 			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
 			errSHA:               nil,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: filepath.Clean("/tmp/test-case/absolute-path/test/service-a"),
-			expectedHash:         "c5de9669d6ad49db99a4a6415e61a378f98eb756fed8e0dc37fdf876436fcac4",
+			expectedBuildContext: "//tmp/test-case/absolute-path/test/service-a",
+			expectedHash:         "eb16bcb66787698131b5a2e0b2ac7fbfc0b78c7f68de95479544f2648fd124b7",
 		},
 		{
 			name: "withoutErrorWithEmptyContext",
@@ -178,7 +177,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
+			expectedBuildContext: "/tmp/test-okteto/working-dir",
 			expectedHash:         "63facbf3f5dede6119682e69dc444fa154d066a8449524a91862f8ada0e96d0f",
 		},
 		{
@@ -191,7 +190,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: filepath.Clean("test/service-a"),
+			expectedBuildContext: "test/service-a",
 			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
 		},
 		{
@@ -204,7 +203,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
+			expectedBuildContext: "/tmp/test-okteto/working-dir",
 			expectedHash:         "0eb548056aa376058d70623c8fd687d57493b1de7093f57102f70a68eeba86de",
 		},
 	}

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -178,7 +178,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: "/tmp/test-okteto/working-dir",
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
 			expectedHash:         "63facbf3f5dede6119682e69dc444fa154d066a8449524a91862f8ada0e96d0f",
 		},
 		{

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 type fakeWorkingDirGetter struct {
-	workingDir string
 	err        error
+	workingDir string
 }
 
 func (f fakeWorkingDirGetter) Get() (string, error) {

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -14,227 +14,228 @@
 package smartbuild
 
 import (
-	"errors"
-	"testing"
+    "errors"
+    "path/filepath"
+    "testing"
 
-	"github.com/okteto/okteto/pkg/build"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+    "github.com/okteto/okteto/pkg/build"
+    "github.com/spf13/afero"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/mock"
 )
 
 type fakeWorkingDirGetter struct {
-	err        error
-	workingDir string
+    err        error
+    workingDir string
 }
 
 func (f fakeWorkingDirGetter) Get() (string, error) {
-	if f.err != nil {
-		return "", f.err
-	}
-	return f.workingDir, nil
+    if f.err != nil {
+        return "", f.err
+    }
+    return f.workingDir, nil
 }
 
 type mockConfigRepo struct {
-	mock.Mock
+    mock.Mock
 }
 
 func (m *mockConfigRepo) GetSHA() (string, error) {
-	args := m.Called()
-	return args.Get(0).(string), args.Error(1)
+    args := m.Called()
+    return args.Get(0).(string), args.Error(1)
 }
 func (m *mockConfigRepo) GetLatestDirSHA(dir string) (string, error) {
-	args := m.Called(dir)
-	return args.String(0), args.Error(1)
+    args := m.Called(dir)
+    return args.String(0), args.Error(1)
 }
 func (m *mockConfigRepo) GetDiffHash(dir string) (string, error) {
-	args := m.Called(dir)
-	return args.String(0), args.Error(1)
+    args := m.Called(dir)
+    return args.String(0), args.Error(1)
 }
 
 func TestServiceHasher_HashProjectCommit(t *testing.T) {
-	fakeErr := errors.New("fake error")
-	tests := []struct {
-		repoCtrl     repositoryCommitRetriever
-		expectedErr  error
-		name         string
-		expectedHash string
-	}{
-		{
-			name: "success",
-			repoCtrl: fakeConfigRepo{
-				sha: "testsha",
-			},
-			expectedHash: "832d66070268d5a47860e9bd4402f504a1c0fe8d0c2dc1ecf814af610de72f0e",
-			expectedErr:  nil,
-		},
-		{
-			name: "error",
-			repoCtrl: fakeConfigRepo{
-				err: fakeErr,
-			},
-			expectedHash: "",
-			expectedErr:  fakeErr,
-		},
-	}
+    fakeErr := errors.New("fake error")
+    tests := []struct {
+        repoCtrl     repositoryCommitRetriever
+        expectedErr  error
+        name         string
+        expectedHash string
+    }{
+        {
+            name: "success",
+            repoCtrl: fakeConfigRepo{
+                sha: "testsha",
+            },
+            expectedHash: "832d66070268d5a47860e9bd4402f504a1c0fe8d0c2dc1ecf814af610de72f0e",
+            expectedErr:  nil,
+        },
+        {
+            name: "error",
+            repoCtrl: fakeConfigRepo{
+                err: fakeErr,
+            },
+            expectedHash: "",
+            expectedErr:  fakeErr,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			wdGetter := fakeWorkingDirGetter{}
-			sh := newServiceHasher(tt.repoCtrl, afero.NewMemMapFs(), wdGetter)
-			hash, err := sh.hashProjectCommit(&build.Info{})
-			assert.Equal(t, tt.expectedHash, hash)
-			assert.ErrorIs(t, err, tt.expectedErr)
-		})
-	}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            wdGetter := fakeWorkingDirGetter{}
+            sh := newServiceHasher(tt.repoCtrl, afero.NewMemMapFs(), wdGetter)
+            hash, err := sh.hashProjectCommit(&build.Info{})
+            assert.Equal(t, tt.expectedHash, hash)
+            assert.ErrorIs(t, err, tt.expectedErr)
+        })
+    }
 }
 
 func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
-	serviceName := "fake-service"
-	tests := []struct {
-		name                 string
-		wdGetter             *fakeWorkingDirGetter
-		context              string
-		dirSHA               string
-		errSHA               error
-		diffHash             string
-		errHash              error
-		expectedBuildContext string
-		expectedHash         string
-	}{
-		{
-			name: "withErrorGettingShaAndDiffHash",
-			wdGetter: &fakeWorkingDirGetter{
-				workingDir: "/tmp/test-okteto/working-dir",
-			},
-			context:              "test",
-			dirSHA:               "",
-			errSHA:               assert.AnError,
-			diffHash:             "",
-			errHash:              assert.AnError,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
-			expectedHash:         "70d446809d8ec0a5c83cd8c74a24b757524e26c85ccd8f8101f40ed3f51275ea",
-		},
-		{
-			name: "withErrorGettingSha",
-			wdGetter: &fakeWorkingDirGetter{
-				workingDir: "/tmp/test-okteto/working-dir",
-			},
-			context:              "test",
-			dirSHA:               "",
-			errSHA:               assert.AnError,
-			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-			errHash:              nil,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
-			expectedHash:         "52f2fa59c20ab2b747ba019f6835d62c0cf76712261966b859e34957c4804578",
-		},
-		{
-			name: "withErrorGettingDiffHash",
-			wdGetter: &fakeWorkingDirGetter{
-				workingDir: "/tmp/test-okteto/working-dir",
-			},
-			context:              "test",
-			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-			errSHA:               nil,
-			diffHash:             "",
-			errHash:              assert.AnError,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
-			expectedHash:         "52b47d89a34e4ed991d415b72b3359ebc1d3204bab998ef94f1bec390dc4f0e0",
-		},
-		{
-			name: "withoutErrorWithRelativePathOnContext",
-			wdGetter: &fakeWorkingDirGetter{
-				workingDir: "/tmp/test-okteto/working-dir",
-			},
-			context:              "test/service-a",
-			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-			errSHA:               nil,
-			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-			errHash:              nil,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test/service-a",
-			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
-		},
-		{
-			name: "withoutErrorWithAbsolutePathOnContext",
-			wdGetter: &fakeWorkingDirGetter{
-				workingDir: "/tmp/test-okteto/working-dir",
-			},
-			context:              "/tmp/test-case/absolute-path/test/service-a",
-			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-			errSHA:               nil,
-			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-			errHash:              nil,
-			expectedBuildContext: "/tmp/test-case/absolute-path/test/service-a",
-			expectedHash:         "c5de9669d6ad49db99a4a6415e61a378f98eb756fed8e0dc37fdf876436fcac4",
-		},
-		{
-			name: "withoutErrorWithEmptyContext",
-			wdGetter: &fakeWorkingDirGetter{
-				workingDir: "/tmp/test-okteto/working-dir",
-			},
-			context:              "",
-			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-			errSHA:               nil,
-			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-			errHash:              nil,
-			expectedBuildContext: "/tmp/test-okteto/working-dir",
-			expectedHash:         "63facbf3f5dede6119682e69dc444fa154d066a8449524a91862f8ada0e96d0f",
-		},
-		{
-			name: "withErrorGettingWorkingDirectoryWithRelativeContext",
-			wdGetter: &fakeWorkingDirGetter{
-				err: assert.AnError,
-			},
-			context:              "test/service-a",
-			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-			errSHA:               nil,
-			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-			errHash:              nil,
-			expectedBuildContext: "test/service-a",
-			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
-		},
-		{
-			name: "withErrorGettingWorkingDirectoryWithAbsoluteContext",
-			wdGetter: &fakeWorkingDirGetter{
-				err: assert.AnError,
-			},
-			context:              "/tmp/test-okteto/working-dir",
-			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
-			errSHA:               nil,
-			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
-			errHash:              nil,
-			expectedBuildContext: "/tmp/test-okteto/working-dir",
-			expectedHash:         "0eb548056aa376058d70623c8fd687d57493b1de7093f57102f70a68eeba86de",
-		},
-	}
+    serviceName := "fake-service"
+    tests := []struct {
+        name                 string
+        wdGetter             *fakeWorkingDirGetter
+        context              string
+        dirSHA               string
+        errSHA               error
+        diffHash             string
+        errHash              error
+        expectedBuildContext string
+        expectedHash         string
+    }{
+        {
+            name: "withErrorGettingShaAndDiffHash",
+            wdGetter: &fakeWorkingDirGetter{
+                workingDir: "/tmp/test-okteto/working-dir",
+            },
+            context:              "test",
+            dirSHA:               "",
+            errSHA:               assert.AnError,
+            diffHash:             "",
+            errHash:              assert.AnError,
+            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+            expectedHash:         "70d446809d8ec0a5c83cd8c74a24b757524e26c85ccd8f8101f40ed3f51275ea",
+        },
+        {
+            name: "withErrorGettingSha",
+            wdGetter: &fakeWorkingDirGetter{
+                workingDir: "/tmp/test-okteto/working-dir",
+            },
+            context:              "test",
+            dirSHA:               "",
+            errSHA:               assert.AnError,
+            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+            errHash:              nil,
+            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+            expectedHash:         "52f2fa59c20ab2b747ba019f6835d62c0cf76712261966b859e34957c4804578",
+        },
+        {
+            name: "withErrorGettingDiffHash",
+            wdGetter: &fakeWorkingDirGetter{
+                workingDir: "/tmp/test-okteto/working-dir",
+            },
+            context:              "test",
+            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+            errSHA:               nil,
+            diffHash:             "",
+            errHash:              assert.AnError,
+            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
+            expectedHash:         "52b47d89a34e4ed991d415b72b3359ebc1d3204bab998ef94f1bec390dc4f0e0",
+        },
+        {
+            name: "withoutErrorWithRelativePathOnContext",
+            wdGetter: &fakeWorkingDirGetter{
+                workingDir: "/tmp/test-okteto/working-dir",
+            },
+            context:              "test/service-a",
+            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+            errSHA:               nil,
+            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+            errHash:              nil,
+            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test/service-a"),
+            expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
+        },
+        {
+            name: "withoutErrorWithAbsolutePathOnContext",
+            wdGetter: &fakeWorkingDirGetter{
+                workingDir: "/tmp/test-okteto/working-dir",
+            },
+            context:              "/tmp/test-case/absolute-path/test/service-a",
+            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+            errSHA:               nil,
+            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+            errHash:              nil,
+            expectedBuildContext: filepath.Clean("/tmp/test-case/absolute-path/test/service-a"),
+            expectedHash:         "c5de9669d6ad49db99a4a6415e61a378f98eb756fed8e0dc37fdf876436fcac4",
+        },
+        {
+            name: "withoutErrorWithEmptyContext",
+            wdGetter: &fakeWorkingDirGetter{
+                workingDir: "/tmp/test-okteto/working-dir",
+            },
+            context:              "",
+            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+            errSHA:               nil,
+            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+            errHash:              nil,
+            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
+            expectedHash:         "63facbf3f5dede6119682e69dc444fa154d066a8449524a91862f8ada0e96d0f",
+        },
+        {
+            name: "withErrorGettingWorkingDirectoryWithRelativeContext",
+            wdGetter: &fakeWorkingDirGetter{
+                err: assert.AnError,
+            },
+            context:              "test/service-a",
+            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+            errSHA:               nil,
+            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+            errHash:              nil,
+            expectedBuildContext: filepath.Clean("test/service-a"),
+            expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
+        },
+        {
+            name: "withErrorGettingWorkingDirectoryWithAbsoluteContext",
+            wdGetter: &fakeWorkingDirGetter{
+                err: assert.AnError,
+            },
+            context:              "/tmp/test-okteto/working-dir",
+            dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+            errSHA:               nil,
+            diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+            errHash:              nil,
+            expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir"),
+            expectedHash:         "0eb548056aa376058d70623c8fd687d57493b1de7093f57102f70a68eeba86de",
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			repoController := &mockConfigRepo{}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            repoController := &mockConfigRepo{}
 
-			buildInfo := &build.Info{
-				Context: tt.context,
-			}
+            buildInfo := &build.Info{
+                Context: tt.context,
+            }
 
-			sh := &serviceHasher{
-				gitRepoCtrl: repoController,
-				fs:          afero.NewMemMapFs(),
-				getCurrentTimestampNano: func() int64 {
-					return int64(12312345252)
-				},
-				serviceShaCache: map[string]string{},
-				wdGetter:        tt.wdGetter,
-			}
+            sh := &serviceHasher{
+                gitRepoCtrl: repoController,
+                fs:          afero.NewMemMapFs(),
+                getCurrentTimestampNano: func() int64 {
+                    return int64(12312345252)
+                },
+                serviceShaCache: map[string]string{},
+                wdGetter:        tt.wdGetter,
+            }
 
-			repoController.On("GetLatestDirSHA", tt.expectedBuildContext).Return(tt.dirSHA, tt.errSHA)
+            repoController.On("GetLatestDirSHA", tt.expectedBuildContext).Return(tt.dirSHA, tt.errSHA)
 
-			repoController.On("GetDiffHash", tt.expectedBuildContext).Return(tt.diffHash, tt.errHash)
+            repoController.On("GetDiffHash", tt.expectedBuildContext).Return(tt.diffHash, tt.errHash)
 
-			hash := sh.hashWithBuildContext(buildInfo, serviceName)
+            hash := sh.hashWithBuildContext(buildInfo, serviceName)
 
-			assert.Equal(t, tt.expectedHash, hash)
+            assert.Equal(t, tt.expectedHash, hash)
 
-			repoController.AssertExpectations(t)
-		})
-	}
+            repoController.AssertExpectations(t)
+        })
+    }
 }

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/okteto/okteto/pkg/build"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type fakeWorkingDirGetter struct {
@@ -32,6 +33,23 @@ func (f fakeWorkingDirGetter) Get() (string, error) {
 		return "", f.err
 	}
 	return f.workingDir, nil
+}
+
+type mockConfigRepo struct {
+	mock.Mock
+}
+
+func (m *mockConfigRepo) GetSHA() (string, error) {
+	args := m.Called()
+	return args.Get(0).(string), args.Error(1)
+}
+func (m *mockConfigRepo) GetLatestDirSHA(dir string) (string, error) {
+	args := m.Called(dir)
+	return args.String(0), args.Error(1)
+}
+func (m *mockConfigRepo) GetDiffHash(dir string) (string, error) {
+	args := m.Called(dir)
+	return args.String(0), args.Error(1)
 }
 
 func TestServiceHasher_HashProjectCommit(t *testing.T) {
@@ -71,43 +89,152 @@ func TestServiceHasher_HashProjectCommit(t *testing.T) {
 	}
 }
 
-func TestServiceHasher_HashBuildContext(t *testing.T) {
-	fakeErr := errors.New("fake error")
+func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 	serviceName := "fake-service"
 	tests := []struct {
-		repoCtrl     repositoryCommitRetriever
-		name         string
-		expectedHash string
+		name                 string
+		wdGetter             *fakeWorkingDirGetter
+		context              string
+		dirSHA               string
+		errSHA               error
+		diffHash             string
+		errHash              error
+		expectedBuildContext string
+		expectedHash         string
 	}{
 		{
-			name: "success",
-			repoCtrl: fakeConfigRepo{
-				sha: "testtreehash",
+			name: "withErrorGettingShaAndDiffHash",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
 			},
-			expectedHash: "b6f9d71cf55933c6e385102e196522fd73c279c1edaa919b565706fb0bc3d8ce",
+			context:              "test",
+			dirSHA:               "",
+			errSHA:               assert.AnError,
+			diffHash:             "",
+			errHash:              assert.AnError,
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
+			expectedHash:         "70d446809d8ec0a5c83cd8c74a24b757524e26c85ccd8f8101f40ed3f51275ea",
 		},
 		{
-			name: "error",
-			repoCtrl: fakeConfigRepo{
-				err: fakeErr,
+			name: "withErrorGettingSha",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
 			},
-			expectedHash: "11cf9a064fe9b8419441515afbc33d22257ce11269ecbea211575f8cf4a33fac",
+			context:              "test",
+			dirSHA:               "",
+			errSHA:               assert.AnError,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
+			expectedHash:         "52f2fa59c20ab2b747ba019f6835d62c0cf76712261966b859e34957c4804578",
+		},
+		{
+			name: "withErrorGettingDiffHash",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "test",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "",
+			errHash:              assert.AnError,
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
+			expectedHash:         "52b47d89a34e4ed991d415b72b3359ebc1d3204bab998ef94f1bec390dc4f0e0",
+		},
+		{
+			name: "withoutErrorWithRelativePathOnContext",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "test/service-a",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: "/tmp/test-okteto/working-dir/test/service-a",
+			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
+		},
+		{
+			name: "withoutErrorWithAbsolutePathOnContext",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "/tmp/test-case/absolute-path/test/service-a",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: "/tmp/test-case/absolute-path/test/service-a",
+			expectedHash:         "c5de9669d6ad49db99a4a6415e61a378f98eb756fed8e0dc37fdf876436fcac4",
+		},
+		{
+			name: "withoutErrorWithEmptyContext",
+			wdGetter: &fakeWorkingDirGetter{
+				workingDir: "/tmp/test-okteto/working-dir",
+			},
+			context:              "",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: "/tmp/test-okteto/working-dir",
+			expectedHash:         "63facbf3f5dede6119682e69dc444fa154d066a8449524a91862f8ada0e96d0f",
+		},
+		{
+			name: "withErrorGettingWorkingDirectoryWithRelativeContext",
+			wdGetter: &fakeWorkingDirGetter{
+				err: assert.AnError,
+			},
+			context:              "test/service-a",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: "test/service-a",
+			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
+		},
+		{
+			name: "withErrorGettingWorkingDirectoryWithAbsoluteContext",
+			wdGetter: &fakeWorkingDirGetter{
+				err: assert.AnError,
+			},
+			context:              "/tmp/test-okteto/working-dir",
+			dirSHA:               "cc46d77bac8ccb52a3972689c95b55ed300adf33",
+			errSHA:               nil,
+			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
+			errHash:              nil,
+			expectedBuildContext: "/tmp/test-okteto/working-dir",
+			expectedHash:         "0eb548056aa376058d70623c8fd687d57493b1de7093f57102f70a68eeba86de",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			repoController := &mockConfigRepo{}
+
+			buildInfo := &build.Info{
+				Context: tt.context,
+			}
+
 			sh := &serviceHasher{
-				gitRepoCtrl: tt.repoCtrl,
+				gitRepoCtrl: repoController,
 				fs:          afero.NewMemMapFs(),
 				getCurrentTimestampNano: func() int64 {
 					return int64(12312345252)
 				},
 				serviceShaCache: map[string]string{},
-				wdGetter:        fakeWorkingDirGetter{},
+				wdGetter:        tt.wdGetter,
 			}
-			hash := sh.hashWithBuildContext(&build.Info{}, serviceName)
+
+			repoController.On("GetLatestDirSHA", tt.expectedBuildContext).Return(tt.dirSHA, tt.errSHA)
+
+			repoController.On("GetDiffHash", tt.expectedBuildContext).Return(tt.diffHash, tt.errHash)
+
+			hash := sh.hashWithBuildContext(buildInfo, serviceName)
+
 			assert.Equal(t, tt.expectedHash, hash)
+
+			repoController.AssertExpectations(t)
 		})
 	}
 }

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -15,6 +15,7 @@ package smartbuild
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/build"
@@ -112,7 +113,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               assert.AnError,
 			diffHash:             "",
 			errHash:              assert.AnError,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
 			expectedHash:         "70d446809d8ec0a5c83cd8c74a24b757524e26c85ccd8f8101f40ed3f51275ea",
 		},
 		{
@@ -125,7 +126,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               assert.AnError,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
 			expectedHash:         "52f2fa59c20ab2b747ba019f6835d62c0cf76712261966b859e34957c4804578",
 		},
 		{
@@ -138,7 +139,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "",
 			errHash:              assert.AnError,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test",
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test"),
 			expectedHash:         "52b47d89a34e4ed991d415b72b3359ebc1d3204bab998ef94f1bec390dc4f0e0",
 		},
 		{
@@ -151,7 +152,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 			errSHA:               nil,
 			diffHash:             "e8a0e7cc771c6947f0808ebaef3f86b2ae8d2cf1",
 			errHash:              nil,
-			expectedBuildContext: "/tmp/test-okteto/working-dir/test/service-a",
+			expectedBuildContext: filepath.Clean("/tmp/test-okteto/working-dir/test/service-a"),
 			expectedHash:         "f01cf2257431831e32332e11d817d2c144fb8668fc73de0aec5b80f3b7379f0d",
 		},
 		{

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -59,13 +59,13 @@ type Ctrl struct {
 }
 
 // NewSmartBuildCtrl creates a new smart build controller
-func NewSmartBuildCtrl(repo repositoryInterface, registry registryController, fs afero.Fs, ioCtrl *io.Controller) *Ctrl {
+func NewSmartBuildCtrl(repo repositoryInterface, registry registryController, fs afero.Fs, ioCtrl *io.Controller, wdGetter osWorkingDirGetter) *Ctrl {
 	isEnabled := env.LoadBooleanOrDefault(OktetoEnableSmartBuildEnvVar, true)
 
 	return &Ctrl{
 		gitRepo:            repo,
 		isEnabled:          isEnabled,
-		hasher:             newServiceHasher(repo, fs),
+		hasher:             newServiceHasher(repo, fs, wdGetter),
 		registryController: registry,
 		ioCtrl:             ioCtrl,
 	}

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -103,7 +103,8 @@ func TestNewSmartBuildCtrl(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(OktetoEnableSmartBuildEnvVar, tt.input.isEnabledValue)
 
-			ctrl := NewSmartBuildCtrl(&fakeConfigRepo{}, &fakeRegistryController{}, afero.NewMemMapFs(), io.NewIOController())
+			wdGetter := fakeWorkingDirGetter{}
+			ctrl := NewSmartBuildCtrl(&fakeConfigRepo{}, &fakeRegistryController{}, afero.NewMemMapFs(), io.NewIOController(), wdGetter)
 
 			assert.Equal(t, tt.output.isEnabled, ctrl.IsEnabled())
 		})
@@ -310,10 +311,11 @@ func Test_getBuildHashFromCommit(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			wdGetter := fakeWorkingDirGetter{}
 			got, err := newServiceHasher(fakeConfigRepo{
 				sha: tc.input.repo.sha,
 				err: tc.input.repo.err,
-			}, afero.NewMemMapFs()).hashProjectCommit(tc.input.buildInfo)
+			}, afero.NewMemMapFs(), wdGetter).hashProjectCommit(tc.input.buildInfo)
 			assert.ErrorIs(t, err, tc.expectedErr)
 			if tc.expected != "" {
 				expectedHash := sha256.Sum256([]byte(tc.expected))

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -47,6 +47,7 @@ type LocalExec struct{}
 
 func (le *LocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
 	c := le.createCommand(ctx, dir, name, arg...)
+	oktetoLog.Debugf("executing command: %s", strings.Join(c.Args, " "))
 
 	return c.Output()
 }
@@ -60,6 +61,8 @@ func (*LocalExec) LookPath(file string) (string, error) {
 func (le *LocalExec) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
 	c1 := le.createCommand(ctx, dir, cmd1, cmd1Args...)
 	c2 := le.createCommand(ctx, dir, cmd2, cmd2Args...)
+
+	oktetoLog.Debugf("running command %s | %s", strings.Join(c1.Args, " "), strings.Join(c2.Args, " "))
 
 	var errOut bytes.Buffer
 	var errOut2 bytes.Buffer


### PR DESCRIPTION
# Proposed changes

Fixes DEV-690

When images specify a parent folder as context, or if the command is executed from a parent folder and the build context a is grand-child folder, the calculation of the Smart Builds context wasn't being done correctly, because the path specified to git commands wasn't right.

Apart from that, in some cases, the build context is a relative path (when the build information is specified in an Okteto manifest), and other times it is an absolute path (when the build information comes from a compose file), so it was confusing the path passed to git commands.

With these changes, we now send always to git a local absolute path to the folder containing the image build context:
* If the build context is already an absolute path, we just pass that value to the git command, as it was already calculated properly
* If the build context is a relative path, we just join the current working directory + the build context. As the build context was already calculated based on the working directory, joining both of them, we have the right absolute path, so git always works with absolute routes to folders.

I added also a few debug commands, so we can see in the traces which commands are executed with git to calculate the build context.

## How to validate

Using the repository https://github.com/ifbyol/test-okteto and the branch `ifbyol/test-smart-build-contexts`, you could test all the different scenarios (each folder is an scenario to test). Without my changes, you can see how some of those cases don't work as expected, and after my changes, smart builds works as expected.

To validate it properly, it should be executed from the root of the repo, but also from other paths, to make sure we always specify the right path to git to do the Smart Build calculations

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

