### PR TITLE
Fix okteto status: namespace load for synthing

### DIFF
--- a/cmd/context/utils.go
+++ b/cmd/context/utils.go
@@ -30,10 +30,8 @@ type SelectItem struct {
 }
 
 type ManifestOptions struct {
-	Name       string
-	Namespace  string
-	Filename   string
-	K8sContext string
+	Name     string
+	Filename string
 }
 
 func getKubernetesContextList(filterOkteto bool) []string {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -64,9 +64,7 @@ func Down(at analyticsTrackerInterface, k8sLogsCtrl *io.K8sLogger, fs afero.Fs) 
 			}
 
 			manifestOpts := contextCMD.ManifestOptions{
-				Filename:   devPath,
-				Namespace:  okteto.GetContext().Namespace,
-				K8sContext: okteto.GetContext().Name,
+				Filename: devPath,
 			}
 			if devPath != "" {
 				workdir := filesystem.GetWorkdirFromManifestPath(devPath)

--- a/cmd/exec/cmd.go
+++ b/cmd/exec/cmd.go
@@ -113,7 +113,7 @@ okteto exec api -- bash`,
 				return err
 			}
 
-			manifestOpts := contextCMD.ManifestOptions{Filename: execFlags.manifestPath, Namespace: execFlags.namespace, K8sContext: execFlags.k8sContext}
+			manifestOpts := contextCMD.ManifestOptions{Filename: execFlags.manifestPath}
 			manifest, err := model.GetManifestV2(manifestOpts.Filename, e.fs)
 			if err != nil {
 				return fmt.Errorf("failed to load manifest: %w", err)

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -59,7 +59,7 @@ func Restart(fs afero.Fs) *cobra.Command {
 
 			ctx := context.Background()
 
-			manifestOpts := contextCMD.ManifestOptions{Filename: devPath, Namespace: namespace, K8sContext: k8sContext}
+			manifestOpts := contextCMD.ManifestOptions{Filename: devPath}
 			manifest, err := model.GetManifestV2(manifestOpts.Filename, afero.NewOsFs())
 			if err != nil {
 				return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -73,7 +73,7 @@ func Status(fs afero.Fs) *cobra.Command {
 				return err
 			}
 
-			manifestOpts := contextCMD.ManifestOptions{Filename: devPath, Namespace: namespace, K8sContext: k8sContext}
+			manifestOpts := contextCMD.ManifestOptions{Filename: devPath}
 			manifest, err := model.GetManifestV2(manifestOpts.Filename, afero.NewOsFs())
 			if err != nil {
 				return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -106,7 +106,8 @@ func Status(fs afero.Fs) *cobra.Command {
 				return err
 			}
 
-			sy, err := syncthing.Load(dev, namespace)
+			ctxNamespace := okteto.GetContext().Namespace
+			sy, err := syncthing.Load(dev, ctxNamespace)
 			if err != nil {
 				oktetoLog.Infof("error accessing the syncthing info file: %s", err)
 				return oktetoErrors.ErrNotInDevMode


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-707

Discovered while testing `okteto status` was not reporting devmode status.

- Removed unused Namespace and Context from manifest Options (keys from struct and assignations) The values are not read
- Load of synthing info was using `namespace` which was only referencing the flag value, but not the context value.

Tested:

overriden flag value with non running
❯ ok status --namespace teresaromero-patata
 i  Using teresaromero-patata @ - as context
 x  Development mode isn't enabled on your deployment
    Run 'okteto up' to enable it and try again

overriden flag value with current namespace
❯ ok status --namespace teresaromero
 i  Using teresaromero @ - as context
 ✓  Synchronization status: 100.00%
 
current namespace
 ❯ ok status
 i  Using teresaromero @ - as context
 ✓  Synchronization status: 100.00%

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
