### PR TITLE
fix: build command to handle Okteto Manifest without a build section

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -190,7 +190,11 @@ func (bc *Command) getBuilder(options *types.BuildOptions, okCtx *okteto.Context
 			}
 			builder = buildv2.NewBuilder(bc.Builder, bc.Registry, bc.ioCtrl, okCtx, bc.k8slogger, callbacks)
 		} else {
-			builder = buildv1.NewBuilder(bc.Builder, bc.ioCtrl)
+			return nil, oktetoErrors.UserError{
+				E: fmt.Errorf("specified Okteto Manifest doesn't contain a build section"),
+				Hint: `Add a build section to your Okteto Manifest to build your images.
+    See more at: https://www.okteto.com/docs/1.25/core/okteto-manifest/#build`,
+			}
 		}
 	}
 

--- a/cmd/build/command_test.go
+++ b/cmd/build/command_test.go
@@ -122,6 +122,10 @@ func getManifestWithError(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return nil, assert.AnError
 }
 
+func getFakeManifestV2NoBuild(_ string, _ afero.Fs) (*model.Manifest, error) {
+	return &model.Manifest{}, nil
+}
+
 func getManifestWithInvalidManifestError(_ string, _ afero.Fs) (*model.Manifest, error) {
 	return nil, oktetoErrors.ErrInvalidManifest
 }
@@ -267,6 +271,19 @@ func TestBuilderIsProperlyGenerated(t *testing.T) {
 			},
 			options:           &types.BuildOptions{},
 			expectedError:     false,
+			isBuildV2Expected: false,
+		},
+		{
+			name: "Manifest without build section. error",
+			buildCommand: &Command{
+				GetManifest:      getFakeManifestV2NoBuild,
+				Registry:         newFakeRegistry(),
+				ioCtrl:           io.NewIOController(),
+				analyticsTracker: fakeAnalyticsTracker{},
+				insights:         fakeAnalyticsTracker{},
+			},
+			options:           &types.BuildOptions{},
+			expectedError:     true,
 			isBuildV2Expected: false,
 		},
 	}


### PR DESCRIPTION
# Proposed changes

When using build command with a compose without build or an okteto manifest without build sections throw an error

## How to validate

1. Using a okteto manifest without build section. 
1. Run okteto build and see error
1.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
