### PR TITLE
Fix `okteto build -f <folder>`

### DIFF
--- a/cmd/build/basic/build.go
+++ b/cmd/build/basic/build.go
@@ -22,10 +22,9 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/env"
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 )
 
@@ -60,17 +59,8 @@ func (ob *Builder) Build(ctx context.Context, options *types.BuildOptions) error
 	if options.File == "" {
 		options.File = filepath.Join(path, "Dockerfile")
 	}
-
-	fs := afero.NewOsFs()
-
-	// check that the manifest file exists
-	if !filesystem.FileExistsWithFilesystem(options.File, fs) {
-		return oktetoErrors.ErrManifestPathNotFound
-	}
-
-	// the Okteto manifest flag should specify a file, not a directory
-	if filesystem.IsDir(options.File, fs) {
-		return oktetoErrors.ErrManifestPathIsDir
+	if err := validator.FileArgumentIsNotDir(afero.NewOsFs(), options.File); err != nil {
+		return err
 	}
 
 	var err error

--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -36,6 +36,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/registry"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -114,12 +115,15 @@ func Build(ctx context.Context, ioCtrl *io.Controller, at, insights buildTracker
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
+			if err := validator.FileArgumentIsNotDir(afero.NewOsFs(), options.File); err != nil {
+				return err
+			}
+
 			ioCtrl.Logger().Info("context loaded")
 
 			bc := NewBuildCommand(ioCtrl, at, insights, oktetoContext, k8slogger)
 
 			builder, err := bc.getBuilder(options, oktetoContext)
-
 			if err != nil {
 				return err
 			}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -851,18 +851,13 @@ func checkOktetoManifestPathFlag(options *Options, fs afero.Fs) error {
 	if err != nil {
 		return err
 	}
+
+	if err := validator.FileArgumentIsNotDir(fs, manifestPathFlag); err != nil {
+		return err
+	}
+
 	// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
 	options.ManifestPathFlag = manifestPathFlag
-
-	// check that the manifest file exists
-	if !filesystem.FileExistsWithFilesystem(manifestPathFlag, fs) {
-		return oktetoErrors.ErrManifestPathNotFound
-	}
-
-	// the Okteto manifest flag should specify a file, not a directory
-	if filesystem.IsDir(manifestPathFlag, fs) {
-		return oktetoErrors.ErrManifestPathIsDir
-	}
 
 	// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir
 	uptManifestPath, err := filesystem.UpdateCWDtoManifestPath(options.ManifestPath)

--- a/cmd/deploy/endpoints.go
+++ b/cmd/deploy/endpoints.go
@@ -32,6 +32,7 @@ import (
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -96,15 +97,10 @@ func Endpoints(ctx context.Context, k8sLogger *io.K8sLogger) *cobra.Command {
 				}
 				options.ManifestPath = filesystem.GetManifestPathFromWorkdir(options.ManifestPath, workdir)
 
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(options.ManifestPath, fs) {
-					return oktetoErrors.ErrManifestPathNotFound
+				if err := validator.FileArgumentIsNotDir(fs, options.ManifestPath); err != nil {
+					return err
 				}
 
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(options.ManifestPath, fs) {
-					return oktetoErrors.ErrManifestPathIsDir
-				}
 			}
 
 			// false for 'json' and 'md' to avoid breaking their syntax

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -46,6 +46,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	oktetoPath "github.com/okteto/okteto/pkg/path"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
@@ -158,14 +159,8 @@ If you need to destroy external resources (like s3 buckets or other Cloud resour
 				// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
 				options.ManifestPathFlag = manifestPathFlag
 
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(manifestPathFlag, fs) {
-					return oktetoErrors.ErrManifestPathNotFound
-				}
-
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(manifestPathFlag, fs) {
-					return oktetoErrors.ErrManifestPathIsDir
+				if err := validator.FileArgumentIsNotDir(fs, options.ManifestPath); err != nil {
+					return err
 				}
 
 				// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -22,11 +22,11 @@ import (
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/doctor"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/filesystem"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -49,16 +49,8 @@ func Doctor(k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oktetoLog.Info("starting doctor command")
 
-			if doctorOpts.DevPath != "" {
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(doctorOpts.DevPath, fs) {
-					return oktetoErrors.ErrManifestPathNotFound
-				}
-
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(doctorOpts.DevPath, fs) {
-					return oktetoErrors.ErrManifestPathIsDir
-				}
+			if err := validator.FileArgumentIsNotDir(fs, doctorOpts.DevPath); err != nil {
+				return err
 			}
 
 			ctx := context.Background()

--- a/cmd/exec/cmd.go
+++ b/cmd/exec/cmd.go
@@ -23,10 +23,10 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	okerrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -92,16 +92,8 @@ okteto exec api -- echo this is a test
 # Get an interactive shell session inside the Development Container 'api'
 okteto exec api -- bash`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if execFlags.manifestPath != "" {
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(execFlags.manifestPath, e.fs) {
-					return okerrors.ErrManifestPathNotFound
-				}
-
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(execFlags.manifestPath, e.fs) {
-					return okerrors.ErrManifestPathIsDir
-				}
+			if err := validator.FileArgumentIsNotDir(e.fs, execFlags.manifestPath); err != nil {
+				return err
 			}
 
 			ctxOpts := &contextCMD.Options{

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -24,11 +24,11 @@ import (
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/filesystem"
 	"github.com/okteto/okteto/pkg/k8s/pods"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -45,16 +45,8 @@ func Restart(fs afero.Fs) *cobra.Command {
 		Args:   utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#restart"),
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if devPath != "" {
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(devPath, fs) {
-					return oktetoErrors.ErrManifestPathNotFound
-				}
-
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(devPath, fs) {
-					return oktetoErrors.ErrManifestPathIsDir
-				}
+			if err := validator.FileArgumentIsNotDir(fs, devPath); err != nil {
+				return err
 			}
 
 			ctx := context.Background()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -26,11 +26,11 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/status"
 	"github.com/okteto/okteto/pkg/config"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	"github.com/okteto/okteto/pkg/filesystem"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/syncthing"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -51,16 +51,8 @@ func Status(fs afero.Fs) *cobra.Command {
 		Short: "Status of the file synchronization process for a given Development Container",
 		Args:  utils.MaximumNArgsAccepted(1, "https://okteto.com/docs/reference/okteto-cli/#status"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if devPath != "" {
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(devPath, fs) {
-					return oktetoErrors.ErrManifestPathNotFound
-				}
-
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(devPath, fs) {
-					return oktetoErrors.ErrManifestPathIsDir
-				}
+			if err := validator.FileArgumentIsNotDir(fs, devPath); err != nil {
+				return err
 			}
 
 			if okteto.InDevContainer() {

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -161,14 +161,8 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
 		options.ManifestPathFlag = manifestPathFlag
 
-		// check that the manifest file exists
-		if !filesystem.FileExistsWithFilesystem(options.ManifestPath, fs) {
-			return analytics.TestMetadata{}, oktetoErrors.ErrManifestPathNotFound
-		}
-
-		// the Okteto manifest flag should specify a file, not a directory
-		if filesystem.IsDir(options.ManifestPath, fs) {
-			return analytics.TestMetadata{}, oktetoErrors.ErrManifestPathIsDir
+		if err := validator.FileArgumentIsNotDir(fs, options.ManifestPath); err != nil {
+			return analytics.TestMetadata{}, err
 		}
 
 		// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -54,6 +54,7 @@ import (
 	"github.com/okteto/okteto/pkg/ssh"
 	"github.com/okteto/okteto/pkg/syncthing"
 	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,14 +152,8 @@ okteto up api -- echo this is a test
 				// as the installer uses root for executing the pipeline, we save the rel path from root as ManifestPathFlag option
 				upOptions.ManifestPathFlag = manifestPathFlag
 
-				// check that the manifest file exists
-				if !filesystem.FileExistsWithFilesystem(manifestPathFlag, fs) {
-					return oktetoErrors.ErrManifestPathNotFound
-				}
-
-				// the Okteto manifest flag should specify a file, not a directory
-				if filesystem.IsDir(manifestPathFlag, fs) {
-					return oktetoErrors.ErrManifestPathIsDir
+				if err := validator.FileArgumentIsNotDir(fs, manifestPathFlag); err != nil {
+					return err
 				}
 
 				// when the manifest path is set by the cmd flag, we are moving cwd so the cmd is executed from that dir

--- a/pkg/validator/arguments.go
+++ b/pkg/validator/arguments.go
@@ -6,7 +6,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-// FileArgumentIsNotDir validates that the file input exists and is not a directory
+// FileArgumentIsNotDir validates the given file, if empty it returns nil
+// errors: ErrManifestPathNotFound, ErrManifestPathIsDir
 func FileArgumentIsNotDir(fs afero.Fs, file string) error {
 	if file == "" {
 		return nil

--- a/pkg/validator/arguments.go
+++ b/pkg/validator/arguments.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package validator
 
 import (

--- a/pkg/validator/arguments.go
+++ b/pkg/validator/arguments.go
@@ -1,0 +1,23 @@
+package validator
+
+import (
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/filesystem"
+	"github.com/spf13/afero"
+)
+
+// FileArgumentIsNotDir validates that the file input exists and is not a directory
+func FileArgumentIsNotDir(fs afero.Fs, file string) error {
+	if file == "" {
+		return nil
+	}
+
+	if !filesystem.FileExistsWithFilesystem(file, fs) {
+		return oktetoErrors.ErrManifestPathNotFound
+	}
+	if filesystem.IsDir(file, fs) {
+		return oktetoErrors.ErrManifestPathIsDir
+	}
+
+	return nil
+}

--- a/pkg/validator/arguments_test.go
+++ b/pkg/validator/arguments_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package validator
 
 import (
@@ -17,9 +30,9 @@ func TestFileArgumentIsNotDir(t *testing.T) {
 		createFile bool
 	}
 	tests := []struct {
-		name    string
-		args    args
 		wantErr error
+		args    args
+		name    string
 	}{
 		{
 			name: "empty file",

--- a/pkg/validator/arguments_test.go
+++ b/pkg/validator/arguments_test.go
@@ -31,8 +31,8 @@ func TestFileArgumentIsNotDir(t *testing.T) {
 	}
 	tests := []struct {
 		wantErr error
-		args    args
 		name    string
+		args    args
 	}{
 		{
 			name: "empty file",

--- a/pkg/validator/arguments_test.go
+++ b/pkg/validator/arguments_test.go
@@ -1,0 +1,76 @@
+package validator
+
+import (
+	"testing"
+
+	okErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileArgumentIsNotDir(t *testing.T) {
+
+	type args struct {
+		fs         afero.Fs
+		file       string
+		dir        string
+		createFile bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "empty file",
+			args: args{
+				fs:   afero.NewMemMapFs(),
+				file: "",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "file not found",
+			args: args{
+				fs:   afero.NewMemMapFs(),
+				file: "file",
+			},
+			wantErr: okErrors.ErrManifestPathNotFound,
+		},
+		{
+			name: "file is a directory",
+			args: args{
+				fs:   afero.NewMemMapFs(),
+				file: "dir",
+				dir:  "dir",
+			},
+			wantErr: okErrors.ErrManifestPathIsDir,
+		},
+		{
+			name: "file is a file",
+			args: args{
+				fs:         afero.NewMemMapFs(),
+				file:       "file",
+				createFile: true,
+			},
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.args.dir != "" {
+				err := tt.args.fs.Mkdir(tt.args.dir, 0755)
+				assert.NoError(t, err)
+			}
+			if tt.args.createFile {
+				_, err := tt.args.fs.Create(tt.args.file)
+				assert.NoError(t, err)
+			}
+
+			err := FileArgumentIsNotDir(tt.args.fs, tt.args.file)
+
+			assert.Equal(t, tt.wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-708

- new function at `validator` to unify the validation of the File argument: it exist and is not a folder
- use the validator at the build command, before it was only verifying at the basic builder
- replace both filesystem functions for the validator to unify the implementation. 

 ## How to validate

With a manifest under a folder (eg: `folder/okteto.yaml`), the manifest having a build section: `okteto build -f folder`. 
This should fail with the fix.
It was building without the fix.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
