### PR TITLE
fix: versions getting last 15 from gh

### DIFF
--- a/cmd/utils/upgrade.go
+++ b/cmd/utils/upgrade.go
@@ -56,7 +56,7 @@ func UpgradeAvailable() string {
 func GetLatestVersionFromGithub() (string, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
-	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 15})
+	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 20})
 	if err != nil {
 		return "", fmt.Errorf("fail to get releases from github: %w", err)
 	}

--- a/cmd/utils/upgrade.go
+++ b/cmd/utils/upgrade.go
@@ -56,7 +56,7 @@ func UpgradeAvailable() string {
 func GetLatestVersionFromGithub() (string, error) {
 	client := github.NewClient(nil)
 	ctx := context.Background()
-	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 10})
+	releases, _, err := client.Repositories.ListReleases(ctx, "okteto", "okteto", &github.ListOptions{PerPage: 15})
 	if err != nil {
 		return "", fmt.Errorf("fail to get releases from github: %w", err)
 	}


### PR DESCRIPTION
# Proposed changes

Get last 15 versions from gh instead of 10 in order to get the last stable version

## How to validate

1. Check e2e tests
1.
1.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
