### PR TITLE
move name inferrer inside destroyCommand.destroy

### DIFF
--- a/cmd/destroy/build_control.go
+++ b/cmd/destroy/build_control.go
@@ -26,6 +26,16 @@ import (
 	"github.com/okteto/okteto/pkg/types"
 )
 
+type buildControlProvider struct {
+	analyticsTracker buildTrackerInterface
+	insights         buildTrackerInterface
+	ioCtrl           *io.Controller
+}
+
+func (bc *buildControlProvider) provide(name string) buildCtrl {
+	return newBuildCtrl(name, bc.analyticsTracker, bc.insights, bc.ioCtrl)
+}
+
 type buildCtrl struct {
 	builder builderInterface
 	name    string

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -376,7 +376,6 @@ func setOptionsNameAndManifestName(ctx context.Context, namespace string, opts *
 	// infer name and set it to the manifest name
 	opts.Name = inferer.InferName(ctx, cwd, namespace, opts.ManifestPathFlag)
 	opts.Manifest.Name = opts.Name
-	return
 }
 
 // destroy runs the logic needed to destroy a dev environment

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -148,13 +148,13 @@ If you need to destroy external resources (like s3 buckets or other Cloud resour
 `,
 		Args: utils.NoArgsAccepted("https://okteto.com/docs/reference/okteto-cli/#destroy"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			initialCWD, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("failed to get the current working directory: %w", err)
-			}
-
 			if options.ManifestPath != "" {
 				// if path is absolute, its transformed to rel from root
+				initialCWD, err := os.Getwd()
+				if err != nil {
+					return fmt.Errorf("failed to get the current working directory: %w", err)
+				}
+
 				manifestPathFlag, err := oktetoPath.GetRelativePathFromCWD(initialCWD, options.ManifestPath)
 				if err != nil {
 					return err
@@ -191,6 +191,12 @@ If you need to destroy external resources (like s3 buckets or other Cloud resour
 
 			if !okteto.IsOkteto() {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
+			}
+
+			// cwd could have been changed by the manifest path flag
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("failed to get the current working directory: %w", err)
 			}
 
 			dynClient, _, err := okteto.GetDynamicClient()
@@ -246,7 +252,7 @@ If you need to destroy external resources (like s3 buckets or other Cloud resour
 				}
 			}
 			options.Manifest = manifest
-			setOptionsNameAndManifestName(ctx, okteto.GetContext().Namespace, options, inferer, initialCWD)
+			setOptionsNameAndManifestName(ctx, okteto.GetContext().Namespace, options, inferer, cwd)
 
 			// We need to create a custom kubeconfig file to avoid to modify the user's kubeconfig when running the
 			// destroy operation locally. This kubeconfig contains the kubernetes configuration got from the okteto


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-706

Debugged the issue and found that the `destroy` command was not taking into account the manifest.name option when is run inside a deploy manifest.

The name inferrer was setting the name as the repo name when the configmap was not found, as a fallback. After this was set, when the manifest was read, the name inside the manifest was not taken into account.

Proposed changes:
- create a buildControlInterface to be able to use the correct name when providing the build controller
- decide the ops.Name in the same place once we have the manifest to have all params taken into account



## How to validate

Build the binary and deploy a dev instance. Reproduce the steps as mentioned on the ticket. 
Fork with changes without the installation of 2.31 https://github.com/teresaromero/okteto-test 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
