### PR TITLE
Support for "priorityClassName" in dev containers

### DIFF
--- a/pkg/k8s/apps/translate.go
+++ b/pkg/k8s/apps/translate.go
@@ -185,6 +185,7 @@ func TranslatePodSpec(podSpec *apiv1.PodSpec, rule *model.TranslationRule) {
 	TranslateOktetoVolumes(podSpec, rule)
 	TranslatePodSecurityContext(podSpec, rule.SecurityContext)
 	TranslatePodServiceAccount(podSpec, rule.ServiceAccount)
+	TranslatePodPriorityClassName(podSpec, rule.PriorityClassName)
 
 	TranslateOktetoNodeSelector(podSpec, rule.NodeSelector)
 	TranslateOktetoAffinity(podSpec, rule.Affinity)
@@ -450,6 +451,13 @@ func TranslatePodSecurityContext(spec *apiv1.PodSpec, s *model.SecurityContext) 
 func TranslatePodServiceAccount(spec *apiv1.PodSpec, sa string) {
 	if sa != "" {
 		spec.ServiceAccountName = sa
+	}
+}
+
+// TranslatePodPriorityClassName translates the priority class the pod uses
+func TranslatePodPriorityClassName(spec *apiv1.PodSpec, pc string) {
+	if pc != "" {
+		spec.PriorityClassName = pc
 	}
 }
 

--- a/pkg/k8s/apps/translate_test.go
+++ b/pkg/k8s/apps/translate_test.go
@@ -68,6 +68,7 @@ dev:
       runAsGroup: 101
       fsGroup: 102
     serviceAccount: sa
+    priorityClassName: class
     sync:
       - .:/app
       - sub:/path
@@ -164,6 +165,7 @@ dev:
 			FSGroup: &fsGroup,
 		},
 		ServiceAccountName:            "sa",
+		PriorityClassName:             "class",
 		TerminationGracePeriodSeconds: pointer.Int64(0),
 		Volumes: []apiv1.Volume{
 			{
@@ -495,6 +497,7 @@ dev:
 			FSGroup: pointer.Int64(0),
 		},
 		ServiceAccountName:            "",
+		PriorityClassName:             "class",
 		TerminationGracePeriodSeconds: pointer.Int64(0),
 		Volumes: []apiv1.Volume{
 			{

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -74,6 +74,7 @@ func Sandbox(dev *model.Dev, namespace string) *appsv1.Deployment {
 				},
 				Spec: apiv1.PodSpec{
 					ServiceAccountName:            dev.ServiceAccount,
+					PriorityClassName:             dev.PriorityClassName,
 					TerminationGracePeriodSeconds: pointer.Int64(0),
 					Containers: []apiv1.Container{
 						{

--- a/pkg/k8s/statefulsets/crud.go
+++ b/pkg/k8s/statefulsets/crud.go
@@ -69,6 +69,7 @@ func Sandbox(dev *model.Dev, namespace string) *appsv1.StatefulSet {
 				},
 				Spec: apiv1.PodSpec{
 					ServiceAccountName:            dev.ServiceAccount,
+					PriorityClassName:             dev.PriorityClassName,
 					TerminationGracePeriodSeconds: pointer.Int64(0),
 					Containers: []apiv1.Container{
 						{

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -68,6 +68,7 @@ type Dev struct {
 	Name                 string                `json:"name,omitempty" yaml:"name,omitempty"`
 	Container            string                `json:"container,omitempty" yaml:"container,omitempty"`
 	ServiceAccount       string                `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
+	PriorityClassName    string                `json:"priorityClassName,omitempty" yaml:"priorityClassName,omitempty"`
 	parentSyncFolder     string
 	Interface            string           `json:"interface,omitempty" yaml:"interface,omitempty"`
 	Mode                 string           `json:"mode,omitempty" yaml:"mode,omitempty"`
@@ -816,21 +817,22 @@ func TranslatePodAffinity(tr *TranslationRule, name string) {
 // ToTranslationRule translates a dev struct into a translation rule
 func (dev *Dev) ToTranslationRule(main *Dev, namespace, username string, reset bool) *TranslationRule {
 	rule := &TranslationRule{
-		Container:        dev.Container,
-		ImagePullPolicy:  dev.ImagePullPolicy,
-		Environment:      dev.Environment,
-		Secrets:          dev.Secrets,
-		WorkDir:          dev.Workdir,
-		PersistentVolume: main.PersistentVolumeEnabled(),
-		Volumes:          []VolumeMount{},
-		SecurityContext:  dev.SecurityContext,
-		ServiceAccount:   dev.ServiceAccount,
-		Resources:        dev.Resources,
-		InitContainer:    dev.InitContainer,
-		Probes:           dev.Probes,
-		Lifecycle:        dev.Lifecycle,
-		NodeSelector:     dev.NodeSelector,
-		Affinity:         (*apiv1.Affinity)(dev.Affinity),
+		Container:         dev.Container,
+		ImagePullPolicy:   dev.ImagePullPolicy,
+		Environment:       dev.Environment,
+		Secrets:           dev.Secrets,
+		WorkDir:           dev.Workdir,
+		PersistentVolume:  main.PersistentVolumeEnabled(),
+		Volumes:           []VolumeMount{},
+		SecurityContext:   dev.SecurityContext,
+		ServiceAccount:    dev.ServiceAccount,
+		PriorityClassName: main.PriorityClassName,
+		Resources:         dev.Resources,
+		InitContainer:     dev.InitContainer,
+		Probes:            dev.Probes,
+		Lifecycle:         dev.Lifecycle,
+		NodeSelector:      dev.NodeSelector,
+		Affinity:          (*apiv1.Affinity)(dev.Affinity),
 	}
 
 	if dev.IsHybridModeEnabled() {
@@ -1080,6 +1082,9 @@ func (service *Dev) validateForExtraFields() error {
 	}
 	if service.ServiceAccount != "" {
 		return fmt.Errorf(errorMessage, "serviceAccount")
+	}
+	if service.PriorityClassName != "" {
+		return fmt.Errorf(errorMessage, "priorityClassName")
 	}
 	if service.RemotePort != 0 {
 		return fmt.Errorf(errorMessage, "remote")

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -193,7 +193,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.DeployCommand":        {"name", "command"},
 				"model.DeployInfo":           {"compose", "endpoints", "divert", "image", "commands", "remote"},
 				"model.DestroyInfo":          {"image", "commands", "remote"},
-				"model.Dev":                  {"resources", "selector", "persistentVolume", "securityContext", "probes", "nodeSelector", "metadata", "affinity", "image", "lifecycle", "replicas", "initContainer", "workdir", "name", "container", "serviceAccount", "interface", "mode", "imagePullPolicy", "tolerations", "command", "forward", "reverse", "externalVolumes", "secrets", "volumes", "envFiles", "environment", "services", "args", "sync", "timeout", "remote", "sshServerPort", "autocreate"},
+				"model.Dev":                  {"resources", "selector", "persistentVolume", "securityContext", "probes", "nodeSelector", "metadata", "affinity", "image", "lifecycle", "replicas", "initContainer", "workdir", "name", "container", "serviceAccount", "priorityClassName", "interface", "mode", "imagePullPolicy", "tolerations", "command", "forward", "reverse", "externalVolumes", "secrets", "volumes", "envFiles", "environment", "services", "args", "sync", "timeout", "remote", "sshServerPort", "autocreate"},
 				"model.DivertDeploy":         {"driver", "namespace", "service", "deployment", "virtualServices", "hosts", "port"},
 				"model.DivertHost":           {"virtualService", "namespace"},
 				"model.DivertVirtualService": {"name", "namespace", "routes"},

--- a/pkg/model/translation.go
+++ b/pkg/model/translation.go
@@ -29,6 +29,7 @@ type TranslationRule struct {
 	NodeSelector      map[string]string    `json:"nodeSelector" yaml:"nodeSelector"`
 	Affinity          *apiv1.Affinity      `json:"affinity" yaml:"affinity"`
 	ServiceAccount    string               `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
+	PriorityClassName string               `json:"priorityClassName,omitempty" yaml:"priorityClassName,omitempty"`
 	WorkDir           string               `json:"workdir"`
 	Marker            string               `json:"marker"`
 	OktetoBinImageTag string               `json:"oktetoBinImageTag"`

--- a/pkg/model/translation_test.go
+++ b/pkg/model/translation_test.go
@@ -47,6 +47,7 @@ func TestDevToTranslationRule(t *testing.T) {
                 amd.com/gpu: 1
         nodeSelector:
             disktype: ssd
+        priorityClassName: class
         affinity:
             podAffinity:
                 requiredDuringSchedulingIgnoredDuringExecution:
@@ -100,6 +101,7 @@ func TestDevToTranslationRule(t *testing.T) {
 			{Name: "BASHOPTS", Value: "histappend"},
 			{Name: "PROMPT_COMMAND", Value: "history -a ; history -c ; history -r"},
 		},
+		PriorityClassName: "class",
 		SecurityContext: &SecurityContext{
 			RunAsUser:  pointer.Int64(0),
 			RunAsGroup: pointer.Int64(0),
@@ -190,6 +192,7 @@ func TestDevToTranslationRule(t *testing.T) {
 			RunAsGroup: pointer.Int64(0),
 			FSGroup:    pointer.Int64(0),
 		},
+		PriorityClassName: "class",
 		Affinity: &apiv1.Affinity{
 			PodAffinity: &apiv1.PodAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{


### PR DESCRIPTION
Priority classes are very useful when using [services](https://www.okteto.com/docs/reference/okteto-manifest/#services-object-optional). By giving more priority to the pods created by `okteto up`, users can enforce that all pods will go to the same node, even if it's required to evict other pods