### PR TITLE
test: change trivy cmd in intergraiton test

### DIFF
--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -35,7 +35,7 @@ deploy:
 deploy:
   image: aquasec/trivy:latest
   commands:
-    - trivy -q image --light alpine:3.14`
+    - trivy help`
 )
 
 // TestDeployInDeployRemote test the scenario where an okteto deploy is run inside an okteto deploy in remote


### PR DESCRIPTION
We have an integration test using the trivy cli to check if the image used in the deployment is the correct one.
Changed the command run to `trivy help` so no db issues are involved
