### PR TITLE
fix: gh actions release script

### DIFF
--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -20,13 +20,16 @@
         echo "DEBUG: RELEASE_TAG: ${RELEASE_TAG}"
         echo "DEBUG: PLATFORMS: ${PLATFORMS}"
 
-        if [ -z "$RELEASE_TAG" ]; then
+        IFS=',' read -ra TAGS_ARRAY <<< "$RELEASE_TAG"
+        
+        if [ -z "${TAGS_ARRAY[0]}" ]; then
                 commit=$(git rev-parse --short HEAD)
-                RELEASE_TAG="$commit"
-                echo "DEBUG: RELEASE_TAG was empty. Using git commit: ${RELEASE_TAG}"
+                TAGS_ARRAY=("$commit" "${TAGS_ARRAY[@]:1}")
+                echo "DEBUG: First element of RELEASE_TAG was empty. Using git commit: ${commit}"
         fi
 
-        IFS=',' read -ra TAGS_ARRAY <<< "$RELEASE_TAG"
+        echo "DEBUG: Final RELEASE_TAG: ${TAGS_ARRAY[*]}"
+        
         echo "DEBUG: Splitting RELEASE_TAG into TAGS_ARRAY:"
         for tag in "${TAGS_ARRAY[@]}"; do
                 echo "  DEBUG: Tag: ${tag}"

--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -102,7 +102,6 @@ repos=(
     pipeline
     create-namespace
     destroy-pipeline
-    apply
     context
     test
 )

--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -242,7 +242,7 @@ for repo in "${repos[@]}"; do
             -token "$GITHUB_TOKEN" \
             -recreate \
             -replace \
-            -commitish "$(git rev-parse "${RELEASE_TAG}")" \
+            -commitish "$(git rev-parse "${RELEASE_BRANCH}")" \
             "${RELEASE_TAG}"
 
         # After updating the release, if the current release is the latest known
@@ -256,7 +256,7 @@ for repo in "${repos[@]}"; do
                 -token "$GITHUB_TOKEN" \
                 -recreate \
                 -replace \
-                -commitish "$(git rev-parse "${RELEASE_TAG}")" \
+                -commitish "$(git rev-parse "${RELEASE_BRANCH}")" \
                 latest
         fi
     else


### PR DESCRIPTION
# Proposed changes

Fixes GitHub release script to use the branch instead of a tag.

git rev-parse doesn't work with a tag