### PR TITLE
Updated ssh key to be used on circleCI jobs to use oktetobot identity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
           at: ./artifacts
       - add_ssh_keys:
           fingerprints:
-            - f7:81:9f:b4:31:3a:4d:46:ce:cf:54:a2:70:46:5a:df
+            - SHA256:+wgdECJJEEyF/iyl8Y8EV/tpOEQIv6zZ/0LRqRChS18
       - run:
           name: Update brew formula
           command: |
@@ -448,7 +448,7 @@ jobs:
       - run: *init-gcloud
       - add_ssh_keys:
           fingerprints:
-            - f7:81:9f:b4:31:3a:4d:46:ce:cf:54:a2:70:46:5a:df
+            - SHA256:+wgdECJJEEyF/iyl8Y8EV/tpOEQIv6zZ/0LRqRChS18
       - run:
           name: Update brew formula
           command: |
@@ -476,7 +476,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - a1:66:22:e1:67:66:fb:d6:3b:a2:7a:6c:d9:9a:46:ba
+            - SHA256:+wgdECJJEEyF/iyl8Y8EV/tpOEQIv6zZ/0LRqRChS18
       - run: ./scripts/ci/release-branch.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,7 @@ jobs:
           at: ./artifacts
       - add_ssh_keys:
           fingerprints:
+            # This key belongs to oktetobot user in GitHub
             - SHA256:+wgdECJJEEyF/iyl8Y8EV/tpOEQIv6zZ/0LRqRChS18
       - run:
           name: Update brew formula
@@ -448,6 +449,7 @@ jobs:
       - run: *init-gcloud
       - add_ssh_keys:
           fingerprints:
+            # This key belongs to oktetobot user in GitHub
             - SHA256:+wgdECJJEEyF/iyl8Y8EV/tpOEQIv6zZ/0LRqRChS18
       - run:
           name: Update brew formula
@@ -476,6 +478,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
+            # This key belongs to oktetobot user in GitHub
             - SHA256:+wgdECJJEEyF/iyl8Y8EV/tpOEQIv6zZ/0LRqRChS18
       - run: ./scripts/ci/release-branch.sh
 

--- a/scripts/ci/release-branch.sh
+++ b/scripts/ci/release-branch.sh
@@ -146,7 +146,7 @@
         fi
         echo "Pushing tag ${NEXT_TAG} to remote repository"
         git config user.name "okteto"
-        git config user.email "ci@okteto.com"
+        git config user.email "test@okteto.com"
         git tag "${NEXT_TAG}" -a -m "Okteto CLI ${NEXT_TAG}"
         git push origin "${NEXT_TAG}"
 ); }

--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -118,7 +118,7 @@ for repo in "${repos[@]}"; do
     pushd "$REPO_DIR" >/dev/null
 
     git config user.name "okteto"
-    git config user.email "ci@okteto.com"
+    git config user.email "test@okteto.com"
 
     git checkout main
 

--- a/scripts/update_homebrew_formula.sh
+++ b/scripts/update_homebrew_formula.sh
@@ -67,6 +67,6 @@ EOF
 cat Formula/okteto.rb
 git add Formula/okteto.rb
 git config user.name "okteto"
-git config user.email "ci@okteto.com"
+git config user.email "test@okteto.com"
 git commit -m "$VERSION release"
 git --no-pager log -1


### PR DESCRIPTION
Fixes https://okteto.atlassian.net/browse/DEV-720

Changed the SSH Key used in circleCI for the repo to use `oktetobot` user's identity.

I already added the key in GitHub to the user, and the key in the CircleCI project.

The `oktetobot` user already has permission in the GitHub actions repo to push.

Previous key wasn't unclear to who belong, the commit are signed by `bokteto` but the SSH key could be for another user, so changed to use this one