### PR TITLE
Enable OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ jobs:
   push-image-tag:
     executor: golang-ci
     environment:
-      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true"
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
     steps:
       - checkout
       - run: *okteto-login
@@ -418,7 +418,7 @@ jobs:
   push-image-dev:
     executor: golang-ci
     environment:
-      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true"
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
     steps:
       - checkout
       - run: *okteto-login
@@ -429,7 +429,7 @@ jobs:
   push-image-master:
     executor: golang-ci
     environment:
-      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true"
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
     steps:
       - checkout
       - run: *okteto-login

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,6 +405,8 @@ jobs:
 
   push-image-tag:
     executor: golang-ci
+    environment:
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true"
     steps:
       - checkout
       - run: *okteto-login
@@ -415,6 +417,8 @@ jobs:
 
   push-image-dev:
     executor: golang-ci
+    environment:
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true"
     steps:
       - checkout
       - run: *okteto-login
@@ -424,6 +428,8 @@ jobs:
 
   push-image-master:
     executor: golang-ci
+    environment:
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true"
     steps:
       - checkout
       - run: *okteto-login


### PR DESCRIPTION
This pull request updates the CircleCI configuration to enable the `OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED` environment variable. This variable is set to "true" for the `push-image-tag`, `push-image-dev`, and `push-image-master` jobs. This allow to override cluster credentials and use the one defined in CI
