### PR TITLE
refactor: remove fatal from context

### DIFF
--- a/cmd/args/lister.go
+++ b/cmd/args/lister.go
@@ -34,7 +34,11 @@ func NewDevModeOnLister(k8sClientProvider okteto.K8sClientProvider) *DevModeOnLi
 }
 
 func (d *DevModeOnLister) List(ctx context.Context, devs model.ManifestDevs, ns string) ([]string, error) {
-	k8sClient, _, err := d.k8sClientProvider.Provide(okteto.GetContext().Cfg)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get context: %w", err)
+	}
+	k8sClient, _, err := d.k8sClientProvider.Provide(okCtx.Cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get k8s client: %w", err)
 	}

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -120,9 +120,13 @@ func NewBuilder(builder buildCmd.OktetoBuilderInterface, registry oktetoRegistry
 
 // NewBuilderFromScratch creates a new okteto builder
 func NewBuilderFromScratch(ioCtrl *io.Controller, onBuildFinish []OnBuildFinish) *OktetoBuilder {
+	okCtxStore, err := okteto.GetContextStore()
+	if err != nil {
+		ioCtrl.Logger().Infof("could not get context store: %s", err)
+	}
 	builder := buildCmd.NewOktetoBuilder(
 		&okteto.ContextStateless{
-			Store: okteto.GetContextStore(),
+			Store: okCtxStore,
 		},
 		afero.NewOsFs(),
 	)
@@ -145,7 +149,7 @@ func NewBuilderFromScratch(ioCtrl *io.Controller, onBuildFinish []OnBuildFinish)
 	buildEnvs := map[string]string{}
 	buildEnvs[OktetoEnableSmartBuildEnvVar] = strconv.FormatBool(config.isSmartBuildsEnable)
 	okCtx := &okteto.ContextStateless{
-		Store: okteto.GetContextStore(),
+		Store: okCtxStore,
 	}
 
 	return &OktetoBuilder{

--- a/cmd/context/context_test.go
+++ b/cmd/context/context_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_initFromDeprecatedToken(t *testing.T) {
@@ -66,9 +67,9 @@ func Test_initFromDeprecatedToken(t *testing.T) {
 			}
 			defer os.Remove(kubepath)
 			okteto.InitContextWithDeprecatedToken()
-			if okteto.GetContextStore().CurrentContext == "" {
-				t.Fatal("Not initialized")
-			}
+			okCtxStore, err := okteto.GetContextStore()
+			assert.NoError(t, err)
+			assert.NotEqual(t, "", okCtxStore.CurrentContext)
 		})
 	}
 }

--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -384,6 +384,12 @@ func TestAutoAuthWhenNotValidTokenOnlyWhenOktetoContextIsRun(t *testing.T) {
 
 	ctxController := newFakeContextCommand(fakeOktetoClient, user, nil)
 
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"https://okteto.example.com": {},
+		},
+		CurrentContext: "https://okteto.example.com",
+	}
 	var tests = []struct {
 		ctxOptions          *Options
 		user                *types.User
@@ -421,7 +427,9 @@ func TestAutoAuthWhenNotValidTokenOnlyWhenOktetoContextIsRun(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ctxController.initOktetoContext(ctx, tt.ctxOptions)
 			if err != nil {
-				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okteto.GetContext().Name).Error() && tt.isAutoAuthTriggered {
+				okCtx, ctxErr := okteto.GetContext()
+				assert.NoError(t, ctxErr)
+				if err.Error() == fmt.Errorf(oktetoErrors.ErrNotLogged, okCtx.Name).Error() && tt.isAutoAuthTriggered {
 					t.Fatalf("Not expecting error but got: %s", err.Error())
 				}
 			}

--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -53,7 +53,10 @@ func DeleteCMD() *cobra.Command {
 }
 
 func Delete(okCtxs []string) error {
-	ctxStore := okteto.GetContextStore()
+	ctxStore, err := okteto.GetContextStore()
+	if err != nil {
+		return err
+	}
 	var errs error
 	validOptions := make([]string, 0)
 	for _, okCtx := range okCtxs {

--- a/cmd/context/delete_test.go
+++ b/cmd/context/delete_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_deleteContext(t *testing.T) {
@@ -95,7 +96,10 @@ func Test_deleteContext(t *testing.T) {
 			if err := Delete(tt.toDelete); err == nil && tt.expectedErr || err != nil && !tt.expectedErr {
 				t.Fatal(err)
 			}
-			if okteto.GetContextStore().CurrentContext != tt.afterContext {
+
+			okCtxStore, err := okteto.GetContextStore()
+			assert.NoError(t, err)
+			if okCtxStore.CurrentContext != tt.afterContext {
 				t.Fatal("not delete correctly")
 			}
 		})

--- a/cmd/context/kubetoken.go
+++ b/cmd/context/kubetoken.go
@@ -136,7 +136,11 @@ func (dkc *dynamicKubetokenController) updateOktetoContextToken(userContext *typ
 		return fmt.Errorf("error providing the okteto client while updating okteto context token: %w", err)
 	}
 
-	kubetoken, err := c.Kubetoken().GetKubeToken(okteto.GetContext().Name, userContext.User.Namespace)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return err
+	}
+	kubetoken, err := c.Kubetoken().GetKubeToken(okCtx.Name, userContext.User.Namespace)
 	if err != nil || kubetoken.Status.Token == "" {
 		return errors.New("dynamic kubernetes token not available: falling back to static token")
 	}

--- a/cmd/context/list.go
+++ b/cmd/context/list.go
@@ -55,7 +55,10 @@ func executeListContext() error {
 		return fmt.Errorf("no contexts are available. Run 'okteto context' to configure your first okteto context")
 	}
 
-	ctxStore := okteto.GetContextStore()
+	ctxStore, err := okteto.GetContextStore()
+	if err != nil {
+		return err
+	}
 
 	var ctxs []okteto.ContextViewer
 	for _, ctxSelector := range contexts {
@@ -65,7 +68,6 @@ func executeListContext() error {
 			Name:     ctxSelector.Name,
 			Builder:  "docker",
 			Registry: "-",
-			Current:  okteto.GetContext().Name == ctxSelector.Name,
 		}
 		if isOkteto {
 			ctxViewer.Registry = okCtx.Registry

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -43,7 +43,11 @@ func (o *Options) InitFromContext() {
 		return
 	}
 
-	ctxStore := okteto.GetContextStore()
+	ctxStore, err := okteto.GetContextStore()
+	if err != nil {
+		oktetoLog.Infof("failed to get context store: %s", err)
+		return
+	}
 
 	if ctxStore.Contexts == nil {
 		return
@@ -93,7 +97,12 @@ func (o *Options) InitFromEnvVars() {
 	}
 
 	if o.Token == "" && envToken != "" {
-		if !okteto.HasBeenLogged(o.Context) || okteto.GetContext().Token != envToken {
+		okCtx, err := okteto.GetContext()
+		if err != nil {
+			oktetoLog.Infof("failed to get context: %s", err)
+			return
+		}
+		if !okteto.HasBeenLogged(o.Context) || okCtx.Token != envToken {
 			usedEnvVars = append(usedEnvVars, model.OktetoTokenEnvVar)
 		}
 		o.Token = envToken

--- a/cmd/context/selector.go
+++ b/cmd/context/selector.go
@@ -42,7 +42,10 @@ func getAvailableContexts(ctxOptions *Options) []utils.SelectorItem {
 
 func getOktetoClusters() []utils.SelectorItem {
 	orderedOktetoClusters := make([]utils.SelectorItem, 0)
-	ctxStore := okteto.GetContextStore()
+	ctxStore, err := okteto.GetContextStore()
+	if err != nil {
+		return orderedOktetoClusters
+	}
 	for ctxName, okCtx := range ctxStore.Contexts {
 		if !okCtx.IsOkteto {
 			continue
@@ -77,7 +80,11 @@ func getK8sClusters(k8sClusters []string) []utils.SelectorItem {
 }
 
 func getInitialPosition(options []utils.SelectorItem) int {
-	currentContext := okteto.GetContextStore().CurrentContext
+	okContextStore, err := okteto.GetContextStore()
+	if err != nil {
+		return -1
+	}
+	currentContext := okContextStore.CurrentContext
 	for indx, item := range options {
 		if item.Enable && item.Name == currentContext {
 			return indx

--- a/cmd/context/show.go
+++ b/cmd/context/show.go
@@ -39,7 +39,10 @@ func Show() *cobra.Command {
 			if err := NewContextCommand().Run(ctx, &Options{raiseNotCtxError: true, Show: false}); err != nil {
 				return err
 			}
-			ctxStore := okteto.GetContextStore()
+			ctxStore, err := okteto.GetContextStore()
+			if err != nil {
+				return err
+			}
 			current := ctxStore.Contexts[ctxStore.CurrentContext]
 			if err := validateOutput(output); err != nil {
 				return err

--- a/cmd/context/update-kubeconfig.go
+++ b/cmd/context/update-kubeconfig.go
@@ -69,7 +69,12 @@ func UpdateKubeconfigCMD(okClientProvider oktetoClientProvider) *cobra.Command {
 				return err
 			}
 
-			return kc.execute(okteto.GetContext(), config.GetKubeconfigPath())
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
+
+			return kc.execute(okCtx, config.GetKubeconfigPath())
 		},
 	}
 

--- a/cmd/context/update-kubeconfig_test.go
+++ b/cmd/context/update-kubeconfig_test.go
@@ -141,7 +141,8 @@ func Test_ExecuteUpdateKubeconfig_DisabledKubetoken(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			okContext := okteto.GetContext()
+			okContext, err := okteto.GetContext()
+			assert.NoError(t, err, "error getting context")
 			kubeconfigPaths := []string{file}
 
 			err = newKubeconfigController(tt.okClientProvider).execute(okContext, kubeconfigPaths)
@@ -254,7 +255,8 @@ func Test_ExecuteUpdateKubeconfig_EnabledKubetoken(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			okContext := okteto.GetContext()
+			okContext, err := okteto.GetContext()
+			assert.NoError(t, err, "error getting context")
 			kubeconfigPaths := []string{file}
 
 			err = newKubeconfigController(okClientProvider).execute(okContext, kubeconfigPaths)
@@ -302,7 +304,8 @@ func Test_ExecuteUpdateKubeconfig_With_OktetoUseStaticKubetokenEnvVar(t *testing
 	}
 	defer os.Remove(file)
 
-	okContext := okteto.GetContext()
+	okContext, err := okteto.GetContext()
+	assert.NoError(t, err, "error getting context")
 	kubeconfigPaths := []string{file}
 	okClientProvider := client.NewFakeOktetoClientProvider(
 		&client.FakeOktetoClient{
@@ -348,7 +351,8 @@ func Test_ExecuteUpdateKubeconfig_ForNonOktetoContext(t *testing.T) {
 	}
 	defer os.Remove(file)
 
-	okContext := okteto.GetContext()
+	okContext, err := okteto.GetContext()
+	assert.NoError(t, err, "error getting context")
 	kubeconfigPaths := []string{file}
 
 	err = newKubeconfigController(nil).execute(okContext, kubeconfigPaths)
@@ -516,7 +520,8 @@ func Test_ExecuteUpdateKubeconfig_WithRightCertificate(t *testing.T) {
 			}
 			defer os.Remove(file)
 
-			okContext := okteto.GetContext()
+			okContext, err := okteto.GetContext()
+			assert.NoError(t, err, "error getting context")
 			kubeconfigPaths := []string{file}
 
 			err = newKubeconfigController(okClientProvider).execute(okContext, kubeconfigPaths)
@@ -572,7 +577,8 @@ func Test_ExecuteUpdateKubeconfig_WithWrongOktetoCertificate(t *testing.T) {
 	}
 	defer os.Remove(file)
 
-	okContext := okteto.GetContext()
+	okContext, err := okteto.GetContext()
+	assert.NoError(t, err, "error getting context")
 	kubeconfigPaths := []string{file}
 
 	err = newKubeconfigController(okClientProvider).execute(okContext, kubeconfigPaths)

--- a/cmd/deploy/command_configuration_test.go
+++ b/cmd/deploy/command_configuration_test.go
@@ -61,7 +61,7 @@ devs:
 	dc := &Command{
 		GetManifest:       getFakeManifest,
 		K8sClientProvider: fakeK8sProvider,
-		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sProvider, nil),
+		CfgMapHandler:     newDefaultConfigMapHandler(fakeK8sProvider, okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext], nil),
 	}
 
 	ctx := context.Background()

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -166,7 +166,8 @@ func Test_newRemoteDeployer(t *testing.T) {
 	getBuildEnvVars := func() map[string]string { return nil }
 	getDependencyEnvVars := func(_ environGetter) map[string]string { return nil }
 	getExecutionEvVars := func(_ context.Context) map[string]string { return make(map[string]string) }
-	got := newRemoteDeployer(getBuildEnvVars, io.NewIOController(), getDependencyEnvVars, getExecutionEvVars)
+	got, err := newRemoteDeployer(getBuildEnvVars, io.NewIOController(), getDependencyEnvVars, getExecutionEvVars)
+	assert.NoError(t, err)
 	require.IsType(t, &remoteDeployer{}, got)
 	require.NotNil(t, got.getBuildEnvVars)
 }

--- a/cmd/destroy/all.go
+++ b/cmd/destroy/all.go
@@ -33,15 +33,18 @@ import (
 type localDestroyAllCommand struct {
 	oktetoClient      *okteto.Client
 	k8sClientProvider okteto.K8sClientProvider
+	okCtx             *okteto.Context
 }
 
 func newLocalDestroyerAll(
 	k8sClientProvider okteto.K8sClientProvider,
 	oktetoClient *okteto.Client,
+	okCtx *okteto.Context,
 ) *localDestroyAllCommand {
 	return &localDestroyAllCommand{
 		k8sClientProvider: k8sClientProvider,
 		oktetoClient:      oktetoClient,
+		okCtx:             okCtx,
 	}
 }
 
@@ -99,7 +102,7 @@ func (lda *localDestroyAllCommand) waitForNamespaceDestroyAllToComplete(ctx cont
 	ticker := time.NewTicker(1 * time.Second)
 	to := time.NewTicker(timeout)
 
-	c, _, err := lda.k8sClientProvider.Provide(okteto.GetContext().Cfg)
+	c, _, err := lda.k8sClientProvider.Provide(lda.okCtx.Cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/destroy/destroy_test.go
+++ b/cmd/destroy/destroy_test.go
@@ -200,6 +200,7 @@ func TestDestroyWithErrorGettingManifestButDestroySuccess(t *testing.T) {
 		ConfigMapHandler: NewConfigmapHandler(fakeClient),
 		nsDestroyer:      destroyer,
 		secrets:          &fakeSecretHandler{},
+		okCtx:            &okteto.Context{},
 		buildCtrlProvider: fakeBuildCtrlProvider{
 			buildCtrl: buildCtrl{
 				builder: fakeBuilderV2{
@@ -238,6 +239,7 @@ func TestDestroyWithErrorDestroyingDependencies(t *testing.T) {
 		getPipelineDestroyer: func() (pipelineDestroyer, error) {
 			return nil, assert.AnError
 		},
+		okCtx: &okteto.Context{},
 		buildCtrlProvider: fakeBuildCtrlProvider{
 			buildCtrl: buildCtrl{
 				builder: fakeBuilderV2{
@@ -278,6 +280,7 @@ func TestDestroyWithErrorDestroyingDivert(t *testing.T) {
 		ConfigMapHandler:  NewConfigmapHandler(fakeClient),
 		nsDestroyer:       destroyer,
 		secrets:           &fakeSecretHandler{},
+		okCtx:             &okteto.Context{},
 		k8sClientProvider: k8sClientProvider,
 		getDivertDriver: func(_ *model.DivertDeploy, _, _ string, _ kubernetes.Interface) (divert.Driver, error) {
 			return nil, assert.AnError
@@ -315,6 +318,7 @@ func TestDestroyWithErrorOnCommands(t *testing.T) {
 		ConfigMapHandler:  NewConfigmapHandler(fakeClient),
 		nsDestroyer:       destroyer,
 		secrets:           &fakeSecretHandler{},
+		okCtx:             &okteto.Context{},
 		k8sClientProvider: k8sClientProvider,
 		executor: &fakeExecutor{
 			err: assert.AnError,
@@ -357,6 +361,7 @@ func TestDestroyWithErrorOnCommandsForcingDestroy(t *testing.T) {
 		ConfigMapHandler:  NewConfigmapHandler(fakeClient),
 		nsDestroyer:       destroyer,
 		secrets:           &fakeSecretHandler{},
+		okCtx:             &okteto.Context{},
 		k8sClientProvider: k8sClientProvider,
 		executor: &fakeExecutor{
 			err: fmt.Errorf("error executing command"),
@@ -402,6 +407,7 @@ func TestDestroyWithErrorDestroyingK8sResources(t *testing.T) {
 		nsDestroyer:       destroyer,
 		secrets:           &fakeSecretHandler{},
 		k8sClientProvider: k8sClientProvider,
+		okCtx:             &okteto.Context{},
 		executor:          &fakeExecutor{},
 		buildCtrlProvider: fakeBuildCtrlProvider{
 			buildCtrl: buildCtrl{
@@ -441,6 +447,7 @@ func TestDestroyK8sResourcesWithErrorDestroyingVolumes(t *testing.T) {
 	}
 	dc := &destroyCommand{
 		nsDestroyer: destroyer,
+		okCtx:       &okteto.Context{},
 	}
 
 	err := dc.destroyK8sResources(ctx, opts)
@@ -460,6 +467,7 @@ func TestDestroyK8sResourcesWithErrorDestroyingHelmAppWithoutForce(t *testing.T)
 	destroyer := &fakeDestroyer{}
 	dc := &destroyCommand{
 		nsDestroyer: destroyer,
+		okCtx:       &okteto.Context{},
 		secrets: &fakeSecretHandler{
 			err: assert.AnError,
 		},
@@ -482,6 +490,7 @@ func TestDestroyK8sResourcesWithErrorDestroyingHelmAppWithForce(t *testing.T) {
 	destroyer := &fakeDestroyer{}
 	dc := &destroyCommand{
 		nsDestroyer: destroyer,
+		okCtx:       &okteto.Context{},
 		secrets: &fakeSecretHandler{
 			err: assert.AnError,
 		},
@@ -506,6 +515,7 @@ func TestDestroyK8sResourcesWithErrorDestroyingWithLabel(t *testing.T) {
 	}
 	dc := &destroyCommand{
 		nsDestroyer: destroyer,
+		okCtx:       &okteto.Context{},
 		secrets:     &fakeSecretHandler{},
 	}
 
@@ -526,6 +536,7 @@ func TestDestroyK8sResourcesWithoutErrors(t *testing.T) {
 	destroyer := &fakeDestroyer{}
 	dc := &destroyCommand{
 		nsDestroyer: destroyer,
+		okCtx:       &okteto.Context{},
 		secrets:     &fakeSecretHandler{},
 	}
 
@@ -646,6 +657,7 @@ func TestDestroyDivertWithErrorGettingKubernetesClient(t *testing.T) {
 	k8sClientProvider := test.NewFakeK8sProvider()
 	k8sClientProvider.ErrProvide = assert.AnError
 	dc := &destroyCommand{
+		okCtx:             &okteto.Context{},
 		k8sClientProvider: k8sClientProvider,
 	}
 
@@ -661,6 +673,7 @@ func TestDestroyDivertWithErrorCreatingDivertDriver(t *testing.T) {
 
 	dc := &destroyCommand{
 		k8sClientProvider: k8sClientProvider,
+		okCtx:             &okteto.Context{},
 		getDivertDriver: func(_ *model.DivertDeploy, _, _ string, _ kubernetes.Interface) (divert.Driver, error) {
 			return nil, assert.AnError
 		},
@@ -679,6 +692,7 @@ func TestDestroyDivertWithoutError(t *testing.T) {
 	divertDriver := &fakeDivertDriver{}
 	dc := &destroyCommand{
 		k8sClientProvider: k8sClientProvider,
+		okCtx:             &okteto.Context{},
 		getDivertDriver: func(_ *model.DivertDeploy, _, _ string, _ kubernetes.Interface) (divert.Driver, error) {
 			return divertDriver, nil
 		},
@@ -695,6 +709,7 @@ func TestDestroyDivertWithoutError(t *testing.T) {
 
 func TestDestroyDependenciesWithErrorGettingCommand(t *testing.T) {
 	dc := &destroyCommand{
+		okCtx: &okteto.Context{},
 		getPipelineDestroyer: func() (pipelineDestroyer, error) {
 			return nil, assert.AnError
 		},
@@ -714,6 +729,7 @@ func TestDestroyDependenciesWithErrorDeletingDep(t *testing.T) {
 	pipDestroyer := &fakePipelineDestroyer{}
 	pipDestroyer.On("ExecuteDestroyPipeline", mock.Anything, mock.Anything).Return(assert.AnError)
 	dc := &destroyCommand{
+		okCtx: &okteto.Context{},
 		getPipelineDestroyer: func() (pipelineDestroyer, error) {
 			return pipDestroyer, nil
 		},
@@ -757,6 +773,7 @@ func TestDestroyDependenciesWithoutError(t *testing.T) {
 	pipDestroyer.On("ExecuteDestroyPipeline", mock.Anything, expectedOpts2).Return(nil)
 	pipDestroyer.On("ExecuteDestroyPipeline", mock.Anything, expectedOpts3).Return(nil)
 	dc := &destroyCommand{
+		okCtx: okteto.CurrentStore.Contexts["example"],
 		getPipelineDestroyer: func() (pipelineDestroyer, error) {
 			return pipDestroyer, nil
 		},
@@ -799,7 +816,8 @@ func TestGetDestroyer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dc := &destroyCommand{}
-			deployer := dc.getDestroyer(tt.opts)
+			deployer, err := dc.getDestroyer(tt.opts)
+			require.NoError(t, err)
 			require.IsType(t, tt.expectedType, deployer)
 		})
 	}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -72,7 +72,10 @@ func Doctor(k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
 			if !okteto.IsOkteto() {
 				if err := manifest.ValidateForCLIOnly(); err != nil {
 					return err
@@ -98,7 +101,7 @@ func Doctor(k8sLogger *io.K8sLogger, fs afero.Fs) *cobra.Command {
 					return err
 				}
 			}
-			filename, err := doctor.Run(ctx, dev, doctorOpts.DevPath, okteto.GetContext().Namespace, c)
+			filename, err := doctor.Run(ctx, dev, doctorOpts.DevPath, okCtx.Namespace, c)
 			if err == nil {
 				oktetoLog.Information("Your doctor file is available at %s", filename)
 			}

--- a/cmd/exec/app.go
+++ b/cmd/exec/app.go
@@ -58,7 +58,11 @@ func newAppRetriever(ioControl *io.Controller, k8sProvider okteto.K8sClientProvi
 // getContainer retrieves the container for the dev environment
 func (ar *appRetriever) getApp(ctx context.Context, dev *model.Dev, namespace string) (apps.App, error) {
 	ar.ioControl.Logger().Info("start to retrieve app")
-	c, _, err := ar.k8sProvider.Provide(okteto.GetContext().Cfg)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get okteto context: %w", err)
+	}
+	c, _, err := ar.k8sProvider.Provide(okCtx.Cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get k8s client: %w", err)
 	}

--- a/cmd/exec/executor.go
+++ b/cmd/exec/executor.go
@@ -51,7 +51,11 @@ type executorProvider struct {
 }
 
 func (e executorProvider) provide(dev *model.Dev, podName, namespace string) (executor, error) {
-	k8sClient, cfg, err := e.k8sClientProvider.Provide(okteto.GetContext().Cfg)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return nil, err
+	}
+	k8sClient, cfg, err := e.k8sClientProvider.Provide(okCtx.Cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubetoken/kubetoken.go
+++ b/cmd/kubetoken/kubetoken.go
@@ -83,7 +83,11 @@ type Options struct {
 }
 
 func defaultKubetokenOptions() *Options {
-	ctxStore := okteto.GetContextStore()
+	ctxStore, err := okteto.GetContextStore()
+	if err != nil {
+		oktetoLog.Debug("failed to get context store")
+		ctxStore = &okteto.ContextStore{}
+	}
 	return &Options{
 		oktetoClientProvider: okteto.NewOktetoClientProvider(),
 		k8sClientProvider:    okteto.NewK8sClientProvider(),

--- a/cmd/kubetoken/validator_test.go
+++ b/cmd/kubetoken/validator_test.go
@@ -135,8 +135,8 @@ func TestPreReqValidator(t *testing.T) {
 				withK8sClientProvider(tc.input.k8sClientProvider),
 				withOktetoClientProvider(tc.input.oktetoClientProvider),
 			)
-			v.getContextStore = func() *okteto.ContextStore {
-				return tc.input.currentStore
+			v.getContextStore = func() (*okteto.ContextStore, error) {
+				return tc.input.currentStore, nil
 			}
 			v.getCtxResource = func(s1, s2 string) *contextCMD.Options {
 				return &contextCMD.Options{
@@ -231,8 +231,8 @@ func TestCtxValidator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			v := newCtxValidator(&contextCMD.Options{
 				Context: tc.input.ctxName,
-			}, tc.input.k8sClientProvider, func() *okteto.ContextStore {
-				return okteto.CurrentStore
+			}, tc.input.k8sClientProvider, func() (*okteto.ContextStore, error) {
+				return okteto.CurrentStore, nil
 			})
 			err := v.validate(tc.input.ctx)
 			assert.ErrorIs(t, err, tc.expected)

--- a/cmd/logs/stern.go
+++ b/cmd/logs/stern.go
@@ -85,10 +85,14 @@ func getSternConfig(manifest *model.Manifest, o *Options, kubeconfigFile string)
 	containerStates := []stern.ContainerState{"running"}
 	fieldSelector := fields.Everything()
 
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return nil, err
+	}
 	return &stern.Config{
 		KubeConfig:          kubeconfigFile,
-		ContextName:         okteto.UrlToKubernetesContext(okteto.GetContext().Name),
-		Namespaces:          []string{okteto.GetContext().Namespace},
+		ContextName:         okteto.UrlToKubernetesContext(okCtx.Name),
+		Namespaces:          []string{okCtx.Namespace},
 		PodQuery:            includePodQuery,
 		ExcludePodQuery:     excludePodQuery,
 		ContainerQuery:      containerQuery,

--- a/cmd/namespace/create.go
+++ b/cmd/namespace/create.go
@@ -49,11 +49,15 @@ func Create(ctx context.Context) *cobra.Command {
 			}
 			options.Namespace = args[0]
 
-			if !okteto.IsOkteto() {
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
+			if !okCtx.IsOkteto {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(okCtx)
 			if err != nil {
 				return err
 			}
@@ -86,9 +90,9 @@ func (nc *Command) Create(ctx context.Context, opts *CreateOptions) error {
 	ctxOptions := &contextCMD.Options{
 		IsCtxCommand: opts.Show,
 		IsOkteto:     true,
-		Token:        okteto.GetContext().Token,
+		Token:        nc.okCtx.Token,
 		Namespace:    oktetoNS,
-		Context:      okteto.GetContext().Name,
+		Context:      nc.okCtx.Name,
 	}
 
 	if opts.SetCurrentNs {

--- a/cmd/namespace/create_test.go
+++ b/cmd/namespace/create_test.go
@@ -70,13 +70,14 @@ func Test_createNamespace(t *testing.T) {
 			nsCmd := &Command{
 				okClient: fakeOktetoClient,
 				ctxCmd:   newFakeContextCommand(fakeOktetoClient, usr),
+				okCtx:    okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 			}
 			err := nsCmd.Create(ctx, &CreateOptions{
 				Members:   tt.members,
 				Namespace: tt.newNs,
 			})
 			assert.Equal(t, nil, err)
-			assert.Equal(t, tt.newNs, okteto.GetContext().Namespace)
+			assert.Equal(t, tt.newNs, okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext].Namespace)
 		})
 	}
 }

--- a/cmd/namespace/delete_test.go
+++ b/cmd/namespace/delete_test.go
@@ -150,10 +150,11 @@ func Test_deleteNamespace(t *testing.T) {
 				CurrentContext: "test-context",
 			}
 
-			nsFakeCommand := NewFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr)
+			nsFakeCommand := NewFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr, okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext])
+
 			err := nsFakeCommand.ExecuteDeleteNamespace(ctx, tt.toDeleteNs, nil)
 			assert.ErrorIs(t, err, tt.err)
-			assert.Equal(t, tt.finalNs, okteto.GetContext().Namespace)
+			assert.Equal(t, tt.finalNs, okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext].Namespace)
 
 			// check namespace has been deleted from list
 			ns, err := tt.fakeOkClient.Namespaces().List(ctx)

--- a/cmd/namespace/list.go
+++ b/cmd/namespace/list.go
@@ -38,11 +38,15 @@ func List(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if !okteto.IsOkteto() {
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
+			if !okCtx.IsOkteto {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(okCtx)
 			if err != nil {
 				return err
 			}
@@ -61,7 +65,7 @@ func (nc *Command) executeListNamespaces(ctx context.Context) error {
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
 	fmt.Fprintf(w, "Namespace\tStatus\n")
 	for _, space := range spaces {
-		if space.ID == okteto.GetContext().Namespace {
+		if space.ID == nc.okCtx.Namespace {
 			space.ID += " *"
 		}
 		fmt.Fprintf(w, "%s\t%v\n", space.ID, space.Status)

--- a/cmd/namespace/list_test.go
+++ b/cmd/namespace/list_test.go
@@ -72,6 +72,7 @@ func Test_listNamespace(t *testing.T) {
 			nsCmd := &Command{
 				okClient: fakeOktetoClient,
 				ctxCmd:   newFakeContextCommand(fakeOktetoClient, usr),
+				okCtx:    okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 			}
 			err := nsCmd.executeListNamespaces(ctx)
 			if tt.err != nil {

--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -29,10 +29,11 @@ type Command struct {
 	ctxCmd            *contextCMD.Command
 	okClient          types.OktetoInterface
 	k8sClientProvider okteto.K8sClientProviderWithLogger
+	okCtx             *okteto.Context
 }
 
 // NewCommand creates a namespace command for use in further operations
-func NewCommand() (*Command, error) {
+func NewCommand(okCtx *okteto.Context) (*Command, error) {
 	c, err := okteto.NewOktetoClient()
 	if err != nil {
 		return nil, err
@@ -42,6 +43,7 @@ func NewCommand() (*Command, error) {
 		ctxCmd:            contextCMD.NewContextCommand(),
 		okClient:          c,
 		k8sClientProvider: okteto.NewK8sClientProviderWithLogger(nil),
+		okCtx:             okCtx,
 	}, nil
 }
 

--- a/cmd/namespace/namespace_test.go
+++ b/cmd/namespace/namespace_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/okteto/okteto/internal/test/client"
 	"github.com/okteto/okteto/pkg/k8s/ingresses"
 	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -50,12 +51,13 @@ func newFakeContextCommand(c *client.FakeOktetoClient, user *types.User) *contex
 	return cmd
 }
 
-func NewFakeNamespaceCommand(okClient *client.FakeOktetoClient, k8sClient kubernetes.Interface, user *types.User) *Command {
+func NewFakeNamespaceCommand(okClient *client.FakeOktetoClient, k8sClient kubernetes.Interface, user *types.User, okCtx *okteto.Context) *Command {
 	return &Command{
 		okClient: okClient,
 		ctxCmd:   newFakeContextCommand(okClient, user),
 		k8sClientProvider: &fakeK8sProvider{
 			k8sClient: k8sClient,
 		},
+		okCtx: okCtx,
 	}
 }

--- a/cmd/namespace/sleep.go
+++ b/cmd/namespace/sleep.go
@@ -35,8 +35,12 @@ func Sleep(ctx context.Context) *cobra.Command {
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{}); err != nil {
 				return err
 			}
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
 
-			nsToSleep := okteto.GetContext().Namespace
+			nsToSleep := okCtx.Namespace
 			if len(args) > 0 {
 				nsToSleep = args[0]
 			}
@@ -45,7 +49,7 @@ func Sleep(ctx context.Context) *cobra.Command {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(okCtx)
 			if err != nil {
 				return err
 			}

--- a/cmd/namespace/sleep_test.go
+++ b/cmd/namespace/sleep_test.go
@@ -98,7 +98,7 @@ func Test_SleepNamespace(t *testing.T) {
 				},
 				CurrentContext: "test-context",
 			}
-			nsFakeCommand := NewFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr)
+			nsFakeCommand := NewFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr, okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext])
 			err := nsFakeCommand.ExecuteSleepNamespace(ctx, tt.toSleepNs)
 			if tt.err != nil {
 				assert.ErrorIs(t, err, tt.err)

--- a/cmd/namespace/use_test.go
+++ b/cmd/namespace/use_test.go
@@ -97,14 +97,14 @@ func Test_useNamespace(t *testing.T) {
 			nsCmd := &Command{
 				okClient: fakeOktetoClient,
 				ctxCmd:   newFakeContextCommand(fakeOktetoClient, usr),
+				okCtx:    okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 			}
 			err := nsCmd.Use(ctx, tt.changeToNs)
 			if tt.expectedErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-
-				assert.Equal(t, tt.changeToNs, okteto.GetContext().Namespace)
+				assert.Equal(t, tt.changeToNs, okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext].Namespace)
 			}
 
 		})

--- a/cmd/namespace/wake.go
+++ b/cmd/namespace/wake.go
@@ -31,7 +31,11 @@ func Wake(ctx context.Context) *cobra.Command {
 		Short: "Wakes an Okteto Namespace. By default, it wakes the default namespace in the Okteto Context",
 		Args:  utils.MaximumNArgsAccepted(1, ""),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			nsToWake := okteto.GetContext().Namespace
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
+			nsToWake := okCtx.Namespace
 			if len(args) > 0 {
 				nsToWake = args[0]
 			}
@@ -43,7 +47,7 @@ func Wake(ctx context.Context) *cobra.Command {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			nsCmd, err := NewCommand()
+			nsCmd, err := NewCommand(okCtx)
 			if err != nil {
 				return err
 			}

--- a/cmd/namespace/wake_test.go
+++ b/cmd/namespace/wake_test.go
@@ -98,7 +98,7 @@ func Test_WakeNamespace(t *testing.T) {
 				},
 				CurrentContext: "test-context",
 			}
-			nsFakeCommand := NewFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr)
+			nsFakeCommand := NewFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr, okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext])
 			err := nsFakeCommand.ExecuteWakeNamespace(ctx, tt.toWakeNs)
 			if tt.err != nil {
 				assert.ErrorIs(t, err, tt.err)

--- a/cmd/pipeline/deploy_test.go
+++ b/cmd/pipeline/deploy_test.go
@@ -221,6 +221,7 @@ func TestDeployPipelineSuccesful(t *testing.T) {
 		okClient: &client.FakeOktetoClient{
 			PipelineClient: client.NewFakePipelineClient(response),
 		},
+		okCtx:             okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 		k8sClientProvider: test.NewFakeK8sProvider(),
 	}
 	opts := &DeployOptions{
@@ -266,6 +267,7 @@ func TestDeployPipelineSuccesfulWithWait(t *testing.T) {
 			PipelineClient: client.NewFakePipelineClient(response),
 			StreamClient:   client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 		},
+		okCtx:             okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 		k8sClientProvider: test.NewFakeK8sProvider(cmap),
 	}
 	opts := &DeployOptions{
@@ -295,6 +297,7 @@ func TestDeployWithError(t *testing.T) {
 		okClient: &client.FakeOktetoClient{
 			PipelineClient: client.NewFakePipelineClient(response),
 		},
+		okCtx:             okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 		k8sClientProvider: test.NewFakeK8sProvider(),
 	}
 	opts := &DeployOptions{
@@ -340,6 +343,7 @@ func TestDeployPipelineSuccesfulWithWaitStreamError(t *testing.T) {
 			PipelineClient: client.NewFakePipelineClient(response),
 			StreamClient:   client.NewFakeStreamClient(&client.FakeStreamResponse{StreamErr: errors.New("error")}),
 		},
+		okCtx:             okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 		k8sClientProvider: test.NewFakeK8sProvider(cmap),
 	}
 	opts := &DeployOptions{
@@ -363,6 +367,7 @@ func Test_DeployPipelineWithReuseParamsNotFoundError(t *testing.T) {
 	}
 	pc := &Command{
 		k8sClientProvider: test.NewFakeK8sProvider(),
+		okCtx:             okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 	}
 	opts := &DeployOptions{
 		Repository:  "https://test",
@@ -390,6 +395,7 @@ func Test_DeployPipelineWithReuseParamsSuccess(t *testing.T) {
 		okClient: &client.FakeOktetoClient{
 			PipelineClient: fakePipelineClient,
 		},
+		okCtx: okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 		k8sClientProvider: test.NewFakeK8sProvider(
 			&v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -446,6 +452,7 @@ func Test_DeployPipelineWithSkipIfExist(t *testing.T) {
 						fakePipelineClientResponses,
 					),
 				},
+				okCtx: okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 				k8sClientProvider: test.NewFakeK8sProvider(
 					&v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
@@ -478,6 +485,7 @@ func Test_DeployPipelineWithSkipIfExist(t *testing.T) {
 						fakePipelineClientResponses,
 					),
 				},
+				okCtx: okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 				k8sClientProvider: test.NewFakeK8sProvider(
 					&v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
@@ -541,6 +549,7 @@ func Test_DeployPipelineWithSkipIfExistAndWait(t *testing.T) {
 						&client.FakeStreamResponse{},
 					),
 				},
+				okCtx: okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 				k8sClientProvider: test.NewFakeK8sProvider(
 					&v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
@@ -581,6 +590,7 @@ func Test_DeployPipelineWithSkipIfExistAndWait(t *testing.T) {
 						},
 					),
 				},
+				okCtx: okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 				k8sClientProvider: test.NewFakeK8sProvider(
 					&v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
@@ -619,6 +629,7 @@ func Test_DeployPipelineWithSkipIfExistAndWait(t *testing.T) {
 						&client.FakeStreamResponse{},
 					),
 				},
+				okCtx: okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 				k8sClientProvider: test.NewFakeK8sProvider(
 					&v1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{

--- a/cmd/pipeline/destroy_test.go
+++ b/cmd/pipeline/destroy_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/internal/test/client"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -39,6 +40,7 @@ func TestDestroyPipelineSuccessful(t *testing.T) {
 		okClient: &client.FakeOktetoClient{
 			PipelineClient: client.NewFakePipelineClient(response),
 		},
+		okCtx: &okteto.Context{},
 	}
 	opts := &DestroyOptions{
 		Name: "test",
@@ -62,6 +64,7 @@ func TestDestroyPipelineSuccessfulWithWait(t *testing.T) {
 			PipelineClient: client.NewFakePipelineClient(response),
 			StreamClient:   client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 		},
+		okCtx: &okteto.Context{},
 	}
 	opts := &DestroyOptions{
 		Name: "test",
@@ -86,6 +89,7 @@ func TestDestroyPipelineSuccessfulWithWaitStreamErr(t *testing.T) {
 			PipelineClient: client.NewFakePipelineClient(response),
 			StreamClient:   client.NewFakeStreamClient(&client.FakeStreamResponse{StreamErr: errors.New("error")}),
 		},
+		okCtx: &okteto.Context{},
 	}
 	opts := &DestroyOptions{
 		Name: "test",
@@ -104,6 +108,7 @@ func TestDestroyNonExistentPipeline(t *testing.T) {
 		okClient: &client.FakeOktetoClient{
 			PipelineClient: client.NewFakePipelineClient(response),
 		},
+		okCtx: &okteto.Context{},
 	}
 	opts := &DestroyOptions{
 		Name: "no exists",
@@ -125,6 +130,7 @@ func TestDestroyNonExistentPipelineWithWait(t *testing.T) {
 			PipelineClient: client.NewFakePipelineClient(response),
 			StreamClient:   client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 		},
+		okCtx: &okteto.Context{},
 	}
 
 	opts := &DestroyOptions{
@@ -145,6 +151,7 @@ func TestDestroyExistentPipelineWithError(t *testing.T) {
 		okClient: &client.FakeOktetoClient{
 			PipelineClient: client.NewFakePipelineClient(response),
 		},
+		okCtx: &okteto.Context{},
 	}
 
 	opts := &DestroyOptions{
@@ -168,6 +175,7 @@ func TestDestroyExistentPipelineTimeoutError(t *testing.T) {
 			PipelineClient: client.NewFakePipelineClient(response),
 			StreamClient:   client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 		},
+		okCtx: &okteto.Context{},
 	}
 
 	opts := &DestroyOptions{

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -85,13 +85,16 @@ func pipelineListCommandHandler(ctx context.Context, flags *listFlags, initOkCtx
 		return err
 	}
 
-	okCtx := okteto.GetContext()
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return err
+	}
 
 	if !okCtx.IsOkteto {
 		return oktetoErrors.ErrContextIsNotOktetoCluster
 	}
 
-	pc, err := NewCommand()
+	pc, err := NewCommand(okCtx)
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -33,10 +33,11 @@ type Interface interface {
 type Command struct {
 	okClient          types.OktetoInterface
 	k8sClientProvider okteto.K8sClientProvider
+	okCtx             *okteto.Context
 }
 
 // NewCommand creates a namespace command to
-func NewCommand() (*Command, error) {
+func NewCommand(okCtx *okteto.Context) (*Command, error) {
 	var okClient = &okteto.Client{}
 	if okteto.IsOkteto() {
 		c, err := okteto.NewOktetoClient()
@@ -48,6 +49,7 @@ func NewCommand() (*Command, error) {
 	return &Command{
 		okClient:          okClient,
 		k8sClientProvider: okteto.NewK8sClientProvider(),
+		okCtx:             okCtx,
 	}, nil
 }
 

--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -76,11 +76,15 @@ okteto preview deploy --wait=false`,
 				return err
 			}
 
-			if !okteto.IsOkteto() {
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
+			if !okCtx.IsOkteto {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			previewCmd, err := NewCommand()
+			previewCmd, err := NewCommand(okCtx)
 			if err != nil {
 				return err
 			}
@@ -108,7 +112,7 @@ func (pw *Command) ExecuteDeployPreview(ctx context.Context, opts *DeployOptions
 		return err
 	}
 
-	oktetoLog.Information("Preview URL: %s", getPreviewURL(opts.name))
+	oktetoLog.Information("Preview URL: %s", getPreviewURL(pw.okCtx.Name, opts.name))
 	if !opts.wait {
 		oktetoLog.Success("Preview environment '%s' scheduled for deployment", opts.name)
 		return nil

--- a/cmd/preview/deploy_test.go
+++ b/cmd/preview/deploy_test.go
@@ -196,6 +196,7 @@ func Test_ExecuteDeployPreview(t *testing.T) {
 				},
 			}
 			pw := &Command{
+				okCtx: okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 				okClient: &client.FakeOktetoClient{
 					PipelineClient: client.NewFakePipelineClient(tt.pipelineResponses),
 					Preview:        client.NewFakePreviewClient(tt.previewResponses),

--- a/cmd/preview/deploy_utils.go
+++ b/cmd/preview/deploy_utils.go
@@ -101,8 +101,7 @@ func getExpandedName(name string) string {
 	return expandedName
 }
 
-func getPreviewURL(name string) string {
-	oktetoURL := okteto.GetContext().Name
+func getPreviewURL(oktetoURL, name string) string {
 	previewURL := fmt.Sprintf("%s/previews/%s", oktetoURL, name)
 	return previewURL
 }

--- a/cmd/preview/deploy_utils_test.go
+++ b/cmd/preview/deploy_utils_test.go
@@ -116,7 +116,7 @@ func Test_getPreviewURL(t *testing.T) {
 
 	t.Run("full-previews-url", func(t *testing.T) {
 		expected := "https://my.okteto.instance/previews/foo-bar"
-		actual := getPreviewURL("foo-bar")
+		actual := getPreviewURL(ctxName, "foo-bar")
 		assert.Equal(t, expected, actual)
 	})
 }

--- a/cmd/preview/preview.go
+++ b/cmd/preview/preview.go
@@ -23,16 +23,18 @@ import (
 
 type Command struct {
 	okClient types.OktetoInterface
+	okCtx    *okteto.Context
 }
 
 // NewCommand creates a namespace command for previews
-func NewCommand() (*Command, error) {
+func NewCommand(okCtx *okteto.Context) (*Command, error) {
 	c, err := okteto.NewOktetoClient()
 	if err != nil {
 		return nil, err
 	}
 	return &Command{
 		okClient: c,
+		okCtx:    okCtx,
 	}, nil
 }
 

--- a/cmd/preview/sleep.go
+++ b/cmd/preview/sleep.go
@@ -38,11 +38,15 @@ func Sleep(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if !okteto.IsOkteto() {
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
+			if !okCtx.IsOkteto {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			prCmd, err := NewCommand()
+			prCmd, err := NewCommand(okCtx)
 			if err != nil {
 				return err
 			}

--- a/cmd/preview/wake.go
+++ b/cmd/preview/wake.go
@@ -38,11 +38,15 @@ func Wake(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			if !okteto.IsOkteto() {
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
+			if !okCtx.IsOkteto {
 				return oktetoErrors.ErrContextIsNotOktetoCluster
 			}
 
-			prCmd, err := NewCommand()
+			prCmd, err := NewCommand(okCtx)
 			if err != nil {
 				return err
 			}

--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -108,7 +108,7 @@ It is important that this command does the minimum and must not do calculations 
 			}
 
 			k8sClientProvider := okteto.NewK8sClientProviderWithLogger(k8sLogger)
-			cmapHandler := deployCMD.NewConfigmapHandler(k8sClientProvider, k8sLogger)
+			cmapHandler := deployCMD.NewConfigmapHandler(k8sClientProvider, oktetoContext, k8sLogger)
 
 			runner, err := deployable.NewDeployRunnerForRemote(
 				options.Name,

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -47,7 +47,8 @@ type DestroyOptions struct {
 
 // DestroyCommand struct with the dependencies needed to run the destroy operation
 type DestroyCommand struct {
-	runner destroyRunner
+	runner        destroyRunner
+	oktetoContext *okteto.ContextStateless
 }
 
 // Destroy starts the destroy command remotely. This is the command executed in the
@@ -120,7 +121,8 @@ It is important that this command does the minimum and must not do calculations 
 			}
 
 			c := &DestroyCommand{
-				runner: runner,
+				runner:        runner,
+				oktetoContext: oktetoContext,
 			}
 
 			return c.Run(params)
@@ -135,7 +137,7 @@ It is important that this command does the minimum and must not do calculations 
 
 func (c *DestroyCommand) Run(params deployable.DestroyParameters) error {
 	// Token should be always masked from the logs
-	oktetoLog.AddMaskedWord(okteto.GetContext().Token)
+	oktetoLog.AddMaskedWord(c.oktetoContext.GetCurrentToken())
 	keyValueVarParts := 2
 	// We mask all the variables received in the command
 	for _, variable := range params.Variables {

--- a/cmd/remoterun/destroy_test.go
+++ b/cmd/remoterun/destroy_test.go
@@ -64,12 +64,16 @@ func TestRun_DestroyCommand(t *testing.T) {
 			},
 		},
 	}
+	okCtx := &okteto.ContextStateless{
+		Store: okteto.CurrentStore,
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runner := &fakeDestroyRunner{}
 			runner.On("RunDestroy", tt.params).Return(tt.expected)
 			command := &DestroyCommand{
-				runner: runner,
+				runner:        runner,
+				oktetoContext: okCtx,
 			}
 			err := command.Run(tt.params)
 

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -109,7 +109,7 @@ commands:
 			}
 
 			// Token should be always masked from the logs
-			oktetoLog.AddMaskedWord(okteto.GetContext().Token)
+			oktetoLog.AddMaskedWord(oktetoContext.GetCurrentToken())
 			keyValueVarParts := 2
 			// We mask all the variables received in the command
 			for _, variable := range params.Variables {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -64,7 +64,10 @@ func Status(fs afero.Fs) *cobra.Command {
 			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Namespace: namespace, Context: k8sContext}); err != nil {
 				return err
 			}
-
+			okCtx, err := okteto.GetContext()
+			if err != nil {
+				return err
+			}
 			manifestOpts := contextCMD.ManifestOptions{Filename: devPath}
 			manifest, err := model.GetManifestV2(manifestOpts.Filename, afero.NewOsFs())
 			if err != nil {
@@ -94,11 +97,11 @@ func Status(fs afero.Fs) *cobra.Command {
 			}
 
 			waitForStates := []config.UpState{config.Synchronizing, config.Ready}
-			if err := status.Wait(dev, okteto.GetContext().Namespace, waitForStates); err != nil {
+			if err := status.Wait(dev, okCtx.Namespace, waitForStates); err != nil {
 				return err
 			}
 
-			ctxNamespace := okteto.GetContext().Namespace
+			ctxNamespace := okCtx.Namespace
 			sy, err := syncthing.Load(dev, ctxNamespace)
 			if err != nil {
 				oktetoLog.Infof("error accessing the syncthing info file: %s", err)

--- a/cmd/up/activate_test.go
+++ b/cmd/up/activate_test.go
@@ -60,6 +60,7 @@ func TestWaitUntilAppAwaken(t *testing.T) {
 					Autocreate: tc.autocreate,
 				},
 				K8sClientProvider: tc.oktetoClientProvider,
+				okCtx:             okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 			}
 			err := up.waitUntilAppIsAwaken(context.Background(), nil)
 			assert.ErrorIs(t, tc.expectedErr, err)
@@ -94,6 +95,7 @@ func TestWaitUntilDevelopmentContainerIsRunning(t *testing.T) {
 			up := &upContext{
 				Dev:               &model.Dev{},
 				K8sClientProvider: tc.oktetoClientProvider,
+				okCtx:             okteto.CurrentStore.Contexts[okteto.CurrentStore.CurrentContext],
 			}
 			err := up.waitUntilDevelopmentContainerIsRunning(context.Background(), nil)
 			assert.ErrorIs(t, tc.expectedErr, err)

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -397,7 +397,7 @@ func (up *upContext) cleanCommand(ctx context.Context) {
 
 	cmd := "cat /var/okteto/bin/version.txt; cat /proc/sys/fs/inotify/max_user_watches; /var/okteto/bin/clean >/dev/null 2>&1"
 
-	k8sClient, restConfig, err := up.K8sClientProvider.Provide(okteto.GetContext().Cfg)
+	k8sClient, restConfig, err := up.K8sClientProvider.Provide(up.okCtx.Cfg)
 	if err != nil {
 		oktetoLog.Infof("failed to clean session: %s", err)
 		return
@@ -430,7 +430,7 @@ func (up *upContext) RunCommand(ctx context.Context, cmd []string) error {
 		return err
 	}
 
-	k8sClient, restConfig, err := up.K8sClientProvider.Provide(okteto.GetContext().Cfg)
+	k8sClient, restConfig, err := up.K8sClientProvider.Provide(up.okCtx.Cfg)
 	if err != nil {
 		return err
 	}
@@ -480,7 +480,7 @@ func (up *upContext) RunCommand(ctx context.Context, cmd []string) error {
 }
 
 func (up *upContext) checkOktetoStartError(ctx context.Context, msg string) error {
-	k8sClient, _, err := up.K8sClientProvider.Provide(okteto.GetContext().Cfg)
+	k8sClient, _, err := up.K8sClientProvider.Provide(up.okCtx.Cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -1085,6 +1085,7 @@ func TestCheckOktetoStartError(t *testing.T) {
 			upCtx := &upContext{
 				Namespace:         "test",
 				Dev:               tt.dev,
+				okCtx:             &okteto.Context{},
 				K8sClientProvider: tt.K8sProvider,
 				Options: &Options{
 					ManifestPathFlag: "test",
@@ -1120,6 +1121,7 @@ func TestCleanCommand(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			upCtx := &upContext{
 				K8sClientProvider: tt.k8sClientProvider,
+				okCtx:             &okteto.Context{},
 			}
 			upCtx.cleanCommand(context.Background())
 

--- a/cmd/up/forwards.go
+++ b/cmd/up/forwards.go
@@ -23,7 +23,6 @@ import (
 	forwardk8s "github.com/okteto/okteto/pkg/k8s/forward"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model/forward"
-	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/ssh"
 	"github.com/okteto/okteto/pkg/syncthing"
 )
@@ -41,7 +40,7 @@ func (up *upContext) forwards(ctx context.Context) error {
 		return up.sshForwards(ctx)
 	}
 
-	k8sClient, restConfig, err := up.K8sClientProvider.Provide(okteto.GetContext().Cfg)
+	k8sClient, restConfig, err := up.K8sClientProvider.Provide(up.okCtx.Cfg)
 	if err != nil {
 		return err
 	}
@@ -85,7 +84,7 @@ func (up *upContext) forwards(ctx context.Context) error {
 }
 
 func (up *upContext) sshForwards(ctx context.Context) error {
-	k8sClient, restConfig, err := up.K8sClientProvider.Provide(okteto.GetContext().Cfg)
+	k8sClient, restConfig, err := up.K8sClientProvider.Provide(up.okCtx.Cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/up/forwards_test.go
+++ b/cmd/up/forwards_test.go
@@ -70,6 +70,7 @@ func TestGlobalForwarderAddsProperlyPortsToForward(t *testing.T) {
 		{
 			name: "add one global forwarder",
 			upContext: &upContext{
+				okCtx: &okteto.Context{},
 				Manifest: &model.Manifest{
 					GlobalForward: []forward.GlobalForward{
 						{
@@ -85,6 +86,7 @@ func TestGlobalForwarderAddsProperlyPortsToForward(t *testing.T) {
 		{
 			name: "add two global forwarder",
 			upContext: &upContext{
+				okCtx: &okteto.Context{},
 				Manifest: &model.Manifest{
 					GlobalForward: []forward.GlobalForward{
 						{
@@ -105,6 +107,7 @@ func TestGlobalForwarderAddsProperlyPortsToForward(t *testing.T) {
 		{
 			name: "add none global forwarder",
 			upContext: &upContext{
+				okCtx: &okteto.Context{},
 				Manifest: &model.Manifest{
 					GlobalForward: []forward.GlobalForward{},
 				},
@@ -151,6 +154,7 @@ func TestForwards(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			up := &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Forward: []forward.Forward{
 						{
@@ -189,6 +193,7 @@ func TestSSHForwarss(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			up := &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Forward: []forward.Forward{
 						{

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -87,6 +87,7 @@ type upContext struct {
 	ShutdownCompleted     chan bool
 	Options               *Options
 	Pod                   *apiv1.Pod
+	okCtx                 *okteto.Context
 	Cancel                context.CancelFunc
 	pidController         pidController
 	inFd                  uintptr

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -41,6 +41,7 @@ func Test_waitUntilExitOrInterrupt(t *testing.T) {
 	up := upContext{
 		Options:           &Options{},
 		K8sClientProvider: test.NewFakeK8sProvider(),
+		okCtx:             &okteto.Context{},
 	}
 	up.CommandResult = make(chan error, 1)
 	up.CommandResult <- nil
@@ -75,6 +76,7 @@ func Test_printDisplayContext(t *testing.T) {
 		{
 			name: "basic",
 			up: &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Name: "dev",
 				},
@@ -86,6 +88,7 @@ func Test_printDisplayContext(t *testing.T) {
 		{
 			name: "single-forward",
 			up: &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Name:    "dev",
 					Forward: []forward.Forward{{Local: 1000, Remote: 1000}},
@@ -98,6 +101,7 @@ func Test_printDisplayContext(t *testing.T) {
 		{
 			name: "multiple-forward",
 			up: &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Name:    "dev",
 					Forward: []forward.Forward{{Local: 1000, Remote: 1000}, {Local: 2000, Remote: 2000}},
@@ -120,6 +124,7 @@ func Test_printDisplayContext(t *testing.T) {
 		{
 			name: "single-reverse",
 			up: &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Name:    "dev",
 					Reverse: []model.Reverse{{Local: 1000, Remote: 1000}},
@@ -132,6 +137,7 @@ func Test_printDisplayContext(t *testing.T) {
 		{
 			name: "multiple-reverse+global-forward",
 			up: &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Name:    "dev",
 					Reverse: []model.Reverse{{Local: 1000, Remote: 1000}, {Local: 2000, Remote: 2000}},
@@ -154,6 +160,7 @@ func Test_printDisplayContext(t *testing.T) {
 		{
 			name: "global-forward",
 			up: &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Name: "dev",
 				},
@@ -171,6 +178,7 @@ func Test_printDisplayContext(t *testing.T) {
 		{
 			name: "multiple-global-forward",
 			up: &upContext{
+				okCtx: &okteto.Context{},
 				Dev: &model.Dev{
 					Name: "dev",
 				},

--- a/integration/actions/context_test.go
+++ b/integration/actions/context_test.go
@@ -54,7 +54,11 @@ func TestContextAction(t *testing.T) {
 func executeContextAction() error {
 	token := os.Getenv(model.OktetoTokenEnvVar)
 	if token == "" {
-		token = okteto.GetContext().Token
+		okCtx, err := okteto.GetContext()
+		if err != nil {
+			return err
+		}
+		token = okCtx.Token
 	}
 
 	actionRepo := fmt.Sprintf("%s%s.git", githubHTTPSURL, contextPath)

--- a/integration/actions/namespace_test.go
+++ b/integration/actions/namespace_test.go
@@ -71,7 +71,11 @@ func executeCreateNamespaceAction(namespace string) error {
 	}
 
 	log.Printf("create namespace output: \n%s\n", string(o))
-	n := okteto.GetContext().Namespace
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return err
+	}
+	n := okCtx.Namespace
 	if namespace != n {
 		return fmt.Errorf("current namespace is %s, expected %s", n, namespace)
 	}
@@ -104,7 +108,11 @@ func executeChangeNamespaceAction(namespace string) error {
 	}
 
 	log.Printf("changing namespace output: \n%s\n", string(o))
-	n := okteto.GetContext().Namespace
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return err
+	}
+	n := okCtx.Namespace
 	if namespace != n {
 		return fmt.Errorf("current namespace is %s, expected %s", n, namespace)
 	}

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -131,7 +131,10 @@ func TestBuildCommandV1(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedImage := fmt.Sprintf("%s/%s/test:okteto", okteto.GetContext().Registry, testNamespace)
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedImage := fmt.Sprintf("%s/%s/test:okteto", okCtx.Registry, testNamespace)
 	require.False(t, isImageBuilt(expectedImage))
 
 	options := &commands.BuildOptions{
@@ -166,7 +169,10 @@ func TestBuildInferredDockerfile(t *testing.T) {
 
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedImage := fmt.Sprintf("%s/%s/test:okteto", okteto.GetContext().Registry, testNamespace)
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedImage := fmt.Sprintf("%s/%s/test:okteto", okCtx.Registry, testNamespace)
 	require.False(t, isImageBuilt(expectedImage))
 
 	options := &commands.BuildOptions{
@@ -200,10 +206,12 @@ func TestBuildCommandV2(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedAppImage))
 
-	expectedApiImage := fmt.Sprintf("%s/%s/%s-api:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	expectedApiImage := fmt.Sprintf("%s/%s/%s-api:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedApiImage))
 
 	options := &commands.BuildOptions{
@@ -239,10 +247,13 @@ func TestBuildCommandV2UsingDepot(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedAppImage))
 
-	expectedApiImage := fmt.Sprintf("%s/%s/%s-api:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	expectedApiImage := fmt.Sprintf("%s/%s/%s-api:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedApiImage))
 
 	options := &commands.BuildOptions{
@@ -294,7 +305,10 @@ func TestBuildCommandV2OnlyOneService(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedImage := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedImage))
 
 	options := &commands.BuildOptions{
@@ -330,10 +344,13 @@ func TestBuildCommandV2SpecifyingServices(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedAppImage := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedAppImage))
 
-	expectedApiImage := fmt.Sprintf("%s/%s/%s-api:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	expectedApiImage := fmt.Sprintf("%s/%s/%s-api:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedApiImage))
 
 	options := &commands.BuildOptions{
@@ -369,7 +386,10 @@ func TestBuildCommandV2FromCompose(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedBuildImage := fmt.Sprintf("%s/%s/%s-vols:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedBuildImage := fmt.Sprintf("%s/%s/%s-vols:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedBuildImage))
 
 	options := &commands.BuildOptions{
@@ -408,7 +428,10 @@ func TestBuildCommandV2WithVolumeMounts(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedBuildImage := fmt.Sprintf("%s/%s/%s-nginx:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedBuildImage := fmt.Sprintf("%s/%s/%s-nginx:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedBuildImage))
 
 	options := &commands.BuildOptions{
@@ -443,7 +466,10 @@ func TestBuildCommandV2Secrets(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
 
-	expectedBuildImage := fmt.Sprintf("%s/%s/%s-test:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
+	expectedBuildImage := fmt.Sprintf("%s/%s/%s-test:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(expectedBuildImage))
 
 	options := &commands.BuildOptions{

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -253,10 +253,13 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
 	// Test that the nginx image has been created correctly
 	nginxDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "nginx", c)
 	require.NoError(t, err)
-	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(nginxImageDev), nginxDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	// Test that the nginx image has been created correctly
@@ -267,7 +270,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/label-1"], "value-label-1")
 	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/label-2"], "value-label-2")
 
-	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	appVolume, err := integration.GetVolume(context.Background(), testNamespace, "data", c)
@@ -354,10 +357,12 @@ func TestDeployPipelineFromComposeWithVolumeMounts(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that the nginx image has been created correctly
 	nginxDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "nginx", c)
 	require.NoError(t, err)
-	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(nginxImageDev), nginxDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	// Test that the deployment for app has the expected annotations and labels
@@ -368,7 +373,7 @@ func TestDeployPipelineFromComposeWithVolumeMounts(t *testing.T) {
 	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/label-1"], "value-label-1")
 	require.Equal(t, appDeployment.ObjectMeta.Annotations["dev.okteto.com/label-2"], "value-label-2")
 
-	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	appVolume, err := integration.GetVolume(context.Background(), testNamespace, "data", c)
@@ -446,16 +451,18 @@ func TestReDeployPipelineFromCompose(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that the nginx image has been created correctly
 	nginxDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "nginx", c)
 	require.NoError(t, err)
-	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(nginxImageDev), nginxDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	// Test that the nginx image has been created correctly
 	appDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "app", c)
 	require.NoError(t, err)
-	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	// Test that the k8s services has been created correctly
@@ -529,6 +536,8 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that the nginx image has been created correctly
 	nginxDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "nginx", c)
 	require.NoError(t, err)
@@ -537,7 +546,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	require.Equal(t, nginxDeployment.ObjectMeta.Annotations["dev.okteto.com/annotation-1"], "value-annotation-1")
 	require.Equal(t, nginxDeployment.ObjectMeta.Annotations["dev.okteto.com/annotation-2"], "value-annotation-2")
 
-	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(nginxImageDev), nginxDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	appVolume, err := integration.GetVolume(context.Background(), testNamespace, "data", c)
@@ -551,7 +560,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	appDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "app", c)
 	require.NoError(t, err)
 
-	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	// Test endpoints are accessible
@@ -606,16 +615,18 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that the nginx image has been created correctly
 	nginxDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "nginx", c)
 	require.NoError(t, err)
-	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	nginxImageDev := fmt.Sprintf("%s/%s/%s-nginx:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.Equal(t, getImageWithSHA(nginxImageDev), nginxDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	// Test that the nginx image has been created correctly
 	appDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "app", c)
 	require.NoError(t, err)
-	appImageDev := fmt.Sprintf("%s/%s/app:okteto", okteto.GetContext().Registry, testNamespace)
+	appImageDev := fmt.Sprintf("%s/%s/app:okteto", okCtx.Registry, testNamespace)
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	// Test that the k8s services has been created correctly

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -151,13 +151,15 @@ func TestDeployOktetoManifest(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that endpoint works
 	autowakeURL := fmt.Sprintf("https://e2etest-%s.%s", testNamespace, appsSubdomain)
 	require.NotEmpty(t, integration.GetContentFromURL(autowakeURL, timeout))
 
 	// Test that image has been built
 
-	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.NotEmpty(t, getImageWithSHA(appImageDev))
 
 	destroyOptions := &commands.DestroyOptions{
@@ -197,8 +199,10 @@ func TestRedeployOktetoManifestForImages(t *testing.T) {
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that image is not built before running okteto deploy
-	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(appImageDev))
 
 	deployOptions := &commands.DeployOptions{
@@ -269,8 +273,10 @@ func TestDeployOktetoManifestWithDestroy(t *testing.T) {
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that image is not built before running okteto deploy
-	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okteto.GetContext().Registry, testNamespace, filepath.Base(dir))
+	appImageDev := fmt.Sprintf("%s/%s/%s-app:okteto", okCtx.Registry, testNamespace, filepath.Base(dir))
 	require.False(t, isImageBuilt(appImageDev))
 
 	deployOptions := &commands.DeployOptions{
@@ -332,9 +338,11 @@ func TestDeployOktetoManifestExportCache(t *testing.T) {
 	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
 	require.NoError(t, err)
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	require.NoError(t, createOktetoManifestWithCache(dir))
 	require.NoError(t, createAppDockerfileWithCache(dir))
-	appImageDev := fmt.Sprintf("%s/%s/app:dev", okteto.GetContext().Registry, testNamespace)
+	appImageDev := fmt.Sprintf("%s/%s/app:dev", okCtx.Registry, testNamespace)
 	require.NoError(t, createK8sManifestWithCache(dir, appImageDev))
 
 	deployOptions := &commands.DeployOptions{
@@ -346,7 +354,7 @@ func TestDeployOktetoManifestExportCache(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
 	// Test that image has been built
-	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okteto.GetContext().Registry, testNamespace)))
+	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okCtx.Registry, testNamespace)))
 
 	destroyOptions := &commands.DestroyOptions{
 		Workdir:    dir,
@@ -391,8 +399,10 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 
 	require.NoError(t, commands.RunOktetoBuild(oktetoPath, buildOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that image has been built
-	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okteto.GetContext().Registry, testNamespace)))
+	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okCtx.Registry, testNamespace)))
 
 	t.Setenv(build.DepotTokenEnvVar, "fakeToken")
 	t.Setenv(build.DepotProjectEnvVar, "fakeProject")
@@ -450,8 +460,10 @@ func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that image has been built
-	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okteto.GetContext().Registry, testNamespace)))
+	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/app:dev", okCtx.Registry, testNamespace)))
 
 	destroyOptions := &commands.DestroyOptions{
 		Workdir:      parentFolder,

--- a/integration/deploy/remote_test.go
+++ b/integration/deploy/remote_test.go
@@ -64,8 +64,10 @@ func TestDeployRemoteWithBuildCommand(t *testing.T) {
 	}
 	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that image has been built
-	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/testing-image:test", okteto.GetContext().Registry, testNamespace)))
+	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/testing-image:test", okCtx.Registry, testNamespace)))
 
 	destroyOptions := &commands.DestroyOptions{
 		Workdir:    dir,

--- a/integration/deploy/smartbuild_test.go
+++ b/integration/deploy/smartbuild_test.go
@@ -65,8 +65,11 @@ func TestDeployOktetoManifestWithSmartBuildCloneCustomImage(t *testing.T) {
 	require.NoError(t, createOktetoManifestWithCustomImage(dir))
 	require.NoError(t, integration.GitInit(dir))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
+
 	testNamespace := integration.GetTestNamespace("DeploySBClone", user)
-	require.NoError(t, createK8sManifestWithCache(dir, fmt.Sprintf("%s/%s/test-app:1.0.0", okteto.GetContext().Registry, testNamespace)))
+	require.NoError(t, createK8sManifestWithCache(dir, fmt.Sprintf("%s/%s/test-app:1.0.0", okCtx.Registry, testNamespace)))
 
 	buildOptions := &commands.BuildOptions{
 		Workdir:    dir,
@@ -97,7 +100,7 @@ func TestDeployOktetoManifestWithSmartBuildCloneCustomImage(t *testing.T) {
 	require.Contains(t, outpput, "Okteto Smart Builds is skipping build of 'app' because it's already built from cache.")
 
 	// Test that image has been built
-	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/test-app:1.0.0", okteto.GetContext().Registry, testNamespace)))
+	require.NotEmpty(t, getImageWithSHA(fmt.Sprintf("%s/%s/test-app:1.0.0", okCtx.Registry, testNamespace)))
 
 	destroyOptions := &commands.DestroyOptions{
 		Workdir:    dir,

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -62,7 +62,12 @@ func GetToken() string {
 	if v := os.Getenv(model.OktetoTokenEnvVar); v != "" {
 		token = v
 	} else {
-		token = okteto.GetContext().Token
+		okCtx, err := okteto.GetContext()
+		if err != nil {
+			log.Printf("failed to get okteto context: %s", err)
+			return ""
+		}
+		token = okCtx.Token
 	}
 	return token
 }
@@ -151,7 +156,11 @@ func SkipIfWindows(t *testing.T) {
 
 // SkipIfNotOktetoCluster skips a tests if is not on an okteto cluster
 func SkipIfNotOktetoCluster(t *testing.T) {
-	if !okteto.GetContext().IsOkteto {
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		t.Skip("Skipping because is not on an okteto cluster")
+	}
+	if !okCtx.IsOkteto {
 		t.Skip("Skipping because is not on an okteto cluster")
 	}
 }

--- a/integration/up/deploy_remote_test.go
+++ b/integration/up/deploy_remote_test.go
@@ -101,10 +101,12 @@ func TestUpWithDeployRemote(t *testing.T) {
 	}
 	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOpts, 1, timeout))
 
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that the app image has been created correctly
 	appDeployment, err := integration.GetDeployment(context.Background(), testNamespace, model.DevCloneName(appName), c)
 	require.NoError(t, err)
-	appImageDev := fmt.Sprintf("%s/%s/test:1.0.0", okteto.GetContext().Registry, testNamespace)
+	appImageDev := fmt.Sprintf("%s/%s/test:1.0.0", okCtx.Registry, testNamespace)
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	indexRemoteEndpoint := fmt.Sprintf("https://%s-%s.%s/index.html", appName, testNamespace, appsSubdomain)

--- a/integration/up/deploy_test.go
+++ b/integration/up/deploy_test.go
@@ -98,11 +98,12 @@ func TestUpWithDeploy(t *testing.T) {
 		ConfigFile: filepath.Join(dir, ".kube", "config"),
 	}
 	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOpts, 1, timeout))
-
+	okCtx, err := okteto.GetContext()
+	require.NoError(t, err)
 	// Test that the app image has been created correctly
 	appDeployment, err := integration.GetDeployment(context.Background(), testNamespace, model.DevCloneName("e2etest"), c)
 	require.NoError(t, err)
-	appImageDev := fmt.Sprintf("%s/%s/test:1.0.0", okteto.GetContext().Registry, testNamespace)
+	appImageDev := fmt.Sprintf("%s/%s/test:1.0.0", okCtx.Registry, testNamespace)
 	require.Equal(t, getImageWithSHA(appImageDev), appDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	indexRemoteEndpoint := fmt.Sprintf("https://e2etest-%s.%s/index.html", testNamespace, appsSubdomain)

--- a/pkg/analytics/config.go
+++ b/pkg/analytics/config.go
@@ -150,10 +150,14 @@ func Enable() error {
 }
 
 func getTrackID() string {
-	if okteto.GetContext().UserID != "" {
-		return okteto.GetContext().UserID
-	}
 	a := get()
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return a.MachineID
+	}
+	if okCtx.UserID != "" {
+		return okCtx.UserID
+	}
 	return a.MachineID
 }
 

--- a/pkg/analytics/track_test.go
+++ b/pkg/analytics/track_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMain(m *testing.M) {
@@ -72,7 +73,9 @@ func Test_getTrackID(t *testing.T) {
 
 			a := get()
 			a.MachineID = tt.machineID
-			okteto.GetContext().UserID = tt.userID
+			okCtx, err := okteto.GetContext()
+			require.NoError(t, err)
+			okCtx.UserID = tt.userID
 
 			trackID := getTrackID()
 

--- a/pkg/cmd/down/run.go
+++ b/pkg/cmd/down/run.go
@@ -21,7 +21,6 @@ import (
 	"github.com/okteto/okteto/pkg/k8s/services"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
-	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/ssh"
 	"github.com/okteto/okteto/pkg/syncthing"
 )
@@ -33,7 +32,7 @@ func (d *Operation) Run(app apps.App, dev *model.Dev, namespace string, trMap ma
 		oktetoLog.Info("no translations available in the deployment")
 	}
 
-	k8sClient, _, err := d.K8sClientProvider.Provide(okteto.GetContext().Cfg)
+	k8sClient, _, err := d.K8sClientProvider.Provide(d.okCtx.Cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pipeline/translate.go
+++ b/pkg/cmd/pipeline/translate.go
@@ -372,11 +372,16 @@ func updateCmap(cmap *apiv1.ConfigMap, data *CfgData) error {
 // AddDevAnnotations add deploy labels to the deployments/sfs
 func AddDevAnnotations(ctx context.Context, manifest *model.Manifest, c kubernetes.Interface) {
 	repo := os.Getenv(model.GithubRepositoryEnvVar)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		oktetoLog.Infof("failed to get context: %s", err)
+		return
+	}
 	for devName, dev := range manifest.Dev {
 		if dev.Autocreate {
 			continue
 		}
-		ns := okteto.GetContext().Namespace
+		ns := okCtx.Namespace
 		app, err := apps.Get(ctx, dev, ns, c)
 		if err != nil {
 			oktetoLog.Infof("could not add %s dev annotations due to: %s", devName, err.Error())

--- a/pkg/deployable/deploy_test.go
+++ b/pkg/deployable/deploy_test.go
@@ -152,6 +152,7 @@ func TestRunDeployWithErrorGettingClient(t *testing.T) {
 
 	r := DeployRunner{
 		K8sClientProvider: k8sProvider,
+		okCtx:             okteto.CurrentStore.Contexts["test"],
 	}
 
 	err := r.RunDeploy(context.Background(), DeployParameters{})
@@ -183,6 +184,7 @@ func TestRunDeployWithErrorModifyingKubeconfig(t *testing.T) {
 		Proxy:              proxy,
 		Kubeconfig:         kubeconfigHandler,
 		TempKubeconfigFile: "temp-kubeconfig",
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 	}
 
 	err := r.RunDeploy(context.Background(), DeployParameters{})
@@ -223,6 +225,7 @@ func TestRunDeployWithEmptyDeployable(t *testing.T) {
 		TempKubeconfigFile: "temp-kubeconfig",
 		Fs:                 afero.NewMemMapFs(),
 		ConfigMapHandler:   &fakeCmapHandler{},
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 	}
 
 	params := DeployParameters{
@@ -261,6 +264,7 @@ func TestRunCommandsSectionWithCommands(t *testing.T) {
 		Fs:                 afero.NewMemMapFs(),
 		ConfigMapHandler:   &fakeCmapHandler{},
 		Executor:           executor,
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 	}
 
 	params := DeployParameters{
@@ -319,6 +323,7 @@ func TestRunCommandsSectionWithErrorInCommands(t *testing.T) {
 		Fs:                 afero.NewMemMapFs(),
 		ConfigMapHandler:   &fakeCmapHandler{},
 		Executor:           executor,
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 	}
 
 	params := DeployParameters{
@@ -379,6 +384,7 @@ func TestRunCommandsSectionWithDivert(t *testing.T) {
 		ConfigMapHandler:   &fakeCmapHandler{},
 		Executor:           executor,
 		DivertDeployer:     divertDeployer,
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 	}
 
 	params := DeployParameters{
@@ -423,6 +429,7 @@ func TestRunCommandsSectionWithErrorDeployingDivert(t *testing.T) {
 		ConfigMapHandler:   &fakeCmapHandler{},
 		Executor:           executor,
 		DivertDeployer:     divertDeployer,
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 	}
 
 	params := DeployParameters{
@@ -470,6 +477,7 @@ func TestRunCommandsSectionWithExternal(t *testing.T) {
 		Executor:           executor,
 		DivertDeployer:     divertDeployer,
 		K8sClientProvider:  k8sProvider,
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 		GetExternalControl: func(_ *rest.Config) ExternalResourceInterface {
 			return externalResource
 		},
@@ -533,6 +541,7 @@ func TestRunCommandsSectionWithErrorDeployingExternal(t *testing.T) {
 		ConfigMapHandler:   &fakeCmapHandler{},
 		Executor:           executor,
 		DivertDeployer:     divertDeployer,
+		okCtx:              okteto.CurrentStore.Contexts["test"],
 		K8sClientProvider:  k8sProvider,
 		GetExternalControl: func(_ *rest.Config) ExternalResourceInterface {
 			return externalResource
@@ -592,6 +601,7 @@ func TestDeployExternalWithErrorGettingClient(t *testing.T) {
 
 	r := DeployRunner{
 		K8sClientProvider: k8sProvider,
+		okCtx:             okteto.CurrentStore.Contexts["test"],
 	}
 
 	params := DeployParameters{

--- a/pkg/deployable/kubeconfig.go
+++ b/pkg/deployable/kubeconfig.go
@@ -75,11 +75,15 @@ func (k *KubeConfig) Modify(port int, sessionToken, destKubeconfigFile string) e
 }
 
 func (*KubeConfig) GetCMDAPIConfig() (*clientcmdapi.Config, error) {
-	if okteto.GetContext().Cfg == nil {
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return nil, err
+	}
+	if okCtx.Cfg == nil {
 		return nil, fmt.Errorf("okteto context not initialized")
 	}
 
-	return okteto.GetContext().Cfg, nil
+	return okCtx.Cfg, nil
 }
 
 // GetTempKubeConfigFile returns where the temp kubeConfigFile for deploy should be stored

--- a/pkg/insights/deploy.go
+++ b/pkg/insights/deploy.go
@@ -50,7 +50,13 @@ type phaseJSON struct {
 
 // TrackDeploy tracks an image build event
 func (ip *Publisher) TrackDeploy(ctx context.Context, name, namespace string, success bool) {
-	k8sClient, _, err := ip.k8sClientProvider.Provide(okteto.GetContext().Cfg)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		ip.ioCtrl.Logger().Infof("could not get okteto context: %s", err)
+		return
+
+	}
+	k8sClient, _, err := ip.k8sClientProvider.Provide(okCtx.Cfg)
 	if err != nil {
 		ip.ioCtrl.Logger().Infof("could not get k8s client: %s", err)
 		return

--- a/pkg/insights/insights.go
+++ b/pkg/insights/insights.go
@@ -54,7 +54,12 @@ func NewInsightsPublisher(k8sClientProvider okteto.K8sClientProvider, ioCtrl io.
 // insightType: the type of the event (for example: build, deploy, etc.)
 // data: the data of the event as JSON string
 func (ip *Publisher) trackEvent(ctx context.Context, namespace, insightType, data string) {
-	k8sClient, _, err := ip.k8sClientProvider.Provide(okteto.GetContext().Cfg)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		ip.ioCtrl.Logger().Infof("could not get context: %s", err)
+		return
+	}
+	k8sClient, _, err := ip.k8sClientProvider.Provide(okCtx.Cfg)
 	if err != nil {
 		ip.ioCtrl.Logger().Infof("could not get k8s client: %s", err)
 		return

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -106,11 +106,15 @@ func GetRunningPodInLoop(ctx context.Context, dev *model.Dev, app App, c kuberne
 
 // GetTranslations fills all the deployments pointed by a development container
 func GetTranslations(ctx context.Context, namespace string, dev *model.Dev, app App, reset bool, c kubernetes.Interface) (map[string]*Translation, error) {
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return nil, err
+	}
 	mainTr := &Translation{
 		MainDev: dev,
 		Dev:     dev,
 		App:     app,
-		Rules:   []*model.TranslationRule{dev.ToTranslationRule(dev, namespace, okteto.GetContext().Username, reset)},
+		Rules:   []*model.TranslationRule{dev.ToTranslationRule(dev, namespace, okCtx.Username, reset)},
 	}
 	result := map[string]*Translation{app.ObjectMeta().Name: mainTr}
 
@@ -141,7 +145,11 @@ func loadServiceTranslations(ctx context.Context, namespace string, dev *model.D
 			return err
 		}
 
-		rule := s.ToTranslationRule(dev, okteto.GetContext().Username, okteto.GetContext().Username, reset)
+		okCtx, err := okteto.GetContext()
+		if err != nil {
+			return err
+		}
+		rule := s.ToTranslationRule(dev, okCtx.Username, okCtx.Username, reset)
 
 		if _, ok := result[app.ObjectMeta().Name]; ok {
 			result[app.ObjectMeta().Name].Rules = append(result[app.ObjectMeta().Name].Rules, rule)

--- a/pkg/k8s/virtualservices/client.go
+++ b/pkg/k8s/virtualservices/client.go
@@ -20,7 +20,11 @@ import (
 
 // GetIstioClient returns a client for istio
 func GetIstioClient() (*istioclientset.Clientset, error) {
-	_, config, err := okteto.NewK8sClientProvider().Provide(okteto.GetContext().Cfg)
+	okCtx, err := okteto.GetContext()
+	if err != nil {
+		return nil, err
+	}
+	_, config, err := okteto.NewK8sClientProvider().Provide(okCtx.Cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/okteto/config.go
+++ b/pkg/okteto/config.go
@@ -61,16 +61,71 @@ func (c ConfigStateless) GetExternalRegistryCredentials(registryHost string) (st
 
 type Config struct{}
 
-func (Config) IsOktetoCluster() bool                             { return IsOkteto() }
-func (Config) GetGlobalNamespace() string                        { return GetContext().GlobalNamespace }
-func (Config) GetNamespace() string                              { return GetContext().Namespace }
-func (Config) GetRegistryURL() string                            { return GetContext().Registry }
-func (Config) GetUserID() string                                 { return GetContext().UserID }
-func (Config) GetToken() string                                  { return GetContext().Token }
-func (Config) GetContextCertificate() (*x509.Certificate, error) { return GetContextCertificate() }
-func (Config) IsInsecureSkipTLSVerifyPolicy() bool               { return GetContext().IsInsecure }
-func (Config) GetServerNameOverride() string                     { return GetServerNameOverride() }
-func (Config) GetContextName() string                            { return GetContext().Name }
+func (Config) IsOktetoCluster() bool { return IsOkteto() }
+func (Config) GetGlobalNamespace() string {
+	okCtx, err := GetContext()
+	if err != nil {
+		return ""
+	}
+	return okCtx.GlobalNamespace
+}
+
+func (Config) GetNamespace() string {
+	okCtx, err := GetContext()
+	if err != nil {
+		return ""
+	}
+	return okCtx.Namespace
+}
+
+func (Config) GetRegistryURL() string {
+	okCtx, err := GetContext()
+	if err != nil {
+		return ""
+	}
+	return okCtx.Registry
+}
+
+func (Config) GetUserID() string {
+	okCtx, err := GetContext()
+	if err != nil {
+		return ""
+	}
+	return okCtx.UserID
+}
+
+func (Config) GetToken() string {
+	okCtx, err := GetContext()
+	if err != nil {
+		return ""
+	}
+	return okCtx.Token
+}
+
+func (Config) GetContextCertificate() (*x509.Certificate, error) {
+	return GetContextCertificate()
+}
+
+func (Config) IsInsecureSkipTLSVerifyPolicy() bool {
+	okCtx, err := GetContext()
+	if err != nil {
+		return false
+	}
+	return okCtx.IsInsecure
+}
+
+func (Config) GetServerNameOverride() string {
+	return GetServerNameOverride()
+}
+
+func (Config) GetContextName() string {
+	okCtx, err := GetContext()
+	if err != nil {
+		return ""
+	}
+	return okCtx.Name
+}
+
 func (Config) GetExternalRegistryCredentials(registryHost string) (string, string, error) {
 	return GetExternalRegistryCredentials(registryHost)
 }

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -282,7 +282,8 @@ func TestGetContextStoreFromStorePath(t *testing.T) {
 
 	require.NoError(t, err)
 	t.Setenv(constants.OktetoFolderEnvVar, tempDir)
-	store := GetContextStoreFromStorePath()
+	store, err := GetContextStoreFromStorePath()
+	require.NoError(t, err)
 
 	expected := &ContextStore{
 		Contexts: map[string]*Context{

--- a/pkg/okteto/stream.go
+++ b/pkg/okteto/stream.go
@@ -49,7 +49,11 @@ type destroyAllLogFormat struct {
 
 // PipelineLogs retrieves logs from the pipeline provided and prints them, returns error
 func (c *streamClient) PipelineLogs(ctx context.Context, name, namespace, actionName string) error {
-	streamURL := fmt.Sprintf(gitDeployUrlTemplate, GetContext().Name, namespace, name, actionName)
+	okCtx, err := GetContext()
+	if err != nil {
+		return err
+	}
+	streamURL := fmt.Sprintf(gitDeployUrlTemplate, okCtx.Name, namespace, name, actionName)
 	url, err := url.Parse(streamURL)
 	if err != nil {
 		return err
@@ -86,8 +90,12 @@ func handlerPipelineLogLine(line string) bool {
 
 // DestroyAllLogs retrieves logs from the pipeline provided and prints them, returns error
 func (c *streamClient) DestroyAllLogs(ctx context.Context, namespace string) error {
-	// GetContext().Name represents baseURL for SSE subscription endpoints
-	streamURL := fmt.Sprintf(destroyAllUrlTempleate, GetContext().Name, namespace)
+	okCtx, err := GetContext()
+	if err != nil {
+		return err
+	}
+	// okCtx.Name represents baseURL for SSE subscription endpoints
+	streamURL := fmt.Sprintf(destroyAllUrlTempleate, okCtx.Name, namespace)
 	url, err := url.Parse(streamURL)
 	if err != nil {
 		return err

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -148,6 +148,7 @@ func TestRemoteTest(t *testing.T) {
 				temporalCtrl:         tempCreator,
 				oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
 				ioCtrl:               io.NewIOController(),
+				okCtx:                okteto.CurrentStore.Contexts["test"],
 				getEnviron: func() []string {
 					return []string{}
 				},
@@ -193,6 +194,7 @@ func TestExtraHosts(t *testing.T) {
 		oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
 		useInternalNetwork:   true,
 		ioCtrl:               io.NewIOController(),
+		okCtx:                &okteto.Context{},
 		getEnviron: func() []string {
 			return []string{}
 		},
@@ -238,6 +240,7 @@ func TestRemoteDeployWithSshAgent(t *testing.T) {
 		temporalCtrl:         filesystem.NewTemporalDirectoryCtrl(fs),
 		oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
 		ioCtrl:               io.NewIOController(),
+		okCtx:                &okteto.Context{},
 		getEnviron: func() []string {
 			return []string{}
 		},
@@ -281,6 +284,7 @@ func TestRemoteDeployWithBadSshAgent(t *testing.T) {
 		temporalCtrl:         filesystem.NewTemporalDirectoryCtrl(fs),
 		oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
 		ioCtrl:               io.NewIOController(),
+		okCtx:                &okteto.Context{},
 		getEnviron: func() []string {
 			return []string{}
 		},


### PR DESCRIPTION
# Proposed changes

Fixes partly DEV-694

This PR refactors all the context package in order to make `okteto.GetContext()` to return an error. 
Throwing a fatal is a bad practice like a panic so as I had to touch this part of the code I refactored it before implementing the bug fix per se

| Before          | After           |
|-----------------|-----------------|
| <img width="622" alt="Screenshot 2024-10-15 at 18 06 52" src="https://github.com/user-attachments/assets/8eca7ab0-5793-45c2-85cd-42fb2256fca0"> | <img width="623" alt="Screenshot 2024-10-15 at 18 06 57" src="https://github.com/user-attachments/assets/a919d65e-c7c1-4c9f-bbdf-180918cdca51"> |




## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
