### PR TITLE
remove validation from context store

### DIFF
--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -267,19 +267,6 @@ func GetContextStoreFromStorePath() *ContextStore {
 	return ctxStore
 }
 
-func ValidateContextStore(ctxStore *ContextStore) error {
-	if ctxStore.Contexts == nil {
-		return fmt.Errorf("contexts cannot be nil")
-	}
-	if ctxStore.CurrentContext == "" {
-		return fmt.Errorf("current-context is empty")
-	}
-	if _, ok := ctxStore.Contexts[ctxStore.CurrentContext]; !ok {
-		return fmt.Errorf("current-context '%s' not found in contexts", ctxStore.CurrentContext)
-	}
-	return nil
-}
-
 func GetContext() *Context {
 	c := GetContextStore()
 	if c.CurrentContext == "" {

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -236,6 +236,9 @@ func GetContextStore() *ContextStore {
 
 	if ContextExists() {
 		ctxStore := GetContextStoreFromStorePath()
+		if ctxStore.Contexts == nil {
+			ctxStore.Contexts = map[string]*Context{}
+		}
 		CurrentStore = ctxStore
 		return ctxStore
 	}
@@ -261,14 +264,10 @@ func GetContextStoreFromStorePath() *ContextStore {
 		oktetoLog.Errorf("error decoding okteto contexts: %v", err)
 		oktetoLog.Fatalf(oktetoErrors.ErrCorruptedOktetoContexts, config.GetOktetoContextFolder())
 	}
-	if err := validateContextStore(ctxStore); err != nil {
-		oktetoLog.Errorf("error validating okteto contexts: %v", err)
-		oktetoLog.Fatalf(oktetoErrors.ErrCorruptedOktetoContexts, config.GetOktetoContextFolder())
-	}
 	return ctxStore
 }
 
-func validateContextStore(ctxStore *ContextStore) error {
+func ValidateContextStore(ctxStore *ContextStore) error {
 	if ctxStore.Contexts == nil {
 		return fmt.Errorf("contexts cannot be nil")
 	}

--- a/pkg/okteto/context_test.go
+++ b/pkg/okteto/context_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -291,71 +290,4 @@ func TestGetContextStoreFromStorePath(t *testing.T) {
 		CurrentContext: "test",
 	}
 	require.EqualValues(t, expected, store)
-}
-
-func TestValidateContextStore(t *testing.T) {
-	tests := []struct {
-		ctxStore    *ContextStore
-		name        string
-		expectedMsg string
-		expectedErr bool
-	}{
-		{
-			name: "Valid ContextStore",
-			ctxStore: &ContextStore{
-				Contexts: map[string]*Context{
-					"context1": {},
-					"context2": {},
-				},
-				CurrentContext: "context1",
-			},
-			expectedErr: false,
-			expectedMsg: "",
-		},
-		{
-			name: "Nil Contexts",
-			ctxStore: &ContextStore{
-				Contexts:       nil,
-				CurrentContext: "context1",
-			},
-			expectedErr: true,
-			expectedMsg: "contexts cannot be nil",
-		},
-		{
-			name: "Empty CurrentContext",
-			ctxStore: &ContextStore{
-				Contexts: map[string]*Context{
-					"context1": {},
-					"context2": {},
-				},
-				CurrentContext: "",
-			},
-			expectedErr: true,
-			expectedMsg: "current-context is empty",
-		},
-		{
-			name: "CurrentContext not in Contexts",
-			ctxStore: &ContextStore{
-				Contexts: map[string]*Context{
-					"context1": {},
-					"context2": {},
-				},
-				CurrentContext: "context3",
-			},
-			expectedErr: true,
-			expectedMsg: "current-context 'context3' not found in contexts",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateContextStore(tt.ctxStore)
-			if tt.expectedErr {
-				assert.Error(t, err)
-				assert.EqualError(t, err, tt.expectedMsg)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes DEV-694

This was a problem introduced by DEV-339. This PR reverts the validation from that PR and fixes the context store if it's not completed. 


## How to validate

1. Modify your context/config.json and remove all the contexts
1. Run okteto deploy/context and check that there is no panic

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
