### PR TITLE
fix lint errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ jobs:
   push-image-tag:
     executor: golang-ci
     environment:
-      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED: "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
     steps:
       - checkout
       - run: *okteto-login
@@ -419,7 +419,7 @@ jobs:
   push-image-dev:
     executor: golang-ci
     environment:
-      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED: "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
     steps:
       - checkout
       - run: *okteto-login
@@ -430,7 +430,7 @@ jobs:
   push-image-master:
     executor: golang-ci
     environment:
-      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED : "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
+      OKTETO_LOCAL_REGISTRY_STORE_PRIORITY_ENABLED: "true" # this is needed to push to Docker Hub using the local credentials instead of the ones from the context cluster
     steps:
       - checkout
       - run: *okteto-login

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ The Okteto Open Source CLI supports the following commands:
 - `okteto down`
 
 > [!NOTE]
- ⚠️ Notice: The open-source version of Okteto only supports the [dev section](https://www.okteto.com/docs/reference/okteto-manifest/#dev-object-optional) of the Okteto manifest. For additional features and full functionality, consider exploring the [Okteto Platform](https://www.okteto.com/get-demo/).
-
+> ⚠️ Notice: The open-source version of Okteto only supports the [dev section](https://www.okteto.com/docs/reference/okteto-manifest/#dev-object-optional) of the Okteto manifest. For additional features and full functionality, consider exploring the [Okteto Platform](https://www.okteto.com/get-demo/).
 
 We have getting started guides for the Open Source mode for the following languages:
 
@@ -109,7 +108,7 @@ Okteto is monthly released into three channels: stable, beta, and dev. When Okte
 
 ## Support and Community
 
-Got questions? Have feedback? Join the conversation in our [Community Forum](https://community.okteto.com/). 
+Got questions? Have feedback? Join the conversation in our [Community Forum](https://community.okteto.com/).
 
 Follow [@OktetoHQ](https://twitter.com/oktetohq) on Twitter for important announcements.
 

--- a/scripts/ci/push-image.sh
+++ b/scripts/ci/push-image.sh
@@ -21,7 +21,7 @@
         echo "DEBUG: PLATFORMS: ${PLATFORMS}"
 
         IFS=',' read -ra TAGS_ARRAY <<< "$RELEASE_TAG"
-        
+
         if [ -z "${TAGS_ARRAY[0]}" ]; then
                 commit=$(git rev-parse --short HEAD)
                 TAGS_ARRAY=("$commit" "${TAGS_ARRAY[@]:1}")
@@ -29,7 +29,7 @@
         fi
 
         echo "DEBUG: Final RELEASE_TAG: ${TAGS_ARRAY[*]}"
-        
+
         echo "DEBUG: Splitting RELEASE_TAG into TAGS_ARRAY:"
         for tag in "${TAGS_ARRAY[@]}"; do
                 echo "  DEBUG: Tag: ${tag}"
@@ -42,7 +42,7 @@
         beta_added=false
         stable_added=false
         for tag in "${TAGS_ARRAY[@]}"; do
-                echo "DEBUG: Processing tag: ${tag}"        
+                echo "DEBUG: Processing tag: ${tag}"
                 prerel="$(semver get prerel "${tag}" || true)"
                 version="$(semver get release "${tag}" || true)"
                 echo "  DEBUG: prerel: ${prerel}"
@@ -50,7 +50,7 @@
 
                 tags_array+=("okteto/okteto:${tag}")
                 echo "  DEBUG: Added tag to tags_array: okteto/okteto:${tag}"
-                echo "  DEBUG: tags_array so far: ${tags_array[@]}"
+                echo "  DEBUG: tags_array so far: ${tags_array[*]}"
 
                 if [ -n "$prerel" ]; then
                         if [ "$beta_added" = false ]; then
@@ -74,7 +74,7 @@
                         echo "  DEBUG: Tag ${tag} is a dev tag"
                 fi
         done
-        
+
         tags=$(IFS=','; echo "${tags_array[*]}")
 
         echo "DEBUG: Final tags string: ${tags}"

--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -139,11 +139,11 @@ for repo in "${repos[@]}"; do
         echo "Updating Dockerfile to use okteto/okteto:${RELEASE_TAG}"
         sed -i.bak -E 's|(FROM okteto/okteto:)[^ ]*|\1'"${RELEASE_TAG}"'|g' Dockerfile
         rm Dockerfile.bak
-        
+
         echo "Dockerfile changes:"
         git --no-pager diff Dockerfile
 
-        git add Dockerfile 
+        git add Dockerfile
         git commit -m "Release ${RELEASE_TAG}" || echo "No changes to commit in repository '$repo'."
     else
         echo "Warning: Dockerfile not found in repository '$repo'. Skipping Dockerfile update."
@@ -166,7 +166,7 @@ for repo in "${repos[@]}"; do
             # Note: We are not using TAG_NAME directly for comparison
             # Instead, we find the version tag that TAG_NAME points to
             current_tag_version=$(git describe --tags "${TAG_NAME}" --abbrev=0 --match "*.*.*" 2>/dev/null || echo "0.0.0")
-            
+
             # Compare the new RELEASE_TAG with the current_tag_version
             # This comparison determines if RELEASE_TAG is newer than the version TAG_NAME points to
             diff=$(semver compare "${RELEASE_TAG}" "${current_tag_version}")


### PR DESCRIPTION
# Proposed changes

Running `make lint` throws errors that are currently at master. The command running on ci is `golangci-lint` and not `make lint` so these errors are just spotted if running `make lint` locally.

 
