### PR TITLE
DEV-758: Implement ssh-forwarder to contact with ssh-agent running in the cluster when executing remote operations (deploy, destroy, test)

### DIFF
--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -141,12 +141,21 @@ It is important that this command does the minimum and must not do calculations 
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 			sshSocket := os.Getenv(constants.OktetoSshAgentSocketEnvVar)
 
-			if sshAgentHostname != "" {
+			if sshAgentHostname != "" && sshAgentPort != "" && sshSocket != "" {
 				forwarder := newSSHForwarder()
 				go func() {
 					err := forwarder.startSshForwarder(ctx, sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 					oktetoLog.Infof("error starting ssh forwarder %v", err)
 				}()
+			} else {
+				message := fmt.Sprintf("ssh forwarded not started because some mandatory configuration parameters are missing. %s=%s, %s=%s and %s=%s",
+					constants.OktetoSshAgentHostnameEnvVar,
+					sshAgentHostname,
+					constants.OktetoSshAgentPortEnvVar,
+					sshAgentPort,
+					constants.OktetoSshAgentSocketEnvVar,
+					sshSocket)
+				oktetoLog.Info(message)
 			}
 
 			return c.Run(ctx, params)

--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -143,7 +143,10 @@ It is important that this command does the minimum and must not do calculations 
 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
-				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+				go func() {
+					err := forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+					oktetoLog.Infof("error starting ssh forwarder %v", err)
+				}()
 			}
 
 			return c.Run(ctx, params)

--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -16,9 +16,11 @@ package remoterun
 import (
 	"context"
 	"fmt"
+	"os"
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	deployCMD "github.com/okteto/okteto/cmd/deploy"
+	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/deployable"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -134,6 +136,11 @@ It is important that this command does the minimum and must not do calculations 
 			c := &DeployCommand{
 				runner: runner,
 			}
+
+			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
+			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
+
+			go startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
 
 			return c.Run(ctx, params)
 		},

--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -140,8 +140,10 @@ It is important that this command does the minimum and must not do calculations 
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 
-			forwarder := newSSHForwarder()
-			go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			if sshAgentHostname != "" {
+				forwarder := newSSHForwarder()
+				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			}
 
 			return c.Run(ctx, params)
 		},

--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -139,10 +139,11 @@ It is important that this command does the minimum and must not do calculations 
 
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
+			sshSocket := os.Getenv(constants.OktetoSshAgentSocketEnvVar)
 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
-				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 			}
 
 			return c.Run(ctx, params)

--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -144,7 +144,7 @@ It is important that this command does the minimum and must not do calculations 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
 				go func() {
-					err := forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+					err := forwarder.startSshForwarder(ctx, sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 					oktetoLog.Infof("error starting ssh forwarder %v", err)
 				}()
 			}

--- a/cmd/remoterun/deploy.go
+++ b/cmd/remoterun/deploy.go
@@ -140,7 +140,8 @@ It is important that this command does the minimum and must not do calculations 
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 
-			go startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			forwarder := newSSHForwarder()
+			go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
 
 			return c.Run(ctx, params)
 		},

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -130,7 +130,7 @@ It is important that this command does the minimum and must not do calculations 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
 				go func() {
-					err := forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+					err := forwarder.startSshForwarder(ctx, sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 					oktetoLog.Infof("error starting ssh forwarder %v", err)
 				}()
 			}

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -123,6 +123,11 @@ It is important that this command does the minimum and must not do calculations 
 				runner: runner,
 			}
 
+			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
+			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
+
+			go startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+
 			return c.Run(params)
 		},
 	}

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -126,7 +126,8 @@ It is important that this command does the minimum and must not do calculations 
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 
-			go startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			forwarder := newSSHForwarder()
+			go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
 
 			return c.Run(params)
 		},

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -126,8 +126,10 @@ It is important that this command does the minimum and must not do calculations 
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 
-			forwarder := newSSHForwarder()
-			go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			if sshAgentHostname != "" {
+				forwarder := newSSHForwarder()
+				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			}
 
 			return c.Run(params)
 		},

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -127,12 +127,21 @@ It is important that this command does the minimum and must not do calculations 
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 			sshSocket := os.Getenv(constants.OktetoSshAgentSocketEnvVar)
 
-			if sshAgentHostname != "" {
+			if sshAgentHostname != "" && sshAgentPort != "" && sshSocket != "" {
 				forwarder := newSSHForwarder()
 				go func() {
 					err := forwarder.startSshForwarder(ctx, sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 					oktetoLog.Infof("error starting ssh forwarder %v", err)
 				}()
+			} else {
+				message := fmt.Sprintf("ssh forwarded not started because some mandatory configuration parameters are missing. %s=%s, %s=%s and %s=%s",
+					constants.OktetoSshAgentHostnameEnvVar,
+					sshAgentHostname,
+					constants.OktetoSshAgentPortEnvVar,
+					sshAgentPort,
+					constants.OktetoSshAgentSocketEnvVar,
+					sshSocket)
+				oktetoLog.Info(message)
 			}
 
 			return c.Run(params)

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -125,10 +125,11 @@ It is important that this command does the minimum and must not do calculations 
 
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
+			sshSocket := os.Getenv(constants.OktetoSshAgentSocketEnvVar)
 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
-				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 			}
 
 			return c.Run(params)

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -129,7 +129,10 @@ It is important that this command does the minimum and must not do calculations 
 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
-				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+				go func() {
+					err := forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+					oktetoLog.Infof("error starting ssh forwarder %v", err)
+				}()
 			}
 
 			return c.Run(params)

--- a/cmd/remoterun/ssh.go
+++ b/cmd/remoterun/ssh.go
@@ -48,7 +48,7 @@ func startSshForwarder(sshAgentHostname, sshAgentPort, userToken string) {
 func handleConnection(localConn net.Conn, host, port, userToken string) {
 	defer localConn.Close()
 
-	// CA is not specified because tt should use System CA root. When remote-run command is executed,
+	// CA is not specified because it should use System CA root. When remote-run command is executed,
 	// the CA should be already available as the CLI set it in the Dockerfile used as a base to
 	// run the command
 	cfg := &tls.Config{}

--- a/cmd/remoterun/ssh.go
+++ b/cmd/remoterun/ssh.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/remote"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -48,22 +47,22 @@ func newTLSConfigWithSystemCA() *tls.Config {
 // startSshForwarder This functions starts the ssh-forwarded process expected to be run on remote-run commands.
 // This process just listens a UNIX socket, and forward the messages to the SSH Agent exposed in the hostname
 // and port received as parameters
-func (s *sshForwarder) startSshForwarder(sshAgentHostname, sshAgentPort, userToken string) {
+func (s *sshForwarder) startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, userToken string) {
 	// Remove existing socket if it exists
-	os.Remove(remote.SshAgentLocalSocket)
+	os.Remove(sshSocket)
 
 	// Listen on the UNIX domain socket
-	localListener, err := net.Listen("unix", remote.SshAgentLocalSocket)
+	localListener, err := net.Listen("unix", sshSocket)
 	if err != nil {
-		oktetoLog.Fatalf("Failed to listen on UNIX socket %s: %v", remote.SshAgentLocalSocket, err)
+		oktetoLog.Fatalf("Failed to listen on UNIX socket %s: %v", sshSocket, err)
 	}
 	defer localListener.Close()
-	oktetoLog.Infof("SSH Agent Forwarder listening on %s\n", remote.SshAgentLocalSocket)
+	oktetoLog.Infof("SSH Agent Forwarder listening on %s\n", sshSocket)
 
 	// Set permissions so only the owner can access the socket
-	err = os.Chmod(remote.SshAgentLocalSocket, 0600)
+	err = os.Chmod(sshSocket, 0600)
 	if err != nil {
-		oktetoLog.Fatalf("Failed to set permissions on UNIX socket %s: %v", remote.SshAgentLocalSocket, err)
+		oktetoLog.Fatalf("Failed to set permissions on UNIX socket %s: %v", sshSocket, err)
 	}
 
 	for {

--- a/cmd/remoterun/ssh.go
+++ b/cmd/remoterun/ssh.go
@@ -47,14 +47,15 @@ func newTLSConfigWithSystemCA() *tls.Config {
 // startSshForwarder This functions starts the ssh-forwarded process expected to be run on remote-run commands.
 // This process just listens a UNIX socket, and forward the messages to the SSH Agent exposed in the hostname
 // and port received as parameters
-func (s *sshForwarder) startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, userToken string) {
+func (s *sshForwarder) startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, userToken string) error {
 	// Remove existing socket if it exists
 	os.Remove(sshSocket)
 
 	// Listen on the UNIX domain socket
 	localListener, err := net.Listen("unix", sshSocket)
 	if err != nil {
-		oktetoLog.Fatalf("Failed to listen on UNIX socket %s: %v", sshSocket, err)
+		oktetoLog.Errorf("Failed to listen on UNIX socket %s: %v", sshSocket, err)
+		return err
 	}
 	defer localListener.Close()
 	oktetoLog.Infof("SSH Agent Forwarder listening on %s\n", sshSocket)
@@ -62,7 +63,8 @@ func (s *sshForwarder) startSshForwarder(sshAgentHostname, sshAgentPort, sshSock
 	// Set permissions so only the owner can access the socket
 	err = os.Chmod(sshSocket, 0600)
 	if err != nil {
-		oktetoLog.Fatalf("Failed to set permissions on UNIX socket %s: %v", sshSocket, err)
+		oktetoLog.Errorf("Failed to set permissions on UNIX socket %s: %v", sshSocket, err)
+		return err
 	}
 
 	for {

--- a/cmd/remoterun/ssh.go
+++ b/cmd/remoterun/ssh.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package remoterun
 
 import (
@@ -47,7 +60,10 @@ func (s *sshForwarder) startSshForwarder(sshAgentHostname, sshAgentPort, userTok
 	oktetoLog.Infof("SSH Agent Forwarder listening on %s\n", remote.SshAgentLocalSocket)
 
 	// Set permissions so only the owner can access the socket
-	os.Chmod(remote.SshAgentLocalSocket, 0600)
+	err = os.Chmod(remote.SshAgentLocalSocket, 0600)
+	if err != nil {
+		oktetoLog.Fatalf("Failed to set permissions on UNIX socket %s: %v", remote.SshAgentLocalSocket, err)
+	}
 
 	for {
 		// Accept connections from local clients

--- a/cmd/remoterun/ssh.go
+++ b/cmd/remoterun/ssh.go
@@ -1,0 +1,118 @@
+package remoterun
+
+import (
+	"bufio"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strings"
+
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/remote"
+)
+
+// startSshForwarder This functions starts the ssh-forwarded process expected to be run on remote-run commands.
+// This process just listens a UNIX socket, and forward the messages to the SSH Agent exposed in the hostname
+// and port received as parameters
+func startSshForwarder(sshAgentHostname, sshAgentPort, userToken string) {
+	// Remove existing socket if it exists
+	os.Remove(remote.SshAgentLocalSocket)
+
+	// Listen on the UNIX domain socket
+	localListener, err := net.Listen("unix", remote.SshAgentLocalSocket)
+	if err != nil {
+		oktetoLog.Fatalf("Failed to listen on UNIX socket %s: %v", remote.SshAgentLocalSocket, err)
+	}
+	defer localListener.Close()
+	oktetoLog.Infof("SSH Agent Forwarder listening on %s\n", remote.SshAgentLocalSocket)
+
+	// Set permissions so only the owner can access the socket
+	os.Chmod(remote.SshAgentLocalSocket, 0600)
+
+	for {
+		// Accept connections from local clients
+		localConn, err := localListener.Accept()
+		if err != nil {
+			oktetoLog.Errorf("Failed to accept local connection: %v", err)
+			continue
+		}
+
+		// Handle each connection concurrently
+		go handleConnection(localConn, sshAgentHostname, sshAgentPort, userToken)
+	}
+}
+
+func handleConnection(localConn net.Conn, host, port, userToken string) {
+	defer localConn.Close()
+
+	// CA is not specified because tt should use System CA root. When remote-run command is executed,
+	// the CA should be already available as the CLI set it in the Dockerfile used as a base to
+	// run the command
+	cfg := &tls.Config{}
+
+	// Connect to the remote SSH agent over TCP
+	remoteConn, err := tls.Dial("tcp", fmt.Sprintf("%s:%s", host, port), cfg)
+	if err != nil {
+		oktetoLog.Errorf("Failed to connect to remote SSH agent: %v", err)
+		return
+	}
+	defer remoteConn.Close()
+
+	// Send the authentication token
+	_, err = remoteConn.Write([]byte(userToken + "\n"))
+	if err != nil {
+		oktetoLog.Errorf("Failed to write auth token to remote SSH agent: %v", err)
+		return
+	}
+
+	// Read the acknowledgment
+	reader := bufio.NewReader(remoteConn)
+	ack, err := reader.ReadString('\n')
+	if err != nil {
+		oktetoLog.Errorf("Failed to read ACK from remote SSH agent: %v", err)
+		return
+	}
+	ack = strings.TrimSpace(ack)
+	if ack != "OK" {
+		oktetoLog.Errorf("Remote SSH agent returned '%s'", ack)
+		return
+	}
+
+	// Channel to receive errors from goroutines
+	errChan := make(chan error, 2)
+
+	// Forward data from local to remote
+	go func() {
+		_, err := io.Copy(remoteConn, localConn)
+		if err != nil && !isClosedNetworkError(err) {
+			oktetoLog.Errorf("Error copying from local to remote: %v", err)
+		}
+		errChan <- err
+	}()
+
+	// Forward data from remote to local
+	go func() {
+		_, err := io.Copy(localConn, remoteConn)
+		if err != nil && !isClosedNetworkError(err) {
+			oktetoLog.Errorf("Error copying from remote to local: %v", err)
+		}
+		errChan <- err
+	}()
+
+	// Wait for both directions to finish
+	<-errChan
+	<-errChan
+
+	// Connections will be closed by deferred calls
+}
+
+func isClosedNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, net.ErrClosed)
+}

--- a/cmd/remoterun/ssh.go
+++ b/cmd/remoterun/ssh.go
@@ -117,7 +117,7 @@ func (s *sshForwarder) handleConnection(localConn net.Conn, host, port, userToke
 	// Forward data from local to remote
 	go func() {
 		_, err := io.Copy(remoteConn, localConn)
-		if err != nil && !isClosedNetworkError(err) {
+		if err != nil && !errors.Is(err, net.ErrClosed) {
 			oktetoLog.Errorf("Error copying from local to remote: %v", err)
 		}
 		errChan <- err
@@ -126,7 +126,7 @@ func (s *sshForwarder) handleConnection(localConn net.Conn, host, port, userToke
 	// Forward data from remote to local
 	go func() {
 		_, err := io.Copy(localConn, remoteConn)
-		if err != nil && !isClosedNetworkError(err) {
+		if err != nil && !errors.Is(err, net.ErrClosed) {
 			oktetoLog.Errorf("Error copying from remote to local: %v", err)
 		}
 		errChan <- err
@@ -137,12 +137,4 @@ func (s *sshForwarder) handleConnection(localConn net.Conn, host, port, userToke
 	<-errChan
 
 	// Connections will be closed by deferred calls
-}
-
-func isClosedNetworkError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	return errors.Is(err, net.ErrClosed)
 }

--- a/cmd/remoterun/ssh.go
+++ b/cmd/remoterun/ssh.go
@@ -31,15 +31,15 @@ type sshForwarder struct {
 	getTLSConfig func() *tls.Config
 }
 
-// CA is not specified because it should use System CA root. When remote-run command is executed,
-// the CA should be already available as the CLI set it in the Dockerfile used as a base to
-// run the command
 func newSSHForwarder() *sshForwarder {
 	return &sshForwarder{
 		getTLSConfig: newTLSConfigWithSystemCA,
 	}
 }
 
+// CA is not specified because it should use System CA root. When remote-run command is executed,
+// the CA should be already available as the CLI set it in the Dockerfile used as a base to
+// run the command
 func newTLSConfigWithSystemCA() *tls.Config {
 	return &tls.Config{}
 }

--- a/cmd/remoterun/ssh_test.go
+++ b/cmd/remoterun/ssh_test.go
@@ -79,8 +79,10 @@ func TestSSHForwarder(t *testing.T) {
 	defer localConn.Close()
 	defer clientConn.Close()
 
+	timeout := 10 * time.Second
 	go func() {
-		forwarder.handleConnection(ctx, localConn, "127.0.0.1", fmt.Sprintf("%d", port), authToken)
+		err := forwarder.handleConnection(ctx, localConn, "127.0.0.1", fmt.Sprintf("%d", port), authToken, timeout)
+		require.NoError(t, err)
 	}()
 
 	// Simulate client writing data

--- a/cmd/remoterun/ssh_test.go
+++ b/cmd/remoterun/ssh_test.go
@@ -1,0 +1,176 @@
+package remoterun
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSHForwarder(t *testing.T) {
+	tlsConfig, err := createTLSConfigForMockServer()
+	require.NoError(t, err)
+
+	port, err := model.GetAvailablePort(model.Localhost)
+	require.NoError(t, err)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	ln, err := tls.Listen("tcp", addr, tlsConfig)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	// Channel to signal when server is ready
+	serverReady := make(chan struct{})
+
+	authToken := "test-token"
+
+	// Start mock SSH agent server
+	go func() {
+		serverReady <- struct{}{}
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go handleMockSSHAgent(conn, authToken)
+		}
+	}()
+
+	<-serverReady
+
+	forwarder := sshForwarder{
+		getTLSConfig: func() *tls.Config {
+			return &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		},
+	}
+
+	// Now create a pair of net.Pipe connections to simulate localConn
+	localConn, clientConn := net.Pipe()
+	defer localConn.Close()
+	defer clientConn.Close()
+
+	go func() {
+		forwarder.handleConnection(localConn, "127.0.0.1", fmt.Sprintf("%d", port), authToken)
+	}()
+
+	// Simulate client writing data
+	testData := []byte("Hello, SSH Agent, this is a test message!")
+	_, err = clientConn.Write(testData)
+	require.NoError(t, err)
+
+	// Read echoed data from clientConn
+	receivedData := make([]byte, len(testData))
+	_, err = clientConn.Read(receivedData)
+	require.NoError(t, err)
+
+	expectedData := "Hello, SSH Agent, this is a test message!"
+	require.Equal(t, expectedData, string(receivedData))
+}
+
+// Mock SSH agent server handler
+func handleMockSSHAgent(conn net.Conn, expectedToken string) {
+	defer conn.Close()
+
+	// Read the authentication token
+	reader := bufio.NewReader(conn)
+	token, err := reader.ReadString('\n')
+	if err != nil {
+		fmt.Printf("Failed to read token from client: %v\n", err)
+		return
+	}
+	token = strings.TrimSpace(token)
+
+	// Verify the token
+	if token != expectedToken {
+		fmt.Printf("Invalid token received: %s\n", token)
+		conn.Write([]byte("Invalid token\n"))
+		return
+	}
+
+	// Send 'OK' acknowledgment
+	_, err = conn.Write([]byte("OK\n"))
+	if err != nil {
+		fmt.Printf("Failed to send OK to client: %v\n", err)
+		return
+	}
+
+	// Echo back data
+	buf := make([]byte, 1024)
+	for {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			_, err := conn.Write(buf[:n])
+			if err != nil {
+				fmt.Printf("Error writing data back to client: %v\n", err)
+				return
+			}
+		}
+		if err != nil {
+			if err != io.EOF {
+				fmt.Printf("Error reading from client: %v\n", err)
+			}
+			return
+		}
+	}
+}
+
+// createTLSConfigForMockServer creates a self-signed certificate to be used by the mock server
+// simulating the ssh-agent running in the cluster
+func createTLSConfigForMockServer() (*tls.Config, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Okteto"},
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(1 * time.Hour), // Valid for one hour
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}

--- a/cmd/remoterun/ssh_test.go
+++ b/cmd/remoterun/ssh_test.go
@@ -15,6 +15,7 @@ package remoterun
 
 import (
 	"bufio"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -34,6 +35,7 @@ import (
 )
 
 func TestSSHForwarder(t *testing.T) {
+	ctx := context.Background()
 	tlsConfig, err := createTLSConfigForMockServer()
 	require.NoError(t, err)
 
@@ -78,7 +80,7 @@ func TestSSHForwarder(t *testing.T) {
 	defer clientConn.Close()
 
 	go func() {
-		forwarder.handleConnection(localConn, "127.0.0.1", fmt.Sprintf("%d", port), authToken)
+		forwarder.handleConnection(ctx, localConn, "127.0.0.1", fmt.Sprintf("%d", port), authToken)
 	}()
 
 	// Simulate client writing data

--- a/cmd/remoterun/ssh_test.go
+++ b/cmd/remoterun/ssh_test.go
@@ -1,3 +1,16 @@
+// Copyright 2024 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package remoterun
 
 import (

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -123,12 +123,21 @@ commands:
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 			sshSocket := os.Getenv(constants.OktetoSshAgentSocketEnvVar)
 
-			if sshAgentHostname != "" {
+			if sshAgentHostname != "" && sshAgentPort != "" && sshSocket != "" {
 				forwarder := newSSHForwarder()
 				go func() {
 					err := forwarder.startSshForwarder(ctx, sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 					oktetoLog.Infof("error starting ssh forwarder %v", err)
 				}()
+			} else {
+				message := fmt.Sprintf("ssh forwarded not started because some mandatory configuration parameters are missing. %s=%s, %s=%s and %s=%s",
+					constants.OktetoSshAgentHostnameEnvVar,
+					sshAgentHostname,
+					constants.OktetoSshAgentPortEnvVar,
+					sshAgentPort,
+					constants.OktetoSshAgentSocketEnvVar,
+					sshSocket)
+				oktetoLog.Info(message)
 			}
 
 			return runner.RunTest(params)

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -122,8 +122,10 @@ commands:
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 
-			forwarder := newSSHForwarder()
-			go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			if sshAgentHostname != "" {
+				forwarder := newSSHForwarder()
+				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			}
 
 			return runner.RunTest(params)
 		},

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -119,6 +119,11 @@ commands:
 				}
 			}
 
+			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
+			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
+
+			go startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+
 			return runner.RunTest(params)
 		},
 	}

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -122,7 +122,8 @@ commands:
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
 
-			go startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+			forwarder := newSSHForwarder()
+			go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
 
 			return runner.RunTest(params)
 		},

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -125,7 +125,10 @@ commands:
 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
-				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+				go func() {
+					err := forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+					oktetoLog.Infof("error starting ssh forwarder %v", err)
+				}()
 			}
 
 			return runner.RunTest(params)

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -121,10 +121,11 @@ commands:
 
 			sshAgentHostname := os.Getenv(constants.OktetoSshAgentHostnameEnvVar)
 			sshAgentPort := os.Getenv(constants.OktetoSshAgentPortEnvVar)
+			sshSocket := os.Getenv(constants.OktetoSshAgentSocketEnvVar)
 
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
-				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, oktetoContext.GetCurrentToken())
+				go forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 			}
 
 			return runner.RunTest(params)

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -126,7 +126,7 @@ commands:
 			if sshAgentHostname != "" {
 				forwarder := newSSHForwarder()
 				go func() {
-					err := forwarder.startSshForwarder(sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
+					err := forwarder.startSshForwarder(ctx, sshAgentHostname, sshAgentPort, sshSocket, oktetoContext.GetCurrentToken())
 					oktetoLog.Infof("error starting ssh forwarder %v", err)
 				}()
 			}

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -25,9 +25,9 @@ import (
 type FakeUserClient struct {
 	errGetPlatformVariables error
 	userCtx                 *types.UserContext
+	ClusterMetadata         types.ClusterMetadata
 	platformVariables       []env.Var
 	err                     []error
-	ClusterMetadata         types.ClusterMetadata
 }
 
 func NewFakeUsersClient(user *types.User, err ...error) *FakeUserClient {

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -25,9 +25,9 @@ import (
 type FakeUserClient struct {
 	errGetPlatformVariables error
 	userCtx                 *types.UserContext
-	ClusterMetadata         types.ClusterMetadata
 	platformVariables       []env.Var
 	err                     []error
+	ClusterMetadata         types.ClusterMetadata
 }
 
 func NewFakeUsersClient(user *types.User, err ...error) *FakeUserClient {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -146,4 +146,10 @@ const (
 
 	// CIEnvVar Env variable defines if the environment is a CI environment
 	CIEnvVar = "CI"
+
+	// OktetoSshAgentHostnameEnvVar Env variable defining the hostname where the SSH Agent is listening
+	OktetoSshAgentHostnameEnvVar = "OKTETO_SSH_AGENT_HOSTNAME"
+
+	// OktetoSshAgentPortEnvVar Env variable defining the port where the SSH Agent is listening
+	OktetoSshAgentPortEnvVar = "OKTETO_SSH_AGENT_PORT"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -152,4 +152,7 @@ const (
 
 	// OktetoSshAgentPortEnvVar Env variable defining the port where the SSH Agent is listening
 	OktetoSshAgentPortEnvVar = "OKTETO_SSH_AGENT_PORT"
+
+	// OktetoSshAgentSocketEnvVar Env variable defining the socket where the ssh-forwarder will listen
+	OktetoSshAgentSocketEnvVar = "OKTETO_SSH_AGENT_SOCKET"
 )

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -258,6 +258,12 @@ func (c *userClient) GetClusterMetadata(ctx context.Context, ns string) (types.C
 			metadata.BuildKitInternalIP = string(v.Value)
 		case "publicDomain":
 			metadata.PublicDomain = string(v.Value)
+		case "sshAgentInternalIP":
+			metadata.SshAgentInternalIP = string(v.Value)
+		case "sshAgentHostname":
+			metadata.SshAgentHostname = string(v.Value)
+		case "sshAgentPort":
+			metadata.SshAgentPort = string(v.Value)
 		}
 	}
 	if metadata.PipelineRunnerImage == "" {

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -259,11 +259,11 @@ func (c *userClient) GetClusterMetadata(ctx context.Context, ns string) (types.C
 		case "publicDomain":
 			metadata.PublicDomain = string(v.Value)
 		case "sshAgentInternalIP":
-			metadata.SshAgentInternalIP = string(v.Value)
+			metadata.SSHAgentInternalIP = string(v.Value)
 		case "sshAgentHostname":
-			metadata.SshAgentHostname = string(v.Value)
+			metadata.SSHAgentHostname = string(v.Value)
 		case "sshAgentPort":
-			metadata.SshAgentPort = string(v.Value)
+			metadata.SSHAgentPort = string(v.Value)
 		}
 	}
 	if metadata.PipelineRunnerImage == "" {

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -92,8 +92,8 @@ ARG {{$key}} {{$val}}
 ENV {{$key}}={{$val}}
 {{end}}
 
-ENV {{ .SshAgentHostnameArgName }}="{{ .SshAgentHostname }}"
-ENV {{ .SshAgentPortArgName }}="{{ .SshAgentPort }}"
+ENV {{ .SSHAgentHostnameArgName }}="{{ .SSHAgentHostname }}"
+ENV {{ .SSHAgentPortArgName }}="{{ .SSHAgentPort }}"
 
 ARG {{ .GitCommitArgName }}
 ARG {{ .GitBranchArgName }}
@@ -110,7 +110,7 @@ RUN \
   {{range $key, $path := .Caches }}--mount=type=cache,target={{$path}},sharing=private {{end}}\
   --mount=type=secret,id=known_hosts \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
-{{ if .SshAgentHostname }}  export SSH_AUTH_SOCK={{ .SshAgentSocket }} && \{{ end }}
+{{ if .SSHAgentHostname }}  export SSH_AUTH_SOCK={{ .SSHAgentSocket }} && \{{ end }}
   /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }}{{ if eq .Command "test" }} || true{{ end }}
 
 {{range $key, $artifact := .Artifacts }}
@@ -168,10 +168,10 @@ type Params struct {
 	// okteto manifest which is resolved through params.ManifestPathFlag
 	ContextAbsolutePathOverride string
 	ManifestPathFlag            string
-	// SshAgentHostname hostname of the ssh-agent service
-	SshAgentHostname string
-	// SshAgentPort port of the ssh-agent service
-	SshAgentPort string
+	// SSHAgentHostname hostname of the ssh-agent service
+	SSHAgentHostname string
+	// SSHAgentPort port of the ssh-agent service
+	SSHAgentPort string
 	Deployable   deployable.Entity
 	CommandFlags []string
 	Caches       []string
@@ -219,11 +219,11 @@ type dockerfileTemplateProperties struct {
 	BuildKitHostArgName          string
 	OktetoRegistryURLArgName     string
 	Command                      string
-	SshAgentHostnameArgName      string
-	SshAgentHostname             string
-	SshAgentPortArgName          string
-	SshAgentPort                 string
-	SshAgentSocket               string
+	SSHAgentHostnameArgName      string
+	SSHAgentHostname             string
+	SSHAgentPortArgName          string
+	SSHAgentPort                 string
+	SSHAgentSocket               string
 	Caches                       []string
 	Artifacts                    []model.Artifact
 	UseRootUser                  bool
@@ -271,8 +271,8 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 		return err
 	}
 
-	params.SshAgentHostname = sc.SshAgentHostname
-	params.SshAgentPort = sc.SshAgentPort
+	params.SSHAgentHostname = sc.SSHAgentHostname
+	params.SSHAgentPort = sc.SSHAgentPort
 
 	dockerfile, err := r.createDockerfile(tmpDir, params)
 	if err != nil {
@@ -358,8 +358,8 @@ func (r *Runner) Run(ctx context.Context, params *Params) error {
 			buildOptions.ExtraHosts = getExtraHosts(registryUrl, subdomain, ip, *sc)
 		}
 
-		if sc.SshAgentHostname != "" {
-			buildOptions.ExtraHosts = append(buildOptions.ExtraHosts, types.HostMap{Hostname: sc.SshAgentHostname, IP: sc.SshAgentInternalIP})
+		if sc.SSHAgentHostname != "" {
+			buildOptions.ExtraHosts = append(buildOptions.ExtraHosts, types.HostMap{Hostname: sc.SSHAgentHostname, IP: sc.SSHAgentInternalIP})
 		}
 	}
 
@@ -425,11 +425,11 @@ func (r *Runner) createDockerfile(tmpDir string, params *Params) (string, error)
 		Caches:                       params.Caches,
 		Artifacts:                    params.Artifacts,
 		UseRootUser:                  params.UseRootUser,
-		SshAgentHostname:             params.SshAgentHostname,
-		SshAgentHostnameArgName:      constants.OktetoSshAgentHostnameEnvVar,
-		SshAgentPort:                 params.SshAgentPort,
-		SshAgentPortArgName:          constants.OktetoSshAgentPortEnvVar,
-		SshAgentSocket:               SshAgentLocalSocket,
+		SSHAgentHostname:             params.SSHAgentHostname,
+		SSHAgentHostnameArgName:      constants.OktetoSshAgentHostnameEnvVar,
+		SSHAgentPort:                 params.SSHAgentPort,
+		SSHAgentPortArgName:          constants.OktetoSshAgentPortEnvVar,
+		SSHAgentSocket:               SshAgentLocalSocket,
 	}
 
 	dockerfileSyntax.prepareEnvVars()

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -168,10 +168,14 @@ type Params struct {
 	// okteto manifest which is resolved through params.ManifestPathFlag
 	ContextAbsolutePathOverride string
 	ManifestPathFlag            string
-	Deployable                  deployable.Entity
-	CommandFlags                []string
-	Caches                      []string
-	Hosts                       []model.Host
+	// SshAgentHostname hostname of the ssh-agent service
+	SshAgentHostname string
+	// SshAgentPort port of the ssh-agent service
+	SshAgentPort string
+	Deployable   deployable.Entity
+	CommandFlags []string
+	Caches       []string
+	Hosts        []model.Host
 	// IgnoreRules are the ignoring rules added to this build execution.
 	// Rules follow the .dockerignore syntax as defined in:
 	// https://docs.docker.com/build/building/context/#syntax
@@ -188,12 +192,6 @@ type Params struct {
 	UseRootUser bool
 
 	NoCache bool
-
-	// SshAgentHostname hostname of the ssh-agent service
-	SshAgentHostname string
-
-	// SshAgentPort port of the ssh-agent service
-	SshAgentPort string
 }
 
 // dockerfileTemplateProperties internal struct with the information needed by the Dockerfile template
@@ -225,10 +223,10 @@ type dockerfileTemplateProperties struct {
 	SshAgentHostname             string
 	SshAgentPortArgName          string
 	SshAgentPort                 string
+	SshAgentSocket               string
 	Caches                       []string
 	Artifacts                    []model.Artifact
 	UseRootUser                  bool
-	SshAgentSocket               string
 }
 
 // NewRunner creates a new Runner for remote

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -92,8 +92,8 @@ ARG {{$key}} {{$val}}
 ENV {{$key}}={{$val}}
 {{end}}
 
-ENV {{ .SshAgentHostnameArgName }}={{ .SshAgentHostname }}
-ENV {{ .SshAgentPortArgName }}={{ .SshAgentPort }}
+ENV {{ .SshAgentHostnameArgName }}="{{ .SshAgentHostname }}"
+ENV {{ .SshAgentPortArgName }}="{{ .SshAgentPort }}"
 
 ARG {{ .GitCommitArgName }}
 ARG {{ .GitBranchArgName }}
@@ -110,7 +110,7 @@ RUN \
   {{range $key, $path := .Caches }}--mount=type=cache,target={{$path}},sharing=private {{end}}\
   --mount=type=secret,id=known_hosts \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
-  export SSH_AUTH_SOCK={{ .SshAgentSocket }} && \
+{{ if .SshAgentHostname }}  export SSH_AUTH_SOCK={{ .SshAgentSocket }} && \{{ end }}
   /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }}{{ if eq .Command "test" }} || true{{ end }}
 
 {{range $key, $artifact := .Artifacts }}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -152,8 +152,8 @@ type Runner struct {
 	oktetoClientProvider OktetoClientProvider
 	ioCtrl               *io.Controller
 	getEnviron           func() []string
-	useInternalNetwork   bool
 	generateSocketName   socketNameGenerator
+	useInternalNetwork   bool
 }
 
 // Params struct to pass the necessary parameters to create the Dockerfile

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -533,10 +533,10 @@ func TestGetExtraHosts(t *testing.T) {
 	ip := "1.2.3.4"
 
 	var tests = []struct {
-		metadata     types.ClusterMetadata
 		name         string
 		expected     []types.HostMap
 		definedHosts []model.Host
+		metadata     types.ClusterMetadata
 	}{
 		{
 			name:     "no metadata information",

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -251,8 +251,8 @@ func TestCreateDockerfile(t *testing.T) {
 					},
 					DockerfileName:   "Dockerfile.deploy",
 					Command:          "deploy",
-					SshAgentHostname: "ssh-agent.default.svc.cluster.local",
-					SshAgentPort:     "3000",
+					SSHAgentHostname: "ssh-agent.default.svc.cluster.local",
+					SSHAgentPort:     "3000",
 					CommandFlags:     []string{"--name \"test\""},
 					UseRootUser:      true,
 				},
@@ -344,8 +344,8 @@ COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 					},
 					DockerfileName:   "Dockerfile.test",
 					Command:          "test",
-					SshAgentHostname: "ssh-agent.default.svc.cluster.local",
-					SshAgentPort:     "3000",
+					SSHAgentHostname: "ssh-agent.default.svc.cluster.local",
+					SSHAgentPort:     "3000",
 					CommandFlags:     []string{"--name \"test\""},
 					Artifacts: []model.Artifact{
 						{

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -14,23 +14,23 @@
 package remote
 
 import (
-    "context"
-    "fmt"
-    "path/filepath"
-    "regexp"
-    "testing"
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"testing"
 
-    "github.com/okteto/okteto/internal/test/client"
-    "github.com/okteto/okteto/pkg/constants"
-    oktetoErrors "github.com/okteto/okteto/pkg/errors"
-    filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
-    "github.com/okteto/okteto/pkg/log/io"
-    "github.com/okteto/okteto/pkg/model"
-    "github.com/okteto/okteto/pkg/okteto"
-    "github.com/okteto/okteto/pkg/types"
-    "github.com/spf13/afero"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	"github.com/okteto/okteto/internal/test/client"
+	"github.com/okteto/okteto/pkg/constants"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
+	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeBuilder struct {
@@ -533,10 +533,10 @@ func TestGetExtraHosts(t *testing.T) {
 	ip := "1.2.3.4"
 
 	var tests = []struct {
+		metadata     types.ClusterMetadata
 		name         string
 		expected     []types.HostMap
 		definedHosts []model.Host
-		metadata     types.ClusterMetadata
 	}{
 		{
 			name:     "no metadata information",

--- a/pkg/types/cluster_metadata.go
+++ b/pkg/types/cluster_metadata.go
@@ -20,9 +20,9 @@ type ClusterMetadata struct {
 	BuildKitInternalIP  string
 	PublicDomain        string
 	CompanyName         string
-	Certificate         []byte
-	IsTrialLicense      bool
 	SshAgentInternalIP  string
 	SshAgentHostname    string
 	SshAgentPort        string
+	Certificate         []byte
+	IsTrialLicense      bool
 }

--- a/pkg/types/cluster_metadata.go
+++ b/pkg/types/cluster_metadata.go
@@ -20,9 +20,9 @@ type ClusterMetadata struct {
 	BuildKitInternalIP  string
 	PublicDomain        string
 	CompanyName         string
-	SshAgentInternalIP  string
-	SshAgentHostname    string
-	SshAgentPort        string
+	SSHAgentInternalIP  string
+	SSHAgentHostname    string
+	SSHAgentPort        string
 	Certificate         []byte
 	IsTrialLicense      bool
 }

--- a/pkg/types/cluster_metadata.go
+++ b/pkg/types/cluster_metadata.go
@@ -22,4 +22,7 @@ type ClusterMetadata struct {
 	CompanyName         string
 	Certificate         []byte
 	IsTrialLicense      bool
+	SshAgentInternalIP  string
+	SshAgentHostname    string
+	SshAgentPort        string
 }


### PR DESCRIPTION
# Proposed changes

Fixes DEV-758

Implement ssh-forwarder process to use ssh-agent running in the Okteto cluster when some command defined in an Okteto Manifest needs ssh, and that Okteto Manifest is executed remotely (okteto deploy --remote, okteto destroy --remote, okteto test).

Main changes included in the PR are:
* As part of any subcommand of `remote-run` command, start a go routine which listens in a local UNIX socket and forward everything received there to the ssh-agent running in the Okteto cluster.
* Modify the Dockerfile generated for remote operations (deploy, destroy and test) to define `SSH_AUTH_SOCK` env var if the ssh-agent host name is defined
* Don't mount anymore the local agent running in the machine
* Retrieve from the cluster metadata query the information related to the ssh-agent (hostname, internal IP and port), and pass it to the `remote-run` command through env variables defined in the generated Dockerfile
* Mount always the known_hosts file if exists locally

## How to validate


1. Update your dev environment with the latest changes of master
2. Build the image from this branch using your environment context.
  * `okteto ctx use https://...`
  * `okteto build -f Dockerfile -t okteto.dev/cli:test-pr` 
5. Take the expanded URL of the image build, and define an admin variable named `OKTETO_REMOTE_CLI_IMAGE` with the URL as value
6. Build the go binary from this branch
7. Take the public SSH of your cluster and add it to your user in GitHub (https://www.okteto.com/docs/admin/private-repositories/ssh-key/)
8. Create an Okteto Manifest like the following one:

```
deploy:
  remote: true
  commands:
    - ssh-add -L
    - git clone <private-repo>
```
9. Execute `okteto deploy` with the binary created from this branch. You should see how it lists one identity, and it should match with the SSH key showed in the admin console of your environment. You should also be able to clone the private repository.
10. You can also try with `destroy` and `test` sections of the Okteto Manifest, as they should work too

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
