### PR TITLE
Introducing Okteto Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Apache License 2.0](https://img.shields.io/github/license/okteto/okteto.svg?style=flat-square)](https://github.com/okteto/okteto/blob/master/LICENSE)
 ![Total Downloads](https://img.shields.io/github/downloads/okteto/okteto/total?logo=github&logoColor=white)
 [![Chat in Slack](https://img.shields.io/badge/slack-@kubernetes/okteto-red.svg?logo=slack)](https://kubernetes.slack.com/messages/CM1QMQGS0/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Okteto%20Guru-006BFF)](https://gurubase.io/g/okteto)
 
 ## Overview
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Okteto Guru](https://gurubase.io/g/okteto) to Gurubase. Okteto Guru uses the data from this repo and data from the [docs](https://www.okteto.com/docs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Okteto Guru", which highlights that Okteto now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Okteto Guru in Gurubase, just let me know that's totally fine.