### PR TITLE
fix: ui build logs

### DIFF
--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -320,7 +320,7 @@ func SolveBuild(ctx context.Context, c *client.Client, opt *client.SolveOpt, pro
 			return err
 		default:
 			// not using shared context to not disrupt display but let it finish reporting errors
-			d, err := progressui.NewDisplay(os.Stdout, progressui.PlainMode)
+			d, err := progressui.NewDisplay(ioCtrl.Out(), progressui.PlainMode)
 			if err != nil {
 				// If an error occurs while attempting to create the tty display,
 				// fallback to using plain mode on stdout (in contrast to stderr).


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-761

This PR fixes that we are not using our in out controller for builds making it that the logs didn't have the correct json format and not showing them in the UI

## How to validate

1. Run export `OKTETO_SMART_BUILDS_ENABLED=false`
1. Run okteto `deploy --log-output json`
1. Check that the build logs are set with the stage and timestamp correctly

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
