### PR TITLE
feat (build): support overriding default frontend image

### DIFF
--- a/cmd/build/command.go
+++ b/cmd/build/command.go
@@ -81,7 +81,7 @@ type registryInterface interface {
 func NewBuildCommand(ioCtrl *io.Controller, analyticsTracker, insights buildTrackerInterface, okCtx *okteto.ContextStateless, k8slogger *io.K8sLogger) *Command {
 	return &Command{
 		GetManifest:      model.GetManifestV2,
-		Builder:          buildCmd.NewOktetoBuilder(okCtx, afero.NewOsFs()),
+		Builder:          buildCmd.NewOktetoBuilder(okCtx, afero.NewOsFs(), ioCtrl),
 		Registry:         registry.NewOktetoRegistry(buildCmd.GetRegistryConfigFromOktetoConfig(okCtx)),
 		ioCtrl:           ioCtrl,
 		k8slogger:        k8slogger,

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -125,6 +125,7 @@ func NewBuilderFromScratch(ioCtrl *io.Controller, onBuildFinish []OnBuildFinish)
 			Store: okteto.GetContextStore(),
 		},
 		afero.NewOsFs(),
+		ioCtrl,
 	)
 	reg := registry.NewOktetoRegistry(okteto.Config{})
 	wdCtrl := filesystem.NewOsWorkingDirectoryCtrl()

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -75,6 +75,7 @@ func newRemoteDeployer(buildVarsGetter buildEnvVarsGetter, ioCtrl *io.Controller
 			Store: okteto.GetContextStore(),
 		},
 		fs,
+		ioCtrl,
 	)
 	runner := remote.NewRunner(ioCtrl, builder)
 	return &remoteDeployer{

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -64,6 +64,7 @@ func newRemoteDestroyer(manifest *model.Manifest, ioCtrl *io.Controller) *remote
 			Store: okteto.GetContextStore(),
 		},
 		fs,
+		ioCtrl,
 	)
 	runner := remote.NewRunner(ioCtrl, builder)
 	if manifest.Destroy == nil {

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -316,6 +316,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 				Store: okteto.GetContextStore(),
 			},
 			fs,
+			ioCtrl,
 		))
 		commands := make([]model.DeployCommand, len(test.Commands))
 

--- a/pkg/build/buildkit/frontend.go
+++ b/pkg/build/buildkit/frontend.go
@@ -1,0 +1,93 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildkit
+
+import (
+	"errors"
+
+	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/types"
+)
+
+// FrontendType represents the type of frontend to use for a build.
+type FrontendType string
+
+const (
+	// defaultFrontend specifies the frontend to use for local builds.
+	defaultFrontend FrontendType = "dockerfile.v0"
+
+	// gatewayFrontend specifies the frontend to use for builds executed in the gateway.
+	gatewayFrontend FrontendType = "gateway.v0"
+
+	// dockerFrontendImage specifies the Docker image to use as the frontend when executing builds in the gateway.
+	dockerFrontendImage = "docker/dockerfile"
+
+	// buildkitFrontendImageEnvVar is the environment variable used to override the default frontend image.
+	buildkitFrontendImageEnvVar = "OKTETO_BUILDKIT_FRONTEND_IMAGE"
+)
+
+var (
+	// errOptionsIsNil is the error returned when the build options are nil.
+	errOptionsIsNil = errors.New("buildOptions cannot be nil")
+)
+
+type FrontendRetriever struct {
+	getEnv func(string) string
+	logger *io.Controller
+}
+
+type Frontend struct {
+	Frontend FrontendType
+	Image    string
+}
+
+func NewFrontendRetriever(getEnv func(string) string, logger *io.Controller) *FrontendRetriever {
+	return &FrontendRetriever{
+		getEnv: getEnv,
+		logger: logger,
+	}
+}
+
+func (f *FrontendRetriever) GetFrontend(buildOptions *types.BuildOptions) (*Frontend, error) {
+	if buildOptions == nil {
+		return nil, errOptionsIsNil
+	}
+
+	customFrontendImage := f.getEnv(buildkitFrontendImageEnvVar)
+	if len(buildOptions.ExtraHosts) > 0 || customFrontendImage != "" {
+		f.logger.Infof("using gateway frontend")
+		return f.getGatewayFrontend(customFrontendImage), nil
+	}
+	f.logger.Infof("using local frontend")
+	return f.getLocalFrontend(), nil
+}
+
+func (f *FrontendRetriever) getLocalFrontend() *Frontend {
+	return &Frontend{
+		Frontend: defaultFrontend,
+		Image:    "",
+	}
+}
+
+func (f *FrontendRetriever) getGatewayFrontend(customFrontendImage string) *Frontend {
+	image := dockerFrontendImage
+	if customFrontendImage != "" {
+		f.logger.Infof("using custom frontend image %s", customFrontendImage)
+		image = customFrontendImage
+	}
+	return &Frontend{
+		Frontend: gatewayFrontend,
+		Image:    image,
+	}
+}

--- a/pkg/build/buildkit/frontend.go
+++ b/pkg/build/buildkit/frontend.go
@@ -58,7 +58,6 @@ func NewFrontendRetriever(logger *io.Controller) *FrontendRetriever {
 
 func (f *FrontendRetriever) GetFrontend(buildOptions *types.BuildOptions) *Frontend {
 	useDockerfileV0 := env.LoadBooleanOrDefault(buildkitUseDockerfileV0EnvVar, false)
-
 	customFrontendImage := os.Getenv(buildkitFrontendImageEnvVar)
 	if len(buildOptions.ExtraHosts) > 0 {
 		f.logger.Infof("using gateway frontend because of extra hosts")

--- a/pkg/build/buildkit/frontend.go
+++ b/pkg/build/buildkit/frontend.go
@@ -16,7 +16,6 @@ package buildkit
 import (
 	"os"
 
-	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/types"
 )
@@ -33,9 +32,6 @@ const (
 
 	// buildkitFrontendImageEnvVar is the environment variable used to override the default frontend image.
 	buildkitFrontendImageEnvVar = "OKTETO_BUILDKIT_FRONTEND_IMAGE"
-
-	// buildkitUseDockerfileV0EnvVar is the environment variable used to enable the use of the dockerfile.v0 frontend.
-	buildkitUseDockerfileV0EnvVar = "OKTETO_BUILDKIT_USE_DOCKERFILE_V0"
 
 	// defaultDockerFrontendImage is the default Docker image to use as the frontend when executing builds in the gateway.
 	defaultDockerFrontendImage = "docker/dockerfile:1.10.0"
@@ -57,22 +53,18 @@ func NewFrontendRetriever(logger *io.Controller) *FrontendRetriever {
 }
 
 func (f *FrontendRetriever) GetFrontend(buildOptions *types.BuildOptions) *Frontend {
-	useDockerfileV0 := env.LoadBooleanOrDefault(buildkitUseDockerfileV0EnvVar, false)
 	customFrontendImage := os.Getenv(buildkitFrontendImageEnvVar)
 	if len(buildOptions.ExtraHosts) > 0 {
 		f.logger.Infof("using gateway frontend because of extra hosts")
 		return f.getGatewayFrontend(customFrontendImage)
 	}
-	if useDockerfileV0 {
-		f.logger.Infof("using dockerfile.v0 frontend because of environment variable")
-		return f.getLocalFrontend()
-	}
+
 	if customFrontendImage != "" {
 		f.logger.Infof("using gateway frontend because of custom frontend image")
 		return f.getGatewayFrontend(customFrontendImage)
 	}
-	f.logger.Infof("using gateway frontend because of default")
-	return f.getGatewayFrontend("")
+	f.logger.Infof("using default frontend")
+	return f.getLocalFrontend()
 }
 
 func (f *FrontendRetriever) getLocalFrontend() *Frontend {

--- a/pkg/build/buildkit/frontend_test.go
+++ b/pkg/build/buildkit/frontend_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestGetFrontend(t *testing.T) {
-	// Define test cases
 	tests := []struct {
 		expectedError    error
 		buildOptions     *types.BuildOptions

--- a/pkg/build/buildkit/frontend_test.go
+++ b/pkg/build/buildkit/frontend_test.go
@@ -1,0 +1,116 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildkit
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFrontend(t *testing.T) {
+	// Define test cases
+	tests := []struct {
+		name             string
+		buildOptions     *types.BuildOptions
+		envValue         string
+		expectedFrontend *Frontend
+		expectedError    error
+	}{
+		{
+			name:             "Nil BuildOptions",
+			buildOptions:     nil,
+			envValue:         "",
+			expectedFrontend: nil,
+			expectedError:    errOptionsIsNil,
+		},
+		{
+			name: "No ExtraHosts, No Custom Env",
+			buildOptions: &types.BuildOptions{
+				ExtraHosts: []types.HostMap{},
+			},
+			envValue: "",
+			expectedFrontend: &Frontend{
+				Frontend: defaultFrontend,
+				Image:    "",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "ExtraHosts Present, No Custom Env",
+			buildOptions: &types.BuildOptions{
+				ExtraHosts: []types.HostMap{
+					{Hostname: "host1", IP: "192.168.1.1"},
+				},
+			},
+			envValue: "",
+			expectedFrontend: &Frontend{
+				Frontend: gatewayFrontend,
+				Image:    dockerFrontendImage,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Custom Frontend Image via Env, No ExtraHosts",
+			buildOptions: &types.BuildOptions{
+				ExtraHosts: []types.HostMap{},
+			},
+			envValue: "custom/image:latest",
+			expectedFrontend: &Frontend{
+				Frontend: gatewayFrontend,
+				Image:    "custom/image:latest",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "ExtraHosts and Custom Frontend Image via Env",
+			buildOptions: &types.BuildOptions{
+				ExtraHosts: []types.HostMap{
+					{Hostname: "host1", IP: "192.168.1.1"},
+				},
+			},
+			envValue: "custom/image:latest",
+			expectedFrontend: &Frontend{
+				Frontend: gatewayFrontend,
+				Image:    "custom/image:latest",
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			getEnv := func(key string) string {
+				if key == buildkitFrontendImageEnvVar {
+					return tt.envValue
+				}
+				return ""
+			}
+			retriever := NewFrontendRetriever(getEnv, io.NewIOController())
+
+			frontend, err := retriever.GetFrontend(tt.buildOptions)
+
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError, "expected error to match")
+				assert.Nil(t, frontend, "expected frontend to be nil")
+			} else {
+				assert.NoError(t, err, "expected no error")
+				assert.Equal(t, tt.expectedFrontend, frontend, "expected frontend to match")
+			}
+		})
+	}
+}

--- a/pkg/build/buildkit/frontend_test.go
+++ b/pkg/build/buildkit/frontend_test.go
@@ -27,28 +27,26 @@ func TestGetFrontend(t *testing.T) {
 		buildOptions     *types.BuildOptions
 		expectedFrontend *Frontend
 		name             string
-		useDockerfileV0  string
 		frontendImage    string
 	}{
 		{
-			name: "No ExtraHosts, No Custom Env No DockerfileV0",
+			name: "No ExtraHosts, No Custom Env",
 			buildOptions: &types.BuildOptions{
 				ExtraHosts: []types.HostMap{},
 			},
 			frontendImage: "",
 			expectedFrontend: &Frontend{
-				Frontend: gatewayFrontend,
-				Image:    defaultDockerFrontendImage,
+				Frontend: defaultFrontend,
+				Image:    "",
 			},
 			expectedError: nil,
 		},
 		{
-			name: "No ExtraHosts, No Custom Env DockerfileV0",
+			name: "No ExtraHosts, No Custom ",
 			buildOptions: &types.BuildOptions{
 				ExtraHosts: []types.HostMap{},
 			},
-			frontendImage:   "",
-			useDockerfileV0: "true",
+			frontendImage: "",
 			expectedFrontend: &Frontend{
 				Frontend: defaultFrontend,
 				Image:    "",
@@ -76,8 +74,7 @@ func TestGetFrontend(t *testing.T) {
 					{Hostname: "host1", IP: "192.168.1.1"},
 				},
 			},
-			frontendImage:   "",
-			useDockerfileV0: "true",
+			frontendImage: "",
 			expectedFrontend: &Frontend{
 				Frontend: gatewayFrontend,
 				Image:    defaultDockerFrontendImage,
@@ -115,7 +112,6 @@ func TestGetFrontend(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(buildkitFrontendImageEnvVar, tt.frontendImage)
-			t.Setenv(buildkitUseDockerfileV0EnvVar, tt.useDockerfileV0)
 			retriever := NewFrontendRetriever(io.NewIOController())
 
 			frontend := retriever.GetFrontend(tt.buildOptions)

--- a/pkg/build/buildkit/frontend_test.go
+++ b/pkg/build/buildkit/frontend_test.go
@@ -24,11 +24,11 @@ import (
 func TestGetFrontend(t *testing.T) {
 	// Define test cases
 	tests := []struct {
-		name             string
-		buildOptions     *types.BuildOptions
-		envValue         string
-		expectedFrontend *Frontend
 		expectedError    error
+		buildOptions     *types.BuildOptions
+		expectedFrontend *Frontend
+		name             string
+		envValue         string
 	}{
 		{
 			name:             "Nil BuildOptions",

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -75,6 +75,7 @@ func NewOktetoBuilder(context OktetoContextInterface, fs afero.Fs, logger *io.Co
 		OktetoContext: context,
 		Fs:            fs,
 		metadata:      &buildkit.BuildMetadata{},
+		logger:        logger,
 	}
 }
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -56,6 +56,7 @@ type OktetoBuilder struct {
 	OktetoContext OktetoContextInterface
 	Fs            afero.Fs
 	metadata      *buildkit.BuildMetadata
+	logger        *io.Controller
 }
 
 func (ob *OktetoBuilder) GetMetadata() *buildkit.BuildMetadata {
@@ -69,7 +70,7 @@ type OktetoRegistryInterface interface {
 
 // NewOktetoBuilder creates a new instance of OktetoBuilder.
 // It takes an OktetoContextInterface and afero.Fs as parameters and returns a pointer to OktetoBuilder.
-func NewOktetoBuilder(context OktetoContextInterface, fs afero.Fs) *OktetoBuilder {
+func NewOktetoBuilder(context OktetoContextInterface, fs afero.Fs, logger *io.Controller) *OktetoBuilder {
 	return &OktetoBuilder{
 		OktetoContext: context,
 		Fs:            fs,
@@ -160,7 +161,7 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 	}
 	defer os.RemoveAll(secretTempFolder)
 
-	opt, err := getSolveOpt(buildOptions, ob.OktetoContext, secretTempFolder, ob.Fs)
+	opt, err := getSolveOpt(buildOptions, ob.OktetoContext, secretTempFolder, ob.Fs, ob.logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create build solver")
 	}

--- a/pkg/cmd/build/buildkit.go
+++ b/pkg/cmd/build/buildkit.go
@@ -104,11 +104,7 @@ func getSolveOpt(buildOptions *types.BuildOptions, okctx OktetoContextInterface,
 		frontendAttrs["no-cache"] = ""
 	}
 
-	frontend, err := okbuildkit.NewFrontendRetriever(os.Getenv, logger).GetFrontend(buildOptions)
-	if err != nil {
-		return nil, err
-	}
-
+	frontend := okbuildkit.NewFrontendRetriever(logger).GetFrontend(buildOptions)
 	if frontend.Image != "" {
 		frontendAttrs["source"] = frontend.Image
 	}

--- a/pkg/cmd/build/depot.go
+++ b/pkg/cmd/build/depot.go
@@ -161,7 +161,7 @@ func (db *depotBuilder) Run(ctx context.Context, buildOptions *types.BuildOption
 		}
 	}()
 
-	opt, err := getSolveOpt(buildOptions, db.okCtx, secretTempFolder, db.fs)
+	opt, err := getSolveOpt(buildOptions, db.okCtx, secretTempFolder, db.fs, db.ioCtrl)
 	if err != nil {
 		return fmt.Errorf("failed to create build solver: %w", err)
 	}

--- a/pkg/cmd/build/log_filter.go
+++ b/pkg/cmd/build/log_filter.go
@@ -71,7 +71,7 @@ func (lf *BuildkitLogsFilter) GetError(ss *client.SolveStatus) error {
 	return nil
 }
 
-// BuildKitFrontendNotFound checks if the log contains a frontend not found error
+// BuildKitFrontendNotFoundErr checks if the log contains a frontend not found error
 var BuildKitFrontendNotFoundErr ConditionFunc = func(vertex *client.Vertex) bool {
 	if vertex.Error == "" {
 		return false

--- a/pkg/cmd/build/log_filter_test.go
+++ b/pkg/cmd/build/log_filter_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestNewBuildKitLogsFilterEmptyRules(t *testing.T) {
-	lf := NewBuildKitLogsFilter([]Rule{})
+	lf := NewBuildKitLogsFilter([]LogRule{}, []ErrorRule{})
 
 	v := &client.Vertex{
 		Name:  "test log message",
@@ -45,14 +45,14 @@ func TestNewBuildKitLogsFilterEmptyRules(t *testing.T) {
 func TestNewBuildKitLogsFilter(t *testing.T) {
 	now := time.Now()
 
-	rules := []Rule{
+	rules := []LogRule{
 		{
 			condition:   BuildKitMissingCacheCondition,
 			transformer: BuildKitMissingCacheTransformer,
 		},
 	}
 
-	lf := NewBuildKitLogsFilter(rules)
+	lf := NewBuildKitLogsFilter(rules, []ErrorRule{})
 
 	v := &client.Vertex{
 		Name:      "importing cache manifest from test-registry.com/test-account/test-repo",


### PR DESCRIPTION
# Proposed changes

Fixes DEV-764

- Created new function to retrieve the frontend based on the env var. Also it's prepared to support new methods like retrieving from the cluster

## How to validate

### Dockerfile without syntax specified

1. Create the following `Dockerfile`
```yaml
FROM ubuntu
RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
  apt update && apt-get --no-install-recommends install -y gcc
```
2. Run `okteto build -f Dockerfile` and check that it works
3. Run `export OKTETO_DOCKERFILE_IMAGE=docker/dockerfile:1.1`
4. Run `okteto build -f Dockerfile` and check that it fails

### Dockerfile with syntax specified

1. Create the following `Dockerfile`
```yaml
# syntax = docker/dockerfile:1.1
FROM ubuntu
RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
  apt update && apt-get --no-install-recommends install -y gcc
```
2. Run `okteto build -f Dockerfile` and check that it doesn't work
3. Run `export OKTETO_DOCKERFILE_IMAGE=docker/dockerfile:1.3`
4. Run `okteto build -f Dockerfile` and check that it doesn't override it




## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
