### PR TITLE
DEV-765: Allow to custom known_hosts from runner image

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -110,7 +110,7 @@ ENV {{$key}}={{$val}}
 RUN \
   {{range $key, $path := .Caches }}--mount=type=cache,target={{$path}},sharing=private {{end}}\
   --mount=type=secret,id=known_hosts \
-  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
+  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts $HOME/.ssh/known_hosts" >> $HOME/.ssh/config && \
 {{ if .SSHAgentHostname }}  export SSH_AUTH_SOCK={{ .SSHAgentSocket }} && \{{ end }}
   /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }}{{ if eq .Command "test" }} || true{{ end }}
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -332,7 +332,7 @@ ENV A="A"
 RUN \
   \
   --mount=type=secret,id=known_hosts \
-  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
+  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts $HOME/.ssh/known_hosts" >> $HOME/.ssh/config && \
   export SSH_AUTH_SOCK=okteto-socket.sock && \
   /okteto/bin/okteto remote-run deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test"
 
@@ -432,7 +432,7 @@ RUN okteto registrytoken install --force --log-output=json
 RUN \
   \
   --mount=type=secret,id=known_hosts \
-  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
+  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts $HOME/.ssh/known_hosts" >> $HOME/.ssh/config && \
   export SSH_AUTH_SOCK=okteto-socket.sock && \
   /okteto/bin/okteto remote-run test --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test" || true
 
@@ -521,7 +521,7 @@ RUN okteto registrytoken install --force --log-output=json
 RUN \
   \
   --mount=type=secret,id=known_hosts \
-  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts" >> $HOME/.ssh/config && \
+  mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts $HOME/.ssh/known_hosts" >> $HOME/.ssh/config && \
 
   /okteto/bin/okteto remote-run deploy --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test"
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-765

Make available a known_hosts file defined in `$HOME/.ssh/known_hosts`, so customers might define their own file in the runner base image, and it would be taken into consideration in the remote operations to perform ssh operations.

In that way, If I use an enterprise GitLab under my org, I could create a runner base image including the known_hosts for that gitlab enterprise domain, so users don't need to have it in their local known_hosts file.

Note: [UserKnownHostsFile](https://man.openbsd.org/ssh_config#UserKnownHostsFile) accepts several files separated by whitespaces. I didn't find documentation about which order applies, but after some testing, I think it just tries them and uses the one that works. I tested having a file with wrong keys defined and another one with the good one, and I had the same result independently of the file I was specifying first.

## How to validate

With the same setup described in [this other PR](https://github.com/okteto/okteto/pull/4537):
* Rename your local known_hosts file (usually located in `$HOME/.ssh/known_hosts`) to something else, for example, `known_hosts_copy`
* If you try to clone a private repository from GitHub, you should get an error validating the host.
* Now, build a custom image like this one changing `<route-to-known-hosts-copy>` by the path of the cope made two steps before. Make sure that the image is available to be used (it should be public or for the proper Okteto registry).
```
FROM okteto/pipeline-runner:1.0.5
COPY --chmod=0600 <route-to-known-hosts-copy> /root/.ssh/known_hosts
```
* Change your dev environment runner image (in helm) to use the one built in the previous step
* Try to run again some example cloning the private repository, it should work as the known hosts is now using the one from the base image

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
