### PR TITLE
refactor: rename env vars to follow same syntax

### DIFF
--- a/pkg/build/buildkit/runner.go
+++ b/pkg/build/buildkit/runner.go
@@ -30,7 +30,7 @@ const (
 	defaultMaxAttempts = 3
 
 	// MaxRetriesForBuildkitTransientErrorsEnvVar is the environment variable to set the number of retries to wait for buildkit to be available
-	MaxRetriesForBuildkitTransientErrorsEnvVar = "OKTETO_MAX_RETRIES_FOR_BUILDKIT_TRANSIENT_ERRORS"
+	MaxRetriesForBuildkitTransientErrorsEnvVar = "OKTETO_BUILDKIT_MAX_RETRIES_FOR_TRANSIENT_ERRORS"
 )
 
 type registryImageChecker interface {

--- a/pkg/build/buildkit/wait.go
+++ b/pkg/build/buildkit/wait.go
@@ -34,7 +34,7 @@ const (
 	maxBuildkitWaitTimeEnvVar = "OKTETO_BUILDKIT_WAIT_TIMEOUT"
 
 	// retryBuildkitTimeEnvVar is the environment variable to set the retry time for buildkit
-	retryBuildkitIntervalEnvVar = "OKTETO_RETRY_BUILDKIT_INTERVAL"
+	retryBuildkitIntervalEnvVar = "OKTETO_BUILDKIT_RETRY_INTERVAL"
 )
 
 // sleeper defines an interface for sleeping


### PR DESCRIPTION
Refactor the variable names to follow same syntax