### PR TITLE
Update `okteto deploy` timeout and wait output

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -468,6 +468,10 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		if hasDeployed {
 			if deployOptions.Wait {
 				if err := dc.DeployWaiter.wait(ctx, deployOptions); err != nil {
+					if err := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); err != nil {
+						oktetoLog.Infof("could not update configmap with timeout error: %s", err)
+						return err
+					}
 					return err
 				}
 			}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -292,7 +292,7 @@ $ okteto deploy --no-build=true`,
 	cmd.Flags().BoolVarP(&options.RunInRemote, "remote", "", false, "run the deploy commands using Remote Execution")
 
 	cmd.Flags().BoolVarP(&options.Wait, "wait", "w", false, "wait until the deployment finishes and pods are healthy")
-	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "the duration to wait for the deployment to complete")
+	cmd.Flags().DurationVarP(&options.Timeout, "timeout", "t", getDefaultTimeout(), "when using `wait`, the maximum time to wait for the resources of the deployment to be healthy")
 
 	return cmd
 }

--- a/cmd/deploy/wait.go
+++ b/cmd/deploy/wait.go
@@ -77,7 +77,7 @@ func (dw *Waiter) waitForResourcesToBeRunning(ctx context.Context, opts *Options
 	for {
 		select {
 		case <-to.C:
-			return fmt.Errorf("'%s' deploy didn't finish after %s", opts.Manifest.Name, opts.Timeout.String())
+			return fmt.Errorf("'%s' resources where not healthy after %s", opts.Manifest.Name, opts.Timeout.String())
 		case <-ticker.C:
 			ns := okteto.GetContext().Namespace
 			dList, err := pipeline.ListDeployments(ctx, opts.Manifest.Name, ns, c)


### PR DESCRIPTION
# Proposed changes

Resolves https://okteto.atlassian.net/browse/DEV-663 
Resolves https://okteto.atlassian.net/browse/DEV-664

Issues reported with wait command where no reproduceable, however this PR updates the copy for the messaging when using the `wait` flag on the `deploy` command.

EDIT: changes relative to the refactor of the wait mechanism have been moved to this PR https://github.com/okteto/okteto/pull/4555 




## How to validate

Build the binary and deploy using the wait flag and different timeouts values to force an error



## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

