### PR TITLE
DEV-774: When inferring dev environment name, check if `OKTETO_NAME` is set if cannot get the name from the repository and before getting the name from the folder

### DIFF
--- a/pkg/devenvironment/name.go
+++ b/pkg/devenvironment/name.go
@@ -14,128 +14,141 @@
 package devenvironment
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
-	"strings"
+    "context"
+    "fmt"
+    "os"
+    "path/filepath"
+    "strings"
 
-	"github.com/okteto/okteto/pkg/discovery"
-	"github.com/okteto/okteto/pkg/k8s/configmaps"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/model"
-	"github.com/okteto/okteto/pkg/model/utils"
-	"github.com/okteto/okteto/pkg/repository"
-	"github.com/spf13/afero"
-	"k8s.io/client-go/kubernetes"
+    "github.com/okteto/okteto/pkg/constants"
+    "github.com/okteto/okteto/pkg/discovery"
+    "github.com/okteto/okteto/pkg/k8s/configmaps"
+    oktetoLog "github.com/okteto/okteto/pkg/log"
+    "github.com/okteto/okteto/pkg/model"
+    "github.com/okteto/okteto/pkg/model/utils"
+    "github.com/okteto/okteto/pkg/repository"
+    "github.com/spf13/afero"
+    "k8s.io/client-go/kubernetes"
 )
+
+type getEnv func(string) string
 
 // NameInferer Allows to infer the name for a dev environment
 type NameInferer struct {
-	k8s              kubernetes.Interface
-	getRepositoryURL func(string) (string, error)
-	fs               afero.Fs
+    k8s              kubernetes.Interface
+    getRepositoryURL func(string) (string, error)
+    getEnv           getEnv
+    fs               afero.Fs
 }
 
 // NewNameInferer allows to create a new instance of a name inferer
 func NewNameInferer(k8s kubernetes.Interface) NameInferer {
-	return NameInferer{
-		k8s:              k8s,
-		getRepositoryURL: utils.GetRepositoryURL,
-		fs:               afero.NewOsFs(),
-	}
+    return NameInferer{
+        k8s:              k8s,
+        getRepositoryURL: utils.GetRepositoryURL,
+        getEnv:           os.Getenv,
+        fs:               afero.NewOsFs(),
+    }
 }
 
 // InferNameFromDevEnvsAndRepository it infers the name from the development environments deployed in the specified namespace
 // or from the git repository URL if no dev environment is found.
 // `manifestPath` is needed because we compare it with the one in dev environments to see if it is the dev environment we look for
 func (n NameInferer) InferNameFromDevEnvsAndRepository(ctx context.Context, repoURL, namespace, manifestPath, discoveredFile string) string {
-	labelSelector := fmt.Sprintf("%s=true", model.GitDeployLabel)
+    labelSelector := fmt.Sprintf("%s=true", model.GitDeployLabel)
 
-	oktetoLog.Infof("found repository url %s", repoURL)
-	cfList, err := configmaps.List(ctx, namespace, labelSelector, n.k8s)
-	if err != nil {
-		oktetoLog.Info("could not get deployed dev environments: %v. Inferring dev environment name from the repository URL", err)
-		return utils.TranslateURLToName(repoURL)
-	}
+    oktetoLog.Infof("found repository url %s", repoURL)
+    cfList, err := configmaps.List(ctx, namespace, labelSelector, n.k8s)
+    if err != nil {
+        oktetoLog.Info("could not get deployed dev environments: %v. Inferring dev environment name from the repository URL", err)
+        return utils.TranslateURLToName(repoURL)
+    }
 
-	oktetoLog.Infof("found '%d' configmaps in the namespace %s", len(cfList), namespace)
+    oktetoLog.Infof("found '%d' configmaps in the namespace %s", len(cfList), namespace)
 
-	// There might be several dev environments with the specified repository and manifest. We retrieve all possibilities
-	var possibleNames []string
-	for _, cmap := range cfList {
-		oktetoLog.Infof("checking configmap %s", cmap.Name)
-		repo := cmap.Data["repository"]
-		if repo == "" {
-			oktetoLog.Infof("configmap %s doesn't have a repository", cmap.Name)
-			continue
-		}
+    // There might be several dev environments with the specified repository and manifest. We retrieve all possibilities
+    var possibleNames []string
+    for _, cmap := range cfList {
+        oktetoLog.Infof("checking configmap %s", cmap.Name)
+        repo := cmap.Data["repository"]
+        if repo == "" {
+            oktetoLog.Infof("configmap %s doesn't have a repository", cmap.Name)
+            continue
+        }
 
-		optsRepo := repository.NewRepository(repoURL)
-		cmapRepo := repository.NewRepository(repo)
-		if !optsRepo.IsEqual(cmapRepo) {
-			oktetoLog.Infof("configmap %s with repo %s doesn't match with found repo %s", cmap.Name, cmapRepo.GetAnonymizedRepo(), repoURL)
-			continue
-		}
+        optsRepo := repository.NewRepository(repoURL)
+        cmapRepo := repository.NewRepository(repo)
+        if !optsRepo.IsEqual(cmapRepo) {
+            oktetoLog.Infof("configmap %s with repo %s doesn't match with found repo %s", cmap.Name, cmapRepo.GetAnonymizedRepo(), repoURL)
+            continue
+        }
 
-		cmapFilename := cmap.Data["filename"]
-		// If the manifestPath is not the default one, we compare it with the one in the configmap
-		if manifestPath != cmapFilename {
-			if manifestPath == "" {
-				// If manifestPath is empty and filename is not equal to one of the default okteto name,
-				// log a message indicating the mismatch between the configmap and the provided manifest.
-				if cmapFilename != discoveredFile {
-					oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
-					continue
-				}
-			} else {
-				// If manifestPath is not empty and filename is not the same as manifestPath,
-				// log a message indicating the mismatch between the configmap and the provided manifest.
-				oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
-				continue
-			}
-		}
-		possibleNames = append(possibleNames, cmap.Data["name"])
-	}
+        cmapFilename := cmap.Data["filename"]
+        // If the manifestPath is not the default one, we compare it with the one in the configmap
+        if manifestPath != cmapFilename {
+            if manifestPath == "" {
+                // If manifestPath is empty and filename is not equal to one of the default okteto name,
+                // log a message indicating the mismatch between the configmap and the provided manifest.
+                if cmapFilename != discoveredFile {
+                    oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
+                    continue
+                }
+            } else {
+                // If manifestPath is not empty and filename is not the same as manifestPath,
+                // log a message indicating the mismatch between the configmap and the provided manifest.
+                oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
+                continue
+            }
+        }
+        possibleNames = append(possibleNames, cmap.Data["name"])
+    }
 
-	// if no names were found we infer the name from the repository URL
-	if len(possibleNames) == 0 {
-		oktetoLog.Info("inferring name from git repository URL")
-		return utils.TranslateURLToName(repoURL)
-	}
+    // if no names were found we infer the name from the repository URL
+    if len(possibleNames) == 0 {
+        oktetoLog.Info("inferring name from git repository URL")
+        return utils.TranslateURLToName(repoURL)
+    }
 
-	// If more than 1 name is found, we print a message to the user know the name that was inferred
-	if len(possibleNames) > 1 {
-		oktetoLog.Warning("found several dev environments candidates to infer the name: %s. Using '%s'", strings.Join(possibleNames, ", "), possibleNames[0])
-	}
+    // If more than 1 name is found, we print a message to the user know the name that was inferred
+    if len(possibleNames) > 1 {
+        oktetoLog.Warning("found several dev environments candidates to infer the name: %s. Using '%s'", strings.Join(possibleNames, ", "), possibleNames[0])
+    }
 
-	oktetoLog.Infof("inferred name from dev environment '%s'", possibleNames[0])
-	return possibleNames[0]
+    oktetoLog.Infof("inferred name from dev environment '%s'", possibleNames[0])
+    return possibleNames[0]
 }
 
 // InferName infers the dev environment name from the folder received as parameter. It has the following preference:
 //   - If cwd (current working directory) contains a repo, we look for a dev environment deployed with the same repository and the same
 //     manifest path, and we took the name from the config map
-//   - If not dev environment is found, we use the repository name to infer the dev environment name
-//   - If the current working directory doesn't have a repository, we get the name from the folder name
+//   - If current working directory doesn't have a repository, we check if OKTETO_NAME env var is set
+//   - If no repository and no OKTETO_NAME env var is set, we take the name from the CWD
 //
 // `manifestPath` is needed because we compare it with the one in dev environments to see if it is the dev environment we look for
 func (n NameInferer) InferName(ctx context.Context, cwd, namespace, manifestPath string) string {
-	repoURL, err := n.getRepositoryURL(cwd)
-	if err != nil {
-		oktetoLog.Info("inferring name from folder")
-		return filepath.Base(cwd)
-	}
+    repoURL, err := n.getRepositoryURL(cwd)
+    if err != nil {
+        // We give priority to OKTETO_NAME env var to use it on cases where the okteto commands are executed as part
+        // of other deploy/destroy commands
+        if name := n.getEnv(constants.OktetoNameEnvVar); name != "" {
+            oktetoLog.Info("inferring name from OKTETO_NAME env var")
+            return name
+        }
 
-	discoveredFile, err := discovery.GetOktetoManifestPathWithFilesystem(cwd, n.fs)
-	if err != nil {
-		oktetoLog.Info("could not detect okteto manifest file")
-	}
-	discoveredFile, err = filepath.Rel(cwd, discoveredFile)
-	if err != nil {
-		oktetoLog.Infof("could not get relative path for %s: %s", discoveredFile, err.Error())
-	}
-	// We need to sanitize paths to be UNIX style, as the ones in the configmaps are
-	sanitizedFile := filepath.ToSlash(discoveredFile)
+        oktetoLog.Info("inferring name from folder")
+        return filepath.Base(cwd)
+    }
 
-	return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath, sanitizedFile)
+    discoveredFile, err := discovery.GetOktetoManifestPathWithFilesystem(cwd, n.fs)
+    if err != nil {
+        oktetoLog.Info("could not detect okteto manifest file")
+    }
+    discoveredFile, err = filepath.Rel(cwd, discoveredFile)
+    if err != nil {
+        oktetoLog.Infof("could not get relative path for %s: %s", discoveredFile, err.Error())
+    }
+    // We need to sanitize paths to be UNIX style, as the ones in the configmaps are
+    sanitizedFile := filepath.ToSlash(discoveredFile)
+
+    return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath, sanitizedFile)
 }

--- a/pkg/devenvironment/name.go
+++ b/pkg/devenvironment/name.go
@@ -14,108 +14,108 @@
 package devenvironment
 
 import (
-    "context"
-    "fmt"
-    "os"
-    "path/filepath"
-    "strings"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
-    "github.com/okteto/okteto/pkg/constants"
-    "github.com/okteto/okteto/pkg/discovery"
-    "github.com/okteto/okteto/pkg/k8s/configmaps"
-    oktetoLog "github.com/okteto/okteto/pkg/log"
-    "github.com/okteto/okteto/pkg/model"
-    "github.com/okteto/okteto/pkg/model/utils"
-    "github.com/okteto/okteto/pkg/repository"
-    "github.com/spf13/afero"
-    "k8s.io/client-go/kubernetes"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/discovery"
+	"github.com/okteto/okteto/pkg/k8s/configmaps"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/model/utils"
+	"github.com/okteto/okteto/pkg/repository"
+	"github.com/spf13/afero"
+	"k8s.io/client-go/kubernetes"
 )
 
 type getEnv func(string) string
 
 // NameInferer Allows to infer the name for a dev environment
 type NameInferer struct {
-    k8s              kubernetes.Interface
-    getRepositoryURL func(string) (string, error)
-    getEnv           getEnv
-    fs               afero.Fs
+	k8s              kubernetes.Interface
+	getRepositoryURL func(string) (string, error)
+	getEnv           getEnv
+	fs               afero.Fs
 }
 
 // NewNameInferer allows to create a new instance of a name inferer
 func NewNameInferer(k8s kubernetes.Interface) NameInferer {
-    return NameInferer{
-        k8s:              k8s,
-        getRepositoryURL: utils.GetRepositoryURL,
-        getEnv:           os.Getenv,
-        fs:               afero.NewOsFs(),
-    }
+	return NameInferer{
+		k8s:              k8s,
+		getRepositoryURL: utils.GetRepositoryURL,
+		getEnv:           os.Getenv,
+		fs:               afero.NewOsFs(),
+	}
 }
 
 // InferNameFromDevEnvsAndRepository it infers the name from the development environments deployed in the specified namespace
 // or from the git repository URL if no dev environment is found.
 // `manifestPath` is needed because we compare it with the one in dev environments to see if it is the dev environment we look for
 func (n NameInferer) InferNameFromDevEnvsAndRepository(ctx context.Context, repoURL, namespace, manifestPath, discoveredFile string) string {
-    labelSelector := fmt.Sprintf("%s=true", model.GitDeployLabel)
+	labelSelector := fmt.Sprintf("%s=true", model.GitDeployLabel)
 
-    oktetoLog.Infof("found repository url %s", repoURL)
-    cfList, err := configmaps.List(ctx, namespace, labelSelector, n.k8s)
-    if err != nil {
-        oktetoLog.Info("could not get deployed dev environments: %v. Inferring dev environment name from the repository URL", err)
-        return utils.TranslateURLToName(repoURL)
-    }
+	oktetoLog.Infof("found repository url %s", repoURL)
+	cfList, err := configmaps.List(ctx, namespace, labelSelector, n.k8s)
+	if err != nil {
+		oktetoLog.Info("could not get deployed dev environments: %v. Inferring dev environment name from the repository URL", err)
+		return utils.TranslateURLToName(repoURL)
+	}
 
-    oktetoLog.Infof("found '%d' configmaps in the namespace %s", len(cfList), namespace)
+	oktetoLog.Infof("found '%d' configmaps in the namespace %s", len(cfList), namespace)
 
-    // There might be several dev environments with the specified repository and manifest. We retrieve all possibilities
-    var possibleNames []string
-    for _, cmap := range cfList {
-        oktetoLog.Infof("checking configmap %s", cmap.Name)
-        repo := cmap.Data["repository"]
-        if repo == "" {
-            oktetoLog.Infof("configmap %s doesn't have a repository", cmap.Name)
-            continue
-        }
+	// There might be several dev environments with the specified repository and manifest. We retrieve all possibilities
+	var possibleNames []string
+	for _, cmap := range cfList {
+		oktetoLog.Infof("checking configmap %s", cmap.Name)
+		repo := cmap.Data["repository"]
+		if repo == "" {
+			oktetoLog.Infof("configmap %s doesn't have a repository", cmap.Name)
+			continue
+		}
 
-        optsRepo := repository.NewRepository(repoURL)
-        cmapRepo := repository.NewRepository(repo)
-        if !optsRepo.IsEqual(cmapRepo) {
-            oktetoLog.Infof("configmap %s with repo %s doesn't match with found repo %s", cmap.Name, cmapRepo.GetAnonymizedRepo(), repoURL)
-            continue
-        }
+		optsRepo := repository.NewRepository(repoURL)
+		cmapRepo := repository.NewRepository(repo)
+		if !optsRepo.IsEqual(cmapRepo) {
+			oktetoLog.Infof("configmap %s with repo %s doesn't match with found repo %s", cmap.Name, cmapRepo.GetAnonymizedRepo(), repoURL)
+			continue
+		}
 
-        cmapFilename := cmap.Data["filename"]
-        // If the manifestPath is not the default one, we compare it with the one in the configmap
-        if manifestPath != cmapFilename {
-            if manifestPath == "" {
-                // If manifestPath is empty and filename is not equal to one of the default okteto name,
-                // log a message indicating the mismatch between the configmap and the provided manifest.
-                if cmapFilename != discoveredFile {
-                    oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
-                    continue
-                }
-            } else {
-                // If manifestPath is not empty and filename is not the same as manifestPath,
-                // log a message indicating the mismatch between the configmap and the provided manifest.
-                oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
-                continue
-            }
-        }
-        possibleNames = append(possibleNames, cmap.Data["name"])
-    }
+		cmapFilename := cmap.Data["filename"]
+		// If the manifestPath is not the default one, we compare it with the one in the configmap
+		if manifestPath != cmapFilename {
+			if manifestPath == "" {
+				// If manifestPath is empty and filename is not equal to one of the default okteto name,
+				// log a message indicating the mismatch between the configmap and the provided manifest.
+				if cmapFilename != discoveredFile {
+					oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
+					continue
+				}
+			} else {
+				// If manifestPath is not empty and filename is not the same as manifestPath,
+				// log a message indicating the mismatch between the configmap and the provided manifest.
+				oktetoLog.Infof("configmap %s with manifest %s doesn't match with provided manifest %s", cmapFilename, cmapRepo.GetAnonymizedRepo(), manifestPath)
+				continue
+			}
+		}
+		possibleNames = append(possibleNames, cmap.Data["name"])
+	}
 
-    // if no names were found we infer the name from the repository URL
-    if len(possibleNames) == 0 {
-        oktetoLog.Info("inferring name from git repository URL")
-        return utils.TranslateURLToName(repoURL)
-    }
+	// if no names were found we infer the name from the repository URL
+	if len(possibleNames) == 0 {
+		oktetoLog.Info("inferring name from git repository URL")
+		return utils.TranslateURLToName(repoURL)
+	}
 
-    // If more than 1 name is found, we print a message to the user know the name that was inferred
-    if len(possibleNames) > 1 {
-        oktetoLog.Warning("found several dev environments candidates to infer the name: %s. Using '%s'", strings.Join(possibleNames, ", "), possibleNames[0])
-    }
+	// If more than 1 name is found, we print a message to the user know the name that was inferred
+	if len(possibleNames) > 1 {
+		oktetoLog.Warning("found several dev environments candidates to infer the name: %s. Using '%s'", strings.Join(possibleNames, ", "), possibleNames[0])
+	}
 
-    oktetoLog.Infof("inferred name from dev environment '%s'", possibleNames[0])
-    return possibleNames[0]
+	oktetoLog.Infof("inferred name from dev environment '%s'", possibleNames[0])
+	return possibleNames[0]
 }
 
 // InferName infers the dev environment name from the folder received as parameter. It has the following preference:
@@ -126,29 +126,29 @@ func (n NameInferer) InferNameFromDevEnvsAndRepository(ctx context.Context, repo
 //
 // `manifestPath` is needed because we compare it with the one in dev environments to see if it is the dev environment we look for
 func (n NameInferer) InferName(ctx context.Context, cwd, namespace, manifestPath string) string {
-    repoURL, err := n.getRepositoryURL(cwd)
-    if err != nil {
-        // We give priority to OKTETO_NAME env var to use it on cases where the okteto commands are executed as part
-        // of other deploy/destroy commands
-        if name := n.getEnv(constants.OktetoNameEnvVar); name != "" {
-            oktetoLog.Info("inferring name from OKTETO_NAME env var")
-            return name
-        }
+	repoURL, err := n.getRepositoryURL(cwd)
+	if err != nil {
+		// We give priority to OKTETO_NAME env var to use it on cases where the okteto commands are executed as part
+		// of other deploy/destroy commands
+		if name := n.getEnv(constants.OktetoNameEnvVar); name != "" {
+			oktetoLog.Info("inferring name from OKTETO_NAME env var")
+			return name
+		}
 
-        oktetoLog.Info("inferring name from folder")
-        return filepath.Base(cwd)
-    }
+		oktetoLog.Info("inferring name from folder")
+		return filepath.Base(cwd)
+	}
 
-    discoveredFile, err := discovery.GetOktetoManifestPathWithFilesystem(cwd, n.fs)
-    if err != nil {
-        oktetoLog.Info("could not detect okteto manifest file")
-    }
-    discoveredFile, err = filepath.Rel(cwd, discoveredFile)
-    if err != nil {
-        oktetoLog.Infof("could not get relative path for %s: %s", discoveredFile, err.Error())
-    }
-    // We need to sanitize paths to be UNIX style, as the ones in the configmaps are
-    sanitizedFile := filepath.ToSlash(discoveredFile)
+	discoveredFile, err := discovery.GetOktetoManifestPathWithFilesystem(cwd, n.fs)
+	if err != nil {
+		oktetoLog.Info("could not detect okteto manifest file")
+	}
+	discoveredFile, err = filepath.Rel(cwd, discoveredFile)
+	if err != nil {
+		oktetoLog.Infof("could not get relative path for %s: %s", discoveredFile, err.Error())
+	}
+	// We need to sanitize paths to be UNIX style, as the ones in the configmaps are
+	sanitizedFile := filepath.ToSlash(discoveredFile)
 
-    return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath, sanitizedFile)
+	return n.InferNameFromDevEnvsAndRepository(ctx, repoURL, namespace, manifestPath, sanitizedFile)
 }


### PR DESCRIPTION
# Proposed changes

Fixes DEV-774

For Okteto manifests executing `okteto deploy` commands within it, it happens that depending on how it is executed (local or remote), the result might be different in terms of dev environments created within the namespace. For example, if you deploy https://github.com/okteto/movies from this commit `88c3faca4e577897643ebf3086e3fd223bd0102c`, you end up with 1 dev environment when deploying it locally, but you end up with 4 if you execute it with `--remote` flag.

The reason is because the repository information might not be available in the BuildKit context for the remote execution (it might be skipped in `.oktetoignore` file), so, when `okteto deploy` defined in the manifest is executed, it cannot infer the name from the repository URL, so it infers it from the folder where the specified Okteto manifest is, getting a different name than the one in the "parent" Okteto manifest. This doesn't happen locally because the git repository information is available, so the child `okteto deploy` get that information and they infer the name from the repo.

The proposed change is to check the env var `OKTETO_NAME` if the repository could not be found when inferring the name. As the deploy commands set the env var with the name of the "parent" dev environment, child executions would have the right name, generating a consistent behavior between remote and local execution. If the environment variable is not defined, we keep inferring the name from the folder.

## How to validate

1. Clone movies sample and checkout this commit `88c3faca4e577897643ebf3086e3fd223bd0102c`
2. Execute `okteto deploy`. When it finishes, you can see how 1 single dev environment is created
3. Now, execute `okteto deploy --remote`. When it finishes, you can see how 4 dev environments are now present in the namespace

In order to validate these changes, you need to build this image to your dev environment registry, and set the environment variable `OKTETO_REMOTE_CLI_IMAGE` to the image you just build (it can be as admin variable or local to your terminal). Once you have that, repeat the same steps described above, and you should see how, executing `okteto deploy` and `okteto deploy --remote` generate the same dev environments

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
