### PR TITLE
move to manifest v2

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -6,6 +6,7 @@ dev:
   cli:
     image: okteto/golang:1
     command: bash
+    workdir: /usr/src/cli
     sync:
       - .:/usr/src/cli
     volumes:

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,8 +1,14 @@
-name: cli
-image: okteto/golang:1
-command: bash
-workdir: /okteto
-volumes:
-  - /go/pkg/
-  - /root/.cache/go-build/
-autocreate: true
+build:
+  cli:
+    context: .
+    dockerfile: Dockerfile
+dev:
+  cli:
+    image: okteto/golang:1
+    command: bash
+    sync:
+      - .:/usr/src/cli
+    volumes:
+      - /go/pkg/
+      - /root/.cache/go-build/
+    autocreate: true


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

Moves CLI repo to use okteto manifest v2


## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1.
1.
1.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
