### PR TITLE
Update golang-ci dependency to 2.7.0 to have CLI 3.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ orbs:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.6.2
+      - image: okteto/golang-ci:2.7.0
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_USER: cindylopez

--- a/cmd/args/parser.go
+++ b/cmd/args/parser.go
@@ -59,7 +59,7 @@ func (p *DevCommandArgParser) Parse(ctx context.Context, argsIn []string, argsLe
 	result := p.parseFromArgs(argsIn, argsLenAtDash)
 
 	if p.checkIfCmdIsEmpty {
-		if result.Command == nil || len(result.Command) == 0 {
+		if len(result.Command) == 0 {
 			return nil, errCommandRequired
 		}
 	}

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -380,7 +380,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
 				return oktetoErrors.UserError{E: fmt.Errorf("insufficient resources"),
 					Hint: "Increase cluster resources or timeout of resources. More information is available here: https://okteto.com/docs/reference/okteto-manifest/#timeout-time-optional"}
 			}
-			return fmt.Errorf(failedSchedulingEvent.Message)
+			return fmt.Errorf("%s", failedSchedulingEvent.Message)
 		}
 		select {
 		case <-ticker.C:
@@ -440,7 +440,7 @@ func (up *upContext) waitUntilDevelopmentContainerIsRunning(ctx context.Context,
 					oktetoLog.Infof("pod event: %s:%s:%s", e.Reason, e.Type, e.Message)
 					continue
 				}
-				return fmt.Errorf(e.Message)
+				return fmt.Errorf("%s", e.Message)
 			case "SuccessfulAttachVolume":
 				failedSchedulingEvent = nil
 				oktetoLog.Success("Persistent volume successfully attached")

--- a/cmd/up/exec.go
+++ b/cmd/up/exec.go
@@ -512,14 +512,14 @@ func (up *upContext) checkOktetoStartError(ctx context.Context, msg string) erro
 
 	if len(up.Dev.Secrets) > 0 {
 		return oktetoErrors.UserError{
-			E: fmt.Errorf(msg),
+			E: fmt.Errorf("%s", msg),
 			Hint: fmt.Sprintf(`Check your development container logs for errors: 'kubectl logs %s',
 	Check that your container can write to the destination path of your secrets.
 	Run '%s' to reset your development container and try again`, up.Pod.Name, utils.GetDownCommand(up.Options.ManifestPathFlag)),
 		}
 	}
 	return oktetoErrors.UserError{
-		E: fmt.Errorf(msg),
+		E: fmt.Errorf("%s", msg),
 		Hint: fmt.Sprintf(`Check your development container logs for errors: 'kubectl logs %s'.
     Run '%s' to reset your development container and try again`, up.Pod.Name, utils.GetDownCommand(up.Options.ManifestPathFlag)),
 	}

--- a/cmd/up/exec_test.go
+++ b/cmd/up/exec_test.go
@@ -1018,7 +1018,7 @@ func TestCheckOktetoStartError(t *testing.T) {
 			dev: &model.Dev{
 				Name: "test",
 			},
-			expected: fmt.Errorf(msg),
+			expected: fmt.Errorf("%s", msg),
 		},
 		{
 			name: "error pv enabled",
@@ -1076,7 +1076,7 @@ func TestCheckOktetoStartError(t *testing.T) {
 					},
 				},
 			},
-			expected: fmt.Errorf(msg),
+			expected: fmt.Errorf("%s", msg),
 		},
 	}
 

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -39,7 +39,7 @@ func NewFakeUsersClientWithContext(userCtx *types.UserContext, err ...error) *Fa
 }
 
 func (c *FakeUserClient) GetContext(_ context.Context, _ string) (*types.UserContext, error) {
-	if c.err != nil && len(c.err) > 0 {
+	if len(c.err) > 0 {
 		err := c.err[0]
 		c.err = c.err[1:]
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func main() {
 			tmp[0] = unicode.ToUpper(tmp[0])
 			message = string(tmp)
 		}
-		oktetoLog.Fail(message) // TODO: Change to use ioController  when we fully move to ioController
+		oktetoLog.Fail("%s", message) // TODO: Change to use ioController  when we fully move to ioController
 		var uErr oktetoErrors.UserError
 		if errors.As(err, &uErr) {
 			if len(uErr.Hint) > 0 {

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -156,7 +156,7 @@ func (i *Info) MarshalYAML() (interface{}, error) {
 	if i.Target != "" {
 		return infoRaw(*i), nil
 	}
-	if i.Args != nil && len(i.Args) != 0 {
+	if len(i.Args) != 0 {
 		return infoRaw(*i), nil
 	}
 	return i.Image, nil

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -184,7 +184,7 @@ func (t *trace) display(progress string) {
 					continue
 				case "Load manifest":
 					if text.Level == "error" {
-						oktetoLog.Fail(text.Message)
+						oktetoLog.Fail("%s", text.Message)
 					}
 				default:
 					// Print the information message about the stage if needed
@@ -198,7 +198,7 @@ func (t *trace) display(progress string) {
 						if text.Stage != "" {
 							t.err = buildkit.CommandErr{
 								Stage:  text.Stage,
-								Err:    fmt.Errorf(text.Message),
+								Err:    fmt.Errorf("%s", text.Message),
 								Output: progress,
 							}
 						}

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -157,7 +157,7 @@ func CheckConditionErrors(deployment *appsv1.Deployment, dev *model.Dev) error {
 			} else if isResourcesRelatedError(c.Message) {
 				return getResourceLimitError(c.Message, dev)
 			}
-			return fmt.Errorf(c.Message)
+			return fmt.Errorf("%s", c.Message)
 		}
 	}
 	return nil
@@ -201,7 +201,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
 		}
 	}
-	return fmt.Errorf(strings.TrimSpace(errorToReturn))
+	return fmt.Errorf("%s", strings.TrimSpace(errorToReturn))
 }
 
 // Deploy creates or updates a deployment

--- a/pkg/k8s/statefulsets/crud.go
+++ b/pkg/k8s/statefulsets/crud.go
@@ -184,7 +184,7 @@ func CheckConditionErrors(sfs *appsv1.StatefulSet, dev *model.Dev) error {
 			} else if isResourcesRelatedError(c.Message) {
 				return getResourceLimitError(c.Message, dev)
 			}
-			return fmt.Errorf(c.Message)
+			return fmt.Errorf("%s", c.Message)
 		}
 	}
 	return nil
@@ -217,7 +217,7 @@ func getResourceLimitError(errorMessage string, dev *model.Dev) error {
 		}
 		errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
 	}
-	return fmt.Errorf(strings.TrimSpace(errorToReturn))
+	return fmt.Errorf("%s", strings.TrimSpace(errorToReturn))
 }
 
 // PatchAnnotations patches the statefulset annotations

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -515,10 +515,10 @@ func validateStackName(name string) error {
 		return fmt.Errorf("name cannot be empty")
 	}
 	if ValidKubeNameRegex.MatchString(name) {
-		return fmt.Errorf(errBadStackName)
+		return fmt.Errorf("%s", errBadStackName)
 	}
 	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") {
-		return fmt.Errorf(errBadStackName)
+		return fmt.Errorf("%s", errBadStackName)
 	}
 	return nil
 }

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -571,7 +571,7 @@ func (s *Syncthing) GetCompletion(ctx context.Context, local bool, device string
 }
 
 // IsHealthy returns the syncthing error or nil
-func (s *Syncthing) IsHealthy(ctx context.Context, local bool, max int) error {
+func (s *Syncthing) IsHealthy(ctx context.Context, local bool, maxRetries int) error {
 	pullErrors, err := s.GetPullErrors(ctx, local)
 	if err != nil {
 		if err == oktetoErrors.ErrBusySyncthing {
@@ -593,7 +593,7 @@ func (s *Syncthing) IsHealthy(ctx context.Context, local bool, max int) error {
 		return err
 	}
 
-	if isHealthyRetries <= max {
+	if isHealthyRetries <= maxRetries {
 		return nil
 	}
 	if err == nil || err == oktetoErrors.ErrBusySyncthing {


### PR DESCRIPTION
# Proposed changes

Updated golang-ci dependency to `2.7.0`. That includes CLI 3.1.0 by default. I will test all the jobs I can, but some of them where already using `3.X` of the CLI as the alias `okteto-login` installs first latest stable version of the CLI

With the new version, golangci-lint started to report new lint issues, so I'm fixing them