### PR TITLE
Configure e2e tests to run in product staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,10 @@ executors:
     docker:
       - image: okteto/golang-ci:2.7.0
     environment:
-      OKTETO_CONTEXT: https://staging.okteto.dev
-      OKTETO_USER: cindylopez
-      OKTETO_APPS_SUBDOMAIN: staging.okteto.dev
+      OKTETO_CONTEXT: https://okteto.staging.dev.okteto.net
+      OKTETO_USER: staging-okteto-bot
+      OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net
+      OKTETO_NAMESPACE_PREFIX: staging
 
 jobs:
   golangci-lint:
@@ -148,7 +149,7 @@ jobs:
           name: Run actions integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_PRODUCT_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-actions
 
@@ -167,7 +168,7 @@ jobs:
             export DEPOT_PROJECT_ID=$DEPOT_PROJECT_ID
             export DEPOT_TOKEN=$DEPOT_TOKEN
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_PRODUCT_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-build
 
@@ -187,7 +188,7 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_PRODUCT_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-deploy
 
@@ -206,7 +207,7 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_PRODUCT_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-up
           environment:
@@ -227,7 +228,7 @@ jobs:
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
             export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
             echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_PRODUCT_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-okteto
 
@@ -246,7 +247,7 @@ jobs:
           # which run the deploy, we set the env var OKTETO_REMOTE_CLI_IMAGE to the one we are building
           name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
           command: |
-            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_PRODUCT_STAGING_TOKEN}
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 build --platform "linux/amd64" --build-arg VERSION_STRING=$CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-linux:${CIRCLE_SHA1}
       - save_cache:
@@ -298,7 +299,7 @@ jobs:
           name: Build OKTETO_REMOTE_CLI_IMAGE for current commit
           command: |
             & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_PRODUCT_STAGING_TOKEN
             & "$($HOME)\project\artifacts\bin\okteto.exe" build --platform "linux/amd64" --build-arg VERSION_STRING=$env:CIRCLE_SHA1 -f Dockerfile . -t okteto.global/cli-e2e-win:$env:CIRCLE_SHA1
       - save_cache:
           key: v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
@@ -332,7 +333,7 @@ jobs:
             $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
             $env:Path+=";$($HOME)\project\artifacts\bin"
             & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_PRODUCT_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/build -tags="integration" --count=1 -v -timeout 10m
 
   e2e-deploy-windows:
@@ -367,7 +368,7 @@ jobs:
             # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
             $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
             & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_PRODUCT_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
 
   e2e-up-windows:
@@ -401,7 +402,7 @@ jobs:
             $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
             $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e-win:$env:CIRCLE_SHA1"
             & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
-            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_STAGING_TOKEN
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_PRODUCT_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
 
   push-image-tag:

--- a/docs/how-to-run-tests.md
+++ b/docs/how-to-run-tests.md
@@ -66,6 +66,7 @@ You will need to set some environment variables to start running e2e tests
 - `OKTETO_PATH`: The path of the okteto binary (It will default to `/usr/bin/okteto`).
 - `OKTETO_APPS_SUBDOMAIN`: The subdomain of the okteto cluster. For example: `product.okteto.dev`
 - `OKTETO_TOKEN`: The token of your okteto user. You can get it from the okteto UI.
+- `OKTETO_NAMESPACE_PREFIX`: The prefix for namespaces created in `OKTETO_URL` instance.
 
 ### Run all e2e tests
 

--- a/integration/actions/apply_test.go
+++ b/integration/actions/apply_test.go
@@ -73,7 +73,7 @@ type deployment struct {
 func TestApplyPipeline(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := integration.GetTestNamespace("applyaction", user)
+	namespace := integration.GetTestNamespace(t.Name())
 	oktetoPath, err := integration.GetOktetoPath()
 	assert.NoError(t, err)
 

--- a/integration/actions/build_test.go
+++ b/integration/actions/build_test.go
@@ -34,7 +34,7 @@ const buildPath = "okteto/build"
 func TestBuildActionPipeline(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := integration.GetTestNamespace("buildaction", user)
+	namespace := integration.GetTestNamespace(t.Name())
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 

--- a/integration/actions/namespace_test.go
+++ b/integration/actions/namespace_test.go
@@ -38,7 +38,7 @@ const (
 func TestNamespaceActionsPipeline(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := integration.GetTestNamespace("namespaceaction", user)
+	namespace := integration.GetTestNamespace(t.Name())
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, executeChangeNamespaceAction(namespace))

--- a/integration/actions/pipeline_test.go
+++ b/integration/actions/pipeline_test.go
@@ -45,7 +45,7 @@ const (
 func TestPipelineActions(t *testing.T) {
 	integration.SkipIfWindows(t)
 
-	namespace := integration.GetTestNamespace("PipelineActions", user)
+	namespace := integration.GetTestNamespace(t.Name())
 
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, executeDeployPipelineAction(t, namespace))
@@ -60,7 +60,7 @@ func TestPipelineActionsWithCompose(t *testing.T) {
 	t.Setenv(model.GithubRefEnvVar, "cli-e2e")
 	t.Setenv(model.GithubServerURLEnvVar, githubHTTPSURL)
 
-	namespace := integration.GetTestNamespace("pipelinecomposeaction", user)
+	namespace := integration.GetTestNamespace(t.Name())
 	assert.NoError(t, executeCreateNamespaceAction(namespace))
 	assert.NoError(t, executeDeployWithComposePipelineAction(namespace))
 	assert.NoError(t, executeDestroyPipelineAction(namespace))

--- a/integration/actions/preview_test.go
+++ b/integration/actions/preview_test.go
@@ -35,7 +35,7 @@ const (
 
 func TestPreviewActions(t *testing.T) {
 	integration.SkipIfWindows(t)
-	namespace := integration.GetTestNamespace("PreviewActions", user)
+	namespace := integration.GetTestNamespace(t.Name())
 
 	assert.NoError(t, executeDeployPreviewAction(namespace))
 	assert.NoError(t, executeDestroyPreviewAction(namespace))

--- a/integration/build/build_test.go
+++ b/integration/build/build_test.go
@@ -123,7 +123,7 @@ func TestBuildCommandV1(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("BuildV1", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -154,7 +154,7 @@ func TestBuildInferredDockerfile(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createDockerfile(dir))
 
-	testNamespace := integration.GetTestNamespace("BuildInferredDockerfile", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -192,7 +192,7 @@ func TestBuildCommandV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("BuildV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -231,7 +231,7 @@ func TestBuildCommandV2UsingDepot(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("BuildCommandV2UsingDepot", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -286,7 +286,7 @@ func TestBuildCommandV2OnlyOneService(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("PartialBuildV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -322,7 +322,7 @@ func TestBuildCommandV2SpecifyingServices(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("CompleteBuildV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -361,7 +361,7 @@ func TestBuildCommandV2FromCompose(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("BuildVolumesV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -400,7 +400,7 @@ func TestBuildCommandV2WithVolumeMounts(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("BuildVolumeMountsV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -435,7 +435,7 @@ func TestBuildCommandV2Secrets(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("BuildSecretsV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/compose_test.go
+++ b/integration/deploy/compose_test.go
@@ -232,7 +232,7 @@ func TestDeployPipelineFromCompose(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployCompose", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -334,7 +334,7 @@ func TestDeployPipelineFromComposeWithVolumeMounts(t *testing.T) {
 	composeContent := []byte(composeTemplateWithVolumeMount)
 	require.NoError(t, os.WriteFile(composePath, composeContent, 0600))
 
-	testNamespace := integration.GetTestNamespace("DeployComposeWithVolMount", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -426,7 +426,7 @@ func TestReDeployPipelineFromCompose(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("ReDeployCompose", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -509,7 +509,7 @@ func TestDeployPipelineFromOktetoStacks(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createStacksScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployStacks", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -585,7 +585,7 @@ func TestDeployComposeFromOktetoManifest(t *testing.T) {
 	require.NoError(t, createComposeScenario(dir))
 	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), oktetoManifestV2WithCompose))
 
-	testNamespace := integration.GetTestNamespace("DeployComposeManifest", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -668,7 +668,7 @@ services:
 	err = os.WriteFile(composePath, composeContent, 0600)
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("NotPanic", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/deploy_remote_test.go
+++ b/integration/deploy/deploy_remote_test.go
@@ -49,7 +49,7 @@ func TestDeployInDeployRemote(t *testing.T) {
 	require.NoError(t, createOktetoManifestWithName(dir, parentManifestContent, "okteto.yml"))
 	require.NoError(t, createOktetoManifestWithName(dir, childManifestContent, "other-okteto.yml"))
 
-	testNamespace := integration.GetTestNamespace("DeployInDeployRemote", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		Token:      token,

--- a/integration/deploy/endpoints_test.go
+++ b/integration/deploy/endpoints_test.go
@@ -149,7 +149,7 @@ func Test_EndpointsFromOktetoManifest_InferredName(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("EndpointManifestInfer", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -212,7 +212,7 @@ func Test_EndpointsFromOktetoManifest_Name(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("EndpointsManifest", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -267,7 +267,7 @@ func Test_EndpointsFromStackWith_InferredName(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createStackWithEndpointsInferredNameScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TEndpointsFromStackInfer", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -337,7 +337,7 @@ func Test_EndpointsFromStack_Name(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createStackWithEndpointsNameScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TEndpointsFromStack", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -407,7 +407,7 @@ func Test_EndpointsFromStackAndManifest(t *testing.T) {
 	require.NoError(t, createStackWithEndpointsNameScenario(dir))
 	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), oktetoManifestV2WithComposeWithEndpoints))
 
-	testNamespace := integration.GetTestNamespace("EndpointsStackAndManif", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -451,7 +451,7 @@ func Test_EndpointsFromOktetoManifest_NameOption(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("EndpointManifestNameOp", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -503,7 +503,7 @@ func Test_EndpointsFromStackWith_NameOption(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createStackWithEndpointsInferredNameScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("TEpStackNameOpt", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/external_test.go
+++ b/integration/deploy/external_test.go
@@ -59,7 +59,7 @@ func Test_ExternalsFromOktetoManifestWithNotesContent(t *testing.T) {
 	require.NoError(t, createExternalNotes(dir))
 	require.NoError(t, createManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("ExternalDeploy", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/helm_test.go
+++ b/integration/deploy/helm_test.go
@@ -108,7 +108,7 @@ func TestDeployPipelineFromHelm(t *testing.T) {
 	require.NoError(t, createHelmChart(dir))
 	require.NoError(t, createOktetoManifestForHelm(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployHelm", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/k8s_manifest_test.go
+++ b/integration/deploy/k8s_manifest_test.go
@@ -95,7 +95,7 @@ func TestDeployDevEnvFromK8s(t *testing.T) {
 	require.NoError(t, createK8sManifest(dir))
 	require.NoError(t, createOktetoManifestForK8s(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployK8sFile", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/manifest_test.go
+++ b/integration/deploy/manifest_test.go
@@ -132,7 +132,7 @@ func TestDeployOktetoManifest(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployManifestV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -186,7 +186,7 @@ func TestRedeployOktetoManifestForImages(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("ReDeploy", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -258,7 +258,7 @@ func TestDeployOktetoManifestWithDestroy(t *testing.T) {
 	require.NoError(t, createAppDockerfile(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployDestroy", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -321,7 +321,7 @@ func TestDeployOktetoManifestExportCache(t *testing.T) {
 
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("DeployExportCache", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -369,7 +369,7 @@ func TestDeployRemoteOktetoManifest(t *testing.T) {
 
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("DeployRemote", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -426,7 +426,7 @@ func TestDeployRemoteOktetoManifestFromParentFolder(t *testing.T) {
 	dir := t.TempDir()
 	parentFolder := filepath.Join(dir, "test-parent")
 
-	testNamespace := integration.GetTestNamespace("DeployRemoteParent", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -493,7 +493,7 @@ func TestDeployOktetoManifestWithinRepository(t *testing.T) {
 
 	require.NoError(t, createOktetoManifest(dir, simpleOktetoManifestContent))
 
-	testNamespace := integration.GetTestNamespace("DeployManifestWithinRepo", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/pipeline_test.go
+++ b/integration/deploy/pipeline_test.go
@@ -57,7 +57,7 @@ func TestDeployPipelineManifest(t *testing.T) {
 	require.NoError(t, createPipelineManifest(dir))
 	require.NoError(t, createK8sManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployPipeline", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		Token:      token,
@@ -101,7 +101,7 @@ func TestDeployPipelineManifestInsidePipeline(t *testing.T) {
 	require.NoError(t, err)
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("Deploy", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/remote_test.go
+++ b/integration/deploy/remote_test.go
@@ -45,7 +45,7 @@ func TestDeployRemoteWithBuildCommand(t *testing.T) {
 
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("DeployRemoteBuild", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -85,7 +85,7 @@ func TestDeployRemoteK8sWithDockerignore(t *testing.T) {
 
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("DeployRemoteK8s", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/deploy/smartbuild_test.go
+++ b/integration/deploy/smartbuild_test.go
@@ -41,19 +41,19 @@ deploy:
 `
 )
 
-// TestDeployOktetoManifestWithSmartBuildCloneCustomImage tests the following scenario:
+// TestDeployWithSmartBuildCloneCustomImage tests the following scenario:
 // - Build in another namespace to generate image in the global registry
 // - Deploy an application with a custom image
 // - Verify the image is not built and used the one previously built
 // - Check that the deployment is successful and the image is the one expected
-func TestDeployOktetoManifestWithSmartBuildCloneCustomImage(t *testing.T) {
+func TestDeployWithSmartBuildCloneCustomImage(t *testing.T) {
 	t.Parallel()
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
 	dir := t.TempDir()
 
-	globalBuildNamespace := integration.GetTestNamespace("SBGlobalBuidl", user)
+	globalBuildNamespace := integration.GetTestNamespace(t.Name())
 	globalNamespaceOpts := &commands.NamespaceOptions{
 		Namespace:  globalBuildNamespace,
 		OktetoHome: dir,
@@ -65,7 +65,7 @@ func TestDeployOktetoManifestWithSmartBuildCloneCustomImage(t *testing.T) {
 	require.NoError(t, createOktetoManifestWithCustomImage(dir))
 	require.NoError(t, integration.GitInit(dir))
 
-	testNamespace := integration.GetTestNamespace("DeploySBClone", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	require.NoError(t, createK8sManifestWithCache(dir, fmt.Sprintf("%s/%s/test-app:1.0.0", okteto.GetContext().Registry, testNamespace)))
 
 	buildOptions := &commands.BuildOptions{

--- a/integration/deploy/variables_test.go
+++ b/integration/deploy/variables_test.go
@@ -75,7 +75,7 @@ func TestDeployAndDestroyOktetoManifestWithEnv(t *testing.T) {
 	err = os.WriteFile(manifestPath, []byte(oktetoManifestWithEnvContent), 0600)
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("DeployDestroyVars", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -138,7 +138,7 @@ func TestDeployVariablesOrder(t *testing.T) {
 
 	dir := t.TempDir()
 
-	testNamespace := integration.GetTestNamespace("DeployVariablesOrder", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -79,16 +79,29 @@ func RunOktetoVersion(oktetoPath string) (string, error) {
 	return string(o), nil
 }
 
+func reduceName(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case 'a', 'e', 'i', 'o', 'u', '_':
+			return -1
+		}
+		return r
+	}, s)
+}
+
 // GetTestNamespace returns the name for a namespace
-func GetTestNamespace(prefix, user string) string {
-	os := runtime.GOOS
-	if os == "windows" {
-		os = "win"
+func GetTestNamespace(name string) string {
+	runtimeOS := runtime.GOOS
+	if runtimeOS == "windows" {
+		runtimeOS = "win"
 	} else {
-		os = os[:3]
+		runtimeOS = runtimeOS[:3]
 	}
-	namespace := fmt.Sprintf("%s-%s-%d-%s", prefix, os, time.Now().Unix(), user)
-	return strings.ToLower(namespace)
+	name = reduceName(strings.ToLower(name))
+	if prefix := os.Getenv("OKTETO_NAMESPACE_PREFIX"); prefix != "" {
+		name = fmt.Sprintf("%s-%s", prefix, name)
+	}
+	return strings.ToLower(fmt.Sprintf("%s-%s-%d", name, runtimeOS, time.Now().Unix()))
 }
 
 // GetCurrentNamespace returns the current namespace of the kubeconfig path

--- a/integration/okteto/autowake_test.go
+++ b/integration/okteto/autowake_test.go
@@ -165,7 +165,7 @@ func TestAutoWakeFromURL(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("AutoWakeURL", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -228,7 +228,7 @@ func TestAutoWakeFromRunningUp(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("AutoWakeUp", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/build_test.go
+++ b/integration/okteto/build_test.go
@@ -51,7 +51,7 @@ func TestBuildReplaceSecretsInManifest(t *testing.T) {
 	require.NoError(t, createDockerfile(dir))
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
-	testNamespace := integration.GetTestNamespace("BuildWithSecrets", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/dependencies_test.go
+++ b/integration/okteto/dependencies_test.go
@@ -61,7 +61,7 @@ func TestDependencies(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	testNamespace := integration.GetTestNamespace("Dependency", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -97,7 +97,7 @@ func TestDependenciesOnRemote(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	testNamespace := integration.GetTestNamespace("RemoteDep", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/deploy_test.go
+++ b/integration/okteto/deploy_test.go
@@ -98,7 +98,7 @@ func TestDeploySuccessOutput(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("SuccessOutput", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -163,7 +163,7 @@ func TestDeployWithNonSanitizedOK(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createComposeScenario(dir))
 
-	testNamespace := integration.GetTestNamespace("DeployWithNonSanitizedOK", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -197,7 +197,7 @@ func TestCmdFailOutput(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createCommandFailureManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("CmdFailOutput", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -262,7 +262,7 @@ func TestRemoteMaskVariables(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createCommandWitMaskValuesManifest(dir))
 
-	testNamespace := integration.GetTestNamespace("RemoteMaskVariables", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -369,7 +369,7 @@ func TestComposeFailOutput(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, createFailCompose(dir))
 
-	testNamespace := integration.GetTestNamespace("ComposeFailOutput", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/pipeline_test.go
+++ b/integration/okteto/pipeline_test.go
@@ -42,7 +42,7 @@ func TestPipelineCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	testNamespace := integration.GetTestNamespace("Pipeline", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -80,7 +80,7 @@ func TestPipelineDeployWithReuse(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := t.TempDir()
-	testNamespace := integration.GetTestNamespace("PipelineDeployWithReuse", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/okteto/preview_test.go
+++ b/integration/okteto/preview_test.go
@@ -31,7 +31,7 @@ func TestPreviewCommand(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("Preview", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	dir := t.TempDir()
 	previewOptions := &commands.DeployPreviewOptions{
 		Namespace:  testNamespace,

--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -124,7 +124,7 @@ func TestOktetoTestsWithPassingTests(t *testing.T) {
 	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
 	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
 
-	testNamespace := integration.GetTestNamespace("TestsWithPassingTests", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -159,7 +159,7 @@ func TestOktetoTestsWithPassingTestsAndArtifacts(t *testing.T) {
 	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
 	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTestAndArtifacts), 0600))
 
-	testNamespace := integration.GetTestNamespace("PassingTestsAndArtifacts", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -212,7 +212,7 @@ func TestOktetoTestsWithFailingTestsAndArtifacts(t *testing.T) {
 	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
 	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithFailingTestAndArtifacts), 0600))
 
-	testNamespace := integration.GetTestNamespace("FailingTestsAndArtifacts", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -251,7 +251,7 @@ func TestOktetoTestsWithAnotherUser(t *testing.T) {
 	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
 	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
 
-	testNamespace := integration.GetTestNamespace("TestsWithAnotherUser", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/autocreate_test.go
+++ b/integration/up/autocreate_test.go
@@ -79,7 +79,7 @@ func TestUpAutocreateV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpAutocreateV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -167,7 +167,7 @@ func TestUpAutocreateV2WithBuild(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpAutocreateV2Build", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/compose_test.go
+++ b/integration/up/compose_test.go
@@ -82,7 +82,7 @@ func TestUpCompose(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpCompose", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/compose_with_okteto_manifest_test.go
+++ b/integration/up/compose_with_okteto_manifest_test.go
@@ -57,7 +57,7 @@ func TestUpComposeWithOktetoManifest(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpComposeAndManifest", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/deploy_remote_test.go
+++ b/integration/up/deploy_remote_test.go
@@ -59,7 +59,7 @@ func TestUpWithDeployRemote(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpDeployRemote", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/deploy_test.go
+++ b/integration/up/deploy_test.go
@@ -61,7 +61,7 @@ func TestUpWithDeploy(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpWithDeploy", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/deployment_test.go
+++ b/integration/up/deployment_test.go
@@ -103,7 +103,7 @@ func TestUpDeploymentV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpDeploymentV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/exec_test.go
+++ b/integration/up/exec_test.go
@@ -32,7 +32,7 @@ func TestExecAutocreate(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("execAutocreate", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,
@@ -89,7 +89,7 @@ func TestExec(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpDeploymentV1", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/globalforward_test.go
+++ b/integration/up/globalforward_test.go
@@ -97,7 +97,7 @@ func TestUpGlobalForwarding(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("GlobalFwd", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/hybridmode_test.go
+++ b/integration/up/hybridmode_test.go
@@ -102,7 +102,7 @@ func TestUpUsingHybridMode(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("HybridMode", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,

--- a/integration/up/statefulset_test.go
+++ b/integration/up/statefulset_test.go
@@ -102,7 +102,7 @@ func TestUpStatefulsetV2(t *testing.T) {
 	oktetoPath, err := integration.GetOktetoPath()
 	require.NoError(t, err)
 
-	testNamespace := integration.GetTestNamespace("UpStatefulsetV2", user)
+	testNamespace := integration.GetTestNamespace(t.Name())
 	namespaceOpts := &commands.NamespaceOptions{
 		Namespace:  testNamespace,
 		OktetoHome: dir,


### PR DESCRIPTION
The main changes are in the first commit; the second commit just applies a refactor in the `GetTestNamespace` function.

The refactor is to generate shorter namespace names. Otherwise, we hit the 63 limit for application endpoints. As part of it, I am not adding the okteto username, I don't think it provides value and adds 18 extra chars.

Tests run 30% on average, and it feels like flakiness improves a lot, too.