### PR TITLE
Fix compose deployServices ticker loop

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -375,6 +375,7 @@ func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernete
 					if err := getErrorDueToRestartLimit(ctx, stack, svcName, k8sClient); err != nil {
 						return err
 					}
+					continue
 				}
 
 				// deploy service

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -16,6 +16,7 @@ package stack
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -336,47 +337,58 @@ func getEndpointsToDeployFromServicesToDeploy(endpoints model.EndpointSpec, serv
 
 func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernetes.Interface, config *rest.Config, options *DeployOptions, divert Divert) error {
 	deployedSvcs := make(map[string]bool)
+	ctx, cancel := context.WithTimeout(ctx, options.Timeout)
+	defer cancel()
+
 	t := time.NewTicker(1 * time.Second)
-	to := time.NewTicker(options.Timeout)
+	defer t.Stop()
 
 	for {
 		select {
-		case <-to.C:
-			return fmt.Errorf("compose '%s' didn't finish after %s", stack.Name, options.Timeout.String())
-		case <-t.C:
-			for len(deployedSvcs) != len(options.ServicesToDeploy) {
-				for _, svcName := range options.ServicesToDeploy {
-					if deployedSvcs[svcName] {
-						continue
-					}
-
-					if !canSvcBeDeployed(ctx, stack, svcName, k8sClient, config) {
-						if failedJobs := getDependingFailedJobs(ctx, stack, svcName, k8sClient); len(failedJobs) > 0 {
-							if len(failedJobs) == 1 {
-								return fmt.Errorf("service '%s' dependency '%s' failed", svcName, failedJobs[0])
-							}
-							return fmt.Errorf("service '%s' dependencies '%s' failed", svcName, strings.Join(failedJobs, ", "))
-						}
-						if failedServices := getServicesWithFailedProbes(ctx, stack, svcName, k8sClient); len(failedServices) > 0 {
-							for key, value := range failedServices {
-								return fmt.Errorf("service '%s' has failed his healthcheck probes: %s", key, value)
-							}
-						}
-						if err := getErrorDueToRestartLimit(ctx, stack, svcName, k8sClient); err != nil {
-							return err
-						}
-						continue
-					}
-					oktetoLog.Spinner(fmt.Sprintf("Deploying service '%s'...", svcName))
-					err := deploySvc(ctx, stack, svcName, k8sClient, divert)
-					if err != nil {
-						return err
-					}
-					deployedSvcs[svcName] = true
-					oktetoLog.Spinner("Waiting for services to be ready...")
-				}
+		case <-ctx.Done():
+			if ctx.Err() != nil {
+				return fmt.Errorf("compose '%s' didn't finish after %s", stack.Name, options.Timeout.String())
 			}
 			return nil
+		case <-t.C:
+			if len(options.ServicesToDeploy) == len(deployedSvcs) {
+				return nil
+			}
+			for _, svcName := range options.ServicesToDeploy {
+				if deployedSvcs[svcName] {
+					continue
+				}
+
+				// prevent service to be deployed as it depends on other services that are not ready
+				if !canSvcBeDeployed(ctx, stack, svcName, k8sClient, config) {
+					if failedJobs := getDependingFailedJobs(ctx, stack, svcName, k8sClient); len(failedJobs) > 0 {
+						if len(failedJobs) == 1 {
+							return fmt.Errorf("service '%s' dependency '%s' failed", svcName, failedJobs[0])
+						}
+						return fmt.Errorf("service '%s' dependencies '%s' failed", svcName, strings.Join(failedJobs, ", "))
+					}
+					if failedServices := getServicesWithFailedProbes(ctx, stack, svcName, k8sClient); len(failedServices) > 0 {
+						for key, value := range failedServices {
+							return fmt.Errorf("service '%s' has failed his healthcheck probes: %s", key, value)
+						}
+					}
+					if err := getErrorDueToRestartLimit(ctx, stack, svcName, k8sClient); err != nil {
+						return err
+					}
+				}
+
+				// deploy service
+				oktetoLog.Spinner(fmt.Sprintf("Deploying service '%s'...", svcName))
+				err := deploySvc(ctx, stack, svcName, k8sClient, divert)
+				if err != nil {
+					if errors.Is(err, context.DeadlineExceeded) {
+						return fmt.Errorf("compose '%s' didn't finish after %s", stack.Name, options.Timeout.String())
+					}
+					return err
+				}
+				deployedSvcs[svcName] = true
+				oktetoLog.Spinner("Waiting for services to be ready...")
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-259

When running a deployment with a docker-compose we skip services that have dependencies with conditions so the primary services are deployed first and wait until the condition is met to deploy the dependant service.

The loop was not being broken when some service was not meeting the expected conditions, so the timeout never took place to break the loop.

- Remove `for` loop that was controlling if deployed services and services to be deployed where the same length, instead use a condition expresion to evaluate if we need to exit the function


improvements:
- Replace the ticker for timeout with context.WithTimeout. This is aiming to improve the timeout exit, gracefully closing the operations that are using the context instead of exiting without terminating.
- Add `defer t.Stop` for the loop ticker in order to prevent the ticker to continue sending ticks to the channel once the function has returned

## How to validate

- build binary, using the repo mentioned on the issue, run `okteto deploy` to check the issue is no longer happening
- in debug mode, add some sleep times on deploySvc and use timeouts to check it gets out the loop when timeout


DEMO https://www.loom.com/share/5962d64fe6854083b608bdc3de31c8c0?sid=2ee92deb-563c-4c10-b358-5eb573d44026



