### PR TITLE
set no output to 20m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,7 +434,9 @@ jobs:
       - checkout
       - run: *okteto-login
       - run: *docker-login
-      - run: ./scripts/ci/push-image.sh "master" "linux/amd64,linux/arm64"
+      - run: 
+          command: ./scripts/ci/push-image.sh "master" "linux/amd64,linux/arm64"
+          no_output_timeout: 20m
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress okteto/okteto:master
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress okteto/bin:latest
 


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Set the no output to 20 min when we build the cli and push to master in different platforms


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
