### PR TITLE
Update error when image does not exist on `okteto deploy`

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -450,8 +450,11 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	oktetoLog.AddToBuffer(oktetoLog.InfoLevel, "EOF")
 
 	if err != nil {
-		if err == oktetoErrors.ErrIntSig {
+		if errors.Is(err, oktetoErrors.ErrIntSig) {
 			return nil
+		}
+		if errors.As(err, &oktetoErrors.UserError{}) {
+			return err
 		}
 		err = oktetoErrors.UserError{E: err}
 		data.Status = pipeline.ErrorStatus

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -453,10 +453,10 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		if errors.Is(err, oktetoErrors.ErrIntSig) {
 			return nil
 		}
-		if errors.As(err, &oktetoErrors.UserError{}) {
-			return err
+		// transform internal errors to user errors
+		if !errors.As(err, &oktetoErrors.UserError{}) {
+			err = oktetoErrors.UserError{E: err}
 		}
-		err = oktetoErrors.UserError{E: err}
 		data.Status = pipeline.ErrorStatus
 	} else {
 		// This has to be set only when the command succeeds for the case in which the deploy is executed within an

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -164,6 +164,7 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		var userErr oktetoErrors.UserError
 		if errors.As(err, &userErr) {
 			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, "error deploying application: %s", userErr.Error())
+			userErr.E = fmt.Errorf("error deploying application: %w", userErr.E)
 			return userErr
 		}
 		return fmt.Errorf("error deploying application: %w", err)

--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -92,15 +92,17 @@ func GetSolveErrorMessage(err error) error {
 		if isOktetoRemoteImage(imageFromError) {
 			err = oktetoErrors.UserError{
 				E: fmt.Errorf("the image '%s' is not accessible or it does not exist", imageFromError),
-				Hint: `Please verify you have access to dockerhub.
-    If you are using airgapped environment check our docs on how to use Okteto Remote in airgapped environments: [TBD]`,
+				Hint: `Please verify you have access to Docker Hub.
+    If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
+    See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/`,
 			}
 
 		} else if isOktetoRemoteForkImage(imageFromError) {
 			err = oktetoErrors.UserError{
 				E: fmt.Errorf("the image '%s' is not accessible or it does not exist", imageFromError),
 				Hint: `Please verify you have migrated correctly to the current version for remote.
-    If you are using airgapped environment check our docs on how to use Okteto Remote in airgapped environments: [TBD]`,
+    If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
+    See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/`,
 			}
 		}
 

--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -81,7 +81,7 @@ func GetErrorMessage(err error, tag string) error {
 		}
 		err = oktetoErrors.UserError{
 			E:    fmt.Errorf("the image '%s' is not accessible or it does not exist", imageTag),
-			Hint: fmt.Sprintf("Please verify the name of the image '%s' to make sure it exists.", imageTag),
+			Hint: fmt.Sprintf("Please verify the name of the image '%s' to make sure it exists.\nWhen using private registries, Okteto Registry Credentials are correctly configured https://www.okteto.com/docs/admin/registry-credentials/", imageTag),
 		}
 	default:
 		var cmdErr CommandErr

--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -81,7 +81,9 @@ func GetErrorMessage(err error, tag string) error {
 		}
 		err = oktetoErrors.UserError{
 			E:    fmt.Errorf("the image '%s' is not accessible or it does not exist", imageTag),
-			Hint: fmt.Sprintf("Please verify the name of the image '%s' to make sure it exists.\nWhen using private registries, Okteto Registry Credentials are correctly configured https://www.okteto.com/docs/admin/registry-credentials/", imageTag),
+			Hint: fmt.Sprintf(`Please verify the name of the image '%s' to make sure it exists.
+    When using private registries, make sure Okteto Registry Credentials are correctly configured.
+    See more at: https://www.okteto.com/docs/admin/registry-credentials/`, imageTag),
 		}
 	default:
 		var cmdErr CommandErr

--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -116,15 +116,14 @@ func GetSolveErrorMessage(err error) error {
 	return err
 }
 
-const (
+var (
 	// regexForImageFromFailedToSolveErr is the regex to extract the image from an error message
 	// buildkit solve errors provide the image name between :
-	regexForImageFromFailedToSolveErr = `: ([a-zA-Z0-9\.\/_-]+(:[a-zA-Z0-9-]+)?):`
+	regexForImageFromFailedToSolveErr = regexp.MustCompile(`: ([a-zA-Z0-9\.\/_-]+(:[a-zA-Z0-9-]+)?):`)
 )
 
 func extractImageFromError(err error) string {
-	re := regexp.MustCompile(regexForImageFromFailedToSolveErr)
-	if matches := re.FindStringSubmatch(err.Error()); len(matches) > 1 {
+	if matches := regexForImageFromFailedToSolveErr.FindStringSubmatch(err.Error()); len(matches) > 1 {
 		return matches[1]
 	}
 	return ""

--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -47,7 +47,7 @@ func (e CommandErr) Error() string {
 	return fmt.Sprintf("error on stage %s: %s", e.Stage, e.Err.Error())
 }
 
-// GetErrorMessage returns the parsed error message
+// GetSolveErrorMessage returns the parsed error message
 func GetSolveErrorMessage(err error) error {
 	if err == nil {
 		return nil
@@ -91,8 +91,8 @@ const (
 
 func extractImageFromError(err error) string {
 	re := regexp.MustCompile(regexForImageFromFailedToSolveErr)
-	if matchs := re.FindStringSubmatch(err.Error()); len(matchs) > 1 {
-		return matchs[1]
+	if matches := re.FindStringSubmatch(err.Error()); len(matches) > 1 {
+		return matches[1]
 	}
 	return ""
 }

--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -80,7 +80,7 @@ func GetErrorMessage(err error, tag string) error {
 			imageTag = extractImageTagFromNotFoundError(err)
 		}
 		err = oktetoErrors.UserError{
-			E:    fmt.Errorf("the image '%s' is not accessible or it does not exist", imageTag),
+			E: fmt.Errorf("the image '%s' is not accessible or it does not exist", imageTag),
 			Hint: fmt.Sprintf(`Please verify the name of the image '%s' to make sure it exists.
     When using private registries, make sure Okteto Registry Credentials are correctly configured.
     See more at: https://www.okteto.com/docs/admin/registry-credentials/`, imageTag),
@@ -97,8 +97,12 @@ func GetErrorMessage(err error, tag string) error {
 	return err
 }
 
+const (
+	regexForImageTag = `([a-zA-Z0-9\.\/_-]+(:[a-zA-Z0-9-]+)?)`
+)
+
 func extractImageTagFromPullAccessDeniedError(err error) string {
-	re := regexp.MustCompile(`([a-zA-Z0-9\.\/_-]+(:[a-zA-Z0-9]+)?): pull access denied`)
+	re := regexp.MustCompile(regexForImageTag + `: pull access denied`)
 	matches := re.FindStringSubmatch(err.Error())
 	if len(matches) > 1 {
 		return matches[1]
@@ -107,7 +111,7 @@ func extractImageTagFromPullAccessDeniedError(err error) string {
 }
 
 func extractImageTagFromNotFoundError(err error) string {
-	re := regexp.MustCompile(`([a-zA-Z0-9\.\/_-]+(:[a-zA-Z0-9]+)?): not found`)
+	re := regexp.MustCompile(regexForImageTag + `: not found`)
 	matches := re.FindStringSubmatch(err.Error())
 	if len(matches) > 1 {
 		return matches[1]

--- a/pkg/build/buildkit/errors_test.go
+++ b/pkg/build/buildkit/errors_test.go
@@ -112,8 +112,9 @@ func Test_GetSolveErrorMessage(t *testing.T) {
 			err:  errors.New("failed to solve: docker.io/okteto/okteto:1.2.4: failed to do request: Head 'https://non-existing.okteto.dev/v2/xxxx/cli/manifests/debug-4': dial tcp: lookup non-existing.okteto.dev on xx.xxxx.x.xx:xx: no such host"),
 			expected: oktetoErrors.UserError{
 				E: fmt.Errorf("the image 'docker.io/okteto/okteto' is not accessible or it does not exist"),
-				Hint: `Please verify you have access to dockerhub.
-    If you are using airgapped environment check our docs on how to use Okteto Remote in airgapped environments: [TBD]`,
+				Hint: `Please verify you have access to Docker Hub.
+    If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
+    See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/`,
 			},
 		},
 		{
@@ -122,7 +123,8 @@ func Test_GetSolveErrorMessage(t *testing.T) {
 			expected: oktetoErrors.UserError{
 				E: fmt.Errorf("the image 'myregistry.com/okteto/okteto' is not accessible or it does not exist"),
 				Hint: `Please verify you have migrated correctly to the current version for remote.
-    If you are using airgapped environment check our docs on how to use Okteto Remote in airgapped environments: [TBD]`,
+    If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
+    See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/`,
 			},
 		},
 		{

--- a/pkg/build/buildkit/errors_test.go
+++ b/pkg/build/buildkit/errors_test.go
@@ -108,6 +108,24 @@ func Test_GetSolveErrorMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "registry host not found - airgapped with official okteto image",
+			err:  errors.New("failed to solve: docker.io/okteto/okteto:1.2.4: failed to do request: Head 'https://non-existing.okteto.dev/v2/xxxx/cli/manifests/debug-4': dial tcp: lookup non-existing.okteto.dev on xx.xxxx.x.xx:xx: no such host"),
+			expected: oktetoErrors.UserError{
+				E: fmt.Errorf("the image 'docker.io/okteto/okteto' is not accessible or it does not exist"),
+				Hint: `Please verify you have access to dockerhub.
+    If you are using airgapped environment check our docs on how to use Okteto Remote in airgapped environments: [TBD]`,
+			},
+		},
+		{
+			name: "registry host not found - airgapped with forked okteto image",
+			err:  errors.New("failed to solve: myregistry.com/okteto/okteto:1.2.4: failed to do request: Head 'https://non-existing.okteto.dev/v2/xxxx/cli/manifests/debug-4': dial tcp: lookup non-existing.okteto.dev on xx.xxxx.x.xx:xx: no such host"),
+			expected: oktetoErrors.UserError{
+				E: fmt.Errorf("the image 'myregistry.com/okteto/okteto' is not accessible or it does not exist"),
+				Hint: `Please verify you have migrated correctly to the current version for remote.
+    If you are using airgapped environment check our docs on how to use Okteto Remote in airgapped environments: [TBD]`,
+			},
+		},
+		{
 			name: "cmd error",
 			err: CommandErr{
 				Err:    assert.AnError,

--- a/pkg/build/buildkit/errors_test.go
+++ b/pkg/build/buildkit/errors_test.go
@@ -235,6 +235,10 @@ func TestExtractImageTagFromPullAccessDeniedError(t *testing.T) {
 			err:      errors.New("failed to solve: myregistry.com/my-namespace/myimage: pull access denied, repository does not exist or may require authorizatio"),
 			expected: "myregistry.com/my-namespace/myimage",
 		},
+		{
+			err:      errors.New("failed to solve: registry/my-namespace:my-tag: pull access denied, repository does not exist or may require authorizatio"),
+			expected: "registry/my-namespace:my-tag",
+		},
 	}
 
 	for _, tt := range tests {
@@ -273,6 +277,10 @@ func Test_extractImageTagFromNotFoundError(t *testing.T) {
 		{
 			err:      errors.New("failed to solve: myregistry.com/my-namespace/myimage: not found"),
 			expected: "myregistry.com/my-namespace/myimage",
+		},
+		{
+			err:      errors.New("failed to solve: registry/my-namespace:my-tag: not found"),
+			expected: "registry/my-namespace:my-tag",
 		},
 	}
 

--- a/pkg/build/buildkit/runner.go
+++ b/pkg/build/buildkit/runner.go
@@ -124,7 +124,7 @@ func (r *Runner) Run(ctx context.Context, opt *client.SolveOpt, outputMode strin
 				}
 				continue
 			}
-			err = GetErrorMessage(err, tag)
+			err = GetSolveErrorMessage(err)
 			analytics.TrackBuildTransientError(false)
 			return err
 		}

--- a/pkg/cmd/build/depot.go
+++ b/pkg/cmd/build/depot.go
@@ -179,8 +179,7 @@ func (db *depotBuilder) Run(ctx context.Context, buildOptions *types.BuildOption
 
 	db.ioCtrl.Logger().Infof("[depot] build URL: %s", build.BuildURL)
 
-	err = run(ctx, client, opt, buildOptions.OutputMode, db.ioCtrl)
-	if err != nil {
+	if err := run(ctx, client, opt, buildOptions.OutputMode, db.ioCtrl); err != nil {
 		if shouldRetryBuild(err, buildOptions.Tag, db.okCtx) {
 			db.ioCtrl.Logger().Infof("Failed to build image: %s", err.Error())
 			db.ioCtrl.Logger().Infof("isRetry: %t", db.isRetry)
@@ -190,19 +189,11 @@ func (db *depotBuilder) Run(ctx context.Context, buildOptions *types.BuildOption
 				err = retryBuilder.Run(ctx, buildOptions, run)
 			}
 		}
-		err = buildkit.GetErrorMessage(err, buildOptions.Tag)
+		err = buildkit.GetSolveErrorMessage(err)
 		return err
 	}
 
-	var tag string
-	if buildOptions != nil {
-		tag = buildOptions.Tag
-		if buildOptions.Manifest != nil && buildOptions.Manifest.Deploy != nil {
-			tag = buildOptions.Manifest.Deploy.Image
-		}
-	}
-	err = buildkit.GetErrorMessage(err, tag)
-	return err
+	return nil
 }
 
 // getBuildkitClient returns a buildkit client connected to the depot's machine.


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-711
Fixes https://okteto.atlassian.net/browse/PROD-229

When running `okteto deploy` with a given manifest that includes an image field on the deploy section, if the image was not found, we were throwing a generic error.

This PR addresses not-found images, as well as the change of the error message when the image is pull access denied.
Included under the same PR the changes relative to include the docs for private registry credentials. Testing this changes came across a bug where the userError was not being displayed correctly, as the output was being overriden by an empty hint user error.

EDIT: 
- added a refactor regarding the regex extracting the image from the message and unified also cases for errors with same output to the user.
- added different hints in case image used is the official cli image or a fork of it

## How to validate

Build binary and run `okteto deploy` with different combinations of images at the deploy section of the manifest


Output 

```
❯ ok deploy
 i  Using - @ - as context
 x  Error deploying application: the image 'docker.io/okteto/okteto:xxxx' is not accessible or it does not exist
    Please verify the name of the image 'docker.io/okteto/okteto:xxxx' to make sure it exists.
    When using private registries, make sure Okteto Registry Credentials are correctly configured.
    See more at: https://www.okteto.com/docs/admin/registry-credentials/
```


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

