### PR TITLE
[JSON Schema] `dev.environment` multi-type support

### DIFF
--- a/pkg/schema/dev.go
+++ b/pkg/schema/dev.go
@@ -57,12 +57,22 @@ func (dev) JSONSchema() *jsonschema.Schema {
 	})
 
 	devProps.Set("environment", &jsonschema.Schema{
-		Type:        &jsonschema.Type{Types: []string{"object"}},
 		Title:       "environment",
 		Description: "Add environment variables to your development container. If a variable already exists on your deployment, it will be overridden with the value specified on the manifest. Environment variables with only a key, or with a value with a $ sign resolve to their values on the machine Okteto is running on",
-		PatternProperties: map[string]*jsonschema.Schema{
-			".*": {
-				Type: &jsonschema.Type{Types: []string{"string", "boolean", "number"}},
+		OneOf: []*jsonschema.Schema{
+			{
+				Type: &jsonschema.Type{Types: []string{"object"}},
+				PatternProperties: map[string]*jsonschema.Schema{
+					".*": {
+						Type: &jsonschema.Type{Types: []string{"string", "boolean", "number"}},
+					},
+				},
+			},
+			{
+				Type: &jsonschema.Type{Types: []string{"array"}},
+				Items: &jsonschema.Schema{
+					Type: &jsonschema.Type{Types: []string{"string"}},
+				},
 			},
 		},
 	})

--- a/schema.json
+++ b/schema.json
@@ -464,17 +464,27 @@
             },
             "environment": {
               "description": "Add environment variables to your development container. If a variable already exists on your deployment, it will be overridden with the value specified on the manifest. Environment variables with only a key, or with a value with a $ sign resolve to their values on the machine Okteto is running on",
-              "patternProperties": {
-                ".*": {
-                  "type": [
-                    "string",
-                    "boolean",
-                    "number"
-                  ]
+              "oneOf": [
+                {
+                  "patternProperties": {
+                    ".*": {
+                      "type": [
+                        "string",
+                        "boolean",
+                        "number"
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
                 }
-              },
-              "title": "environment",
-              "type": "object"
+              ],
+              "title": "environment"
             },
             "externalVolumes": {
               "description": "A list of persistent volume claims that you want to mount in your development container",


### PR DESCRIPTION
This PR allows `dev.environment` to be either list or object.