### PR TITLE
Implement use of OKTETO_DEV_PERSISTENT_VOLUME_SIZE

### DIFF
--- a/pkg/model/volumes.go
+++ b/pkg/model/volumes.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -25,6 +26,9 @@ import (
 
 const (
 	defaultVolumeSize = "5Gi"
+
+	// devPersistentVolumeEnabledEnvVar is the name of the environment variable to change the defaultVolumeSize value
+	devPersistentVolumeSizeEnvVar = "OKTETO_DEV_PERSISTENT_VOLUME_SIZE"
 )
 
 func (dev *Dev) translateDeprecatedVolumeFields() error {
@@ -205,13 +209,24 @@ func (dev *Dev) PersistentVolumeLabels() Labels {
 	return dev.PersistentVolumeInfo.Labels
 }
 
-// PersistentVolumeSize returns the persistent volume size
+// devPersistentVolumeSizeEnvValueOrDefault returns the value of the environment variable OKTETO_DEV_PERSISTENT_VOLUME_SIZE
+// if not set, it will return the default value at defaultVolumeSize local variable
+func devPersistentVolumeSizeEnvValueOrDefault() string {
+	if v, ok := os.LookupEnv(devPersistentVolumeSizeEnvVar); ok && v != "" {
+		return v
+	}
+	return defaultVolumeSize
+}
+
+// PersistentVolumeSize returns the persistent volume size set at the dev object
+// if not set, it will return the value of the environment variable OKTETO_DEV_PERSISTENT_VOLUME_SIZE
+// if the env is not set, the default value at defaultVolumeSize local variable
 func (dev *Dev) PersistentVolumeSize() string {
 	if dev.PersistentVolumeInfo == nil {
-		return defaultVolumeSize
+		return devPersistentVolumeSizeEnvValueOrDefault()
 	}
 	if dev.PersistentVolumeInfo.Size == "" {
-		return defaultVolumeSize
+		return devPersistentVolumeSizeEnvValueOrDefault()
 	}
 	return dev.PersistentVolumeInfo.Size
 }

--- a/pkg/model/volumes_test.go
+++ b/pkg/model/volumes_test.go
@@ -978,29 +978,49 @@ func Test_PersistentVolumeLabels(t *testing.T) {
 
 func Test_PersistentVolumeSize(t *testing.T) {
 	var tests = []struct {
-		name string
-		dev  *Dev
-		want string
+		name                            string
+		dev                             *Dev
+		devPersistentVolumeSizeEnvValue string
+		want                            string
 	}{
 		{
-			name: "nil",
+			name: "PersistentVolumeInfo nil - default",
 			dev:  &Dev{},
 			want: defaultVolumeSize,
 		},
 		{
-			name: "empty",
+			name: "PersistentVolumeInfo empty - default",
 			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{}},
 			want: defaultVolumeSize,
 		},
 		{
-			name: "size",
+			name: "PersistentVolumeInfo exists - default",
 			dev:  &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{Size: "15Gi"}},
 			want: "15Gi",
+		},
+		{
+			name:                            "PersistentVolumeInfo nil - ENV",
+			dev:                             &Dev{},
+			devPersistentVolumeSizeEnvValue: "6Gi",
+			want:                            "6Gi",
+		},
+		{
+			name:                            "PersistentVolumeInfo empty - ENV",
+			devPersistentVolumeSizeEnvValue: "6Gi",
+			dev:                             &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{}},
+			want:                            "6Gi",
+		},
+		{
+			name:                            "PersistentVolumeInfo exists - ENV",
+			devPersistentVolumeSizeEnvValue: "6Gi",
+			dev:                             &Dev{PersistentVolumeInfo: &PersistentVolumeInfo{Size: "15Gi"}},
+			want:                            "15Gi",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(devPersistentVolumeSizeEnvVar, tt.devPersistentVolumeSizeEnvValue)
 			result := tt.dev.PersistentVolumeSize()
 			if result != tt.want {
 				t.Errorf("'%s' did get an expected result '%s' vs '%s'", tt.name, tt.want, result)


### PR DESCRIPTION

# Proposed changes

Resolves https://okteto.atlassian.net/browse/PROD-253

When assigning a volume size to the pvc running `okteto up` the default value is overriden by the env value if present.

Default value is used when there is no definition of size at the manifest.

## How to validate

Build binary, add the variable to admin variables at the cluster with a value.
Run okteto up and check the value is the one set by the env, different than the 5Gi default one
Run okteto up with a manifest that has a defined size, the pvc should be the one on the manifest.

Added unit test for the new cases.


