### PR TITLE
Remove endpoints from deprecated function resources

### DIFF
--- a/pkg/okteto/endpoint.go
+++ b/pkg/okteto/endpoint.go
@@ -43,7 +43,6 @@ type Component struct {
 type Space struct {
 	Deployments  []Component
 	Statefulsets []Component
-	Functions    []Component
 	Externals    []Component
 }
 
@@ -69,7 +68,6 @@ func (c *endpointClient) List(ctx context.Context, ns, deployedBy string) ([]str
 	for _, endpoint := range filterEndpointsFromComponent(queryStruct.Response.Externals, deployedBy) {
 		endpoints = append(endpoints, fmt.Sprintf("%s (external)", endpoint))
 	}
-	endpoints = append(endpoints, filterEndpointsFromComponent(queryStruct.Response.Functions, deployedBy)...)
 
 	return endpoints, nil
 }

--- a/pkg/okteto/endpoint_test.go
+++ b/pkg/okteto/endpoint_test.go
@@ -90,23 +90,12 @@ func TestListEndpoints(t *testing.T) {
 									DeployedBy: "test",
 								},
 							},
-							Functions: []Component{
-								{
-									Endpoints: []EndpointInfo{
-										{
-											Url: "https://this.is.a.test.ok",
-										},
-									},
-									DeployedBy: "test",
-								},
-							},
 						},
 					},
 				},
 			},
 			expected: expected{
 				result: []string{
-					"https://this.is.a.test.ok",
 					"https://this.is.a.test.okk",
 					"https://this.is.a.test.okkk (external)",
 					"https://this.is.a.test.okkkk",


### PR DESCRIPTION
"Functions" has been deprecated for some time and returns empty list, but removing usage here so we can clean up API eventually.

## How to validate

```shell
make build
OKTETO_CONTEXT=<SOME-CTX> ./bin/okteto endpoints
```