### PR TITLE
Fix liveness probe with depends_on relation

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -470,7 +470,7 @@ func getServicesWithFailedProbes(ctx context.Context, stack *model.Stack, svcNam
 	svc := stack.Services[svcName]
 	dependingServices := make([]string, 0)
 	for dependingSvc, condition := range svc.DependsOn {
-		if stack.Services[dependingSvc].Healtcheck != nil && condition.Condition == model.DependsOnServiceHealthy {
+		if stack.Services[dependingSvc].HealthCheck != nil && condition.Condition == model.DependsOnServiceHealthy {
 			dependingServices = append(dependingServices, dependingSvc)
 		}
 	}
@@ -576,7 +576,7 @@ func isSvcHealthy(ctx context.Context, stack *model.Stack, svcName string, clien
 	if !isSvcRunning(ctx, svc, stack.Namespace, svcName, client) {
 		return false
 	}
-	if svc.Healtcheck != nil {
+	if svc.HealthCheck != nil {
 		return true
 	} else {
 		return isAnyPortAvailable(ctx, svc, stack, svcName, client, config)

--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -720,34 +720,34 @@ type healthcheckProbes struct {
 
 func getSvcHealthProbe(svc *model.Service) healthcheckProbes {
 	result := healthcheckProbes{}
-	if svc.Healtcheck != nil {
+	if svc.HealthCheck != nil {
 		var handler apiv1.ProbeHandler
-		if len(svc.Healtcheck.Test) != 0 {
+		if len(svc.HealthCheck.Test) != 0 {
 			handler = apiv1.ProbeHandler{
 				Exec: &apiv1.ExecAction{
-					Command: svc.Healtcheck.Test,
+					Command: svc.HealthCheck.Test,
 				},
 			}
 		} else {
 			handler = apiv1.ProbeHandler{
 				HTTPGet: &apiv1.HTTPGetAction{
-					Path: svc.Healtcheck.HTTP.Path,
-					Port: intstr.IntOrString{IntVal: svc.Healtcheck.HTTP.Port},
+					Path: svc.HealthCheck.HTTP.Path,
+					Port: intstr.IntOrString{IntVal: svc.HealthCheck.HTTP.Port},
 				},
 			}
 		}
 		probe := &apiv1.Probe{
 			ProbeHandler:        handler,
-			TimeoutSeconds:      int32(svc.Healtcheck.Timeout.Seconds()),
-			PeriodSeconds:       int32(svc.Healtcheck.Interval.Seconds()),
-			FailureThreshold:    int32(svc.Healtcheck.Retries),
-			InitialDelaySeconds: int32(svc.Healtcheck.StartPeriod.Seconds()),
+			TimeoutSeconds:      int32(svc.HealthCheck.Timeout.Seconds()),
+			PeriodSeconds:       int32(svc.HealthCheck.Interval.Seconds()),
+			FailureThreshold:    int32(svc.HealthCheck.Retries),
+			InitialDelaySeconds: int32(svc.HealthCheck.StartPeriod.Seconds()),
 		}
 
-		if svc.Healtcheck.Readiness {
+		if svc.HealthCheck.Readiness {
 			result.readiness = probe
 		}
-		if svc.Healtcheck.Liveness {
+		if svc.HealthCheck.Liveness {
 			result.liveness = probe
 		}
 	}

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -1114,7 +1114,7 @@ func Test_translateSvcProbe(t *testing.T) {
 		{
 			name: "nil healthcheck",
 			svc: &model.Service{
-				Healtcheck: nil,
+				HealthCheck: nil,
 			},
 			expected: healthcheckProbes{
 				readiness: nil,
@@ -1124,7 +1124,7 @@ func Test_translateSvcProbe(t *testing.T) {
 		{
 			name: "healthcheck http",
 			svc: &model.Service{
-				Healtcheck: &model.HealthCheck{
+				HealthCheck: &model.HealthCheck{
 					HTTP: &model.HTTPHealtcheck{
 						Path: "/",
 						Port: 8080,
@@ -1148,7 +1148,7 @@ func Test_translateSvcProbe(t *testing.T) {
 		{
 			name: "healthcheck http with other fields both ",
 			svc: &model.Service{
-				Healtcheck: &model.HealthCheck{
+				HealthCheck: &model.HealthCheck{
 					HTTP: &model.HTTPHealtcheck{
 						Path: "/",
 						Port: 8080,
@@ -1191,7 +1191,7 @@ func Test_translateSvcProbe(t *testing.T) {
 		{
 			name: "healthcheck exec only readiness",
 			svc: &model.Service{
-				Healtcheck: &model.HealthCheck{
+				HealthCheck: &model.HealthCheck{
 					Test: model.HealtcheckTest{
 						"curl", "db-service:8080/readiness",
 					},
@@ -1212,7 +1212,7 @@ func Test_translateSvcProbe(t *testing.T) {
 		{
 			name: "healthcheck exec with others fields only liveness",
 			svc: &model.Service{
-				Healtcheck: &model.HealthCheck{
+				HealthCheck: &model.HealthCheck{
 					Test: model.HealtcheckTest{
 						"curl", "db-service:8080/readiness",
 					},

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -83,7 +83,7 @@ func (cs ComposeServices) getNames() []string {
 
 // Service represents an okteto stack service
 type Service struct {
-	Healtcheck    *HealthCheck          `yaml:"healthcheck,omitempty"`
+	HealthCheck   *HealthCheck          `yaml:"healthcheck,omitempty"`
 	Labels        Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Resources     *StackResources       `yaml:"resources,omitempty"` // For okteto stack only
 	NodeSelector  Selector              `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
@@ -721,8 +721,8 @@ func (stack *Stack) mergeServices(otherStack *Stack) *Stack {
 		if svc.Build != nil {
 			resultSvc.Build = svc.Build
 		}
-		if svc.Healtcheck != nil {
-			resultSvc.Healtcheck = svc.Healtcheck
+		if svc.HealthCheck != nil {
+			resultSvc.HealthCheck = svc.HealthCheck
 		}
 
 		if len(svc.CapAdd) > 0 {

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -377,10 +377,13 @@ func setLivenessFromDependsOnServiceHealthy(svc *Service, svcName string, s *Sta
 	for _, depService := range s.Services {
 		// if dependent service has a service_healty dependency for svcName, then set liveness probe to true
 		if condition, ok := depService.DependsOn[svcName]; ok && condition.Condition == DependsOnServiceHealthy {
-			if svc.Healtcheck == nil {
-				svc.Healtcheck = &HealthCheck{}
+			if svc.HealthCheck == nil {
+				svc.HealthCheck = &HealthCheck{}
 			}
-			svc.Healtcheck.Liveness = true
+			if svc.HealthCheck.Disable {
+				return
+			}
+			svc.HealthCheck.Liveness = true
 			return
 		}
 	}
@@ -410,8 +413,8 @@ func (serviceRaw *ServiceRaw) ToService(svcName string, stack *Stack) (*Service,
 		return nil, err
 	}
 	if serviceRaw.Healthcheck != nil && !serviceRaw.Healthcheck.Disable {
-		svc.Healtcheck = serviceRaw.Healthcheck
-		translateHealtcheckCurlToHTTP(svc.Healtcheck)
+		svc.HealthCheck = serviceRaw.Healthcheck
+		translateHealtcheckCurlToHTTP(svc.HealthCheck)
 		setLivenessFromDependsOnServiceHealthy(svc, svcName, stack)
 	}
 

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -373,9 +373,9 @@ func getAccessiblePorts(ports []PortRaw) []PortRaw {
 
 // setLivenessFromDependsOnServiceHealthy sets the liveness probe to true if the service depends on another service being healthy
 func setLivenessFromDependsOnServiceHealthy(svc *Service, svcName string, s *Stack) {
-	// loop for each service in the stack to find if some of it is dependant of svcName for being healthy
+	// loop for each service in the stack to find if some of it is dependent of svcName for being healthy
 	for _, depService := range s.Services {
-		// if dependant service has a service_healty dependency for svcName, then set liveness probe to true
+		// if dependent service has a service_healty dependency for svcName, then set liveness probe to true
 		if condition, ok := depService.DependsOn[svcName]; ok && condition.Condition == DependsOnServiceHealthy {
 			if svc.Healtcheck == nil {
 				svc.Healtcheck = &HealthCheck{}

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -2290,13 +2290,13 @@ func Test_TranslateOktetoStackPortsToComposePorts(t *testing.T) {
 func Test_setLivenessFromDependsOnServiceHealthy(t *testing.T) {
 	type args struct {
 		svc     *Service
-		svcName string
 		s       *Stack
+		svcName string
 	}
 	tests := []struct {
-		name string
 		args args
 		want *Service
+		name string
 	}{
 		{
 			name: "app depends_on service_healthy db",

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -429,7 +429,7 @@ func Test_HealthcheckUnmarshalling(t *testing.T) {
 			}
 
 			if !tt.expectedError {
-				assert.Equal(t, tt.expected, s.Services["app"].Healtcheck)
+				assert.Equal(t, tt.expected, s.Services["app"].HealthCheck)
 			}
 
 		})
@@ -2308,7 +2308,7 @@ func Test_setLivenessFromDependsOnServiceHealthy(t *testing.T) {
 						"app": {
 							DependsOn: DependsOn{
 								"db": {
-									Condition: "service_healthy",
+									Condition: DependsOnServiceHealthy,
 								},
 							},
 						},
@@ -2317,13 +2317,42 @@ func Test_setLivenessFromDependsOnServiceHealthy(t *testing.T) {
 				},
 			},
 			want: &Service{
-				Healtcheck: &HealthCheck{
+				HealthCheck: &HealthCheck{
 					Liveness: true,
 				},
 			},
 		},
 		{
-			name: "app depends_on service_ready db",
+			name: "app depends_on service_healthy db, healthchek disabled",
+			args: args{
+				svc: &Service{
+					HealthCheck: &HealthCheck{
+						Disable: true,
+					},
+				},
+				svcName: "db",
+				s: &Stack{
+					Services: map[string]*Service{
+						"app": {
+							DependsOn: DependsOn{
+								"db": {
+									Condition: DependsOnServiceHealthy,
+								},
+							},
+						},
+						"db": {},
+					},
+				},
+			},
+			want: &Service{
+				HealthCheck: &HealthCheck{
+					Disable:  true,
+					Liveness: false,
+				},
+			},
+		},
+		{
+			name: "app depends_on service_running db",
 			args: args{
 				svc:     &Service{},
 				svcName: "db",
@@ -2332,7 +2361,7 @@ func Test_setLivenessFromDependsOnServiceHealthy(t *testing.T) {
 						"app": {
 							DependsOn: DependsOn{
 								"db": {
-									Condition: "service_ready",
+									Condition: DependsOnServiceRunning,
 								},
 							},
 						},

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -673,7 +673,7 @@ func TestStack_Merge(t *testing.T) {
 							Context:    "test",
 							Dockerfile: "test-Dockerfile",
 						},
-						Healtcheck: &HealthCheck{
+						HealthCheck: &HealthCheck{
 							HTTP: &HTTPHealtcheck{
 								Path: "/api",
 								Port: 8008,
@@ -689,7 +689,7 @@ func TestStack_Merge(t *testing.T) {
 							Context:    "test-overwrite",
 							Dockerfile: "test-overwrite-Dockerfile",
 						},
-						Healtcheck: &HealthCheck{
+						HealthCheck: &HealthCheck{
 							HTTP: &HTTPHealtcheck{
 								Path: "/",
 								Port: 8008,
@@ -705,7 +705,7 @@ func TestStack_Merge(t *testing.T) {
 							Context:    "test-overwrite",
 							Dockerfile: "test-overwrite-Dockerfile",
 						},
-						Healtcheck: &HealthCheck{
+						HealthCheck: &HealthCheck{
 							HTTP: &HTTPHealtcheck{
 								Path: "/",
 								Port: 8008,


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-260

When using `depends_on` conditions under a compose manifest, we are not translating this condition correctly into liveness probe.

Liveness probe is currently only assigned if the user uses a custom field under the healthcheck of a service. If other service depends on this one under the condition of healthy, the liveness probe is not used.

This changes propose that when a compose is using the healthy condition, this translate into a liveness condition of the kubernetes pod.

## How to validate

build the binary and run a deployment with compose services that depend on each other, for example the one on the issue


