### PR TITLE
feat: get cli image from cluster metadata

### DIFF
--- a/pkg/config/image.go
+++ b/pkg/config/image.go
@@ -21,6 +21,8 @@ import (
 )
 
 var (
+	// ClusterCliRepository defines the okteto cli repository for all the operations.
+	// This env var is set when executing the okteto context at the beginning of any command
 	ClusterCliRepository = ""
 )
 

--- a/pkg/config/image_test.go
+++ b/pkg/config/image_test.go
@@ -23,29 +23,54 @@ import (
 
 func Test_GetRemoteImage(t *testing.T) {
 	var tests = []struct {
-		name                                 string
-		versionString, expected, cliImageEnv string
+		name                                          string
+		versionString, expected, cliImageEnv, cliRepo string
 	}{
+		// {
+		// 	name:          "no version string and no env return stable",
+		// 	versionString: "",
+		// 	expected:      "okteto/okteto:stable",
+		// },
+		// {
+		// 	name:          "no version string return env value",
+		// 	versionString: "",
+		// 	cliImageEnv:   "okteto/remote:test",
+		// 	expected:      "okteto/remote:test",
+		// },
+		// {
+		// 	name:          "found version string",
+		// 	versionString: "2.2.2",
+		// 	expected:      "okteto/okteto:2.2.2",
+		// },
+		// {
+		// 	name:          "found incorrect version string return stable",
+		// 	versionString: "2.a.2",
+		// 	expected:      "okteto/okteto:stable",
+		// },
 		{
-			name:          "no version string and no env return stable",
+			name:          "Cluster Repo / no version string and no env return stable",
 			versionString: "",
-			expected:      "okteto/okteto:stable",
+			cliRepo:       "cluster/cli",
+			expected:      "cluster/cli:stable",
 		},
 		{
-			name:          "no version string return env value",
+			name:          "Cluster Repo / no version string return env value",
 			versionString: "",
+			cliRepo:       "cluster/cli",
 			cliImageEnv:   "okteto/remote:test",
 			expected:      "okteto/remote:test",
 		},
 		{
-			name:          "found version string",
+			name:          "Cluster Repo / found version string",
 			versionString: "2.2.2",
-			expected:      "okteto/okteto:2.2.2",
+			cliRepo:       "cluster/cli",
+			expected:      "cluster/cli:2.2.2",
 		},
 		{
-			name:          "found incorrect version string return stable",
+			name:          "Cluster Repo / found incorrect version string return stable",
 			versionString: "2.a.2",
-			expected:      "okteto/okteto:stable",
+			cliRepo:       "cluster/cli",
+			expected:      "cluster/cli:stable",
 		},
 	}
 
@@ -55,7 +80,7 @@ func Test_GetRemoteImage(t *testing.T) {
 			if tt.cliImageEnv != "" {
 				t.Setenv(oktetoDeployRemoteImageEnvVar, tt.cliImageEnv)
 			}
-
+			ClusterCliRepository = tt.cliRepo
 			version := NewImageConfig(io.NewIOController()).GetRemoteImage(tt.versionString)
 			require.Equal(t, version, tt.expected)
 		})
@@ -117,6 +142,7 @@ func TestGetBinImage(t *testing.T) {
 					}
 					return ""
 				},
+				cliRepository: "okteto/okteto",
 			}
 
 			image := c.GetBinImage()
@@ -157,6 +183,7 @@ func TestGetOktetoImage(t *testing.T) {
 				getEnv: func(s string) string {
 					return ""
 				},
+				cliRepository: "okteto/okteto",
 			}
 
 			image := c.GetOktetoImage()

--- a/pkg/config/image_test.go
+++ b/pkg/config/image_test.go
@@ -26,27 +26,27 @@ func Test_GetRemoteImage(t *testing.T) {
 		name                                          string
 		versionString, expected, cliImageEnv, cliRepo string
 	}{
-		// {
-		// 	name:          "no version string and no env return stable",
-		// 	versionString: "",
-		// 	expected:      "okteto/okteto:stable",
-		// },
-		// {
-		// 	name:          "no version string return env value",
-		// 	versionString: "",
-		// 	cliImageEnv:   "okteto/remote:test",
-		// 	expected:      "okteto/remote:test",
-		// },
-		// {
-		// 	name:          "found version string",
-		// 	versionString: "2.2.2",
-		// 	expected:      "okteto/okteto:2.2.2",
-		// },
-		// {
-		// 	name:          "found incorrect version string return stable",
-		// 	versionString: "2.a.2",
-		// 	expected:      "okteto/okteto:stable",
-		// },
+		{
+			name:          "no version string and no env return stable",
+			versionString: "",
+			expected:      "okteto/okteto:stable",
+		},
+		{
+			name:          "no version string return env value",
+			versionString: "",
+			cliImageEnv:   "okteto/remote:test",
+			expected:      "okteto/remote:test",
+		},
+		{
+			name:          "found version string",
+			versionString: "2.2.2",
+			expected:      "okteto/okteto:2.2.2",
+		},
+		{
+			name:          "found incorrect version string return stable",
+			versionString: "2.a.2",
+			expected:      "okteto/okteto:stable",
+		},
 		{
 			name:          "Cluster Repo / no version string and no env return stable",
 			versionString: "",

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -328,14 +328,21 @@ func (c *userClient) GetExecutionEnv(ctx context.Context) (map[string]string, er
 	return result, nil
 }
 
+// getRegistryAndRepositoryFromImage returns the registry and repository from an image name
+// Valid image names are:
+// - registry/repository:tag
+// - registry/repository@digest
+// - repository:tag
+// - repository@digest
 func getRegistryAndRepositoryFromImage(image string) (string, error) {
 	// Check for multiple '@' symbols which indicate an invalid image name
 	if strings.Count(image, "@") > 1 {
 		return "", fmt.Errorf("invalid image name, multiple '@'")
 	}
 
+	imageWithDigestParts := 2
 	// Remove any digest (part after '@')
-	imageNoDigest := strings.SplitN(image, "@", 2)[0]
+	imageNoDigest := strings.SplitN(image, "@", imageWithDigestParts)[0]
 
 	// Split the image into components separated by '/'
 	parts := strings.Split(imageNoDigest, "/")

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -21,6 +21,7 @@ import (
 
 	dockertypes "github.com/docker/cli/cli/config/types"
 	dockercredentials "github.com/docker/docker-credential-helpers/credentials"
+	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/env"
 	"github.com/okteto/okteto/pkg/errors"
@@ -250,6 +251,12 @@ func (c *userClient) GetClusterMetadata(ctx context.Context, ns string) (types.C
 			metadata.ServerName = string(v.Value)
 		case "pipelineRunnerImage":
 			metadata.PipelineRunnerImage = string(v.Value)
+		case "cliImage":
+			metadata.CliImage = string(v.Value)
+			config.ClusterCliRepository, err = getRegistryAndRepositoryFromImage(string(v.Value))
+			if err != nil {
+				return metadata, err
+			}
 		case "isTrial":
 			metadata.IsTrialLicense = string(v.Value) == "true"
 		case "companyName":
@@ -319,4 +326,59 @@ func (c *userClient) GetExecutionEnv(ctx context.Context) (map[string]string, er
 		result[string(envVar.Name)] = string(envVar.Value)
 	}
 	return result, nil
+}
+
+func getRegistryAndRepositoryFromImage(image string) (string, error) {
+	// Check for multiple '@' symbols which indicate an invalid image name
+	if strings.Count(image, "@") > 1 {
+		return "", fmt.Errorf("invalid image name, multiple '@'")
+	}
+
+	// Remove any digest (part after '@')
+	imageNoDigest := strings.SplitN(image, "@", 2)[0]
+
+	// Split the image into components separated by '/'
+	parts := strings.Split(imageNoDigest, "/")
+
+	var rest []string
+	var domain string
+
+	// Determine if a registry is specified
+	if len(parts) == 1 || (len(parts) >= 2 && !strings.ContainsAny(parts[0], ".:") && parts[0] != "localhost") {
+		// No registry specified, default to docker.io
+		domain = "docker.io"
+		rest = parts
+	} else {
+		domain = parts[0]
+		rest = parts[1:]
+	}
+
+	// Reconstruct the repository path
+	repositoryPath := strings.Join(rest, "/")
+
+	// Remove any tag (part after the last ':') from the last component
+	repoParts := strings.Split(repositoryPath, "/")
+	lastPart := repoParts[len(repoParts)-1]
+
+	if strings.Count(lastPart, ":") > 1 {
+		return "", fmt.Errorf("invalid repository name, multiple ':' in the last component")
+	}
+
+	if colonIndex := strings.LastIndex(lastPart, ":"); colonIndex != -1 {
+		// Remove the tag
+		lastPart = lastPart[:colonIndex]
+		repoParts[len(repoParts)-1] = lastPart
+	}
+
+	repositoryPath = strings.Join(repoParts, "/")
+
+	// Handle official images by adding 'library/' if no namespace is specified
+	if domain == "docker.io" && !strings.Contains(repositoryPath, "/") {
+		repositoryPath = "library/" + repositoryPath
+	}
+
+	// Combine domain and repositoryPath
+	fullImage := domain + "/" + repositoryPath
+
+	return fullImage, nil
 }

--- a/pkg/okteto/secrets_test.go
+++ b/pkg/okteto/secrets_test.go
@@ -829,3 +829,73 @@ func TestGetExecutionEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestGetImageWithoutTag(t *testing.T) {
+	tests := []struct {
+		image   string
+		want    string
+		wantErr bool
+	}{
+		{
+			image: "ubuntu",
+			want:  "docker.io/library/ubuntu",
+		},
+		{
+			image: "ubuntu:latest",
+			want:  "docker.io/library/ubuntu",
+		},
+		{
+			image: "library/ubuntu",
+			want:  "docker.io/library/ubuntu",
+		},
+		{
+			image: "docker.io/library/ubuntu",
+			want:  "docker.io/library/ubuntu",
+		},
+		{
+			image: "myregistrydomain.com:5000/fedora/httpd:version1.0",
+			want:  "myregistrydomain.com:5000/fedora/httpd",
+		},
+		{
+			image: "localhost:5000/myrepo/myimage:tag",
+			want:  "localhost:5000/myrepo/myimage",
+		},
+		{
+			image: "gcr.io/myproject/myimage:tag",
+			want:  "gcr.io/myproject/myimage",
+		},
+		{
+			image: "docker.io/nginx:latest",
+			want:  "docker.io/library/nginx",
+		},
+		{
+			image: "myregistrydomain.com/myimage@sha256:abcdef",
+			want:  "myregistrydomain.com/myimage",
+		},
+		{
+			image: "registry.gitlab.com/group/project/image:tag",
+			want:  "registry.gitlab.com/group/project/image",
+		},
+		{
+			image: "localhost/myimage:tag",
+			want:  "localhost/myimage",
+		},
+		{
+			image:   "invalid@image@name",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			got, err := getRegistryAndRepositoryFromImage(tt.image)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getRegistryAndRepositoryFromImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getRegistryAndRepositoryFromImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/types/cluster_metadata.go
+++ b/pkg/types/cluster_metadata.go
@@ -20,6 +20,7 @@ type ClusterMetadata struct {
 	BuildKitInternalIP  string
 	PublicDomain        string
 	CompanyName         string
+	CliImage            string
 	SSHAgentInternalIP  string
 	SSHAgentHostname    string
 	SSHAgentPort        string


### PR DESCRIPTION
# Proposed changes

Fixes PROD-231

- Retrieve from the backend graphql the cli image and parse it so it didn't have any tag.
- When getting the correct image we used that cli image retrieved previously to generate the correct image tag

## How to validate

1. Use the correct backend
1. Deploy a compose
1. Deploy a k8s file on remote
1. Run a okteto up hybrid 
1. Run a okteto up 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
