### PR TITLE
 Setenv OKTETO_DOMAIN when okteto context use cmd

### DIFF
--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -142,6 +142,7 @@ func (c *Command) Run(ctx context.Context, ctxOptions *Options) error {
 	}
 
 	os.Setenv(model.OktetoNamespaceEnvVar, okteto.GetContext().Namespace)
+	os.Setenv(model.OktetoDomainEnvVar, okteto.GetSubdomain())
 
 	if ctxOptions.Show {
 		oktetoLog.Information("Using %s @ %s as context", okteto.GetContext().Namespace, okteto.RemoveSchema(okteto.GetContext().Name))


### PR DESCRIPTION
# Proposed changes

Fixes DEV-254

the env OKTETO_DOMAIN was not being set when init the context when running `okteto deploy`. If the deploy is done using the `remote` the env is read and set so the issue is not reproduceable.

The PR sets the env when reading the context.

## How to validate

build binary and reproduce the example https://www.okteto.com/docs/core/endpoints/automatic-ssl/#customizing-the-endpoints-shown-in-the-okteto-dashboard for compose

