### PR TITLE
feat: support rootless runners (PLAT-745)

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -60,7 +60,7 @@ FROM {{ .UserRunnerImage }} as runner
 USER 0
 ENV PATH="${PATH}:/okteto/bin"
 WORKDIR /okteto
-RUN chown -R $(id -u):$(id -g) /okteto
+RUN chown -R $(id -u):$(id -g) /okteto || (echo '{"level":"error", "stage": "remote deploy", "message":"The /okteto directory or its subdirectories have incorrect user/group ownership. Check your \"deploy.image\" container definition or contact your instance admin."}' && exit 1)
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -59,8 +59,8 @@ FROM {{ .UserRunnerImage }} as runner
 
 USER 0
 ENV PATH="${PATH}:/okteto/bin"
-RUN if [ -d /okteto ]; then echo "/okteto folder is reserved for internal use"; exit 1; fi
 WORKDIR /okteto
+RUN chown -R $(id -u):$(id -g) /okteto
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -280,6 +280,8 @@ FROM test-image as runner
 
 USER 0
 ENV PATH="${PATH}:/okteto/bin"
+RUN if [ -d /okteto ]; then echo "/okteto folder is reserved for internal use"; exit 1; fi
+WORKDIR /okteto
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 
@@ -294,11 +296,11 @@ ARG OKTETO_DEPLOYABLE
 ARG GITHUB_REPOSITORY
 ARG BUILDKIT_HOST
 ARG OKTETO_REGISTRY_URL
-RUN mkdir -p /etc/ssl/certs/
-RUN echo "$OKTETO_TLS_CERT_BASE64" | base64 -d > /etc/ssl/certs/okteto.crt
+RUN mkdir -p /okteto/.ssl/certs && echo "$OKTETO_TLS_CERT_BASE64" | base64 -d > /okteto/.ssl/certs/okteto.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs:/okteto/.ssl/certs
 
-COPY . /okteto/src
 WORKDIR /okteto/src
+COPY --chmod=0777 . /okteto/src
 
 
 ENV OKTETO_BUILD_SVC2_IMAGE="TWO_VALUE"
@@ -322,7 +324,7 @@ ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
-RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
+RUN echo "$OKTETO_INVALIDATE_CACHE" > /okteto/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
 
@@ -339,7 +341,7 @@ RUN \
 
 
 FROM scratch
-COPY --from=runner /etc/.oktetocachekey .oktetocachekey
+COPY --from=runner /okteto/.oktetocachekey /okteto/.oktetocachekey
 
 `,
 				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
@@ -382,6 +384,8 @@ FROM okteto/okteto:stable as okteto-cli
 FROM test-image as runner
 
 ENV PATH="${PATH}:/okteto/bin"
+RUN if [ -d /okteto ]; then echo "/okteto folder is reserved for internal use"; exit 1; fi
+WORKDIR /okteto
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 
@@ -396,11 +400,11 @@ ARG OKTETO_DEPLOYABLE
 ARG GITHUB_REPOSITORY
 ARG BUILDKIT_HOST
 ARG OKTETO_REGISTRY_URL
-RUN mkdir -p /etc/ssl/certs/
-RUN echo "$OKTETO_TLS_CERT_BASE64" | base64 -d > /etc/ssl/certs/okteto.crt
+RUN mkdir -p /okteto/.ssl/certs && echo "$OKTETO_TLS_CERT_BASE64" | base64 -d > /okteto/.ssl/certs/okteto.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs:/okteto/.ssl/certs
 
-COPY . /okteto/src
 WORKDIR /okteto/src
+COPY --chmod=0777 . /okteto/src
 
 
 ENV OKTETO_BUILD_SVC2_IMAGE="TWO_VALUE"
@@ -424,7 +428,7 @@ ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
-RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
+RUN echo "$OKTETO_INVALIDATE_CACHE" > /okteto/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
 
@@ -481,6 +485,8 @@ FROM test-image as runner
 
 USER 0
 ENV PATH="${PATH}:/okteto/bin"
+RUN if [ -d /okteto ]; then echo "/okteto folder is reserved for internal use"; exit 1; fi
+WORKDIR /okteto
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 
@@ -495,11 +501,11 @@ ARG OKTETO_DEPLOYABLE
 ARG GITHUB_REPOSITORY
 ARG BUILDKIT_HOST
 ARG OKTETO_REGISTRY_URL
-RUN mkdir -p /etc/ssl/certs/
-RUN echo "$OKTETO_TLS_CERT_BASE64" | base64 -d > /etc/ssl/certs/okteto.crt
+RUN mkdir -p /okteto/.ssl/certs && echo "$OKTETO_TLS_CERT_BASE64" | base64 -d > /okteto/.ssl/certs/okteto.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs:/okteto/.ssl/certs
 
-COPY . /okteto/src
 WORKDIR /okteto/src
+COPY --chmod=0777 . /okteto/src
 
 
 
@@ -513,7 +519,7 @@ ARG OKTETO_GIT_COMMIT
 ARG OKTETO_GIT_BRANCH
 ARG OKTETO_INVALIDATE_CACHE
 
-RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
+RUN echo "$OKTETO_INVALIDATE_CACHE" > /okteto/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
 
@@ -528,7 +534,7 @@ RUN \
 
 
 FROM scratch
-COPY --from=runner /etc/.oktetocachekey .oktetocachekey
+COPY --from=runner /okteto/.oktetocachekey /okteto/.oktetocachekey
 
 `,
 				buildEnvVars:      map[string]string{},

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -279,8 +279,8 @@ FROM test-image as runner
 
 USER 0
 ENV PATH="${PATH}:/okteto/bin"
-RUN if [ -d /okteto ]; then echo "/okteto folder is reserved for internal use"; exit 1; fi
 WORKDIR /okteto
+RUN chown -R $(id -u):$(id -g) /okteto
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 
@@ -384,8 +384,8 @@ FROM test-image as runner
 
 USER 0
 ENV PATH="${PATH}:/okteto/bin"
-RUN if [ -d /okteto ]; then echo "/okteto folder is reserved for internal use"; exit 1; fi
 WORKDIR /okteto
+RUN chown -R $(id -u):$(id -g) /okteto
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 
@@ -484,8 +484,8 @@ FROM test-image as runner
 
 USER 0
 ENV PATH="${PATH}:/okteto/bin"
-RUN if [ -d /okteto ]; then echo "/okteto folder is reserved for internal use"; exit 1; fi
 WORKDIR /okteto
+RUN chown -R $(id -u):$(id -g) /okteto
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
 


### PR DESCRIPTION
# Proposed changes

Resolves PLAT-745

Modify Deploy Remote Dockerfile template to support rootless runner container images.

- Use `WORKDIR` to create (if it doesn't exist) a folder owned by the `USER` inherited from the runner container image.
- Add a `RUN` prior to `WORKDIR` to validate that `/okteto` folder has the right user/group ownership. If it doesn't, `WORKDIR` would not alter the ownership which could cause other issues below, that's why it fails the validation.
- Change the way CA is injected by piping it to a rootless writable file path and using `SSL_CERT_DIR` environment variable to tell openssl compatible libraries ([including Go](https://pkg.go.dev/crypto/x509#SystemCertPool)) to consume it.
- Change the filepath where `.oktetocachekey` is stored to a rootless writable file path.
- Use again `WORKDIR` to create `/okteto/src` folder with the right ownership and move it before `COPY`.
- Use `--chmod=0777` to make /okteto/src content readable, writable and executable by world, which includes any rootless user defined in the image. Using `0777` in this scenario is not a security concern because builds are contained.

Challenges:
- Can't set values from `RUN` (e.g. `id -u`) to `ENV` to be used as `USER $var`.
- Can't interpolate values dinamically at `RUN --chown=$var` or `RUN --mount`.
- `VOLUME` doesn't create folders in buildkit.

Other alternatives evaluated and discarded:
- Using multi stage to read the user id via `id -u` and do `chown` in a stage by forcefully setting `USER 0`. Discarded because it would use a rootful stage at some point.
- Splitting Deploy Remote in two phases to obtain the user id of the runner container image and set it directly in the template later. Discarded due to complexity.

## How to validate

```yaml
deploy:
  image: okteto/pipeline-runner:1.0.6-rootless
  commands:
    # write to new file
    - echo foo > new_file
    # write to existing file
    - echo bar > okteto.yml
```