### PR TITLE
Use always user 0 for remote operations to make it work for rootless runner images

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -362,7 +362,6 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			Caches:                      test.Caches,
 			IgnoreRules:                 testIgnoreRules,
 			Artifacts:                   test.Artifacts,
-			UseRootUser:                 true,
 			NoCache:                     options.NoCache,
 			Hosts:                       test.Hosts,
 		}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -57,9 +57,7 @@ FROM {{ .OktetoCLIImage }} as okteto-cli
 
 FROM {{ .UserRunnerImage }} as runner
 
-{{ if .UseRootUser -}}
 USER 0
-{{ end -}}
 ENV PATH="${PATH}:/okteto/bin"
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
@@ -191,9 +189,6 @@ type Params struct {
 	// .oktetodeployignore file. Disabled by default
 	UseOktetoDeployIgnoreFile bool
 
-	// UseRootUser is a flag to indicate if the user should be root
-	UseRootUser bool
-
 	NoCache bool
 }
 
@@ -230,7 +225,6 @@ type dockerfileTemplateProperties struct {
 	SSHAgentSocket               string
 	Caches                       []string
 	Artifacts                    []model.Artifact
-	UseRootUser                  bool
 }
 
 // NewRunner creates a new Runner for remote
@@ -429,7 +423,6 @@ func (r *Runner) createDockerfile(tmpDir string, params *Params) (string, error)
 		Command:                      params.Command,
 		Caches:                       params.Caches,
 		Artifacts:                    params.Artifacts,
-		UseRootUser:                  params.UseRootUser,
 		SSHAgentHostname:             params.SSHAgentHostname,
 		SSHAgentHostnameArgName:      constants.OktetoSshAgentHostnameEnvVar,
 		SSHAgentPort:                 params.SSHAgentPort,

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -14,266 +14,265 @@
 package remote
 
 import (
-	"context"
-	"fmt"
-	"path/filepath"
-	"regexp"
-	"testing"
+    "context"
+    "fmt"
+    "path/filepath"
+    "regexp"
+    "testing"
 
-	"github.com/okteto/okteto/internal/test/client"
-	"github.com/okteto/okteto/pkg/constants"
-	oktetoErrors "github.com/okteto/okteto/pkg/errors"
-	filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
-	"github.com/okteto/okteto/pkg/log/io"
-	"github.com/okteto/okteto/pkg/model"
-	"github.com/okteto/okteto/pkg/okteto"
-	"github.com/okteto/okteto/pkg/types"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+    "github.com/okteto/okteto/internal/test/client"
+    "github.com/okteto/okteto/pkg/constants"
+    oktetoErrors "github.com/okteto/okteto/pkg/errors"
+    filesystem "github.com/okteto/okteto/pkg/filesystem/fake"
+    "github.com/okteto/okteto/pkg/log/io"
+    "github.com/okteto/okteto/pkg/model"
+    "github.com/okteto/okteto/pkg/okteto"
+    "github.com/okteto/okteto/pkg/types"
+    "github.com/spf13/afero"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
 )
 
 type fakeBuilder struct {
-	err           error
-	assertOptions func(o *types.BuildOptions)
+    err           error
+    assertOptions func(o *types.BuildOptions)
 }
 
 func (f fakeBuilder) Run(_ context.Context, opts *types.BuildOptions, _ *io.Controller) error {
-	if f.assertOptions != nil {
-		f.assertOptions(opts)
-	}
-	return f.err
+    if f.assertOptions != nil {
+        f.assertOptions(opts)
+    }
+    return f.err
 }
 
 type fakeNameGenerator struct {
-	name string
+    name string
 }
 
 func (f fakeNameGenerator) GenerateName() string { return f.name }
 
 func TestRemoteTest(t *testing.T) {
-	ctx := context.Background()
-	fakeManifest := &model.Manifest{
-		Deploy: &model.DeployInfo{
-			Image: "test-image",
-		},
-	}
-	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
-	fs := afero.NewMemMapFs()
-	tempCreator := filesystem.NewTemporalDirectoryCtrl(fs)
+    ctx := context.Background()
+    fakeManifest := &model.Manifest{
+        Deploy: &model.DeployInfo{
+            Image: "test-image",
+        },
+    }
+    wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+    fs := afero.NewMemMapFs()
+    tempCreator := filesystem.NewTemporalDirectoryCtrl(fs)
 
-	type config struct {
-		wd            filesystem.FakeWorkingDirectoryCtrlErrors
-		tempFsCreator error
-		params        *Params
-		builderErr    error
-		cert          []byte
-	}
-	var tests = []struct {
-		expected error
-		name     string
-		config   config
-	}{
-		{
-			name: "OS can't access to the working directory",
-			config: config{
-				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
-					Getter: assert.AnError,
-				},
-				params: &Params{},
-				cert:   []byte("this-is-my-cert-there-are-many-like-it-but-this-one-is-mine"),
-			},
-			expected: assert.AnError,
-		},
-		{
-			name: "OS can't create temporal directory",
-			config: config{
-				params:        &Params{},
-				tempFsCreator: assert.AnError,
-			},
-			expected: assert.AnError,
-		},
-		{
-			name: "OS can't change to the previous working directory",
-			config: config{
-				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
-					Setter: assert.AnError,
-				},
-				params: &Params{
-					Manifest: fakeManifest,
-				},
-			},
-			expected: assert.AnError,
-		},
-		{
-			name: "build incorrect",
-			config: config{
-				params: &Params{
-					Manifest: fakeManifest,
-				},
-				builderErr: assert.AnError,
-			},
-			expected: oktetoErrors.UserError{
-				E: assert.AnError,
-			},
-		},
-		{
-			name: "everything correct",
-			config: config{
-				params: &Params{
-					Manifest: fakeManifest,
-				},
-			},
-		},
-	}
+    type config struct {
+        wd            filesystem.FakeWorkingDirectoryCtrlErrors
+        tempFsCreator error
+        params        *Params
+        builderErr    error
+        cert          []byte
+    }
+    var tests = []struct {
+        expected error
+        name     string
+        config   config
+    }{
+        {
+            name: "OS can't access to the working directory",
+            config: config{
+                wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+                    Getter: assert.AnError,
+                },
+                params: &Params{},
+                cert:   []byte("this-is-my-cert-there-are-many-like-it-but-this-one-is-mine"),
+            },
+            expected: assert.AnError,
+        },
+        {
+            name: "OS can't create temporal directory",
+            config: config{
+                params:        &Params{},
+                tempFsCreator: assert.AnError,
+            },
+            expected: assert.AnError,
+        },
+        {
+            name: "OS can't change to the previous working directory",
+            config: config{
+                wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+                    Setter: assert.AnError,
+                },
+                params: &Params{
+                    Manifest: fakeManifest,
+                },
+            },
+            expected: assert.AnError,
+        },
+        {
+            name: "build incorrect",
+            config: config{
+                params: &Params{
+                    Manifest: fakeManifest,
+                },
+                builderErr: assert.AnError,
+            },
+            expected: oktetoErrors.UserError{
+                E: assert.AnError,
+            },
+        },
+        {
+            name: "everything correct",
+            config: config{
+                params: &Params{
+                    Manifest: fakeManifest,
+                },
+            },
+        },
+    }
 
-	okteto.CurrentStore = &okteto.ContextStore{
-		CurrentContext: "test",
-		Contexts: map[string]*okteto.Context{
-			"test": {
-				Namespace: "namespace",
-			},
-		},
-	}
+    okteto.CurrentStore = &okteto.ContextStore{
+        CurrentContext: "test",
+        Contexts: map[string]*okteto.Context{
+            "test": {
+                Namespace: "namespace",
+            },
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			wdCtrl.SetErrors(tt.config.wd)
-			tempCreator.SetError(tt.config.tempFsCreator)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            wdCtrl.SetErrors(tt.config.wd)
+            tempCreator.SetError(tt.config.tempFsCreator)
 
-			usersClient := client.NewFakeUsersClient(&types.User{})
-			usersClient.ClusterMetadata = types.ClusterMetadata{Certificate: tt.config.cert}
-			oktetoClient := &client.FakeOktetoClient{
-				Users: usersClient,
-			}
-			nameGenerator := fakeNameGenerator{
-				name: "test",
-			}
-			rdc := Runner{
-				builder:              fakeBuilder{err: tt.config.builderErr},
-				fs:                   fs,
-				workingDirectoryCtrl: wdCtrl,
-				temporalCtrl:         tempCreator,
-				oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
-				ioCtrl:               io.NewIOController(),
-				getEnviron: func() []string {
-					return []string{}
-				},
-				generateSocketName: nameGenerator.GenerateName,
-			}
-			err := rdc.Run(ctx, tt.config.params)
-			if tt.expected != nil {
-				assert.ErrorContains(t, err, tt.expected.Error())
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+            usersClient := client.NewFakeUsersClient(&types.User{})
+            usersClient.ClusterMetadata = types.ClusterMetadata{Certificate: tt.config.cert}
+            oktetoClient := &client.FakeOktetoClient{
+                Users: usersClient,
+            }
+            nameGenerator := fakeNameGenerator{
+                name: "test",
+            }
+            rdc := Runner{
+                builder:              fakeBuilder{err: tt.config.builderErr},
+                fs:                   fs,
+                workingDirectoryCtrl: wdCtrl,
+                temporalCtrl:         tempCreator,
+                oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
+                ioCtrl:               io.NewIOController(),
+                getEnviron: func() []string {
+                    return []string{}
+                },
+                generateSocketName: nameGenerator.GenerateName,
+            }
+            err := rdc.Run(ctx, tt.config.params)
+            if tt.expected != nil {
+                assert.ErrorContains(t, err, tt.expected.Error())
+            } else {
+                assert.NoError(t, err)
+            }
+        })
+    }
 }
 
 func TestExtraHosts(t *testing.T) {
-	ctx := context.Background()
-	fakeManifest := &model.Manifest{
-		Deploy: &model.DeployInfo{
-			Image: "test-image",
-		},
-	}
-	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
-	fs := afero.NewMemMapFs()
-	tempCreator := filesystem.NewTemporalDirectoryCtrl(fs)
+    ctx := context.Background()
+    fakeManifest := &model.Manifest{
+        Deploy: &model.DeployInfo{
+            Image: "test-image",
+        },
+    }
+    wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+    fs := afero.NewMemMapFs()
+    tempCreator := filesystem.NewTemporalDirectoryCtrl(fs)
 
-	usersClient := client.NewFakeUsersClient(&types.User{})
-	usersClient.ClusterMetadata = types.ClusterMetadata{ServerName: "1.2.3.4:443"}
-	oktetoClient := &client.FakeOktetoClient{
-		Users: usersClient,
-	}
-	nameGenerator := fakeNameGenerator{
-		name: "test",
-	}
-	rdc := Runner{
-		builder: fakeBuilder{
-			assertOptions: func(o *types.BuildOptions) {
-				require.Len(t, o.ExtraHosts, 2)
-				for _, eh := range o.ExtraHosts {
-					require.Equal(t, eh.IP, "1.2.3.4")
-				}
-			},
-		},
-		fs:                   fs,
-		workingDirectoryCtrl: wdCtrl,
-		temporalCtrl:         tempCreator,
-		oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
-		useInternalNetwork:   true,
-		ioCtrl:               io.NewIOController(),
-		getEnviron: func() []string {
-			return []string{}
-		},
-		generateSocketName: nameGenerator.GenerateName,
-	}
+    usersClient := client.NewFakeUsersClient(&types.User{})
+    usersClient.ClusterMetadata = types.ClusterMetadata{ServerName: "1.2.3.4:443"}
+    oktetoClient := &client.FakeOktetoClient{
+        Users: usersClient,
+    }
+    nameGenerator := fakeNameGenerator{
+        name: "test",
+    }
+    rdc := Runner{
+        builder: fakeBuilder{
+            assertOptions: func(o *types.BuildOptions) {
+                require.Len(t, o.ExtraHosts, 2)
+                for _, eh := range o.ExtraHosts {
+                    require.Equal(t, eh.IP, "1.2.3.4")
+                }
+            },
+        },
+        fs:                   fs,
+        workingDirectoryCtrl: wdCtrl,
+        temporalCtrl:         tempCreator,
+        oktetoClientProvider: client.NewFakeOktetoClientProvider(oktetoClient),
+        useInternalNetwork:   true,
+        ioCtrl:               io.NewIOController(),
+        getEnviron: func() []string {
+            return []string{}
+        },
+        generateSocketName: nameGenerator.GenerateName,
+    }
 
-	err := rdc.Run(ctx, &Params{
-		Manifest: fakeManifest,
-	})
-	require.NoError(t, err)
+    err := rdc.Run(ctx, &Params{
+        Manifest: fakeManifest,
+    })
+    require.NoError(t, err)
 }
 
 func TestCreateDockerfile(t *testing.T) {
-	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
-	fs := afero.NewMemMapFs()
-	fakeManifest := &model.Manifest{
-		Deploy: &model.DeployInfo{},
-	}
-	type config struct {
-		wd     filesystem.FakeWorkingDirectoryCtrlErrors
-		params *Params
-	}
-	type expected struct {
-		err               error
-		buildEnvVars      map[string]string
-		dependencyEnvVars map[string]string
-		dockerfileName    string
-		dockerfileContent string
-	}
-	var tests = []struct {
-		expected expected
-		config   config
-		name     string
-	}{
-		{
-			name: "OS can't access working directory",
-			config: config{
-				wd: filesystem.FakeWorkingDirectoryCtrlErrors{
-					Getter: assert.AnError,
-				},
-			},
-			expected: expected{
-				dockerfileName: "",
-				err:            assert.AnError,
-			},
-		},
-		{
-			name: "with dockerignore",
-			config: config{
-				params: &Params{
-					BaseImage:           "test-image",
-					ExecutionEnvVars:    map[string]string{"A": "A"},
-					Manifest:            fakeManifest,
-					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
-					DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
-					OktetoCommandSpecificEnvVars: map[string]string{
-						constants.OktetoIsPreviewEnvVar: "true",
-					},
-					DockerfileName:   "Dockerfile.deploy",
-					Command:          "deploy",
-					SSHAgentHostname: "ssh-agent.default.svc.cluster.local",
-					SSHAgentPort:     "3000",
-					CommandFlags:     []string{"--name \"test\""},
-					UseRootUser:      true,
-				},
-			},
-			expected: expected{
-				dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
-				dockerfileContent: `
+    wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+    fs := afero.NewMemMapFs()
+    fakeManifest := &model.Manifest{
+        Deploy: &model.DeployInfo{},
+    }
+    type config struct {
+        wd     filesystem.FakeWorkingDirectoryCtrlErrors
+        params *Params
+    }
+    type expected struct {
+        err               error
+        buildEnvVars      map[string]string
+        dependencyEnvVars map[string]string
+        dockerfileName    string
+        dockerfileContent string
+    }
+    var tests = []struct {
+        expected expected
+        config   config
+        name     string
+    }{
+        {
+            name: "OS can't access working directory",
+            config: config{
+                wd: filesystem.FakeWorkingDirectoryCtrlErrors{
+                    Getter: assert.AnError,
+                },
+            },
+            expected: expected{
+                dockerfileName: "",
+                err:            assert.AnError,
+            },
+        },
+        {
+            name: "with dockerignore",
+            config: config{
+                params: &Params{
+                    BaseImage:           "test-image",
+                    ExecutionEnvVars:    map[string]string{"A": "A"},
+                    Manifest:            fakeManifest,
+                    BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
+                    DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
+                    OktetoCommandSpecificEnvVars: map[string]string{
+                        constants.OktetoIsPreviewEnvVar: "true",
+                    },
+                    DockerfileName:   "Dockerfile.deploy",
+                    Command:          "deploy",
+                    SSHAgentHostname: "ssh-agent.default.svc.cluster.local",
+                    SSHAgentPort:     "3000",
+                    CommandFlags:     []string{"--name \"test\""},
+                },
+            },
+            expected: expected{
+                dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
+                dockerfileContent: `
 FROM okteto/okteto:stable as okteto-cli
 
 FROM test-image as runner
@@ -342,45 +341,46 @@ FROM scratch
 COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 
 `,
-				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
-				dependencyEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
-			},
-		},
-		{
-			name: "okteto test",
-			config: config{
-				params: &Params{
-					BaseImage:           "test-image",
-					Manifest:            fakeManifest,
-					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
-					DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
-					OktetoCommandSpecificEnvVars: map[string]string{
-						constants.CIEnvVar: "true",
-					},
-					DockerfileName:   "Dockerfile.test",
-					Command:          "test",
-					SSHAgentHostname: "ssh-agent.default.svc.cluster.local",
-					SSHAgentPort:     "3000",
-					CommandFlags:     []string{"--name \"test\""},
-					Artifacts: []model.Artifact{
-						{
-							Path:        "coverage.txt",
-							Destination: "coverage.txt",
-						},
-						{
-							Path:        "report.json",
-							Destination: "/testing/report.json",
-						},
-					},
-				},
-			},
-			expected: expected{
-				dockerfileName: filepath.Clean("/test/Dockerfile.test"),
-				dockerfileContent: `
+                buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
+                dependencyEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
+            },
+        },
+        {
+            name: "okteto test",
+            config: config{
+                params: &Params{
+                    BaseImage:           "test-image",
+                    Manifest:            fakeManifest,
+                    BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
+                    DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
+                    OktetoCommandSpecificEnvVars: map[string]string{
+                        constants.CIEnvVar: "true",
+                    },
+                    DockerfileName:   "Dockerfile.test",
+                    Command:          "test",
+                    SSHAgentHostname: "ssh-agent.default.svc.cluster.local",
+                    SSHAgentPort:     "3000",
+                    CommandFlags:     []string{"--name \"test\""},
+                    Artifacts: []model.Artifact{
+                        {
+                            Path:        "coverage.txt",
+                            Destination: "coverage.txt",
+                        },
+                        {
+                            Path:        "report.json",
+                            Destination: "/testing/report.json",
+                        },
+                    },
+                },
+            },
+            expected: expected{
+                dockerfileName: filepath.Clean("/test/Dockerfile.test"),
+                dockerfileContent: `
 FROM okteto/okteto:stable as okteto-cli
 
 FROM test-image as runner
 
+USER 0
 ENV PATH="${PATH}:/okteto/bin"
 COPY --from=okteto-cli /usr/local/bin/* /okteto/bin/
 
@@ -452,29 +452,28 @@ FROM scratch
 COPY --from=runner /okteto/artifacts/ /
 
 `,
-				buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
-				dependencyEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
-			},
-		},
-		{
-			name: "without ssh-agent hostname",
-			config: config{
-				params: &Params{
-					BaseImage:                    "test-image",
-					ExecutionEnvVars:             map[string]string{},
-					Manifest:                     fakeManifest,
-					BuildEnvVars:                 map[string]string{},
-					DependenciesEnvVars:          map[string]string{},
-					OktetoCommandSpecificEnvVars: map[string]string{},
-					DockerfileName:               "Dockerfile.deploy",
-					Command:                      "deploy",
-					CommandFlags:                 []string{"--name \"test\""},
-					UseRootUser:                  true,
-				},
-			},
-			expected: expected{
-				dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
-				dockerfileContent: `
+                buildEnvVars:      map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
+                dependencyEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
+            },
+        },
+        {
+            name: "without ssh-agent hostname",
+            config: config{
+                params: &Params{
+                    BaseImage:                    "test-image",
+                    ExecutionEnvVars:             map[string]string{},
+                    Manifest:                     fakeManifest,
+                    BuildEnvVars:                 map[string]string{},
+                    DependenciesEnvVars:          map[string]string{},
+                    OktetoCommandSpecificEnvVars: map[string]string{},
+                    DockerfileName:               "Dockerfile.deploy",
+                    Command:                      "deploy",
+                    CommandFlags:                 []string{"--name \"test\""},
+                },
+            },
+            expected: expected{
+                dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
+                dockerfileContent: `
 FROM okteto/okteto:stable as okteto-cli
 
 FROM test-image as runner
@@ -531,367 +530,367 @@ FROM scratch
 COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 
 `,
-				buildEnvVars:      map[string]string{},
-				dependencyEnvVars: map[string]string{},
-			},
-		},
-	}
+                buildEnvVars:      map[string]string{},
+                dependencyEnvVars: map[string]string{},
+            },
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			wdCtrl.SetErrors(tt.config.wd)
-			nameGenerator := fakeNameGenerator{
-				name: "okteto-socket.sock",
-			}
-			rdc := Runner{
-				fs:                   fs,
-				workingDirectoryCtrl: wdCtrl,
-				getEnviron: func() []string {
-					return []string{}
-				},
-				ioCtrl:             io.NewIOController(),
-				generateSocketName: nameGenerator.GenerateName,
-			}
-			dockerfileName, err := rdc.createDockerfile("/test", tt.config.params)
-			assert.ErrorIs(t, err, tt.expected.err)
-			assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            wdCtrl.SetErrors(tt.config.wd)
+            nameGenerator := fakeNameGenerator{
+                name: "okteto-socket.sock",
+            }
+            rdc := Runner{
+                fs:                   fs,
+                workingDirectoryCtrl: wdCtrl,
+                getEnviron: func() []string {
+                    return []string{}
+                },
+                ioCtrl:             io.NewIOController(),
+                generateSocketName: nameGenerator.GenerateName,
+            }
+            dockerfileName, err := rdc.createDockerfile("/test", tt.config.params)
+            assert.ErrorIs(t, err, tt.expected.err)
+            assert.Equal(t, tt.expected.dockerfileName, dockerfileName)
 
-			if dockerfileName != "" {
-				bFile, err := afero.ReadFile(fs, dockerfileName)
-				assert.NoError(t, err)
-				assert.EqualValues(t, tt.expected.dockerfileContent, string(bFile))
-			}
+            if dockerfileName != "" {
+                bFile, err := afero.ReadFile(fs, dockerfileName)
+                assert.NoError(t, err)
+                assert.EqualValues(t, tt.expected.dockerfileContent, string(bFile))
+            }
 
-			if tt.expected.err == nil {
-				_, err = rdc.fs.Stat(filepath.Join("/test", tt.config.params.DockerfileName))
-				assert.NoError(t, err)
-			}
+            if tt.expected.err == nil {
+                _, err = rdc.fs.Stat(filepath.Join("/test", tt.config.params.DockerfileName))
+                assert.NoError(t, err)
+            }
 
-		})
-	}
+        })
+    }
 }
 
 func TestDockerfileWithCache(t *testing.T) {
-	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
-	nameGenerator := fakeNameGenerator{
-		name: "okteto-socket.sock",
-	}
-	fs := afero.NewMemMapFs()
-	rdc := Runner{
-		fs:                   fs,
-		workingDirectoryCtrl: wdCtrl,
-		getEnviron: func() []string {
-			return []string{}
-		},
-		ioCtrl:             io.NewIOController(),
-		generateSocketName: nameGenerator.GenerateName,
-	}
-	caches := []string{"/my", "/cache", "/list"}
-	dockerfileName, err := rdc.createDockerfile("/test", &Params{
-		Caches:         caches,
-		DockerfileName: "myDockerfile",
-	})
-	require.NoError(t, err)
-	require.Equal(t, filepath.Clean("/test/myDockerfile"), dockerfileName)
-	d, err := afero.ReadFile(fs, dockerfileName)
-	require.NoError(t, err)
-	for _, cache := range caches {
-		pattern := fmt.Sprintf("--mount=type=cache,target=%s", cache)
-		ok, err := regexp.MatchString(pattern, string(d))
-		require.NoError(t, err)
-		require.True(t, ok)
-	}
+    wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+    nameGenerator := fakeNameGenerator{
+        name: "okteto-socket.sock",
+    }
+    fs := afero.NewMemMapFs()
+    rdc := Runner{
+        fs:                   fs,
+        workingDirectoryCtrl: wdCtrl,
+        getEnviron: func() []string {
+            return []string{}
+        },
+        ioCtrl:             io.NewIOController(),
+        generateSocketName: nameGenerator.GenerateName,
+    }
+    caches := []string{"/my", "/cache", "/list"}
+    dockerfileName, err := rdc.createDockerfile("/test", &Params{
+        Caches:         caches,
+        DockerfileName: "myDockerfile",
+    })
+    require.NoError(t, err)
+    require.Equal(t, filepath.Clean("/test/myDockerfile"), dockerfileName)
+    d, err := afero.ReadFile(fs, dockerfileName)
+    require.NoError(t, err)
+    for _, cache := range caches {
+        pattern := fmt.Sprintf("--mount=type=cache,target=%s", cache)
+        ok, err := regexp.MatchString(pattern, string(d))
+        require.NoError(t, err)
+        require.True(t, ok)
+    }
 }
 
 func TestGetExtraHosts(t *testing.T) {
-	registryURL := "registry.test.dev.okteto.net"
-	subdomain := "test.dev.okteto.net"
-	ip := "1.2.3.4"
+    registryURL := "registry.test.dev.okteto.net"
+    subdomain := "test.dev.okteto.net"
+    ip := "1.2.3.4"
 
-	var tests = []struct {
-		name         string
-		expected     []types.HostMap
-		definedHosts []model.Host
-		metadata     types.ClusterMetadata
-	}{
-		{
-			name:     "no metadata information",
-			metadata: types.ClusterMetadata{},
-			expected: []types.HostMap{
-				{Hostname: registryURL, IP: ip},
-				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
-			},
-		},
-		{
-			name: "with buildkit internal ip",
-			metadata: types.ClusterMetadata{
-				BuildKitInternalIP: "4.3.2.1",
-			},
-			expected: []types.HostMap{
-				{Hostname: registryURL, IP: ip},
-				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
-				{Hostname: fmt.Sprintf("buildkit.%s", subdomain), IP: "4.3.2.1"},
-			},
-		},
-		{
-			name: "with public domain",
-			metadata: types.ClusterMetadata{
-				PublicDomain: "publicdomain.dev.okteto.net",
-			},
-			expected: []types.HostMap{
-				{Hostname: registryURL, IP: ip},
-				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
-				{Hostname: "publicdomain.dev.okteto.net", IP: ip},
-			},
-		},
-		{
-			name: "with defined hosts",
-			metadata: types.ClusterMetadata{
-				PublicDomain: "publicdomain.dev.okteto.net",
-			},
-			definedHosts: []model.Host{
-				{
-					Hostname: "test.dev.okteto.net",
-					IP:       ip,
-				},
-				{
-					Hostname: "test2.dev.okteto.net",
-					IP:       ip,
-				},
-			},
-			expected: []types.HostMap{
-				{Hostname: registryURL, IP: ip},
-				{Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
-				{Hostname: "publicdomain.dev.okteto.net", IP: ip},
-			},
-		},
-	}
+    var tests = []struct {
+        name         string
+        expected     []types.HostMap
+        definedHosts []model.Host
+        metadata     types.ClusterMetadata
+    }{
+        {
+            name:     "no metadata information",
+            metadata: types.ClusterMetadata{},
+            expected: []types.HostMap{
+                {Hostname: registryURL, IP: ip},
+                {Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+            },
+        },
+        {
+            name: "with buildkit internal ip",
+            metadata: types.ClusterMetadata{
+                BuildKitInternalIP: "4.3.2.1",
+            },
+            expected: []types.HostMap{
+                {Hostname: registryURL, IP: ip},
+                {Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+                {Hostname: fmt.Sprintf("buildkit.%s", subdomain), IP: "4.3.2.1"},
+            },
+        },
+        {
+            name: "with public domain",
+            metadata: types.ClusterMetadata{
+                PublicDomain: "publicdomain.dev.okteto.net",
+            },
+            expected: []types.HostMap{
+                {Hostname: registryURL, IP: ip},
+                {Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+                {Hostname: "publicdomain.dev.okteto.net", IP: ip},
+            },
+        },
+        {
+            name: "with defined hosts",
+            metadata: types.ClusterMetadata{
+                PublicDomain: "publicdomain.dev.okteto.net",
+            },
+            definedHosts: []model.Host{
+                {
+                    Hostname: "test.dev.okteto.net",
+                    IP:       ip,
+                },
+                {
+                    Hostname: "test2.dev.okteto.net",
+                    IP:       ip,
+                },
+            },
+            expected: []types.HostMap{
+                {Hostname: registryURL, IP: ip},
+                {Hostname: fmt.Sprintf("kubernetes.%s", subdomain), IP: ip},
+                {Hostname: "publicdomain.dev.okteto.net", IP: ip},
+            },
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			extraHosts := getExtraHosts(registryURL, subdomain, ip, tt.metadata)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            extraHosts := getExtraHosts(registryURL, subdomain, ip, tt.metadata)
 
-			assert.EqualValues(t, tt.expected, extraHosts)
-		})
-	}
+            assert.EqualValues(t, tt.expected, extraHosts)
+        })
+    }
 }
 
 func TestGetContextPath(t *testing.T) {
-	cwd := filepath.Clean("/path/to/current/directory")
+    cwd := filepath.Clean("/path/to/current/directory")
 
-	rd := Runner{
-		fs: afero.NewMemMapFs(),
-	}
+    rd := Runner{
+        fs: afero.NewMemMapFs(),
+    }
 
-	t.Run("Manifest path is empty", func(t *testing.T) {
-		expected := cwd
-		result := rd.getContextPath(cwd, "")
-		assert.Equal(t, expected, result)
-	})
+    t.Run("Manifest path is empty", func(t *testing.T) {
+        expected := cwd
+        result := rd.getContextPath(cwd, "")
+        assert.Equal(t, expected, result)
+    })
 
-	t.Run("Manifest path is a absolute path and directory", func(t *testing.T) {
-		manifestPath := filepath.Clean("/path/to/current/directory")
-		expected := manifestPath
-		rd.fs = afero.NewMemMapFs()
-		rd.fs.MkdirAll(manifestPath, 0755)
-		result := rd.getContextPath(cwd, manifestPath)
-		assert.Equal(t, expected, result)
-	})
+    t.Run("Manifest path is a absolute path and directory", func(t *testing.T) {
+        manifestPath := filepath.Clean("/path/to/current/directory")
+        expected := manifestPath
+        rd.fs = afero.NewMemMapFs()
+        rd.fs.MkdirAll(manifestPath, 0755)
+        result := rd.getContextPath(cwd, manifestPath)
+        assert.Equal(t, expected, result)
+    })
 
-	t.Run("Manifest path is a file and absolute path", func(t *testing.T) {
-		manifestPath := filepath.Clean("/path/to/current/directory/file.yaml")
-		expected := filepath.Clean("/path/to/current/directory")
-		rd.fs = afero.NewMemMapFs()
-		rd.fs.MkdirAll(expected, 0755)
-		rd.fs.Create(manifestPath)
-		result := rd.getContextPath(cwd, manifestPath)
-		assert.Equal(t, expected, result)
-	})
+    t.Run("Manifest path is a file and absolute path", func(t *testing.T) {
+        manifestPath := filepath.Clean("/path/to/current/directory/file.yaml")
+        expected := filepath.Clean("/path/to/current/directory")
+        rd.fs = afero.NewMemMapFs()
+        rd.fs.MkdirAll(expected, 0755)
+        rd.fs.Create(manifestPath)
+        result := rd.getContextPath(cwd, manifestPath)
+        assert.Equal(t, expected, result)
+    })
 
-	t.Run("Manifest path is pointing to a file in the .okteto folder and absolute path", func(t *testing.T) {
-		manifestPath := filepath.Clean("/path/to/current/directory/.okteto/file.yaml")
-		expected := filepath.Clean("/path/to/current/directory")
-		rd.fs = afero.NewMemMapFs()
-		rd.fs.MkdirAll(expected, 0755)
-		rd.fs.Create(manifestPath)
-		result := rd.getContextPath(cwd, manifestPath)
-		assert.Equal(t, expected, result)
-	})
+    t.Run("Manifest path is pointing to a file in the .okteto folder and absolute path", func(t *testing.T) {
+        manifestPath := filepath.Clean("/path/to/current/directory/.okteto/file.yaml")
+        expected := filepath.Clean("/path/to/current/directory")
+        rd.fs = afero.NewMemMapFs()
+        rd.fs.MkdirAll(expected, 0755)
+        rd.fs.Create(manifestPath)
+        result := rd.getContextPath(cwd, manifestPath)
+        assert.Equal(t, expected, result)
+    })
 
-	t.Run("Manifest path does not exist", func(t *testing.T) {
-		expected := cwd
-		result := rd.getContextPath(cwd, "nonexistent.yaml")
-		assert.Equal(t, expected, result)
-	})
+    t.Run("Manifest path does not exist", func(t *testing.T) {
+        expected := cwd
+        result := rd.getContextPath(cwd, "nonexistent.yaml")
+        assert.Equal(t, expected, result)
+    })
 }
 
 func TestGetOriginalCWD(t *testing.T) {
 
-	t.Run("error getting the working directory", func(t *testing.T) {
-		wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
-		wdCtrl.SetErrors(filesystem.FakeWorkingDirectoryCtrlErrors{
-			Getter: assert.AnError,
-		})
-		_, err := GetOriginalCWD(wdCtrl, "")
+    t.Run("error getting the working directory", func(t *testing.T) {
+        wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
+        wdCtrl.SetErrors(filesystem.FakeWorkingDirectoryCtrlErrors{
+            Getter: assert.AnError,
+        })
+        _, err := GetOriginalCWD(wdCtrl, "")
 
-		require.Error(t, err)
-	})
+        require.Error(t, err)
+    })
 
-	t.Run("with empty manifest path", func(t *testing.T) {
-		wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/tmp/test"))
-		result, err := GetOriginalCWD(wdCtrl, "")
-		expected := filepath.Clean("/tmp/test")
+    t.Run("with empty manifest path", func(t *testing.T) {
+        wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/tmp/test"))
+        result, err := GetOriginalCWD(wdCtrl, "")
+        expected := filepath.Clean("/tmp/test")
 
-		require.NoError(t, err)
-		require.Equal(t, expected, result)
-	})
+        require.NoError(t, err)
+        require.Equal(t, expected, result)
+    })
 
-	t.Run("with manifest path to a dir", func(t *testing.T) {
-		wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/tmp/test"))
-		path := filepath.Join("test", ".okteto")
-		result, err := GetOriginalCWD(wdCtrl, path)
+    t.Run("with manifest path to a dir", func(t *testing.T) {
+        wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/tmp/test"))
+        path := filepath.Join("test", ".okteto")
+        result, err := GetOriginalCWD(wdCtrl, path)
 
-		expected := filepath.Clean("/tmp")
-		require.NoError(t, err)
-		require.Equal(t, expected, result)
-	})
+        expected := filepath.Clean("/tmp")
+        require.NoError(t, err)
+        require.Equal(t, expected, result)
+    })
 
-	t.Run("with manifest path to a file", func(t *testing.T) {
-		wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/tmp/test"))
+    t.Run("with manifest path to a file", func(t *testing.T) {
+        wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/tmp/test"))
 
-		path := filepath.Join("test", "okteto.yml")
-		result, err := GetOriginalCWD(wdCtrl, path)
+        path := filepath.Join("test", "okteto.yml")
+        result, err := GetOriginalCWD(wdCtrl, path)
 
-		expected := filepath.Clean("/tmp")
-		require.NoError(t, err)
-		require.Equal(t, expected, result)
-	})
+        expected := filepath.Clean("/tmp")
+        require.NoError(t, err)
+        require.Equal(t, expected, result)
+    })
 }
 
 func TestCreateDockerignoreFileWithFilesystem(t *testing.T) {
-	dockerignoreWd := "/test/"
+    dockerignoreWd := "/test/"
 
-	type config struct {
-		wd string
-	}
-	var tests = []struct {
-		name            string
-		expectedContent string
-		config          config
-		rules           []string
-		useDeployIgnore bool
-	}{
-		{
-			name: "dockerignore present copy .oktetodeployignore to .dockerignore without manifest",
-			config: config{
-				wd: dockerignoreWd,
-			},
-			expectedContent: "test/*\n",
-			useDeployIgnore: true,
-		},
-		{
-			name: "dockerignore present copy .oktetodeployignore to .dockerignore with rules",
-			config: config{
-				wd: dockerignoreWd,
-			},
-			expectedContent: "test/*\nbackend?\nfrontend/**\n",
-			rules:           []string{"backend?", "frontend/**"},
-			useDeployIgnore: true,
-		},
-		{
-			name:            "without dockerignore",
-			config:          config{},
-			expectedContent: "# Okteto docker ignore\n",
-			useDeployIgnore: true,
-		},
-		{
-			name: "dockerignore present copy .oktetodeployignore to .dockerignore with rules",
-			config: config{
-				wd: dockerignoreWd,
-			},
-			expectedContent: "backend?\nfrontend/**\n",
-			rules:           []string{"backend?", "frontend/**"},
-			useDeployIgnore: false,
-		},
-	}
+    type config struct {
+        wd string
+    }
+    var tests = []struct {
+        name            string
+        expectedContent string
+        config          config
+        rules           []string
+        useDeployIgnore bool
+    }{
+        {
+            name: "dockerignore present copy .oktetodeployignore to .dockerignore without manifest",
+            config: config{
+                wd: dockerignoreWd,
+            },
+            expectedContent: "test/*\n",
+            useDeployIgnore: true,
+        },
+        {
+            name: "dockerignore present copy .oktetodeployignore to .dockerignore with rules",
+            config: config{
+                wd: dockerignoreWd,
+            },
+            expectedContent: "test/*\nbackend?\nfrontend/**\n",
+            rules:           []string{"backend?", "frontend/**"},
+            useDeployIgnore: true,
+        },
+        {
+            name:            "without dockerignore",
+            config:          config{},
+            expectedContent: "# Okteto docker ignore\n",
+            useDeployIgnore: true,
+        },
+        {
+            name: "dockerignore present copy .oktetodeployignore to .dockerignore with rules",
+            config: config{
+                wd: dockerignoreWd,
+            },
+            expectedContent: "backend?\nfrontend/**\n",
+            rules:           []string{"backend?", "frontend/**"},
+            useDeployIgnore: false,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tempDir := t.TempDir()
-			fs := afero.NewMemMapFs()
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            tempDir := t.TempDir()
+            fs := afero.NewMemMapFs()
 
-			assert.NoError(t, fs.MkdirAll(dockerignoreWd, 0755))
-			assert.NoError(t, afero.WriteFile(fs, filepath.Join(dockerignoreWd, ".oktetodeployignore"), []byte("test/*"), 0644))
+            assert.NoError(t, fs.MkdirAll(dockerignoreWd, 0755))
+            assert.NoError(t, afero.WriteFile(fs, filepath.Join(dockerignoreWd, ".oktetodeployignore"), []byte("test/*"), 0644))
 
-			err := createDockerignoreFileWithFilesystem(tt.config.wd, tempDir, tt.rules, tt.useDeployIgnore, fs)
-			assert.NoError(t, err)
-			b, err := afero.ReadFile(fs, filepath.Join(tempDir, ".dockerignore"))
-			assert.Equal(t, tt.expectedContent, string(b))
-			assert.NoError(t, err)
+            err := createDockerignoreFileWithFilesystem(tt.config.wd, tempDir, tt.rules, tt.useDeployIgnore, fs)
+            assert.NoError(t, err)
+            b, err := afero.ReadFile(fs, filepath.Join(tempDir, ".dockerignore"))
+            assert.Equal(t, tt.expectedContent, string(b))
+            assert.NoError(t, err)
 
-		})
-	}
+        })
+    }
 }
 
 func TestGetOktetoPrefixEnvVars(t *testing.T) {
-	expectedEnvVars := map[string]string{
-		"OKTETO_ENV_VAR_1":                        "value1",
-		"OKTETO_ENV_VAR_2":                        "value2",
-		"OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED": "MYVALUEWITHEQUAL=INVALUE",
-	}
+    expectedEnvVars := map[string]string{
+        "OKTETO_ENV_VAR_1":                        "value1",
+        "OKTETO_ENV_VAR_2":                        "value2",
+        "OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED": "MYVALUEWITHEQUAL=INVALUE",
+    }
 
-	environ := []string{
-		"OKTETO_ENV_VAR_1=value1",
-		"OKTETO_ENV_VAR_2=value2",
-		"NON_OKTETO_ENV_VAR=value3",
-		"OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED=MYVALUEWITHEQUAL=INVALUE",
-		"OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED",
-	}
+    environ := []string{
+        "OKTETO_ENV_VAR_1=value1",
+        "OKTETO_ENV_VAR_2=value2",
+        "NON_OKTETO_ENV_VAR=value3",
+        "OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED=MYVALUEWITHEQUAL=INVALUE",
+        "OKTETO_ENV_VAR_WITHOUT_VALUE_IS_SKIPPED",
+    }
 
-	prefixEnvVars := getOktetoPrefixEnvVars(environ)
+    prefixEnvVars := getOktetoPrefixEnvVars(environ)
 
-	for key, value := range expectedEnvVars {
-		assert.Equal(t, value, prefixEnvVars[key])
-	}
+    for key, value := range expectedEnvVars {
+        assert.Equal(t, value, prefixEnvVars[key])
+    }
 }
 
 func TestFormatEnvVarValueForDocker(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "single line",
-			input:    "value",
-			expected: "\"value\"",
-		},
-		{
-			name:     "multiple lines",
-			input:    "line1\nline2\nline3",
-			expected: "\"line1\\nline2\\nline3\"",
-		},
-		{
-			name:     "empty string",
-			input:    "",
-			expected: "\"\"",
-		},
-		{
-			name:     "single newline",
-			input:    "\n",
-			expected: "\"\\n\"",
-		},
-		{
-			name:     "trailing newline",
-			input:    "line1\nline2\n",
-			expected: "\"line1\\nline2\\n\"",
-		},
-	}
+    tests := []struct {
+        name     string
+        input    string
+        expected string
+    }{
+        {
+            name:     "single line",
+            input:    "value",
+            expected: "\"value\"",
+        },
+        {
+            name:     "multiple lines",
+            input:    "line1\nline2\nline3",
+            expected: "\"line1\\nline2\\nline3\"",
+        },
+        {
+            name:     "empty string",
+            input:    "",
+            expected: "\"\"",
+        },
+        {
+            name:     "single newline",
+            input:    "\n",
+            expected: "\"\\n\"",
+        },
+        {
+            name:     "trailing newline",
+            input:    "line1\nline2\n",
+            expected: "\"line1\\nline2\\n\"",
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := formatEnvVarValueForDocker(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            result := formatEnvVarValueForDocker(tt.input)
+            assert.Equal(t, tt.expected, result)
+        })
+    }
 }


### PR DESCRIPTION
# Proposed changes

We are going to start using rootless image for the pipeline-runner, but some of the operations we do in the Dockerfile used for remote operations need to be root. So, there is a PR doing some changes to the Dockerfile to keep working on both (root and rootless) scenarios, but those changes might be risky for this release, so for now, we just always use USER 0 as we were doing for `okteto test`. And we can test carefully the other PR before the following release.

These changes should be safe as right now we don't support rootless images, so all remote operations should be already running with root user

## How to validate

Deploy and destroy different manifests with different base images. You can also try to use some rootless image (`pipeline-runner:1.0.6-rootless`) to verify it keeps working (before these changes, that image wouldn't work).


<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
