### PR TITLE
Enhance healthcheck failure handling and logging

### DIFF
--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -370,13 +370,13 @@ func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernete
 					}
 					if failedServices := getServicesWithFailedProbes(ctx, stack, svcName, k8sClient); len(failedServices) > 0 {
 						for service, err := range failedServices {
-							message := fmt.Sprintf("Service '%s' cannot be deployed because dependent service '%s' is failing its healthcheck probes: %s", svcName, service, err)
+							errMessage := fmt.Errorf("Service '%s' cannot be deployed because dependent service '%s' is failing its healthcheck probes: %s", svcName, service, err)
 							if oktetoErrors.IsLivenessProbeFailed(err) {
-								return fmt.Errorf(message)
+								return errMessage
 							} else if oktetoErrors.IsReadinessProbeFailed(err) {
 								if _, ok := serviceWarnings[service]; !ok {
-									oktetoLog.Information(message)
-									serviceWarnings[service] = message
+									oktetoLog.Information(errMessage.Error())
+									serviceWarnings[service] = errMessage.Error()
 								}
 							}
 						}

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -370,11 +370,11 @@ func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernete
 					}
 					if failedServices := getServicesWithFailedProbes(ctx, stack, svcName, k8sClient); len(failedServices) > 0 {
 						for service, err := range failedServices {
+							message := fmt.Sprintf("Service '%s' cannot be deployed because dependant service '%s' is failing its healthcheck probes: %s", svcName, service, err)
 							if oktetoErrors.IsLivenessProbeFailed(err) {
-								return fmt.Errorf("service '%s' has failed its healthcheck probes: %w", service, err)
+								return fmt.Errorf(message)
 							} else if oktetoErrors.IsReadinessProbeFailed(err) {
 								if _, ok := serviceWarnings[service]; !ok {
-									message := fmt.Sprintf("service '%s' is failing its healthcheck probes: %s", service, err)
 									oktetoLog.Information(message)
 									serviceWarnings[service] = message
 								}

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -371,9 +371,9 @@ func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernete
 					if failedServices := getServicesWithFailedProbes(ctx, stack, svcName, k8sClient); len(failedServices) > 0 {
 						for service, err := range failedServices {
 							errMessage := fmt.Errorf("Service '%s' cannot be deployed because dependent service '%s' is failing its healthcheck probes: %s", svcName, service, err)
-							if oktetoErrors.IsLivenessProbeFailed(err) {
+							if errors.Is(err, oktetoErrors.ErrLivenessProbeFailed) {
 								return errMessage
-							} else if oktetoErrors.IsReadinessProbeFailed(err) {
+							} else if errors.Is(err, oktetoErrors.ErrReadinessProbeFailed) {
 								if _, ok := serviceWarnings[service]; !ok {
 									oktetoLog.Information(errMessage.Error())
 									serviceWarnings[service] = errMessage.Error()

--- a/pkg/cmd/stack/deploy.go
+++ b/pkg/cmd/stack/deploy.go
@@ -370,7 +370,7 @@ func deployServices(ctx context.Context, stack *model.Stack, k8sClient kubernete
 					}
 					if failedServices := getServicesWithFailedProbes(ctx, stack, svcName, k8sClient); len(failedServices) > 0 {
 						for service, err := range failedServices {
-							message := fmt.Sprintf("Service '%s' cannot be deployed because dependant service '%s' is failing its healthcheck probes: %s", svcName, service, err)
+							message := fmt.Sprintf("Service '%s' cannot be deployed because dependent service '%s' is failing its healthcheck probes: %s", svcName, service, err)
 							if oktetoErrors.IsLivenessProbeFailed(err) {
 								return fmt.Errorf(message)
 							} else if oktetoErrors.IsReadinessProbeFailed(err) {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -288,11 +288,3 @@ func IsClosedNetwork(err error) bool {
 func IsErrGitHubNotVerifiedEmail(err error) bool {
 	return err.Error() == ErrGitHubNotVerifiedEmail.Error()
 }
-
-func IsReadinessProbeFailed(err error) bool {
-	return err == ErrReadinessProbeFailed
-}
-
-func IsLivenessProbeFailed(err error) bool {
-	return err == ErrLivenessProbeFailed
-}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -218,6 +218,9 @@ var (
 		E:    fmt.Errorf("the Okteto manifest specified is a directory, please specify a file"),
 		Hint: "Check the path to the Okteto manifest file",
 	}
+
+	ErrReadinessProbeFailed = errors.New("readiness probe failed")
+	ErrLivenessProbeFailed  = errors.New("liveness probe failed")
 )
 
 // IsForbidden raised if the Okteto API returns 401
@@ -284,4 +287,12 @@ func IsClosedNetwork(err error) bool {
 
 func IsErrGitHubNotVerifiedEmail(err error) bool {
 	return err.Error() == ErrGitHubNotVerifiedEmail.Error()
+}
+
+func IsReadinessProbeFailed(err error) bool {
+	return err == ErrReadinessProbeFailed
+}
+
+func IsLivenessProbeFailed(err error) bool {
+	return err == ErrLivenessProbeFailed
 }


### PR DESCRIPTION
# Proposed changes

Fixes https://okteto.atlassian.net/browse/DEV-260

This PR proposes a change to show an information log whenever a readiness probe is failing and a service is waiting for being deployed.
It keeps the behaviour of returning an error when a liveness probe fails.

Refactors:
 Events: detect the readiness and the liveness probe fail message and return new `Failure` so the code can identify the origin.
Pod probes detection: when readiness fails, log a message while waiting for being deployed, when livenes return error.

<img width="1008" alt="Screenshot 2024-12-02 at 14 15 49" src="https://github.com/user-attachments/assets/d6c87e8a-3ab3-47ef-9ef0-80690e5f2eb3">
<img width="1008" alt="Screenshot 2024-12-02 at 14 16 35" src="https://github.com/user-attachments/assets/51a86c65-7d9f-44d9-8052-6d1e414e6b43">


## How to validate

Build the binary and configure different probes and healthchecks 

