### PR TITLE
Handle new unschedulable status

### DIFF
--- a/pkg/okteto/namespace.go
+++ b/pkg/okteto/namespace.go
@@ -21,19 +21,21 @@ import (
 )
 
 const (
-	RunningStatus     = "running"
-	NotRunningStatus  = "not-running"
-	CompletedStatus   = "completed"
-	PullingStatus     = "pulling"
-	ProgressingStatus = "progressing"
-	BootingStatus     = "booting"
-	ErrorStatus       = "error"
+	RunningStatus       = "running"
+	NotRunningStatus    = "not-running"
+	CompletedStatus     = "completed"
+	PullingStatus       = "pulling"
+	ProgressingStatus   = "progressing"
+	BootingStatus       = "booting"
+	ErrorStatus         = "error"
+	UnschedulableStatus = "unschedulable"
 )
 
 var TransitionStatus = map[string]bool{
-	BootingStatus:     true,
-	ProgressingStatus: true,
-	PullingStatus:     true,
+	BootingStatus:       true,
+	ProgressingStatus:   true,
+	PullingStatus:       true,
+	UnschedulableStatus: true,
 }
 
 type namespaceClient struct {


### PR DESCRIPTION
Include the new `Unschedulable` status as a transition status. This makes deploys and dependencies wait for the deploy timeout before marking is as failed. Note that in the backend we have a 3min cutoff for unschedulable resources so any timeout larger than that was not being considered.

This change is dependant on the backend return this new status.


