### PR TITLE
feat: add FSGroup to PodSecurityContext in StatefulSet translation

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -214,6 +214,9 @@ func translateStatefulSet(svcName string, s *model.Stack, divert Divert) *appsv1
 		Affinity:                      translateAffinity(svc),
 		NodeSelector:                  svc.NodeSelector,
 		Volumes:                       translateVolumes(svc),
+		SecurityContext: &apiv1.PodSecurityContext{
+			FSGroup: pointer.Int64(1000),
+		},
 		Containers: []apiv1.Container{
 			{
 				Name:            svcName,

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -261,7 +261,10 @@ func Test_translateStatefulSet(t *testing.T) {
 		"node2": "value2",
 	}
 	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
-
+	podSecurityContext := &apiv1.PodSecurityContext{
+		FSGroup: pointer.Int64(1000),
+	}
+	assert.Equal(t, result.Spec.Template.Spec.SecurityContext, podSecurityContext)
 	if *result.Spec.Replicas != 3 {
 		t.Errorf("Wrong statefulset spec.replicas: '%d'", *result.Spec.Replicas)
 	}


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes an issue discovered while testing CLI beta.

The problem was that now we are using the CLI as a rootless image and that causes inhability to run chmod on the init container. 

This PR fixes that adding the FSgroup to 1000

## How to validate

Using compose-getting-started
1. Run okteto deploy
1. Check that redis started correctly


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

<!-- Remove comment when okteto/okteto is out of wait list for Copilot for Pull Requests
----

<details>
<summary>🧪 Copilot generated PR description</summary>

copilot:all

</details>
-->
