### PR TITLE
fix version warning

### DIFF
--- a/cmd/context/create_test.go
+++ b/cmd/context/create_test.go
@@ -953,7 +953,7 @@ func Test_loadDotEnv(t *testing.T) {
 	}
 }
 
-func TestCheckCLIMinVersion(t *testing.T) {
+func TestCheckCLIVersion(t *testing.T) {
 	tests := []struct {
 		expectedErr        error
 		name               string
@@ -993,6 +993,12 @@ func TestCheckCLIMinVersion(t *testing.T) {
 			currentVersion:     "some-non-semver-version",
 			minVersion:         "3.0.0",
 			recommendedVersion: "3.1.0",
+		},
+		{
+			name:               "beta version",
+			currentVersion:     "3.2.0-beta.2",
+			minVersion:         "3.2.0",
+			recommendedVersion: "3.2.0-beta.2",
 		},
 	}
 


### PR DESCRIPTION
We were considering the patch, prerel and build of the cluster version in the comparison for warnings so we were displaying this warning:

```
 !  Your Okteto CLI version 3.2 is newer than the recommended version of your Okteto instance: 3.2. Downgrade to the recommended version or set OKTETO_SKIP_CLUSTER_CLI_VERSION=true to suppress this message.
```

We now strip all the patch, prerel and build prior so that we always compare major minor ONLY