### PR TITLE
[JSON Schema] Add `deploy.compose` object notation

### DIFF
--- a/pkg/schema/deploy.go
+++ b/pkg/schema/deploy.go
@@ -148,6 +148,13 @@ func (deploy) JSONSchema() *jsonschema.Schema {
 				Description: "Path to the compose file",
 			},
 			{
+				Type:                 &jsonschema.Type{Types: []string{"object"}},
+				Properties:           composeFileProps,
+				Required:             []string{"file"},
+				AdditionalProperties: jsonschema.FalseSchema,
+				Description:          "Single compose configuration",
+			},
+			{
 				Type:        &jsonschema.Type{Types: []string{"array"}},
 				Description: "List of compose configurations",
 				Items: &jsonschema.Schema{

--- a/schema.json
+++ b/schema.json
@@ -206,6 +206,27 @@
                   "type": "string"
                 },
                 {
+                  "additionalProperties": false,
+                  "description": "Single compose configuration",
+                  "properties": {
+                    "file": {
+                      "description": "Path to the compose file",
+                      "type": "string"
+                    },
+                    "services": {
+                      "description": "List of services to deploy",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "file"
+                  ],
+                  "type": "object"
+                },
+                {
                   "description": "List of compose configurations",
                   "items": {
                     "additionalProperties": false,


### PR DESCRIPTION
In our Okteto Manifest reference, section [deploy with compose](https://www.okteto.com/docs/reference/okteto-manifest/#deploy-with-compose) we documented this syntax:

```yaml
deploy:
  compose:
    - file: docker-compose.yml
      services:
        - frontend
    - file: docker-compose.dev.yml
      services:
        - api
```

But as you can see from [this sample](https://github.com/okteto/docker-secret-test/blob/main/okteto.yml#L7-L11) which works, it's also supported this format;

```
deploy:
  compose: 
    file: docker-compose.yml
    services:
    - web
```

This PR adds the object notation to the Okteto Manifest JSON Schema.