### PR TITLE
Added execution of integration tests for okteto test command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,27 @@ jobs:
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
             make integration-okteto
 
+  e2e-okteto-test:
+    executor: golang-ci
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v4-pkg-cache-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: ./artifacts
+      - run:
+          name: Run okteto test integration tests
+          command: |
+            export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_REMOTE_CLI_IMAGE=okteto.global/cli-e2e:${CIRCLE_SHA1}
+            export OKTETO_BIN=okteto.global/cli-e2e:${CIRCLE_SHA1}
+            echo "OKTETO_REMOTE_CLI_IMAGE=$OKTETO_REMOTE_CLI_IMAGE"
+            echo "OKTETO_BIN=$OKTETO_BIN"
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${API_PRODUCT_STAGING_TOKEN}
+            $(pwd)/artifacts/bin/okteto-Linux-x86_64 analytics --disable
+            make integration-okteto-test
+
   test-e2e-setup:
     executor: golang-ci
     steps:
@@ -351,6 +372,42 @@ jobs:
             & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
             & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_PRODUCT_STAGING_TOKEN
             go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
+
+  e2e-okteto-test-windows:
+    executor:
+      name: win/server-2022
+      version: 2024.04.1
+    environment:
+      OKTETO_CONTEXT: https://staging.okteto.dev
+      OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net
+      OKTETO_NAMESPACE_PREFIX: staging
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v5-pkg-cache-windows-1-15-{{ checksum "go.sum" }}
+      - attach_workspace:
+          at: .\artifacts
+      - run:
+          name: Install kubectl and helm
+          command: |
+            go version
+            choco install kubernetes-cli -y
+            choco install kubernetes-helm -y
+      - run:
+          name: Run okteto test integration tests
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
+          command: |
+            $env:OKTETO_PATH="$($HOME)\project\artifacts\bin\okteto.exe"
+            $env:Path+=";$($HOME)\project\artifacts\bin"
+            $env:SSH_AUTH_SOCK = (Get-Command ssh-agent).Definition -replace 'ssh-agent.exe','ssh-agent.sock'
+            # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
+            $env:OKTETO_REMOTE_CLI_IMAGE="okteto.global/cli-e2e:$env:CIRCLE_SHA1"
+            $env:OKTETO_BIN="okteto.global/cli-e2e:${CIRCLE_SHA1}"
+            & "$($HOME)\project\artifacts\bin\okteto.exe" analytics --disable
+            & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:API_PRODUCT_STAGING_TOKEN
+            go test github.com/okteto/okteto/integration/test -tags="integration" --count=1 -v -timeout 20m
 
   e2e-up-windows:
     executor:
@@ -539,6 +596,13 @@ workflows:
             branches:
               only:
                 - master
+      - e2e-okteto-test-windows:
+          requires:
+            - test-e2e-setup
+          filters:
+            branches:
+              only:
+                - master
       - e2e-build:
           requires:
             - test-e2e-setup
@@ -568,6 +632,13 @@ workflows:
               only:
                 - master
       - e2e-okteto:
+          requires:
+            - test-e2e-setup
+          filters:
+            branches:
+              only:
+                - master
+      - e2e-okteto-test:
           requires:
             - test-e2e-setup
           filters:
@@ -628,6 +699,9 @@ workflows:
           requires:
             - test-e2e-setup
       - e2e-okteto:
+          requires:
+            - test-e2e-setup
+      - e2e-okteto-test:
           requires:
             - test-e2e-setup
       - release-branch-job:
@@ -740,6 +814,9 @@ workflows:
       - e2e-okteto:
           requires:
             - test-e2e-setup
+      - e2e-okteto-test:
+          requires:
+            - test-e2e-setup
       - e2e-build-windows:
           requires:
             - test-e2e-setup
@@ -747,6 +824,9 @@ workflows:
           requires:
             - test-e2e-setup
       - e2e-up-windows:
+          requires:
+            - test-e2e-setup
+      - e2e-okteto-test-windows:
           requires:
             - test-e2e-setup
 
@@ -775,6 +855,9 @@ workflows:
       - e2e-okteto:
           requires:
             - test-e2e-setup
+      - e2e-okteto-test:
+          requires:
+            - test-e2e-setup
 
   # run-e2e-windows is triggered by okteto-bot via Github Actions when adding the run-e2e-windows label to the PR
   # e2e test for windows platform are run
@@ -793,5 +876,8 @@ workflows:
           requires:
             - test-e2e-setup
       - e2e-up-windows:
+          requires:
+            - test-e2e-setup
+      - e2e-okteto-test-windows:
           requires:
             - test-e2e-setup

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ integration-up:
 	go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
 
 .PHONY: integration-okteto-test
-integration-up:
+integration-okteto-test:
 	go test github.com/okteto/okteto/integration/test -tags="integration" --count=1 -v -timeout 45m
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ integration-okteto:
 integration-up:
 	go test github.com/okteto/okteto/integration/up -tags="integration" --count=1 -v -timeout 45m
 
+.PHONY: integration-okteto-test
+integration-up:
+	go test github.com/okteto/okteto/integration/test -tags="integration" --count=1 -v -timeout 45m
+
 .PHONY: build
 build:
 	$(BUILDCOMMAND) -o ${BINDIR}/okteto

--- a/integration/commands/test.go
+++ b/integration/commands/test.go
@@ -26,7 +26,7 @@ import (
 
 // TestOptions defines the options that can be added to a test command
 type TestOptions struct {
-	TestName     string
+	TestNames    []string
 	Workdir      string
 	ManifestPath string
 	LogLevel     string
@@ -55,7 +55,7 @@ func getTestCmd(oktetoPath string, testOptions *TestOptions) *exec.Cmd {
 		cmd.Dir = testOptions.Workdir
 	}
 
-	cmd.Args = append(cmd.Args, testOptions.TestName)
+	cmd.Args = append(cmd.Args, testOptions.TestNames...)
 	if testOptions.NoCache {
 		cmd.Args = append(cmd.Args, "--no-cache")
 	}

--- a/integration/commands/test.go
+++ b/integration/commands/test.go
@@ -54,9 +54,8 @@ func getTestCmd(oktetoPath string, testOptions *TestOptions) *exec.Cmd {
 	if testOptions.Workdir != "" {
 		cmd.Dir = testOptions.Workdir
 	}
-	if len(testOptions.TestName) > 0 {
-		cmd.Args = append(cmd.Args, testOptions.TestName)
-	}
+
+	cmd.Args = append(cmd.Args, testOptions.TestName)
 	if testOptions.NoCache {
 		cmd.Args = append(cmd.Args, "--no-cache")
 	}

--- a/integration/commands/test.go
+++ b/integration/commands/test.go
@@ -26,7 +26,6 @@ import (
 
 // TestOptions defines the options that can be added to a test command
 type TestOptions struct {
-	TestNames    []string
 	Workdir      string
 	ManifestPath string
 	LogLevel     string
@@ -34,6 +33,7 @@ type TestOptions struct {
 	Namespace    string
 	OktetoHome   string
 	Token        string
+	TestNames    []string
 	NoCache      bool
 }
 

--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -17,19 +17,19 @@
 package test
 
 import (
-    "os"
-    "path/filepath"
-    "testing"
+	"os"
+	"path/filepath"
+	"testing"
 
-    "github.com/okteto/okteto/integration"
-    "github.com/okteto/okteto/integration/commands"
-    oktetoLog "github.com/okteto/okteto/pkg/log"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	"github.com/okteto/okteto/integration"
+	"github.com/okteto/okteto/integration/commands"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
-    oktetoManifestWithPassingTest = `
+	oktetoManifestWithPassingTest = `
 test:
   unit:
     context: .
@@ -41,7 +41,7 @@ deploy:
   - echo "deploying"
 `
 
-    oktetoManifestWithPassingTestAndArtifacts = `
+	oktetoManifestWithPassingTestAndArtifacts = `
 test:
   unit:
     context: .
@@ -57,7 +57,7 @@ deploy:
   - echo "deploying"
 `
 
-    oktetoManifestWithFailingTestAndArtifacts = `
+	oktetoManifestWithFailingTestAndArtifacts = `
 test:
   unit:
     context: .
@@ -71,7 +71,7 @@ test:
 deploy:
   - echo "deploying"
 `
-    dockerfileWithAnotherUser = `
+	dockerfileWithAnotherUser = `
 FROM ubuntu:latest
 
 WORKDIR /app
@@ -80,7 +80,7 @@ COPY . .
 RUN chown -R 1000:1000 /app
 USER 1000
 `
-    oktetoManifestWithImageReferencedInBuildSection = `
+	oktetoManifestWithImageReferencedInBuildSection = `
 build:
   tests:
     context: .
@@ -93,180 +93,180 @@ test:
 )
 
 var (
-    token = ""
+	token = ""
 )
 
 func TestMain(m *testing.M) {
-    token = integration.GetToken()
+	token = integration.GetToken()
 
-    exitCode := m.Run()
-    os.Exit(exitCode)
+	exitCode := m.Run()
+	os.Exit(exitCode)
 }
 
 // TestOktetoTestsWithPassingTests validates the simplest happy path of okteto test
 func TestOktetoTestsWithPassingTests(t *testing.T) {
-    integration.SkipIfNotOktetoCluster(t)
-    t.Parallel()
-    oktetoPath, err := integration.GetOktetoPath()
-    require.NoError(t, err)
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
 
-    dir := t.TempDir()
+	dir := t.TempDir()
 
-    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
 
-    testNamespace := integration.GetTestNamespace(t.Name())
-    namespaceOpts := &commands.NamespaceOptions{
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-    }
-    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	testNamespace := integration.GetTestNamespace(t.Name())
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-    testOptions := &commands.TestOptions{
-        Workdir:    dir,
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-        NoCache:    true,
-    }
-    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-    require.NoError(t, err)
-    assert.Contains(t, out, "Test container 'unit' passed")
+	testOptions := &commands.TestOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		NoCache:    true,
+	}
+	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Test container 'unit' passed")
 
-    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestOktetoTestsWithPassingTestsAndArtifacts validates the happy path of okteto test with the export of artifacts
 func TestOktetoTestsWithPassingTestsAndArtifacts(t *testing.T) {
-    integration.SkipIfNotOktetoCluster(t)
-    t.Parallel()
-    oktetoPath, err := integration.GetOktetoPath()
-    require.NoError(t, err)
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
 
-    dir := t.TempDir()
+	dir := t.TempDir()
 
-    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTestAndArtifacts), 0600))
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTestAndArtifacts), 0600))
 
-    testNamespace := integration.GetTestNamespace(t.Name())
-    namespaceOpts := &commands.NamespaceOptions{
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-    }
-    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	testNamespace := integration.GetTestNamespace(t.Name())
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-    testOptions := &commands.TestOptions{
-        Workdir:    dir,
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-        NoCache:    true,
-    }
-    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-    require.NoError(t, err)
-    assert.Contains(t, out, "Test container 'unit' passed")
-    coveragePath := filepath.Join(dir, "coverage.txt")
-    coverage, err := os.ReadFile(coveragePath)
-    require.NoError(t, err)
-    assert.Equal(t, "OK\n", string(coverage))
+	testOptions := &commands.TestOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		NoCache:    true,
+	}
+	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Test container 'unit' passed")
+	coveragePath := filepath.Join(dir, "coverage.txt")
+	coverage, err := os.ReadFile(coveragePath)
+	require.NoError(t, err)
+	assert.Equal(t, "OK\n", string(coverage))
 
-    // check that 'reports' exists and is a directory
-    reportsDirPath := filepath.Join(dir, "reports")
-    reportsDir, err := os.Open(reportsDirPath)
-    assert.NoError(t, err)
-    defer func() {
-        if err := reportsDir.Close(); err != nil {
-            oktetoLog.Debugf("Error closing directory %s: %s", reportsDirPath, err)
-        }
-    }()
+	// check that 'reports' exists and is a directory
+	reportsDirPath := filepath.Join(dir, "reports")
+	reportsDir, err := os.Open(reportsDirPath)
+	assert.NoError(t, err)
+	defer func() {
+		if err := reportsDir.Close(); err != nil {
+			oktetoLog.Debugf("Error closing directory %s: %s", reportsDirPath, err)
+		}
+	}()
 
-    reportsInfo, err := reportsDir.Stat()
-    require.NoError(t, err)
-    assert.True(t, reportsInfo.IsDir())
+	reportsInfo, err := reportsDir.Stat()
+	require.NoError(t, err)
+	assert.True(t, reportsInfo.IsDir())
 
-    // check that additional-coverage.txt exists and has the expected content
-    additionalCoveragePath := filepath.Join(reportsDirPath, "additional-coverage.txt")
-    additionalCoverage, err := os.ReadFile(additionalCoveragePath)
-    require.NoError(t, err)
-    assert.Equal(t, "OK\n", string(additionalCoverage))
+	// check that additional-coverage.txt exists and has the expected content
+	additionalCoveragePath := filepath.Join(reportsDirPath, "additional-coverage.txt")
+	additionalCoverage, err := os.ReadFile(additionalCoveragePath)
+	require.NoError(t, err)
+	assert.Equal(t, "OK\n", string(additionalCoverage))
 
-    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestOktetoTestsWithFailingTestsAndArtifacts validates the scenario where tests fail but we are able to export artifacts anyway
 func TestOktetoTestsWithFailingTestsAndArtifacts(t *testing.T) {
-    integration.SkipIfNotOktetoCluster(t)
-    t.Parallel()
-    oktetoPath, err := integration.GetOktetoPath()
-    require.NoError(t, err)
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
 
-    dir := t.TempDir()
+	dir := t.TempDir()
 
-    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithFailingTestAndArtifacts), 0600))
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithFailingTestAndArtifacts), 0600))
 
-    testNamespace := integration.GetTestNamespace(t.Name())
-    namespaceOpts := &commands.NamespaceOptions{
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-    }
-    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	testNamespace := integration.GetTestNamespace(t.Name())
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-    testOptions := &commands.TestOptions{
-        Workdir:    dir,
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-        NoCache:    true,
-    }
-    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-    require.Error(t, err)
-    assert.Contains(t, out, "Test container 'unit' failed")
-    coveragePath := filepath.Join(dir, "coverage.txt")
-    coverage, err := os.ReadFile(coveragePath)
-    require.NoError(t, err)
-    assert.Equal(t, "NOT-OK\n", string(coverage))
+	testOptions := &commands.TestOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		NoCache:    true,
+	}
+	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+	require.Error(t, err)
+	assert.Contains(t, out, "Test container 'unit' failed")
+	coveragePath := filepath.Join(dir, "coverage.txt")
+	coverage, err := os.ReadFile(coveragePath)
+	require.NoError(t, err)
+	assert.Equal(t, "NOT-OK\n", string(coverage))
 
-    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestOktetoTestsWithAnotherUser validates the simplest happy path of okteto test
 func TestOktetoTestsWithAnotherUser(t *testing.T) {
-    integration.SkipIfNotOktetoCluster(t)
-    t.Parallel()
-    oktetoPath, err := integration.GetOktetoPath()
-    require.NoError(t, err)
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
 
-    dir := t.TempDir()
+	dir := t.TempDir()
 
-    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
+	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
 
-    testNamespace := integration.GetTestNamespace(t.Name())
-    namespaceOpts := &commands.NamespaceOptions{
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-    }
-    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+	testNamespace := integration.GetTestNamespace(t.Name())
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-    testOptions := &commands.TestOptions{
-        Workdir:    dir,
-        Namespace:  testNamespace,
-        OktetoHome: dir,
-        Token:      token,
-        NoCache:    true,
-    }
-    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-    require.NoError(t, err)
-    assert.Contains(t, out, "Test container 'unit' passed")
+	testOptions := &commands.TestOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		NoCache:    true,
+	}
+	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Test container 'unit' passed")
 
-    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -297,7 +297,7 @@ func TestOktetoTestsRunningSubsetOfTests(t *testing.T) {
 		OktetoHome: dir,
 		Token:      token,
 		NoCache:    true,
-		TestName:   "unit e2e",
+		TestNames:  []string{"unit", "e2e"},
 	}
 	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
 	require.NoError(t, err)

--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -138,8 +138,8 @@ func TestOktetoTestsWithPassingTests(t *testing.T) {
 	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
-// TestOktetoTestsWithPassingTestsAndArtifacts validates the happy path of okteto test with the export of artifacts
-func TestOktetoTestsWithPassingTestsAndArtifacts(t *testing.T) {
+// TestOktetoTestsWithArtifactsAndPassingTests validates the happy path of okteto test with the export of artifacts
+func TestOktetoTestsWithArtifactsAndPassingTests(t *testing.T) {
 	integration.SkipIfNotOktetoCluster(t)
 	t.Parallel()
 	oktetoPath, err := integration.GetOktetoPath()

--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -17,18 +17,19 @@
 package test
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
+    "os"
+    "path/filepath"
+    "testing"
 
-	"github.com/okteto/okteto/integration"
-	"github.com/okteto/okteto/integration/commands"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+    "github.com/okteto/okteto/integration"
+    "github.com/okteto/okteto/integration/commands"
+    oktetoLog "github.com/okteto/okteto/pkg/log"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
 )
 
 const (
-	oktetoManifestWithPassingTest = `
+    oktetoManifestWithPassingTest = `
 test:
   unit:
     context: .
@@ -40,7 +41,7 @@ deploy:
   - echo "deploying"
 `
 
-	oktetoManifestWithPassingTestAndArtifacts = `
+    oktetoManifestWithPassingTestAndArtifacts = `
 test:
   unit:
     context: .
@@ -56,7 +57,7 @@ deploy:
   - echo "deploying"
 `
 
-	oktetoManifestWithFailingTestAndArtifacts = `
+    oktetoManifestWithFailingTestAndArtifacts = `
 test:
   unit:
     context: .
@@ -70,7 +71,7 @@ test:
 deploy:
   - echo "deploying"
 `
-	dockerfileWithAnotherUser = `
+    dockerfileWithAnotherUser = `
 FROM ubuntu:latest
 
 WORKDIR /app
@@ -79,7 +80,7 @@ COPY . .
 RUN chown -R 1000:1000 /app
 USER 1000
 `
-	oktetoManifestWithImageReferencedInBuildSection = `
+    oktetoManifestWithImageReferencedInBuildSection = `
 build:
   tests:
     context: .
@@ -92,174 +93,180 @@ test:
 )
 
 var (
-	token = ""
+    token = ""
 )
 
 func TestMain(m *testing.M) {
-	token = integration.GetToken()
+    token = integration.GetToken()
 
-	exitCode := m.Run()
-	os.Exit(exitCode)
+    exitCode := m.Run()
+    os.Exit(exitCode)
 }
 
 // TestOktetoTestsWithPassingTests validates the simplest happy path of okteto test
 func TestOktetoTestsWithPassingTests(t *testing.T) {
-	integration.SkipIfNotOktetoCluster(t)
-	t.Parallel()
-	oktetoPath, err := integration.GetOktetoPath()
-	require.NoError(t, err)
+    integration.SkipIfNotOktetoCluster(t)
+    t.Parallel()
+    oktetoPath, err := integration.GetOktetoPath()
+    require.NoError(t, err)
 
-	dir := t.TempDir()
+    dir := t.TempDir()
 
-	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
+    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
 
-	testNamespace := integration.GetTestNamespace(t.Name())
-	namespaceOpts := &commands.NamespaceOptions{
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-	}
-	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+    testNamespace := integration.GetTestNamespace(t.Name())
+    namespaceOpts := &commands.NamespaceOptions{
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+    }
+    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-	testOptions := &commands.TestOptions{
-		Workdir:    dir,
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-		NoCache:    true,
-	}
-	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-	require.NoError(t, err)
-	assert.Contains(t, out, "Test container 'unit' passed")
+    testOptions := &commands.TestOptions{
+        Workdir:    dir,
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+        NoCache:    true,
+    }
+    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+    require.NoError(t, err)
+    assert.Contains(t, out, "Test container 'unit' passed")
 
-	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestOktetoTestsWithPassingTestsAndArtifacts validates the happy path of okteto test with the export of artifacts
 func TestOktetoTestsWithPassingTestsAndArtifacts(t *testing.T) {
-	integration.SkipIfNotOktetoCluster(t)
-	t.Parallel()
-	oktetoPath, err := integration.GetOktetoPath()
-	require.NoError(t, err)
+    integration.SkipIfNotOktetoCluster(t)
+    t.Parallel()
+    oktetoPath, err := integration.GetOktetoPath()
+    require.NoError(t, err)
 
-	dir := t.TempDir()
+    dir := t.TempDir()
 
-	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTestAndArtifacts), 0600))
+    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTestAndArtifacts), 0600))
 
-	testNamespace := integration.GetTestNamespace(t.Name())
-	namespaceOpts := &commands.NamespaceOptions{
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-	}
-	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+    testNamespace := integration.GetTestNamespace(t.Name())
+    namespaceOpts := &commands.NamespaceOptions{
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+    }
+    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-	testOptions := &commands.TestOptions{
-		Workdir:    dir,
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-		NoCache:    true,
-	}
-	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-	require.NoError(t, err)
-	assert.Contains(t, out, "Test container 'unit' passed")
-	coveragePath := filepath.Join(dir, "coverage.txt")
-	coverage, err := os.ReadFile(coveragePath)
-	require.NoError(t, err)
-	assert.Equal(t, "OK\n", string(coverage))
+    testOptions := &commands.TestOptions{
+        Workdir:    dir,
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+        NoCache:    true,
+    }
+    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+    require.NoError(t, err)
+    assert.Contains(t, out, "Test container 'unit' passed")
+    coveragePath := filepath.Join(dir, "coverage.txt")
+    coverage, err := os.ReadFile(coveragePath)
+    require.NoError(t, err)
+    assert.Equal(t, "OK\n", string(coverage))
 
-	// check that 'reports' exists and is a directory
-	reportsDirPath := filepath.Join(dir, "reports")
-	reportsDir, err := os.Open(reportsDirPath)
-	assert.NoError(t, err)
-	reportsInfo, err := reportsDir.Stat()
-	require.NoError(t, err)
-	assert.True(t, reportsInfo.IsDir())
+    // check that 'reports' exists and is a directory
+    reportsDirPath := filepath.Join(dir, "reports")
+    reportsDir, err := os.Open(reportsDirPath)
+    assert.NoError(t, err)
+    defer func() {
+        if err := reportsDir.Close(); err != nil {
+            oktetoLog.Debugf("Error closing directory %s: %s", reportsDirPath, err)
+        }
+    }()
 
-	// check that additional-coverage.txt exists and has the expected content
-	additionalCoveragePath := filepath.Join(reportsDirPath, "additional-coverage.txt")
-	additionalCoverage, err := os.ReadFile(additionalCoveragePath)
-	require.NoError(t, err)
-	assert.Equal(t, "OK\n", string(additionalCoverage))
+    reportsInfo, err := reportsDir.Stat()
+    require.NoError(t, err)
+    assert.True(t, reportsInfo.IsDir())
 
-	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+    // check that additional-coverage.txt exists and has the expected content
+    additionalCoveragePath := filepath.Join(reportsDirPath, "additional-coverage.txt")
+    additionalCoverage, err := os.ReadFile(additionalCoveragePath)
+    require.NoError(t, err)
+    assert.Equal(t, "OK\n", string(additionalCoverage))
+
+    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestOktetoTestsWithFailingTestsAndArtifacts validates the scenario where tests fail but we are able to export artifacts anyway
 func TestOktetoTestsWithFailingTestsAndArtifacts(t *testing.T) {
-	integration.SkipIfNotOktetoCluster(t)
-	t.Parallel()
-	oktetoPath, err := integration.GetOktetoPath()
-	require.NoError(t, err)
+    integration.SkipIfNotOktetoCluster(t)
+    t.Parallel()
+    oktetoPath, err := integration.GetOktetoPath()
+    require.NoError(t, err)
 
-	dir := t.TempDir()
+    dir := t.TempDir()
 
-	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithFailingTestAndArtifacts), 0600))
+    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithFailingTestAndArtifacts), 0600))
 
-	testNamespace := integration.GetTestNamespace(t.Name())
-	namespaceOpts := &commands.NamespaceOptions{
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-	}
-	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+    testNamespace := integration.GetTestNamespace(t.Name())
+    namespaceOpts := &commands.NamespaceOptions{
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+    }
+    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-	testOptions := &commands.TestOptions{
-		Workdir:    dir,
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-		NoCache:    true,
-	}
-	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-	require.Error(t, err)
-	assert.Contains(t, out, "Test container 'unit' failed")
-	coveragePath := filepath.Join(dir, "coverage.txt")
-	coverage, err := os.ReadFile(coveragePath)
-	require.NoError(t, err)
-	assert.Equal(t, "NOT-OK\n", string(coverage))
+    testOptions := &commands.TestOptions{
+        Workdir:    dir,
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+        NoCache:    true,
+    }
+    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+    require.Error(t, err)
+    assert.Contains(t, out, "Test container 'unit' failed")
+    coveragePath := filepath.Join(dir, "coverage.txt")
+    coverage, err := os.ReadFile(coveragePath)
+    require.NoError(t, err)
+    assert.Equal(t, "NOT-OK\n", string(coverage))
 
-	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 
 // TestOktetoTestsWithAnotherUser validates the simplest happy path of okteto test
 func TestOktetoTestsWithAnotherUser(t *testing.T) {
-	integration.SkipIfNotOktetoCluster(t)
-	t.Parallel()
-	oktetoPath, err := integration.GetOktetoPath()
-	require.NoError(t, err)
+    integration.SkipIfNotOktetoCluster(t)
+    t.Parallel()
+    oktetoPath, err := integration.GetOktetoPath()
+    require.NoError(t, err)
 
-	dir := t.TempDir()
+    dir := t.TempDir()
 
-	oktetoManifestPath := filepath.Join(dir, "okteto.yml")
-	assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
+    oktetoManifestPath := filepath.Join(dir, "okteto.yml")
+    assert.NoError(t, os.WriteFile(oktetoManifestPath, []byte(oktetoManifestWithPassingTest), 0600))
 
-	testNamespace := integration.GetTestNamespace(t.Name())
-	namespaceOpts := &commands.NamespaceOptions{
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-	}
-	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
-	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
+    testNamespace := integration.GetTestNamespace(t.Name())
+    namespaceOpts := &commands.NamespaceOptions{
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+    }
+    require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+    require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, dir))
 
-	testOptions := &commands.TestOptions{
-		Workdir:    dir,
-		Namespace:  testNamespace,
-		OktetoHome: dir,
-		Token:      token,
-		NoCache:    true,
-	}
-	out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
-	require.NoError(t, err)
-	assert.Contains(t, out, "Test container 'unit' passed")
+    testOptions := &commands.TestOptions{
+        Workdir:    dir,
+        Namespace:  testNamespace,
+        OktetoHome: dir,
+        Token:      token,
+        NoCache:    true,
+    }
+    out, err := commands.RunOktetoTestAndGetOutput(oktetoPath, testOptions)
+    require.NoError(t, err)
+    assert.Contains(t, out, "Test container 'unit' passed")
 
-	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+    require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/test/test_test.go
+++ b/integration/test/test_test.go
@@ -17,14 +17,12 @@
 package test
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/okteto/okteto/integration"
 	"github.com/okteto/okteto/integration/commands"
-	"github.com/okteto/okteto/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -94,18 +92,10 @@ test:
 )
 
 var (
-	user  = ""
 	token = ""
 )
 
 func TestMain(m *testing.M) {
-	if u, ok := os.LookupEnv(model.OktetoUserEnvVar); !ok {
-		log.Println("OKTETO_USER is not defined")
-		os.Exit(1)
-	} else {
-		user = u
-	}
-
 	token = integration.GetToken()
 
 	exitCode := m.Run()


### PR DESCRIPTION
# Proposed changes

While I was working on a fix for okteto test, I realize we have integration tests for `okteto test`, but they were not being running in none of the flows we have, so adding them

Added also a test to cover the case of executing a subset of tests
