### PR TITLE
Fix error image tag and hint message

### DIFF
--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -121,7 +121,7 @@ func GetSolveErrorMessage(err error) error {
 var (
 	// regexForImageFromFailedToSolveErr is the regex to extract the image from an error message
 	// buildkit solve errors provide the image name between :
-	regexForImageFromFailedToSolveErr = regexp.MustCompile(`: ([a-zA-Z0-9\.\/_-]+(:[a-zA-Z0-9-]+)?):`)
+	regexForImageFromFailedToSolveErr = regexp.MustCompile(`: ([a-zA-Z0-9\.\/_-]+(:[a-zA-Z0-9.-]+)?):`)
 )
 
 func extractImageFromError(err error) string {

--- a/pkg/build/buildkit/errors_test.go
+++ b/pkg/build/buildkit/errors_test.go
@@ -108,20 +108,20 @@ func Test_GetSolveErrorMessage(t *testing.T) {
 			},
 		},
 		{
-			name: "registry host not found - airgapped with official okteto image",
+			name: "registry host not found - airgapped with official okteto cli image",
 			err:  errors.New("failed to solve: docker.io/okteto/okteto:1.2.4: failed to do request: Head 'https://non-existing.okteto.dev/v2/xxxx/cli/manifests/debug-4': dial tcp: lookup non-existing.okteto.dev on xx.xxxx.x.xx:xx: no such host"),
 			expected: oktetoErrors.UserError{
-				E: fmt.Errorf("the image 'docker.io/okteto/okteto' is not accessible or it does not exist"),
+				E: fmt.Errorf("the image 'docker.io/okteto/okteto:1.2.4' is not accessible or it does not exist"),
 				Hint: `Please verify you have access to Docker Hub.
     If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
     See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/`,
 			},
 		},
 		{
-			name: "registry host not found - airgapped with forked okteto image",
+			name: "registry host not found - airgapped with forked okteto cli image",
 			err:  errors.New("failed to solve: myregistry.com/okteto/okteto:1.2.4: failed to do request: Head 'https://non-existing.okteto.dev/v2/xxxx/cli/manifests/debug-4': dial tcp: lookup non-existing.okteto.dev on xx.xxxx.x.xx:xx: no such host"),
 			expected: oktetoErrors.UserError{
-				E: fmt.Errorf("the image 'myregistry.com/okteto/okteto' is not accessible or it does not exist"),
+				E: fmt.Errorf("the image 'myregistry.com/okteto/okteto:1.2.4' is not accessible or it does not exist"),
 				Hint: `Please verify you have migrated correctly to the current version for remote.
     If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
     See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/`,

--- a/pkg/build/buildkit/errors_test.go
+++ b/pkg/build/buildkit/errors_test.go
@@ -128,6 +128,16 @@ func Test_GetSolveErrorMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "okteto image not found",
+			err:  errors.New("build failed: failed to solve: okteto/pipeline-runner:1.27.0-rc.14: failed to resolve source metadata for docker.io/okteto/pipeline-runner:1.27.0-rc.14: failed to do request: Head \"https://registry-1.docker.io/v2/okteto/pipeline-runner/manifests/1.27.0-rc.14\": dial tcp: lookup registry-1.docker.io on 10.96.0.10:53: no such host"),
+			expected: oktetoErrors.UserError{
+				E: fmt.Errorf("the image 'okteto/pipeline-runner:1.27.0-rc.14' is not accessible or it does not exist"),
+				Hint: `Please verify you have access to Docker Hub.
+    If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
+    See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/`,
+			},
+		},
+		{
 			name: "cmd error",
 			err: CommandErr{
 				Err:    assert.AnError,


### PR DESCRIPTION
# Proposed changes

Follow up for https://github.com/okteto/okteto/pull/4572

When extracting the image from the error, the regex was missing the tag when it had `-` or `.`. This PR solves this bug.

Additionally, i observed that when running `okteto deploy --remote` without a connection to the internet, the image returned by the solve error was randomly* `pipeline-installer` or `okteto`. When the pipeline-runner image was unable to be resolved, the error was not recognized correctly.

The image failing was randomly returning the error, as when running the remote deploy, the dockerfile uses the okteto image and the pipeline image, so these operations to pull the image are parallel and can resolve one after the other or viceversa.

```
❯ ok deploy --remote
 !  Insecure mode enabled
 i  Using okteto-admin @ okteto.localtest.me as context
 x  Error deploying application: the image 'okteto/pipeline-runner:1.27.0-rc.14' is not accessible or it does not exist
    Please verify you have access to Docker Hub.
    If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
    See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/

❯ ok deploy --remote
 !  Insecure mode enabled
 i  Using okteto-admin @ okteto.localtest.me as context
 x  Error deploying application: the image 'docker.io/okteto/okteto:stable' is not accessible or it does not exist
    Please verify you have access to Docker Hub.
    If you are using an airgapped environment, make sure Okteto Remote is correctly configured in airgapped environments:
    See more at: https://www.okteto.com/docs/self-hosted/manage/air-gapped/
```

## How to validate

- build binary
- option A: override okteto image using the deploy manifest field, check the tag is being extracted correctly
- option B: setup a local okteto instance and run okteto deploy --remote without internet connection.

