### PR TITLE
add validation for empty commands in manifest tests

### DIFF
--- a/pkg/model/test.go
+++ b/pkg/model/test.go
@@ -41,6 +41,7 @@ var (
 	ErrHostMalformed   = fmt.Errorf("host is malformed")
 	ErrInvalidHostName = fmt.Errorf("invalid hostname")
 	ErrInvalidIp       = fmt.Errorf("invalid ip")
+	ErrEmptyCommands   = fmt.Errorf("commands cannot be empty")
 )
 
 func (test ManifestTests) Validate() error {
@@ -52,6 +53,9 @@ func (test ManifestTests) Validate() error {
 	for _, t := range test {
 		if t != nil {
 			hasAtLeastOne = true
+			if len(t.Commands) == 0 {
+				return ErrEmptyCommands
+			}
 			break
 		}
 	}

--- a/pkg/model/test_test.go
+++ b/pkg/model/test_test.go
@@ -124,9 +124,9 @@ ip: ${NON_EXISTENT}`),
 
 func TestManifestTestsValidate(t *testing.T) {
 	tests := []struct {
-		name          string
-		manifestTests ManifestTests
 		expectedError error
+		manifestTests ManifestTests
+		name          string
 	}{
 		{
 			name:          "nil manifest tests",

--- a/pkg/model/test_test.go
+++ b/pkg/model/test_test.go
@@ -121,3 +121,53 @@ ip: ${NON_EXISTENT}`),
 		})
 	}
 }
+
+func TestManifestTestsValidate(t *testing.T) {
+	tests := []struct {
+		name          string
+		manifestTests ManifestTests
+		expectedError error
+	}{
+		{
+			name:          "nil manifest tests",
+			manifestTests: nil,
+			expectedError: ErrNoTestsDefined,
+		},
+		{
+			name:          "empty manifest tests",
+			manifestTests: ManifestTests{},
+			expectedError: ErrNoTestsDefined,
+		},
+		{
+			name: "manifest tests with empty commands",
+			manifestTests: ManifestTests{
+				"unit": &Test{
+					Commands: []TestCommand{},
+				},
+			},
+			expectedError: ErrEmptyCommands,
+		},
+		{
+			name: "valid manifest tests",
+			manifestTests: ManifestTests{
+				"unit": &Test{
+					Commands: []TestCommand{
+						{Name: "test", Command: "echo test"},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.manifestTests.Validate()
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-807

Add validation for the manifest for test.
As we want to enforce the field to not be empty, an error is returned.


## How to validate

Create a test manifest and run `okteto test <name>`

For example

```
test:
  unit:
    context: .
```

Output:

```
❯ ok test unit
 i  Using - @ - as context
 x  Commands cannot be empty
```


