### PR TITLE
Add internal flag to buildkit solveOpt

### DIFF
--- a/pkg/build/buildkit/opt.go
+++ b/pkg/build/buildkit/opt.go
@@ -225,6 +225,11 @@ func (b *SolveOptBuilder) Build(ctx context.Context, buildOptions *types.BuildOp
 		Session:       attachable,
 		CacheImports:  []client.CacheOptionsEntry{},
 		CacheExports:  []client.CacheOptionsEntry{},
+		// Setting the internal flag marks the build as internal which prevents the
+		// build from appearing in build history and improves performance.
+		// NOTE: if at some point we want to expose build history through buildkit's
+		// API, we should remove this flag.
+		Internal: env.LoadBoolean("OKTETO_BUILDKIT_INTERNAL_MODE"),
 	}
 
 	if buildOptions.Tag != "" {


### PR DESCRIPTION
I've been searching in docs and general searches and couldn't find much about this flag. This is the ref in code: https://github.com/moby/buildkit/blob/master/api/services/control/control.proto#L74

We should test this before making it the default/GA.

