### PR TITLE
Skip min CLI version check for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ executors:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net
       OKTETO_NAMESPACE_PREFIX: staging
+      OKTETO_SKIP_CLUSTER_CLI_VERSION: true
 
 jobs:
   golangci-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,7 @@ jobs:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net
       OKTETO_NAMESPACE_PREFIX: staging
+      OKTETO_SKIP_CLUSTER_CLI_VERSION: true
     steps:
       - checkout
       - restore_cache:
@@ -346,6 +347,7 @@ jobs:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net
       OKTETO_NAMESPACE_PREFIX: staging
+      OKTETO_SKIP_CLUSTER_CLI_VERSION: true
     steps:
       - checkout
       - restore_cache:
@@ -382,6 +384,7 @@ jobs:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net
       OKTETO_NAMESPACE_PREFIX: staging
+      OKTETO_SKIP_CLUSTER_CLI_VERSION: true
     steps:
       - checkout
       - restore_cache:
@@ -418,6 +421,7 @@ jobs:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net
       OKTETO_NAMESPACE_PREFIX: staging
+      OKTETO_SKIP_CLUSTER_CLI_VERSION: true
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
This change is required to unblock the staging environment and fix our integration tests.

Context: with the introduction of the min version check for the CLI, we introduced a warning that breaks the JSON output of some commands (ie `okteto endpoints --output json`).

As we will be testing dev builds of the CLI, it's ok to keep this env var in the long term.