### PR TITLE
remove security context and fsgroup on initialization

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -214,9 +214,6 @@ func translateStatefulSet(svcName string, s *model.Stack, divert Divert) *appsv1
 		Affinity:                      translateAffinity(svc),
 		NodeSelector:                  svc.NodeSelector,
 		Volumes:                       translateVolumes(svc),
-		SecurityContext: &apiv1.PodSecurityContext{
-			FSGroup: pointer.Int64(1000),
-		},
 		Containers: []apiv1.Container{
 			{
 				Name:            svcName,
@@ -346,10 +343,6 @@ func getAddPermissionsInitContainer(svcName string, svc *model.Service) apiv1.Co
 		ImagePullPolicy: apiv1.PullIfNotPresent,
 		Command:         initContainerCommand,
 		VolumeMounts:    initContainerVolumeMounts,
-		SecurityContext: &apiv1.SecurityContext{
-			RunAsUser:  pointer.Int64(0),
-			RunAsGroup: pointer.Int64(0),
-		},
 	}
 	return initContainer
 }

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -261,10 +261,6 @@ func Test_translateStatefulSet(t *testing.T) {
 		"node2": "value2",
 	}
 	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
-	podSecurityContext := &apiv1.PodSecurityContext{
-		FSGroup: pointer.Int64(1000),
-	}
-	assert.Equal(t, result.Spec.Template.Spec.SecurityContext, podSecurityContext)
 	if *result.Spec.Replicas != 3 {
 		t.Errorf("Wrong statefulset spec.replicas: '%d'", *result.Spec.Replicas)
 	}
@@ -292,10 +288,6 @@ func Test_translateStatefulSet(t *testing.T) {
 				MountPath: "/data",
 				Name:      pvcName,
 			},
-		},
-		SecurityContext: &apiv1.SecurityContext{
-			RunAsUser:  pointer.Int64(0),
-			RunAsGroup: pointer.Int64(0),
 		},
 	}
 	assert.Equal(t, initContainer, result.Spec.Template.Spec.InitContainers[0])
@@ -652,10 +644,6 @@ func Test_translateJobWithVolumes(t *testing.T) {
 				MountPath: "/data",
 				Name:      pvcName,
 			},
-		},
-		SecurityContext: &apiv1.SecurityContext{
-			RunAsUser:  pointer.Int64(0),
-			RunAsGroup: pointer.Int64(0),
 		},
 	}
 	if !reflect.DeepEqual(result.Spec.Template.Spec.InitContainers[0], initContainer) {


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes an issue where certain images couldn't start (`rabbitmq:3.13.0-management`) because there is a check that make usre the user is the same as the first one.

## How to validate

1. Deploy the following compose file:
```yaml
services:
  queue:
    image: rabbitmq:3.13.0-management
    ports:
      - 5672
      - 15672
    volumes:
      - /var/lib/rabbitmq
    healthcheck:
      interval: 10s
      timeout: 1m
      retries: 5
      start_period: 3s
      test: rabbitmq-diagnostics -q ping%    
```
2. Run okteto destroy
3. Run okteto deploy
4. See that the queue service can start

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
