### PR TITLE
optimise builds during okteto up

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters-settings:
   goheader:
     values:
       regexp:
-        YEAR: 2023|2024
+        YEAR: 2023|2024|2025
     template-path: .copyright-header.tmpl
   mnd:
     checks:

--- a/cmd/up/build.go
+++ b/cmd/up/build.go
@@ -1,0 +1,119 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"context"
+	"errors"
+
+	buildv2 "github.com/okteto/okteto/cmd/build/v2"
+	"github.com/okteto/okteto/pkg/build"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/types"
+)
+
+type upBuilder struct {
+	builder  builderInterface
+	registry registryInterface
+	manifest *model.Manifest
+	devName  string
+}
+
+func newUpBuilder(m *model.Manifest, devName string, builder builderInterface, reg registryInterface) *upBuilder {
+	return &upBuilder{
+		builder:  builder,
+		manifest: m,
+		devName:  devName,
+		registry: reg,
+	}
+}
+
+func (ub *upBuilder) build(ctx context.Context) error {
+	// check if the dev image uses the same image as the original service
+	if ub.manifest.Dev[ub.devName].Image == "" {
+		return nil
+	}
+
+	// check if the dev image has a OKTETO_BUILD syntax
+	buildSvc, err := ub.builder.GetSvcToBuildFromRegex(ub.manifest, ub.getBuildSvcFromDev)
+	if err != nil && !errors.Is(err, buildv2.ErrImageIsNotAOktetoBuildSyntax) {
+		return err
+	}
+
+	// check if the dev image is present on the build section
+	if buildSvc == "" {
+		devImage := ub.manifest.Dev[ub.devName].Image
+		buildSvc = ub.getBuildServiceFromImage(devImage)
+		// it's not present on the build section, we don't need to build anything
+		if buildSvc == "" {
+			return nil
+		}
+	}
+
+	// get all the services that need to be built
+	visited := make(map[string]bool)
+	dependentSvcs := ub.getDependentServices(buildSvc, ub.manifest.Build, visited)
+
+	toBuildCheck := []string{buildSvc}
+	toBuildCheck = append(toBuildCheck, dependentSvcs...)
+
+	// check if the services are already built
+	svcsToBuild, err := ub.builder.GetServicesToBuildDuringExecution(ctx, ub.manifest, toBuildCheck)
+	if err != nil {
+		return err
+	}
+	if len(svcsToBuild) == 0 {
+		return nil
+	}
+	buildOptions := &types.BuildOptions{
+		CommandArgs: svcsToBuild,
+		Manifest:    ub.manifest,
+	}
+	return ub.builder.Build(ctx, buildOptions)
+}
+
+func (ub *upBuilder) getBuildSvcFromDev(manifest *model.Manifest) string {
+	dev := ub.manifest.Dev[ub.devName]
+	if dev == nil {
+		return ""
+	}
+	return dev.Image
+}
+
+func (ub *upBuilder) getBuildServiceFromImage(image string) string {
+	for svc, info := range ub.manifest.Build {
+		if ub.registry.ExpandImage(info.Image) == ub.registry.ExpandImage(image) {
+			return svc
+		}
+	}
+	return ""
+}
+
+func (ub *upBuilder) getDependentServices(buildSvc string, bm build.ManifestBuild, visited map[string]bool) []string {
+	// If the key has been visited, we return an empty list
+	if visited[buildSvc] {
+		return nil
+	}
+	visited[buildSvc] = true
+
+	var result []string
+	for _, dep := range bm[buildSvc].DependsOn {
+		result = append(result, dep)
+
+		subDeps := ub.getDependentServices(dep, bm, visited)
+		result = append(result, subDeps...)
+	}
+
+	return result
+}

--- a/cmd/up/build_test.go
+++ b/cmd/up/build_test.go
@@ -3,7 +3,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,11 +41,11 @@ func TestUpBuilder_Build(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
+		expectError error
 		manifest    *model.Manifest
 		builder     *fakeBuilder
 		name        string
 		devName     string
-		expectError error
 	}{
 		{
 			name: "DevImageIsEmpty_returnsNil",

--- a/cmd/up/build_test.go
+++ b/cmd/up/build_test.go
@@ -41,10 +41,10 @@ func TestUpBuilder_Build(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name        string
 		manifest    *model.Manifest
-		devName     string
 		builder     *fakeBuilder
+		name        string
+		devName     string
 		expectError error
 	}{
 		{

--- a/cmd/up/build_test.go
+++ b/cmd/up/build_test.go
@@ -1,0 +1,322 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	buildv2 "github.com/okteto/okteto/cmd/build/v2"
+	"github.com/okteto/okteto/pkg/build"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRegistry struct{}
+
+func (fb fakeRegistry) GetImageTagWithDigest(imageTag string) (string, error) {
+	return "", nil
+}
+func (fb fakeRegistry) GetImageTag(image, service, namespace string) string {
+	return ""
+}
+func (fb fakeRegistry) ExpandImage(image string) string {
+	return strings.Replace(image, "okteto.dev", "okteto.registry/ns", 1)
+}
+
+func TestUpBuilder_Build(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		manifest    *model.Manifest
+		devName     string
+		builder     *fakeBuilder
+		expectError error
+	}{
+		{
+			name: "DevImageIsEmpty_returnsNil",
+			manifest: &model.Manifest{
+				Dev: map[string]*model.Dev{
+					"my-dev": {Image: ""},
+				},
+			},
+			devName:     "my-dev",
+			builder:     &fakeBuilder{},
+			expectError: nil,
+		},
+		{
+			name: "GetSvcToBuildFromRegexError_returnsError",
+			manifest: &model.Manifest{
+				Dev: map[string]*model.Dev{
+					"my-dev": {Image: "$OKTETO_BUILD_NONEXISTENT_IMAGE"},
+				},
+			},
+			devName: "my-dev",
+			builder: &fakeBuilder{
+				getSvcFromRegexErr: assert.AnError,
+			},
+			expectError: assert.AnError,
+		},
+		{
+			name:    "GetSvcToBuildFromRegexErrorIsNotOktetoBuildSyntaxAndNotFound_returnsNil",
+			devName: "my-dev",
+			manifest: &model.Manifest{
+				Dev: map[string]*model.Dev{
+					"my-dev": {Image: "my-image"},
+				},
+			},
+			builder: &fakeBuilder{
+				getSvcFromRegexErr: buildv2.ErrImageIsNotAOktetoBuildSyntax,
+			},
+			expectError: nil,
+		},
+		{
+			name:    "Error while checking if images are built",
+			devName: "my-dev",
+			manifest: &model.Manifest{
+				Build: build.ManifestBuild{
+					"my-dev": {Image: "my-image"},
+				},
+				Dev: map[string]*model.Dev{
+					"my-dev": {Image: "my-image"},
+				},
+			},
+			builder: &fakeBuilder{
+				getSvcFromRegexErr: buildv2.ErrImageIsNotAOktetoBuildSyntax,
+				getServicesErr:     assert.AnError,
+			},
+			expectError: assert.AnError,
+		},
+		{
+			name:    "Nothing to build",
+			devName: "my-dev",
+			manifest: &model.Manifest{
+				Build: build.ManifestBuild{
+					"my-dev": {Image: "my-image"},
+				},
+				Dev: map[string]*model.Dev{
+					"my-dev": {Image: "my-image"},
+				},
+			},
+			builder: &fakeBuilder{
+				getSvcFromRegexErr: buildv2.ErrImageIsNotAOktetoBuildSyntax,
+			},
+			expectError: nil,
+		},
+		{
+			name:    "Build",
+			devName: "my-dev",
+			manifest: &model.Manifest{
+				Build: build.ManifestBuild{
+					"my-dev": {Image: "my-image"},
+				},
+				Dev: map[string]*model.Dev{
+					"my-dev": {Image: "my-image"},
+				},
+			},
+			builder: &fakeBuilder{
+				getSvcFromRegexErr: buildv2.ErrImageIsNotAOktetoBuildSyntax,
+				services:           []string{"my-dev"},
+			},
+			expectError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ub := &upBuilder{
+				manifest: tt.manifest,
+				devName:  tt.devName,
+				builder:  tt.builder,
+				registry: &fakeRegistry{},
+			}
+			err := ub.build(ctx)
+			require.ErrorIs(t, err, tt.expectError)
+		})
+	}
+}
+
+func TestGetBuildServiceFromImage(t *testing.T) {
+	tests := []struct {
+		name        string
+		image       string
+		manifest    *model.Manifest
+		wantService string
+	}{
+		{
+			name:  "Exact match found",
+			image: "okteto.dev/imageA:tag",
+			manifest: &model.Manifest{
+				Build: build.ManifestBuild{
+					"svcA": {Image: "okteto.registry/ns/imageA:tag"},
+					"svcB": {Image: "registry.com/repo/imageB:tag"},
+				},
+			},
+			wantService: "svcA",
+		},
+		{
+			name:  "Normalized image match found (okteto.dev in dev)",
+			image: "okteto.registry/ns/imageA:latest",
+			manifest: &model.Manifest{
+				Build: build.ManifestBuild{
+					"svcA": {Image: "okteto.dev/imageA:latest"},
+					"svcB": {Image: "registry.com/repo/imageB:latest"},
+				},
+			},
+			wantService: "svcA",
+		},
+		{
+			name:  "Normalized image match found (okteto.dev in build)",
+			image: "okteto.registry/ns/imageA:latest",
+			manifest: &model.Manifest{
+				Build: build.ManifestBuild{
+					"svcA": {Image: "okteto.dev/imageA:latest"},
+					"svcB": {Image: "registry.com/repo/imageB:latest"},
+				},
+			},
+			wantService: "svcA",
+		},
+		{
+			name:  "No match found",
+			image: "registry.com/repo/imageC:tag",
+			manifest: &model.Manifest{
+				Build: build.ManifestBuild{
+					"svcA": {Image: "registry.com/repo/imageA:tag"},
+					"svcB": {Image: "registry.com/repo/imageB:tag"},
+				},
+			},
+			wantService: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ub := &upBuilder{
+				manifest: tt.manifest,
+				registry: &fakeRegistry{},
+			}
+
+			gotService := ub.getBuildServiceFromImage(tt.image)
+			assert.Equal(t, tt.wantService, gotService)
+		})
+	}
+}
+
+func TestGetBuildSvcFromDev(t *testing.T) {
+	tests := []struct {
+		name       string
+		manifest   *model.Manifest
+		devName    string
+		ubManifest *model.Manifest
+		wantImage  string
+	}{
+		{
+			name: "Dev service exists with image",
+			manifest: &model.Manifest{
+				Dev: model.ManifestDevs{
+					"serviceA": {Image: "registry.com/repo/imageA:tag"},
+				},
+			},
+			devName:   "serviceA",
+			wantImage: "registry.com/repo/imageA:tag",
+		},
+		{
+			name: "Dev service does not exist",
+			manifest: &model.Manifest{
+				Dev: model.ManifestDevs{
+					"serviceA": {Image: "registry.com/repo/imageA:tag"},
+				},
+			},
+			devName:   "serviceB",
+			wantImage: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ub := &upBuilder{
+				manifest: tt.manifest,
+				devName:  tt.devName,
+			}
+
+			gotImage := ub.getBuildSvcFromDev(tt.manifest)
+			assert.Equal(t, tt.wantImage, gotImage)
+		})
+	}
+}
+
+func TestGetDependentServices(t *testing.T) {
+	tests := []struct {
+		name       string
+		buildSvc   string
+		bm         build.ManifestBuild
+		visited    map[string]bool
+		wantResult []string
+	}{
+		{
+			name:     "No dependencies",
+			buildSvc: "svcA",
+			bm: build.ManifestBuild{
+				"svcA": {DependsOn: []string{}},
+			},
+			visited:    map[string]bool{},
+			wantResult: nil,
+		},
+		{
+			name:     "Single level dependencies",
+			buildSvc: "svcA",
+			bm: build.ManifestBuild{
+				"svcA": {DependsOn: []string{"svcB", "svcC"}},
+				"svcB": {DependsOn: []string{}},
+				"svcC": {DependsOn: []string{}},
+			},
+			visited:    map[string]bool{},
+			wantResult: []string{"svcB", "svcC"},
+		},
+		{
+			name:     "Nested dependencies",
+			buildSvc: "svcA",
+			bm: build.ManifestBuild{
+				"svcA": {DependsOn: []string{"svcB"}},
+				"svcB": {DependsOn: []string{"svcC"}},
+				"svcC": {DependsOn: []string{}},
+			},
+			visited:    map[string]bool{},
+			wantResult: []string{"svcB", "svcC"},
+		},
+		{
+			name:     "Already visited service",
+			buildSvc: "svcA",
+			bm: build.ManifestBuild{
+				"svcA": {DependsOn: []string{"svcB"}},
+				"svcB": {DependsOn: []string{"svcC"}},
+				"svcC": {DependsOn: []string{}},
+			},
+			visited:    map[string]bool{"svcA": true},
+			wantResult: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ub := &upBuilder{}
+			gotResult := ub.getDependentServices(tt.buildSvc, tt.bm, tt.visited)
+			assert.Equal(t, tt.wantResult, gotResult)
+		})
+	}
+}

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -33,11 +33,13 @@ import (
 type registryInterface interface {
 	GetImageTagWithDigest(imageTag string) (string, error)
 	GetImageTag(image, service, namespace string) string
+	ExpandImage(image string) string
 }
 
 type builderInterface interface {
 	GetServicesToBuildDuringExecution(ctx context.Context, manifest *model.Manifest, svcToDeploy []string) ([]string, error)
 	Build(ctx context.Context, options *types.BuildOptions) error
+	GetSvcToBuildFromRegex(manifest *model.Manifest, imgFinder model.ImageFromManifest) (string, error)
 	GetBuildEnvVars() map[string]string
 }
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -306,7 +306,7 @@ okteto up api -- echo this is a test
 			}
 
 			// build images and set env vars for the services at the manifest
-			if err := buildServicesAndSetBuildEnvs(ctx, oktetoManifest, up.builder); err != nil {
+			if err := newUpBuilder(oktetoManifest, argsparserResult.DevName, up.builder, up.Registry).build(ctx); err != nil {
 				return err
 			}
 
@@ -883,22 +883,6 @@ func printDisplayContext(up *upContext) {
 	}
 
 	oktetoLog.Println()
-}
-
-// buildServicesAndSetBuildEnvs get services to build and run build to set build envs
-func buildServicesAndSetBuildEnvs(ctx context.Context, m *model.Manifest, builder builderInterface) error {
-	svcsToBuild, err := builder.GetServicesToBuildDuringExecution(ctx, m, []string{})
-	if err != nil {
-		return err
-	}
-	if len(svcsToBuild) == 0 {
-		return nil
-	}
-	buildOptions := &types.BuildOptions{
-		CommandArgs: svcsToBuild,
-		Manifest:    m,
-	}
-	return builder.Build(ctx, buildOptions)
 }
 
 // wakeNamespaceIfApplies wakes the namespace if it is sleeping

--- a/pkg/build/manifest_section.go
+++ b/pkg/build/manifest_section.go
@@ -39,6 +39,21 @@ func (b *ManifestBuild) Validate() error {
 		svcsDependents := fmt.Sprintf("%s and %s", strings.Join(cycle[:len(cycle)-1], ", "), cycle[len(cycle)-1])
 		return fmt.Errorf("manifest validation failed: cyclic dependendecy found between %s", svcsDependents)
 	}
+
+	imageNames := map[string]bool{}
+	repeatedImageNames := []string{}
+	for _, v := range *b {
+		if v.Image == "" {
+			continue
+		}
+		if _, ok := imageNames[v.Image]; ok {
+			repeatedImageNames = append(repeatedImageNames, v.Image)
+		}
+		imageNames[v.Image] = true
+	}
+	if len(repeatedImageNames) > 0 {
+		oktetoLog.Warning("The following images are repeated in the build section: [%s]", strings.Join(repeatedImageNames, ", "))
+	}
 	return nil
 }
 

--- a/pkg/build/manifest_section_test.go
+++ b/pkg/build/manifest_section_test.go
@@ -25,8 +25,8 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		input        *ManifestBuild
 		name         string
-		expectErr    bool
 		expectedWarn string
+		expectErr    bool
 	}{
 		{
 			name: "nil manifest info",

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -207,3 +207,8 @@ func (or OktetoRegistry) Clone(from, to string) (string, error) {
 	}
 	return r, nil
 }
+
+// ExpandImage expands the image to include the registry
+func (or OktetoRegistry) ExpandImage(image string) string {
+	return or.imageCtrl.expandImageRegistries(image)
+}


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-835

This PR checks that only the images that will be used in the okteot up stage are the ones being built. If the images are already built or there is no image from the build skip it.

## How to validate

1. Create the following files:
```yaml
# okteto-deploy.yaml
build:
  this:
    context: .

deploy:
  - echo hello world
```

```yaml
# okteto-dev.yaml
build:
  svc1:
    context: .
    depends_on: svc2
  svc2:
    context: .
  svc3:
    context: .
    image: okteto.dev/image:dev
dev:
  dev1:
    image: alpine
    command: sh
    autocreate: true
  dev2:
    image: $OKTETO_BUILD_SVC1_IMAGE
    command: sh
    autocreate: true
  dev3:
    image: okteto.dev/image:dev
    command: sh
    autocreate: true
  dev4:
    image: registry.product.okteto.dev/jlo-test/image:dev
    command: sh
    autocreate: true
  dev5:
    command: sh
    autocreate: true
```

```Dockerfile
FROM alpine
RUN echo hello world
```
2. Run `okteto deploy -f okteto-deploy.yaml`
3. Run `okteto up -f okteto-dev.yaml` for every dev and check that it starts to build

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
