### PR TITLE
Resolve platform env for test in remote-run

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -102,7 +102,6 @@ type getDeployerFunc func(
 	*io.Controller,
 	*io.K8sLogger,
 	dependencyEnvVarsGetter,
-	executionEnvVarsGetter,
 ) (Deployer, error)
 
 type cleanUpFunc func(context.Context, error)
@@ -513,7 +512,6 @@ func (dc *Command) deploy(ctx context.Context, deployOptions *Options, cwd strin
 		dc.IoCtrl,
 		dc.K8sLogger,
 		GetDependencyEnvVars,
-		deployable.GetPlatformEnvironment,
 	)
 	if err != nil {
 		return err
@@ -631,11 +629,10 @@ func GetDeployer(ctx context.Context,
 	ioCtrl *io.Controller,
 	k8Logger *io.K8sLogger,
 	dependencyEnvVarsGetter dependencyEnvVarsGetter,
-	executionEnvVarGetter executionEnvVarsGetter,
 ) (Deployer, error) {
 	if ShouldRunInRemote(opts) {
 		oktetoLog.Info("Deploying remotely...")
-		return newRemoteDeployer(buildEnvVarsGetter, ioCtrl, dependencyEnvVarsGetter, executionEnvVarGetter), nil
+		return newRemoteDeployer(buildEnvVarsGetter, ioCtrl, dependencyEnvVarsGetter), nil
 	}
 
 	var execDir string

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -236,7 +236,6 @@ func (f *fakeDeployer) Get(ctx context.Context,
 	ioCtrl *io.Controller,
 	k8Logger *io.K8sLogger,
 	dependencyEnvVarsGetter dependencyEnvVarsGetter,
-	executionEnvVarGetter executionEnvVarsGetter,
 ) (Deployer, error) {
 	args := f.Called(ctx, opts, buildEnvVarsGetter, cmapHandler, k8sProvider, ioCtrl, k8Logger, dependencyEnvVarsGetter)
 	return args.Get(0).(Deployer), args.Error(1)

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -54,8 +54,6 @@ type buildEnvVarsGetter func() map[string]string
 
 type dependencyEnvVarsGetter func(environGetter environGetter) map[string]string
 
-type executionEnvVarsGetter func(ctx context.Context) map[string]string
-
 type remoteDeployer struct {
 	getBuildEnvVars buildEnvVarsGetter
 	runner          remoteRunner
@@ -64,12 +62,11 @@ type remoteDeployer struct {
 	ioCtrl *io.Controller
 
 	getDependencyEnvVars dependencyEnvVarsGetter
-	getExecutionEnvVars  executionEnvVarsGetter
 	workdirCtrl          filesystem.WorkingDirectoryInterface
 }
 
 // newRemoteDeployer creates the remote deployer
-func newRemoteDeployer(buildVarsGetter buildEnvVarsGetter, ioCtrl *io.Controller, getDependencyEnvVars dependencyEnvVarsGetter, executionEnvVarGetter executionEnvVarsGetter) *remoteDeployer {
+func newRemoteDeployer(buildVarsGetter buildEnvVarsGetter, ioCtrl *io.Controller, getDependencyEnvVars dependencyEnvVarsGetter) *remoteDeployer {
 	fs := afero.NewOsFs()
 	builder := buildCmd.NewOktetoBuilder(
 		&okteto.ContextStateless{
@@ -84,7 +81,6 @@ func newRemoteDeployer(buildVarsGetter buildEnvVarsGetter, ioCtrl *io.Controller
 		runner:               runner,
 		ioCtrl:               ioCtrl,
 		getDependencyEnvVars: getDependencyEnvVars,
-		getExecutionEnvVars:  executionEnvVarGetter,
 		workdirCtrl:          filesystem.NewOsWorkingDirectoryCtrl(),
 	}
 }
@@ -143,7 +139,6 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		OktetoCommandSpecificEnvVars: map[string]string{
 			constants.OktetoIsPreviewEnvVar: os.Getenv(constants.OktetoIsPreviewEnvVar),
 		},
-		ExecutionEnvVars:            rd.getExecutionEnvVars(ctx),
 		DockerfileName:              dockerfileTemporalName,
 		Deployable:                  dep,
 		Manifest:                    deployOptions.Manifest,

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -166,8 +166,7 @@ func TestGetCommandFlags(t *testing.T) {
 func Test_newRemoteDeployer(t *testing.T) {
 	getBuildEnvVars := func() map[string]string { return nil }
 	getDependencyEnvVars := func(_ environGetter) map[string]string { return nil }
-	getExecutionEvVars := func(_ context.Context) map[string]string { return make(map[string]string) }
-	got := newRemoteDeployer(getBuildEnvVars, io.NewIOController(), getDependencyEnvVars, getExecutionEvVars)
+	got := newRemoteDeployer(getBuildEnvVars, io.NewIOController(), getDependencyEnvVars)
 	require.IsType(t, &remoteDeployer{}, got)
 	require.NotNil(t, got.getBuildEnvVars)
 }
@@ -203,7 +202,6 @@ func TestDeployRemoteWithCtx(t *testing.T) {
 		CommandFlags:        []string{"--name \"test\""},
 		BuildEnvVars:        map[string]string{"BUILD_VAR_1": "value"},
 		DependenciesEnvVars: map[string]string{"DEP_VAR_1": "value"},
-		ExecutionEnvVars:    map[string]string{"PLAT_VAR_1": "value"},
 		DockerfileName:      dockerfileTemporalName,
 		Deployable: deployable.Entity{
 			Divert:   manifest.Deploy.Divert,
@@ -228,9 +226,6 @@ func TestDeployRemoteWithCtx(t *testing.T) {
 		},
 		getDependencyEnvVars: func(environGetter) map[string]string {
 			return map[string]string{"DEP_VAR_1": "value"}
-		},
-		getExecutionEnvVars: func(ctx context.Context) map[string]string {
-			return map[string]string{"PLAT_VAR_1": "value"}
 		},
 	}
 	opts := &Options{
@@ -272,7 +267,6 @@ func TestDeployRemote(t *testing.T) {
 		CommandFlags:        []string{"--name \"test\""},
 		BuildEnvVars:        map[string]string{"BUILD_VAR_1": "value"},
 		DependenciesEnvVars: map[string]string{"DEP_VAR_1": "value"},
-		ExecutionEnvVars:    map[string]string{"PLAT_VAR_1": "value"},
 		DockerfileName:      dockerfileTemporalName,
 		Deployable: deployable.Entity{
 			Divert:   manifest.Deploy.Divert,
@@ -297,9 +291,6 @@ func TestDeployRemote(t *testing.T) {
 		},
 		getDependencyEnvVars: func(environGetter) map[string]string {
 			return map[string]string{"DEP_VAR_1": "value"}
-		},
-		getExecutionEnvVars: func(ctx context.Context) map[string]string {
-			return map[string]string{"PLAT_VAR_1": "value"}
 		},
 	}
 	opts := &Options{
@@ -342,7 +333,6 @@ func TestDeployRemoteWithError(t *testing.T) {
 		CommandFlags:        []string{"--name \"test\""},
 		BuildEnvVars:        map[string]string{"BUILD_VAR_1": "value"},
 		DependenciesEnvVars: map[string]string{"DEP_VAR_1": "value"},
-		ExecutionEnvVars:    map[string]string{"PLAT_VAR_1": "value"},
 		DockerfileName:      dockerfileTemporalName,
 		Deployable: deployable.Entity{
 			Divert:   manifest.Deploy.Divert,
@@ -403,9 +393,6 @@ func TestDeployRemoteWithError(t *testing.T) {
 				},
 				getDependencyEnvVars: func(environGetter) map[string]string {
 					return map[string]string{"DEP_VAR_1": "value"}
-				},
-				getExecutionEnvVars: func(_ context.Context) map[string]string {
-					return map[string]string{"PLAT_VAR_1": "value"}
 				},
 			}
 			opts := &Options{

--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -26,7 +26,7 @@ import (
 )
 
 type runner interface {
-	RunDestroy(params deployable.DestroyParameters) error
+	RunDestroy(ctx context.Context, params deployable.DestroyParameters) error
 	CleanUp(err error)
 }
 
@@ -67,7 +67,7 @@ func (ld *localDestroyCommand) Destroy(ctx context.Context, opts *Options) error
 			},
 			Variables: vars,
 		}
-		if err := ld.runner.RunDestroy(params); err != nil {
+		if err := ld.runner.RunDestroy(ctx, params); err != nil {
 			exit <- err
 			return
 		}

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -139,7 +139,6 @@ func (rd *remoteDestroyCommand) Destroy(ctx context.Context, opts *Options) erro
 		TemplateName:     templateName,
 		CommandFlags:     commandFlags,
 		BuildEnvVars:     make(map[string]string),
-		ExecutionEnvVars: deployable.GetPlatformEnvironment(ctx),
 		OktetoCommandSpecificEnvVars: map[string]string{
 			constants.OktetoIsPreviewEnvVar: os.Getenv(constants.OktetoIsPreviewEnvVar),
 		},

--- a/cmd/remoterun/destroy.go
+++ b/cmd/remoterun/destroy.go
@@ -35,7 +35,7 @@ import (
 
 // destroyRunner interface with the operations needed to execute the destroy operations
 type destroyRunner interface {
-	RunDestroy(params deployable.DestroyParameters) error
+	RunDestroy(ctx context.Context, params deployable.DestroyParameters) error
 }
 
 // DestroyOptions flags accepted by the remote-run destroy command
@@ -144,7 +144,7 @@ It is important that this command does the minimum and must not do calculations 
 				oktetoLog.Info(message)
 			}
 
-			return c.Run(params)
+			return c.Run(ctx, params)
 		},
 	}
 
@@ -154,7 +154,7 @@ It is important that this command does the minimum and must not do calculations 
 	return cmd
 }
 
-func (c *DestroyCommand) Run(params deployable.DestroyParameters) error {
+func (c *DestroyCommand) Run(ctx context.Context, params deployable.DestroyParameters) error {
 	// Token should be always masked from the logs
 	oktetoLog.AddMaskedWord(okteto.GetContext().Token)
 	keyValueVarParts := 2
@@ -166,7 +166,7 @@ func (c *DestroyCommand) Run(params deployable.DestroyParameters) error {
 		}
 	}
 
-	return c.runner.RunDestroy(params)
+	return c.runner.RunDestroy(ctx, params)
 }
 
 func getTempKubeConfigFile(operation string, name string) string {

--- a/cmd/remoterun/destroy_test.go
+++ b/cmd/remoterun/destroy_test.go
@@ -14,6 +14,7 @@
 package remoterun
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -27,7 +28,7 @@ type fakeDestroyRunner struct {
 	mock.Mock
 }
 
-func (f *fakeDestroyRunner) RunDestroy(params deployable.DestroyParameters) error {
+func (f *fakeDestroyRunner) RunDestroy(ctx context.Context, params deployable.DestroyParameters) error {
 	args := f.Called(params)
 	return args.Error(0)
 }
@@ -71,7 +72,7 @@ func TestRun_DestroyCommand(t *testing.T) {
 			command := &DestroyCommand{
 				runner: runner,
 			}
-			err := command.Run(tt.params)
+			err := command.Run(context.Background(), tt.params)
 
 			require.Equal(t, err, tt.expected)
 			runner.AssertExpectations(t)

--- a/cmd/remoterun/test.go
+++ b/cmd/remoterun/test.go
@@ -140,7 +140,7 @@ commands:
 				oktetoLog.Info(message)
 			}
 
-			return runner.RunTest(params)
+			return runner.RunTest(context.Background(), params)
 		},
 	}
 

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -349,7 +349,6 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			CommandFlags:        commandFlags,
 			BuildEnvVars:        builder.GetBuildEnvVars(),
 			DependenciesEnvVars: deployCMD.GetDependencyEnvVars(os.Environ),
-			ExecutionEnvVars:    deployable.GetPlatformEnvironment(ctx),
 			DockerfileName:      "Dockerfile.test",
 			OktetoCommandSpecificEnvVars: map[string]string{
 				constants.OktetoIsPreviewEnvVar: os.Getenv(constants.OktetoIsPreviewEnvVar),

--- a/pkg/deployable/destroy.go
+++ b/pkg/deployable/destroy.go
@@ -14,6 +14,7 @@
 package deployable
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/okteto/okteto/cmd/utils/executor"
@@ -39,9 +40,14 @@ type DestroyParameters struct {
 }
 
 // RunDestroy executes the custom commands received as part of DestroyParameters
-func (dr *DestroyRunner) RunDestroy(params DestroyParameters) error {
+func (dr *DestroyRunner) RunDestroy(ctx context.Context, params DestroyParameters) error {
 	var commandErr error
 	lastCommandName := ""
+
+	for k, v := range GetPlatformEnvironment(ctx) {
+		params.Variables = append(params.Variables, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	for _, command := range params.Deployable.Commands {
 		oktetoLog.Information("Running '%s'", command.Name)
 		lastCommandName = command.Name

--- a/pkg/deployable/destroy_test.go
+++ b/pkg/deployable/destroy_test.go
@@ -14,6 +14,7 @@
 package deployable
 
 import (
+	"context"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -63,7 +64,7 @@ func TestRunDestroyWithError(t *testing.T) {
 		},
 	}
 
-	err := runner.RunDestroy(params)
+	err := runner.RunDestroy(context.Background(), params)
 
 	expectedExecutedCommands := []model.DeployCommand{
 		{
@@ -99,7 +100,7 @@ func TestRunDestroyWithErrorAndForceDestroy(t *testing.T) {
 		ForceDestroy: true,
 	}
 
-	err := runner.RunDestroy(params)
+	err := runner.RunDestroy(context.Background(), params)
 
 	expectedExecutedCommands := []model.DeployCommand{
 		{
@@ -137,7 +138,7 @@ func TestRunDestroyWithoutError(t *testing.T) {
 		ForceDestroy: true,
 	}
 
-	err := runner.RunDestroy(params)
+	err := runner.RunDestroy(context.Background(), params)
 
 	expectedExecutedCommands := []model.DeployCommand{
 		{

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -14,6 +14,9 @@
 package deployable
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/okteto/okteto/cmd/utils/executor"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/spf13/afero"
@@ -36,12 +39,16 @@ type TestParameters struct {
 }
 
 // RunTest executes the custom commands received as part of TestParameters
-func (dr *TestRunner) RunTest(params TestParameters) error {
+func (dr *TestRunner) RunTest(ctx context.Context, params TestParameters) error {
 	oktetoLog.SetStage(params.Name)
 
 	oktetoEnvFile, unlinkEnv, err := createTempOktetoEnvFile(dr.Fs)
 	if err != nil {
 		return err
+	}
+
+	for k, v := range GetPlatformEnvironment(ctx) {
+		params.Variables = append(params.Variables, fmt.Sprintf("%s=%s", k, v))
 	}
 
 	envStepper := NewEnvStepper(oktetoEnvFile.Name())

--- a/pkg/deployable/test_test.go
+++ b/pkg/deployable/test_test.go
@@ -14,6 +14,7 @@
 package deployable
 
 import (
+	"context"
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
@@ -39,7 +40,7 @@ func TestTestRunner(t *testing.T) {
 	}
 	executor.On("Execute", cmd1, expectedVars).Return(nil).Once()
 
-	err := runner.RunTest(TestParameters{
+	err := runner.RunTest(context.Background(), TestParameters{
 		Name:      "test",
 		Namespace: "ns",
 		Deployable: Entity{

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -99,10 +99,6 @@ ARG {{ .InvalidateCacheArgName }}
 RUN echo "${{ .InvalidateCacheArgName }}" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
-{{ range $key, $val := .OktetoExecutionEnvVars}}
-ENV {{$key}}={{$val}}
-{{ end }}
-
 RUN \
   {{range $key, $path := .Caches }}--mount=type=cache,target={{$path}},sharing=private {{end}}\
   --mount=type=secret,id=known_hosts \
@@ -156,7 +152,6 @@ type Params struct {
 	BuildEnvVars                 map[string]string
 	DependenciesEnvVars          map[string]string
 	OktetoCommandSpecificEnvVars map[string]string
-	ExecutionEnvVars             map[string]string
 	Manifest                     *model.Manifest
 	Command                      string
 	// CacheInvalidationKey is the value use to invalidate the cache. Defaults
@@ -201,7 +196,6 @@ type dockerfileTemplateProperties struct {
 	OktetoDependencyEnvVars      map[string]string
 	OktetoPrefixEnvVars          map[string]string
 	OktetoCommandSpecificEnvVars map[string]string
-	OktetoExecutionEnvVars       map[string]string
 	ContextArgName               string
 	NamespaceArgName             string
 	TokenArgName                 string
@@ -423,7 +417,6 @@ func (r *Runner) createDockerfile(tmpDir string, params *Params) (string, error)
 		OktetoDependencyEnvVars:      params.DependenciesEnvVars,
 		OktetoPrefixEnvVars:          getOktetoPrefixEnvVars(r.getEnviron()),
 		OktetoCommandSpecificEnvVars: params.OktetoCommandSpecificEnvVars,
-		OktetoExecutionEnvVars:       params.ExecutionEnvVars,
 		Command:                      params.Command,
 		Caches:                       params.Caches,
 		Artifacts:                    params.Artifacts,
@@ -605,9 +598,6 @@ func (dfP *dockerfileTemplateProperties) prepareEnvVars() {
 	}
 	for k, v := range dfP.OktetoPrefixEnvVars {
 		dfP.OktetoPrefixEnvVars[k] = formatEnvVarValueForDocker(v)
-	}
-	for k, v := range dfP.OktetoExecutionEnvVars {
-		dfP.OktetoExecutionEnvVars[k] = formatEnvVarValueForDocker(v)
 	}
 }
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -255,7 +255,6 @@ func TestCreateDockerfile(t *testing.T) {
 			config: config{
 				params: &Params{
 					BaseImage:           "test-image",
-					ExecutionEnvVars:    map[string]string{"A": "A"},
 					Manifest:            fakeManifest,
 					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
 					DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
@@ -321,10 +320,6 @@ ARG OKTETO_INVALIDATE_CACHE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
-
-
-ENV A="A"
-
 
 RUN \
   \
@@ -424,8 +419,6 @@ ARG OKTETO_INVALIDATE_CACHE
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
-
-
 RUN \
   \
   --mount=type=secret,id=known_hosts \
@@ -458,7 +451,6 @@ COPY --from=runner /okteto/artifacts/ /
 			config: config{
 				params: &Params{
 					BaseImage:                    "test-image",
-					ExecutionEnvVars:             map[string]string{},
 					Manifest:                     fakeManifest,
 					BuildEnvVars:                 map[string]string{},
 					DependenciesEnvVars:          map[string]string{},
@@ -510,8 +502,6 @@ ARG OKTETO_INVALIDATE_CACHE
 
 RUN echo "$OKTETO_INVALIDATE_CACHE" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
-
-
 
 RUN \
   \


### PR DESCRIPTION
Adds platform environment to `remote-run`. We were already doing is in the deploys but for some reason not in destroy and test. After adding `skipIfNoFileChanges` to test, if cloud credentials was configured cache was always busted regardless of the flag becase cloud credentials are generared each time.

