### PR TITLE
feat: add test event insights

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -45,6 +45,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	oktetoPath "github.com/okteto/okteto/pkg/path"
 	"github.com/okteto/okteto/pkg/remote"
+	"github.com/okteto/okteto/pkg/repository"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
@@ -69,7 +70,11 @@ type builder interface {
 	Build(ctx context.Context, options *types.BuildOptions) error
 }
 
-func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at *analytics.Tracker) *cobra.Command {
+type insightsTracker interface {
+	TrackTest(ctx context.Context, meta *analytics.SingleTestMetadata)
+}
+
+func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at *analytics.Tracker, insights insightsTracker) *cobra.Command {
 	options := &Options{}
 	cmd := &cobra.Command{
 		Use:   "test [testName...]",
@@ -96,7 +101,7 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 
 			go func() {
 				startTime := time.Now()
-				metadata, err := doRun(ctx, testContainers, options, ioCtrl, k8sLogger, &ProxyTracker{at})
+				metadata, err := doRun(ctx, testContainers, options, ioCtrl, k8sLogger, &ProxyTracker{at}, insights)
 				metadata.Err = err
 				metadata.Duration = time.Since(startTime)
 				at.TrackTest(metadata)
@@ -128,7 +133,7 @@ func Test(ctx context.Context, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, a
 	return cmd
 }
 
-func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, tracker *ProxyTracker) (analytics.TestMetadata, error) {
+func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtrl *io.Controller, k8sLogger *io.K8sLogger, tracker *ProxyTracker, at insightsTracker) (analytics.TestMetadata, error) {
 	fs := afero.NewOsFs()
 
 	ctxOpts := &contextCMD.Options{
@@ -309,6 +314,16 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		WasBuilt:    wasBuilt,
 	}
 
+	testAnalytics := make([]*analytics.SingleTestMetadata, 0)
+
+	// send all events appended on each build
+	defer func([]*analytics.SingleTestMetadata) {
+		for _, meta := range testAnalytics {
+			m := meta
+			at.TrackTest(ctx, m)
+		}
+	}(testAnalytics)
+
 	for _, name := range testServices {
 		test := manifest.Test[name]
 
@@ -379,7 +394,18 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		}
 
 		ioCtrl.Out().Infof("Executing test container '%s'", name)
-		if err := runner.Run(ctx, params); err != nil {
+		testMetadata := analytics.SingleTestMetadata{
+			DevenvName: manifest.Name,
+			TestName:   name,
+			Namespace:  okteto.GetContext().Namespace,
+			Repository: repository.NewRepository(manifest.ManifestPath).GetAnonymizedRepo(),
+		}
+		testStartTime := time.Now()
+		err = runner.Run(ctx, params)
+		testMetadata.Duration = time.Since(testStartTime)
+		testMetadata.Success = err == nil
+		testAnalytics = append(testAnalytics, &testMetadata)
+		if err != nil {
 			return metadata, err
 		}
 		oktetoLog.Success("Test container '%s' passed", name)

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 	root.AddCommand(logs.Logs(ctx, k8sLogger, fs))
 	root.AddCommand(generateFigSpec.NewCmdGenFigSpec())
 	root.AddCommand(remoterun.RemoteRun(ctx, k8sLogger))
-	root.AddCommand(test.Test(ctx, ioController, k8sLogger, at))
+	root.AddCommand(test.Test(ctx, ioController, k8sLogger, at, insights))
 	root.AddCommand(cmd.GenerateSchema())
 	root.AddCommand(cmd.Validate(fs))
 

--- a/pkg/analytics/test.go
+++ b/pkg/analytics/test.go
@@ -42,6 +42,27 @@ type TestMetadata struct {
 	StagesCount int
 }
 
+// SingleTestMetadata contains the metadata of a single test execution
+type SingleTestMetadata struct {
+	// DevenvName is the name of the development environment where the test was run
+	DevenvName string `json:"devenv_name"`
+
+	// Namespace is the namespace where the test was run
+	Namespace string `json:"namespace"`
+
+	// TestName is the name of the test that was run
+	TestName string `json:"test_name"`
+
+	// Repository is the repository where the test was run
+	Repository string `json:"repository"`
+
+	// Duration is the duration of the test execution
+	Duration time.Duration `json:"duration"`
+
+	// Success is whether the test succeeded or not
+	Success bool `json:"success"`
+}
+
 // TrackTest sends a tracking event to mixpanel when the user runs test through the command okteto test
 func (a *Tracker) TrackTest(metadata TestMetadata) {
 	props := map[string]any{

--- a/pkg/insights/test.go
+++ b/pkg/insights/test.go
@@ -21,47 +21,45 @@ import (
 )
 
 const (
-	// buildInsightType represents the type of the build event
-	buildInsightType = "build"
+	// testInsightType represents the type of the test event
+	testInsightType = "test"
 
-	// buildSchemaVersion represents the schema version of the build event
+	// testSchemaVersion represents the schema version of the test event
 	// This version should be updated if the structure of the event changes
-	buildSchemaVersion = "1.0"
+	testSchemaVersion = "1.0"
 )
 
-// buildEventJSON represents the JSON structure of a build event
-type buildEventJSON struct {
+// testEventJSON represents the JSON structure of a test event
+type testEventJSON struct {
 	DevenvName    string  `json:"devenv_name"`
-	ImageName     string  `json:"image_name"`
 	Namespace     string  `json:"namespace"`
+	TestName      string  `json:"test_name"`
 	Repository    string  `json:"repository"`
-	SchemaVersion string  `json:"schema_version"`
 	Duration      float64 `json:"duration"`
-	SmartBuildHit bool    `json:"smart_build_hit"`
 	Success       bool    `json:"success"`
+	SchemaVersion string  `json:"schema_version"`
 }
 
 // TrackImageBuild tracks an image build event
-func (ip *Publisher) TrackImageBuild(ctx context.Context, meta *analytics.ImageBuildMetadata) {
-	eventJSON, err := json.Marshal(ip.convertImageBuildMetadataToEvent(meta))
+func (ip *Publisher) TrackTest(ctx context.Context, meta *analytics.SingleTestMetadata) {
+	eventJSON, err := json.Marshal(ip.convertTestMetadataToEvent(meta))
 	if err != nil {
 		ip.ioCtrl.Logger().Infof("failed to marshal event metadata: %s", err)
 		return
 	}
 
-	ip.trackEvent(ctx, meta.Namespace, buildInsightType, string(eventJSON))
+	ip.trackEvent(ctx, meta.Namespace, testInsightType, string(eventJSON))
 }
 
-// convertImageBuildMetadataToEvent converts an ImageBuildMetadata to a buildEventJSON
-func (*Publisher) convertImageBuildMetadataToEvent(metadata *analytics.ImageBuildMetadata) buildEventJSON {
-	return buildEventJSON{
+// convertTestMetadataToEvent converts an ImageBuildMetadata to a buildEventJSON
+func (*Publisher) convertTestMetadataToEvent(metadata *analytics.SingleTestMetadata) testEventJSON {
+	return testEventJSON{
 		DevenvName:    metadata.DevenvName,
-		ImageName:     metadata.Name,
 		Namespace:     metadata.Namespace,
-		Repository:    metadata.RepoURL,
-		SmartBuildHit: metadata.CacheHit,
+		TestName:      metadata.TestName,
+		Repository:    metadata.Repository,
+		Duration:      metadata.Duration.Seconds(),
 		Success:       metadata.Success,
-		Duration:      metadata.BuildDuration.Seconds(),
-		SchemaVersion: buildSchemaVersion,
+		SchemaVersion: testSchemaVersion,
 	}
 }

--- a/pkg/insights/test_test.go
+++ b/pkg/insights/test_test.go
@@ -1,0 +1,86 @@
+package insights
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/okteto/okteto/internal/test"
+	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/log/io"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestConvertTestdMetadataToEvent(t *testing.T) {
+	metadata := &analytics.SingleTestMetadata{
+		DevenvName: "test-devenv",
+		TestName:   "test-test",
+		Repository: "test-repo",
+		Namespace:  "test-namespace",
+		Duration:   time.Duration(5) * time.Second,
+		Success:    true,
+	}
+
+	publisher := &Publisher{}
+	expectedEvent := testEventJSON{
+		DevenvName:    "test-devenv",
+		Namespace:     "test-namespace",
+		Repository:    "test-repo",
+		Success:       true,
+		Duration:      5.0,
+		SchemaVersion: "1.0",
+		TestName:      "test-test",
+	}
+
+	event := publisher.convertTestMetadataToEvent(metadata)
+	assert.Equal(t, expectedEvent, event)
+}
+
+func TestTrackTest(t *testing.T) {
+	ctx := context.Background()
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Cfg: &api.Config{},
+			},
+		},
+	}
+
+	ip := &Publisher{
+		ioCtrl:            *io.NewIOController(),
+		k8sClientProvider: test.NewFakeK8sProvider(),
+	}
+
+	meta := &analytics.SingleTestMetadata{
+		DevenvName: "test-devenv",
+		TestName:   "test-test",
+		Repository: "test-repo",
+		Namespace:  "test-namespace",
+		Duration:   time.Duration(5) * time.Second,
+		Success:    true,
+	}
+
+	c, _, err := ip.k8sClientProvider.Provide(&api.Config{})
+	require.NoError(t, err)
+
+	events, err := c.EventsV1().Events("test-namespace").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 0)
+
+	ip.TrackTest(ctx, meta)
+
+	events, err = c.EventsV1().Events("test-namespace").List(ctx, v1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, events.Items, 1)
+	insightEvent := events.Items[0]
+	assert.Equal(t, "okteto_insights_build", insightEvent.Reason)
+	assert.Equal(t, "Normal", insightEvent.Type)
+	assert.Equal(t, "build", insightEvent.Action)
+	assert.Contains(t, "build", insightEvent.Name)
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -124,6 +124,9 @@ func cleanPath(path string) string {
 
 // GetAnonymizedRepo returns a clean repo url string without sensible information
 func (r Repository) GetAnonymizedRepo() string {
+	if r.url.String() == "file:" {
+		return ""
+	}
 	return r.url.String()
 }
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-306

Send an event everytime a test is run so it gets propagated into the cluster

## How to validate

1. Using the right backend
1. Run `okteto test` on a repo that has them configured 
1. Run `curl -H 'Authorization: Bearer ${INSIGHT_TOKEN}' ${CLUSTER_URL}/metrics' | grep -E 'okteto_usage_test'`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
