### PR TITLE
Optimize remote executions of deploy and destroy operations when buildkit execution is not needed

### DIFF
--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -97,6 +97,10 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		Commands: deployOptions.Manifest.Deploy.Commands,
 		External: deployOptions.Manifest.External,
 	}
+	if dep.IsEmpty() {
+		rd.ioCtrl.Logger().Info("no deployable entities found in the manifest, skipping remote deploy")
+		return nil
+	}
 
 	commandsFlags, err := GetCommandFlags(deployOptions.Name, deployOptions.Variables)
 	if err != nil {

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -237,6 +237,37 @@ func TestDeployRemoteWithCtx(t *testing.T) {
 	require.NoError(t, err)
 	runner.AssertExpectations(t)
 }
+
+func TestDeployRemoteEmptyDeployableEntity(t *testing.T) {
+	workdirCtrl := fakefs.NewFakeWorkingDirectoryCtrl("/path/to/manifest")
+	manifest := &model.Manifest{
+		Deploy: &model.DeployInfo{
+			Image:          "test-image",
+			ComposeSection: &model.ComposeSectionInfo{},
+		},
+	}
+
+	runner := &fakeRemoteRunner{}
+	rd := &remoteDeployer{
+		runner:      runner,
+		workdirCtrl: workdirCtrl,
+		getBuildEnvVars: func() map[string]string {
+			return map[string]string{"BUILD_VAR_1": "value"}
+		},
+		getDependencyEnvVars: func(environGetter) map[string]string {
+			return map[string]string{"DEP_VAR_1": "value"}
+		},
+		ioCtrl: io.NewIOController(),
+	}
+	opts := &Options{
+		Name:             "test",
+		Manifest:         manifest,
+		ManifestPathFlag: "/path/to/manifest/okteto.yml",
+	}
+	err := rd.Deploy(context.Background(), opts)
+	require.NoError(t, err)
+}
+
 func TestDeployRemote(t *testing.T) {
 	workdirCtrl := fakefs.NewFakeWorkingDirectoryCtrl("/path/to/manifest")
 	manifest := &model.Manifest{

--- a/pkg/deployable/deploy.go
+++ b/pkg/deployable/deploy.go
@@ -99,6 +99,11 @@ type Entity struct {
 	Commands []model.DeployCommand
 }
 
+// IsEmpty checks if the deployable entity is empty
+func (e Entity) IsEmpty() bool {
+	return len(e.Commands) == 0 && e.Divert.IsEmpty() && e.External.IsEmpty()
+}
+
 // DeployParameters represents the parameters for deploying a remote entity
 type DeployParameters struct {
 	Name         string

--- a/pkg/deployable/deploy_test.go
+++ b/pkg/deployable/deploy_test.go
@@ -633,3 +633,86 @@ func TestCleaUp(t *testing.T) {
 	proxy.AssertExpectations(t)
 	executor.AssertExpectations(t)
 }
+
+func TestEntityIsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		e    Entity
+		want bool
+	}{
+		{
+			name: "All nil",
+			e: Entity{
+				External: nil,
+				Divert:   nil,
+				Commands: nil,
+			},
+			want: true,
+		},
+		{
+			name: "All empty",
+			e: Entity{
+				External: externalresource.Section{},
+				Divert:   &model.DivertDeploy{},
+				Commands: []model.DeployCommand{},
+			},
+			want: true,
+		},
+		{
+			name: "Non-empty Commands",
+			e: Entity{
+				External: nil,
+				Divert:   nil,
+				Commands: []model.DeployCommand{
+					{
+						Name:    "test",
+						Command: "echo",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Non-empty Divert",
+			e: Entity{
+				External: nil,
+				Divert:   &model.DivertDeploy{Driver: "nginx"},
+				Commands: nil,
+			},
+			want: false,
+		},
+		{
+			name: "Non-empty External",
+			e: Entity{
+				External: externalresource.Section{
+					"test": {
+						Icon: "icon",
+					},
+				},
+				Divert:   nil,
+				Commands: nil,
+			},
+			want: false,
+		},
+		{
+			name: "Multiple non-empty fields",
+			e: Entity{
+				External: externalresource.Section{
+					"test": {
+						Icon: "icon",
+					},
+				},
+				Divert:   &model.DivertDeploy{Driver: "nginx"},
+				Commands: nil,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.e.IsEmpty()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -1281,3 +1281,15 @@ func (m *Manifest) ValidateForCLIOnly() error {
 	}
 	return nil
 }
+
+// IsEmpty returns true if the manifest is empty
+func (d *DivertDeploy) IsEmpty() bool {
+	return d == nil ||
+		d.Driver == "" &&
+			d.Namespace == "" &&
+			len(d.VirtualServices) == 0 &&
+			len(d.Hosts) == 0 &&
+			d.DeprecatedService == "" &&
+			d.DeprecatedDeployment == "" &&
+			d.DeprecatedPort == 0
+}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -2074,8 +2074,8 @@ func TestManifest_IsEmpty(t *testing.T) {
 
 func TestDivertDeployIsEmpty(t *testing.T) {
 	tests := []struct {
-		name string
 		d    *DivertDeploy
+		name string
 		want bool
 	}{
 		{

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -2071,3 +2071,107 @@ func TestManifest_IsEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestDivertDeployIsEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		d    *DivertDeploy
+		want bool
+	}{
+		{
+			name: "nil DivertDeploy",
+			d:    nil,
+			want: true,
+		},
+		{
+			name: "Empty DivertDeploy",
+			d:    &DivertDeploy{},
+			want: true,
+		},
+		{
+			name: "Non-empty Driver",
+			d: &DivertDeploy{
+				Driver: "nginx",
+			},
+			want: false,
+		},
+		{
+			name: "Non-empty Namespace",
+			d: &DivertDeploy{
+				Namespace: "default",
+			},
+			want: false,
+		},
+		{
+			name: "Non-empty VirtualServices",
+			d: &DivertDeploy{
+				VirtualServices: []DivertVirtualService{
+					{
+						Name: "vs1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Non-empty Hosts",
+			d: &DivertDeploy{
+				Hosts: []DivertHost{
+					{
+						VirtualService: "vs1",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Non-empty DeprecatedService",
+			d: &DivertDeploy{
+				DeprecatedService: "old-service",
+			},
+			want: false,
+		},
+		{
+			name: "Non-empty DeprecatedDeployment",
+			d: &DivertDeploy{
+				DeprecatedDeployment: "old-deployment",
+			},
+			want: false,
+		},
+		{
+			name: "Non-zero DeprecatedPort",
+			d: &DivertDeploy{
+				DeprecatedPort: 8080,
+			},
+			want: false,
+		},
+		{
+			name: "Multiple non-empty fields",
+			d: &DivertDeploy{
+				Driver:    "driver",
+				Namespace: "namespace",
+				VirtualServices: []DivertVirtualService{
+					{
+						Name: "vs1",
+					},
+				},
+				Hosts: []DivertHost{
+					{
+						VirtualService: "vs1",
+					},
+				},
+				DeprecatedService:    "ds",
+				DeprecatedDeployment: "dd",
+				DeprecatedPort:       9090,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.d.IsEmpty()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-841

When we were deploying a compose we were transferring the repo context even if it was not needed because we were only deploying a compose file.

- Checks if all the sections of the deployable entity are empty or nil and if that check is true we don't transfer the data to buildkit so we optimise in time and don't waste it.
- We don't need it for destroy because we are already checking [if there is any command to run before transferring the data.](https://github.com/okteto/okteto/blob/master/cmd/destroy/destroy.go#L481)

## How to validate

1. Create a big context file like a 1Gb file: 
```bash
dd if=/dev/zero of=1GB_file bs=1M count=1024
```
2. Create the following okteto file:
```yaml
deploy:
  compose: compose.yml
```
3. Create the following compose file:
```yaml
services:
  nginx:
    image: nginx:latest
    ports:
      - "80:80"
```
4. Run okteto deploy and check that the context is not transfered

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
