### PR TITLE
fix: cli was not waiting if buildkit not available

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -156,6 +156,10 @@ func (ob *OktetoBuilder) buildWithOkteto(ctx context.Context, buildOptions *type
 
 	reg := registry.NewOktetoRegistry(GetRegistryConfigFromOktetoConfig(ob.OktetoContext))
 
+	if err := buildkitWaiter.WaitUntilIsUp(ctx); err != nil {
+		return err
+	}
+
 	optBuilder, err := buildkit.NewSolveOptBuilder(buildkitClientFactory, reg, ob.OktetoContext, ob.Fs, ioCtrl)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Proposed changes

Bug introduced in #4577 

We needed to get some buildkit info to create the buildkit options. We introduced the bug checking if we should or not add the frontend versus the buildkit server information. In order to do that we need to wait for the buildkit server to be up and running  

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Scale buildkit sts replicas to 0
1. Run `okteto build` on a manifest with build section

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
