### PR TITLE
Fine tune codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
 
     patch:
       default:
-        target: 75%
+        target: 60%
         only_pulls: true
 
 github_checks:
@@ -18,6 +18,6 @@ github_checks:
 
 ignore:
   - '**/*_test.go'
-  - integration/*
-  - scripts/*
-  - internal/*
+  - "integration"
+  - "scripts"
+  - "internal"


### PR DESCRIPTION
# Proposed changes

I was checking codecov, and the integration folder and internal were being considered to calculate the % of code covered by tests, but all the code within that folder is test related. According to the [docs](https://docs.codecov.com/docs/ignoring-paths#ignoring-a-specific-folder), specifying just the folder name should be enough.

Also, as we are not forcing the minimum coverage in the PRs, and given that there are parts of the codes where unit tests are complex to cover, I'm reducing the target. While we keep iterating and improving the code base we can increase it


