### PR TITLE
Change how test namespace name for e2e tests are generated to avoid conflicts when names are too long

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ aliases:
   - &release-regex /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
   - &release-branch-regex /^release-\d+\.\d+$/
   - &docker-login echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+  - &install-cli curl https://get.okteto.com -sSfL | sh
 
 parameters:
   # The following parameters are filled by GH Actions to run CircleCI jobs
@@ -155,6 +156,8 @@ jobs:
             - v4-pkg-cache-{{ checksum "go.sum" }}
       - attach_workspace:
           at: ./artifacts
+      # Install the latest CLI public available, as the actions tests uses the installed version to checkout the action branch to test
+      - run: *install-cli
       - run:
           name: Run actions integration tests
           command: |

--- a/integration/k8s-client.go
+++ b/integration/k8s-client.go
@@ -22,31 +22,13 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/integration/commands"
-	"github.com/okteto/okteto/pkg/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
-
-// K8sClient returns a kubernetes client for current KUBECONFIG
-func K8sClient() (*kubernetes.Clientset, *rest.Config, error) {
-	clientConfig := getClientConfig(config.GetKubeconfigPath(), "")
-
-	config, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, nil, err
-	}
-	return client, config, nil
-}
 
 func getClientConfig(kubeconfigPaths []string, kubeContext string) clientcmd.ClientConfig {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()

--- a/integration/k8s-client.go
+++ b/integration/k8s-client.go
@@ -26,22 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
-
-func getClientConfig(kubeconfigPaths []string, kubeContext string) clientcmd.ClientConfig {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.DefaultClientConfig = &clientcmd.DefaultClientConfig
-	loadingRules.Precedence = kubeconfigPaths
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		loadingRules,
-		&clientcmd.ConfigOverrides{
-			CurrentContext: kubeContext,
-			ClusterInfo:    clientcmdapi.Cluster{Server: ""},
-		},
-	)
-}
 
 func GetPodsBySelector(ctx context.Context, ns, selector string, client kubernetes.Interface) (*corev1.PodList, error) {
 	return client.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{LabelSelector: selector})

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -96,10 +96,11 @@ func GetTestNamespace(name string) string {
 		runtimeOS = runtimeOS[:3]
 	}
 	name = reduceName(strings.ToLower(name))
+	finalName := fmt.Sprintf("%d-%s-%s", time.Now().Unix(), runtimeOS, name)
 	if prefix := os.Getenv("OKTETO_NAMESPACE_PREFIX"); prefix != "" {
-		name = fmt.Sprintf("%s-%s", prefix, name)
+		finalName = fmt.Sprintf("%s-%s", prefix, finalName)
 	}
-	return strings.ToLower(fmt.Sprintf("%d-%s-%s", time.Now().Unix(), runtimeOS, name))
+	return finalName
 }
 
 // GetContentFromURL returns the content of the url

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/okteto/okteto/pkg/config"
-	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
 )
@@ -101,12 +99,7 @@ func GetTestNamespace(name string) string {
 	if prefix := os.Getenv("OKTETO_NAMESPACE_PREFIX"); prefix != "" {
 		name = fmt.Sprintf("%s-%s", prefix, name)
 	}
-	return strings.ToLower(fmt.Sprintf("%s-%s-%d", name, runtimeOS, time.Now().Unix()))
-}
-
-// GetCurrentNamespace returns the current namespace of the kubeconfig path
-func GetCurrentNamespace() string {
-	return kubeconfig.CurrentNamespace(config.GetKubeconfigPath())
+	return strings.ToLower(fmt.Sprintf("%d-%s-%s", time.Now().Unix(), runtimeOS, name))
 }
 
 // GetContentFromURL returns the content of the url

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -78,16 +78,6 @@ func RunOktetoVersion(oktetoPath string) (string, error) {
 	return string(o), nil
 }
 
-func reduceName(s string) string {
-	return strings.Map(func(r rune) rune {
-		switch r {
-		case 'a', 'e', 'i', 'o', 'u', '_':
-			return -1
-		}
-		return r
-	}, s)
-}
-
 // GetTestNamespace returns the name for a namespace
 func GetTestNamespace(name string) string {
 	runtimeOS := runtime.GOOS

--- a/integration/okteto.go
+++ b/integration/okteto.go
@@ -14,6 +14,7 @@
 package integration
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"log"
@@ -95,8 +96,9 @@ func GetTestNamespace(name string) string {
 	} else {
 		runtimeOS = runtimeOS[:3]
 	}
-	name = reduceName(strings.ToLower(name))
-	finalName := fmt.Sprintf("%d-%s-%s", time.Now().Unix(), runtimeOS, name)
+	// To avoid namespace name conflicts, we hash the test name, and add a timestamp and the OS as prefix
+	sha := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
+	finalName := fmt.Sprintf("%d-%s-%s", time.Now().Unix(), runtimeOS, sha[:8])
 	if prefix := os.Getenv("OKTETO_NAMESPACE_PREFIX"); prefix != "" {
 		finalName = fmt.Sprintf("%s-%s", prefix, finalName)
 	}


### PR DESCRIPTION
# Proposed changes

Names for namespaces in e2e tests were being generated by the following pattern: `<test name without vowels>-<os>-<timestamp>`. This could provoke that 2 different tests executions fail on some operations. For example, when destroying the namespace. 

Why? When a namespace is deleted, a job is created, the job always have the format `namespace-destroy-all-<namespace-name>-<timestamp>`. If the namespace name is too long, we trim the job name due to kubernetes restriction. That makes that 2 namespaces for the same test suite, but different test execution in parallel would generate the same job name.

For example, namespaces `staging-tstpglblfrwrdng-win-1739978086` and `staging-tstpglblfrwrdng-win-1739980622` created in the same second would generate the same job name `namespace-destroy-all-staging-tstpglblfrwrdng-win-17-1740074410`, provoking a failure in one of them.

To prevent that, what I'm proposing is to change the namespace name generation to be shorter and have the "dynamic part" (the timestamp) at the beginning of the namespace name. In that way, collisions would be minimized.

**IMPORTANT:** With this change, the namespace names stop using the test name. I think it is fine because as they were now (without vowels), it was hard to know the tests sometimes, and when a test fail, we usually log the failed test and the namespace name, but open to discuss it

I also removed the function `GetCurrentNamespace` which wasn't being used

## How to validate

I'm going to run the tests several times to verify everything keeps working fine


