### PR TITLE
feat: add depends_on annotation support for services

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -60,7 +60,7 @@ const (
 	oktetoComposeVolumeAffinityEnabledEnvVar = "OKTETO_COMPOSE_VOLUME_AFFINITY_ENABLED"
 
 	// dependsOnAnnotation represents the annotation to define the depends_on field
-	dependsOnAnnotation = "okteto.dev/depends-on"
+	dependsOnAnnotation = "dev.okteto.com/depends-on"
 )
 
 // +enum


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Adds a new annotation  for waking up in the specific order.

## How to validate

1. Deploy a compose file
1. Sleep the namespace
1. Wake the namespace

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
