### PR TITLE
DEV-877: Split ignorer logic for Smart Build into 2 different functions according to the flag, and use a temporary file for the SHA calculation

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -35,7 +35,8 @@ import (
 )
 
 const (
-	gitOperationTimeout = 5 * time.Second
+	gitOperationTimeout    = 5 * time.Second
+	limitDiffSizeToLogInMB = 1024 * 1024
 )
 
 var (
@@ -364,7 +365,13 @@ func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
 	}
 
 	hashFrom := fmt.Sprintf("%s-%s", diffResponse.diff, untrackedFilesResponse.untrackedFilesDiff)
-	oktetoLog.Infof("hashing diff: %s", hashFrom)
+	logDiff := hashFrom
+	if len(hashFrom) > limitDiffSizeToLogInMB {
+		logDiff = hashFrom[:limitDiffSizeToLogInMB]
+	}
+
+	// As the diff might be huge, setting an arbitrary limit in the chars we print in the logs, if not, it could cause performance issues
+	oktetoLog.Infof("hashing diff: %v", logDiff)
 	diffHash := sha256.Sum256([]byte(hashFrom))
 	return hex.EncodeToString(diffHash[:]), nil
 }

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -14,510 +14,517 @@
 package repository
 
 import (
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"errors"
-	"fmt"
-	"path/filepath"
-	"sort"
-	"strings"
-	"time"
+    "context"
+    "crypto/sha256"
+    "encoding/hex"
+    "errors"
+    "fmt"
+    "path/filepath"
+    "sort"
+    "strings"
+    "time"
 
-	giturls "github.com/chainguard-dev/git-urls"
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/okteto/okteto/pkg/env"
-	"github.com/okteto/okteto/pkg/ignore"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/spf13/afero"
+    giturls "github.com/chainguard-dev/git-urls"
+    "github.com/go-git/go-git/v5"
+    "github.com/go-git/go-git/v5/plumbing"
+    "github.com/go-git/go-git/v5/plumbing/object"
+    "github.com/okteto/okteto/pkg/env"
+    "github.com/okteto/okteto/pkg/ignore"
+    oktetoLog "github.com/okteto/okteto/pkg/log"
+    "github.com/spf13/afero"
 )
 
 const (
-	gitOperationTimeout = 5 * time.Second
+    gitOperationTimeout = 5 * time.Second
 )
 
 var (
-	errNotCleanRepo    = errors.New("repository is not clean")
-	errTimeoutExceeded = errors.New("timeout exceeded")
-	errFindingRepo     = errors.New("top level git repo directory cannot be found")
+    errNotCleanRepo    = errors.New("repository is not clean")
+    errTimeoutExceeded = errors.New("timeout exceeded")
+    errFindingRepo     = errors.New("top level git repo directory cannot be found")
 )
 
 type gitRepoController struct {
-	repoGetter repositoryGetterInterface
-	fs         afero.Fs
-	ignorer    func(subpath string) ignore.Ignorer
-	path       string
+    repoGetter        repositoryGetterInterface
+    fs                afero.Fs
+    ignorer           func(subpath string) ignore.Ignorer
+    path              string
+    shouldIgnoreFiles bool
 }
 
 func newGitRepoController(path string) gitRepoController {
-	return gitRepoController{
-		repoGetter: gitRepositoryGetter{},
-		path:       path,
-		fs:         afero.NewOsFs(),
-		ignorer: func(subpath string) ignore.Ignorer {
-			if !env.LoadBoolean("OKTETO_SMART_BUILDS_IGNORE_FILES_ENABLED") {
-				return ignore.Never
-			}
-			return ignore.NewMultiIgnorer(
-				ignore.NewDockerIgnorer(filepath.Join(subpath, ".dockerignore")),
-			)
-
-		},
-	}
+    shouldIgnoreFiles := env.LoadBoolean("OKTETO_SMART_BUILDS_IGNORE_FILES_ENABLED")
+    return gitRepoController{
+        repoGetter: gitRepositoryGetter{},
+        path:       path,
+        fs:         afero.NewOsFs(),
+        ignorer: func(subpath string) ignore.Ignorer {
+            if !shouldIgnoreFiles {
+                return ignore.Never
+            }
+            return ignore.NewMultiIgnorer(
+                ignore.NewDockerIgnorer(filepath.Join(subpath, ".dockerignore")),
+            )
+        },
+        shouldIgnoreFiles: shouldIgnoreFiles,
+    }
 }
 
 type cleanStatus struct {
-	err     error
-	isClean bool
+    err     error
+    isClean bool
 }
 
 func (r gitRepoController) getCurrentBranch() (string, error) {
-	repo, err := r.repoGetter.get(r.path)
-	if err != nil {
-		return "", fmt.Errorf("failed to analyze git repo: %w", err)
-	}
-	head, err := repo.Head()
-	if err != nil {
-		return "", fmt.Errorf("failed to analyze git repo: %w", err)
-	}
-	return head.Name().Short(), nil
+    repo, err := r.repoGetter.get(r.path)
+    if err != nil {
+        return "", fmt.Errorf("failed to analyze git repo: %w", err)
+    }
+    head, err := repo.Head()
+    if err != nil {
+        return "", fmt.Errorf("failed to analyze git repo: %w", err)
+    }
+    return head.Name().Short(), nil
 }
 
 func (r gitRepoController) calculateIsClean(ctx context.Context) (bool, error) {
-	repo, err := r.repoGetter.get(r.path)
-	if err != nil {
-		return false, fmt.Errorf("failed to analyze git repo: %w", err)
-	}
+    repo, err := r.repoGetter.get(r.path)
+    if err != nil {
+        return false, fmt.Errorf("failed to analyze git repo: %w", err)
+    }
 
-	worktree, err := repo.Worktree()
-	if err != nil {
-		return false, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
-	}
-	status, err := worktree.Status(ctx, "", NewLocalGit("git", &LocalExec{}, r.ignorer))
-	if err != nil {
-		return false, fmt.Errorf("failed to infer the git repo's status: %w", err)
-	}
+    worktree, err := repo.Worktree()
+    if err != nil {
+        return false, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
+    }
+    status, err := worktree.Status(ctx, "", NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
+    if err != nil {
+        return false, fmt.Errorf("failed to infer the git repo's status: %w", err)
+    }
 
-	return status.IsClean(), nil
+    return status.IsClean(), nil
 }
 
 func (r gitRepoController) getRepoURL() (string, error) {
-	url, err := giturls.Parse(r.path)
-	if err != nil {
-		oktetoLog.Infof("could not parse url: %s", err)
-	}
-	if url.Scheme != "file" {
-		return r.sanitiseURL(url.String()), nil
-	}
+    url, err := giturls.Parse(r.path)
+    if err != nil {
+        oktetoLog.Infof("could not parse url: %s", err)
+    }
+    if url.Scheme != "file" {
+        return r.sanitiseURL(url.String()), nil
+    }
 
-	repo, err := FindTopLevelGitRepoFromPath(r.path)
-	if err != nil {
-		return "", fmt.Errorf("failed to analyze git repo: %w", err)
-	}
-	origin, err := repo.Remote("origin")
-	if err != nil {
-		if err != git.ErrRemoteNotFound {
-			return "", fmt.Errorf("failed to get the git repo's remote configuration: %w", err)
-		}
-	}
+    repo, err := FindTopLevelGitRepoFromPath(r.path)
+    if err != nil {
+        return "", fmt.Errorf("failed to analyze git repo: %w", err)
+    }
+    origin, err := repo.Remote("origin")
+    if err != nil {
+        if err != git.ErrRemoteNotFound {
+            return "", fmt.Errorf("failed to get the git repo's remote configuration: %w", err)
+        }
+    }
 
-	if origin != nil {
-		return r.sanitiseURL(origin.Config().URLs[0]), nil
-	}
+    if origin != nil {
+        return r.sanitiseURL(origin.Config().URLs[0]), nil
+    }
 
-	remotes, err := repo.Remotes()
-	if err != nil {
-		return "", fmt.Errorf("failed to get git repo's remote information: %w", err)
-	}
+    remotes, err := repo.Remotes()
+    if err != nil {
+        return "", fmt.Errorf("failed to get git repo's remote information: %w", err)
+    }
 
-	if len(remotes) == 0 {
-		return "", fmt.Errorf("git repo doesn't have any remote")
-	}
+    if len(remotes) == 0 {
+        return "", fmt.Errorf("git repo doesn't have any remote")
+    }
 
-	return r.sanitiseURL(remotes[0].Config().URLs[0]), nil
+    return r.sanitiseURL(remotes[0].Config().URLs[0]), nil
 }
 
 func (r gitRepoController) sanitiseURL(u string) string {
-	url, err := giturls.Parse(u)
-	if err != nil {
-		oktetoLog.Infof("could not parse url: %s", err)
-		return u
-	}
-	url.Path = strings.Replace(url.Path, "//", "/", -1)
-	return url.String()
+    url, err := giturls.Parse(u)
+    if err != nil {
+        oktetoLog.Infof("could not parse url: %s", err)
+        return u
+    }
+    url.Path = strings.Replace(url.Path, "//", "/", -1)
+    return url.String()
 }
 
 // isClean checks if the repository have changes over the commit
 func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
-	// We use context.TODO() in a few places to call isClean, so let's make sure
-	// we set proper internal timeouts to not leak goroutines
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+    // We use context.TODO() in a few places to call isClean, so let's make sure
+    // we set proper internal timeouts to not leak goroutines
+    ctx, cancel := context.WithCancel(ctx)
+    defer cancel()
 
-	timeoutCh := make(chan struct{})
-	ch := make(chan cleanStatus)
+    timeoutCh := make(chan struct{})
+    ch := make(chan cleanStatus)
 
-	go func() {
-		time.Sleep(time.Second)
-		close(timeoutCh)
-		cancel()
-		ch <- cleanStatus{errTimeoutExceeded, false}
-	}()
+    go func() {
+        time.Sleep(time.Second)
+        close(timeoutCh)
+        cancel()
+        ch <- cleanStatus{errTimeoutExceeded, false}
+    }()
 
-	go func() {
-		clean, err := r.calculateIsClean(ctx)
-		select {
-		case <-timeoutCh:
-		case ch <- cleanStatus{err, clean}:
-		}
-	}()
+    go func() {
+        clean, err := r.calculateIsClean(ctx)
+        select {
+        case <-timeoutCh:
+        case ch <- cleanStatus{err, clean}:
+        }
+    }()
 
-	s := <-ch
+    s := <-ch
 
-	if errors.Is(s.err, errTimeoutExceeded) {
-		oktetoLog.Debug("Timeout exceeded calculating git status: assuming dirty commit")
-	}
+    if errors.Is(s.err, errTimeoutExceeded) {
+        oktetoLog.Debug("Timeout exceeded calculating git status: assuming dirty commit")
+    }
 
-	return s.isClean, s.err
+    return s.isClean, s.err
 }
 
 // GetSHA returns the last commit sha of the repository
 func (r gitRepoController) getSHA() (string, error) {
-	isClean, err := r.isClean(context.TODO())
-	if err != nil {
-		return "", fmt.Errorf("%w: failed to check if repo is clean: %w", errNotCleanRepo, err)
-	}
-	if !isClean {
-		return "", errNotCleanRepo
-	}
-	repo, err := r.repoGetter.get(r.path)
-	if err != nil {
-		return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
-	}
-	head, err := repo.Head()
-	if err != nil {
-		return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
-	}
-	return head.Hash().String(), nil
+    isClean, err := r.isClean(context.TODO())
+    if err != nil {
+        return "", fmt.Errorf("%w: failed to check if repo is clean: %w", errNotCleanRepo, err)
+    }
+    if !isClean {
+        return "", errNotCleanRepo
+    }
+    repo, err := r.repoGetter.get(r.path)
+    if err != nil {
+        return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
+    }
+    head, err := repo.Head()
+    if err != nil {
+        return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
+    }
+    return head.Hash().String(), nil
 }
 
 type commitResponse struct {
-	err    error
-	commit string
+    err    error
+    commit string
 }
 
 // GetLatestDirSHA It calculates a sha of the contextDir specified as parameter based on the content
 func (r gitRepoController) GetLatestDirSHA(contextDir string) (string, error) {
-	// We use context.TODO() in a few places to call isClean, so let's make sure
-	// we set proper internal timeouts to not leak goroutines
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+    // We use context.TODO() in a few places to call isClean, so let's make sure
+    // we set proper internal timeouts to not leak goroutines
+    ctx, cancel := context.WithCancel(context.TODO())
+    defer cancel()
 
-	timeoutCh := make(chan struct{})
-	ch := make(chan commitResponse)
+    timeoutCh := make(chan struct{})
+    ch := make(chan commitResponse)
 
-	go func() {
-		time.Sleep(gitOperationTimeout)
-		close(timeoutCh)
-		cancel()
-		ch <- commitResponse{
-			commit: "",
-			err:    errTimeoutExceeded,
-		}
-	}()
+    go func() {
+        time.Sleep(gitOperationTimeout)
+        close(timeoutCh)
+        cancel()
+        ch <- commitResponse{
+            commit: "",
+            err:    errTimeoutExceeded,
+        }
+    }()
 
-	go func() {
-		commit, err := r.calculateLatestDirSHA(ctx, contextDir)
-		select {
-		case <-timeoutCh:
-		case ch <- commitResponse{
-			commit: commit,
-			err:    err,
-		}:
-		}
-	}()
+    go func() {
+        commit, err := r.calculateLatestDirSHA(ctx, contextDir)
+        select {
+        case <-timeoutCh:
+        case ch <- commitResponse{
+            commit: commit,
+            err:    err,
+        }:
+        }
+    }()
 
-	s := <-ch
+    s := <-ch
 
-	if errors.Is(s.err, errTimeoutExceeded) {
-		oktetoLog.Debugf("Timeout exceeded calculating git commit for '%s': assuming dirty commit", contextDir)
-	}
+    if errors.Is(s.err, errTimeoutExceeded) {
+        oktetoLog.Debugf("Timeout exceeded calculating git commit for '%s': assuming dirty commit", contextDir)
+    }
 
-	return s.commit, s.err
+    return s.commit, s.err
 }
 
 type diffResponse struct {
-	err  error
-	diff string
+    err  error
+    diff string
 }
 
 type untrackedFilesResponse struct {
-	err                error
-	untrackedFilesDiff string
+    err                error
+    untrackedFilesDiff string
 }
 
 func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
-	// We use context.TODO() in a few places to call GetDiffHash, so let's make sure
-	// we set proper internal timeouts to not leak goroutines
-	ctx, cancel := context.WithCancel(context.TODO())
-	defer cancel()
+    // We use context.TODO() in a few places to call GetDiffHash, so let's make sure
+    // we set proper internal timeouts to not leak goroutines
+    ctx, cancel := context.WithCancel(context.TODO())
+    defer cancel()
 
-	timeoutCh := make(chan struct{})
-	diffCh := make(chan diffResponse)
-	untrackedFilesCh := make(chan untrackedFilesResponse)
+    timeoutCh := make(chan struct{})
+    diffCh := make(chan diffResponse)
+    untrackedFilesCh := make(chan untrackedFilesResponse)
 
-	repo, err := r.repoGetter.get(r.path)
-	if err != nil {
-		return "", fmt.Errorf("failed to analyze git repo: %w", err)
-	}
-	worktree, err := repo.Worktree()
-	if err != nil {
-		return "", fmt.Errorf("failed to get git repo root: %w", err)
-	}
+    repo, err := r.repoGetter.get(r.path)
+    if err != nil {
+        return "", fmt.Errorf("failed to analyze git repo: %w", err)
+    }
 
-	// go func that cancels the context after the timeout
-	go func() {
-		time.Sleep(gitOperationTimeout)
-		close(timeoutCh)
-		cancel()
-		diffCh <- diffResponse{
-			diff: "",
-			err:  errTimeoutExceeded,
-		}
-		untrackedFilesCh <- untrackedFilesResponse{
-			untrackedFilesDiff: "",
-			err:                errTimeoutExceeded,
-		}
-	}()
+    // go func that cancels the context after the timeout
+    go func() {
+        time.Sleep(gitOperationTimeout)
+        close(timeoutCh)
+        cancel()
+        diffCh <- diffResponse{
+            diff: "",
+            err:  errTimeoutExceeded,
+        }
+        untrackedFilesCh <- untrackedFilesResponse{
+            untrackedFilesDiff: "",
+            err:                errTimeoutExceeded,
+        }
+    }()
 
-	// go func that calculates the diff using git diff
-	go func() {
-		diff, err := repo.GetDiff(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer))
-		select {
-		case <-timeoutCh:
-			oktetoLog.Debug("Timeout exceeded calculating git diff: assuming dirty commit")
-		case diffCh <- diffResponse{
-			diff: diff,
-			err:  err,
-		}:
-		}
-	}()
+    // go func that calculates the diff using git diff
+    go func() {
+        diff, err := repo.GetDiff(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
+        select {
+        case <-timeoutCh:
+            oktetoLog.Debug("Timeout exceeded calculating git diff: assuming dirty commit")
+        case diffCh <- diffResponse{
+            diff: diff,
+            err:  err,
+        }:
+        }
+    }()
 
-	// go func that calculates the diff for the untracked files
-	go func() {
-		untrackedFiles, err := repo.calculateUntrackedFiles(ctx, contextDir)
-		if err != nil {
-			select {
-			case <-timeoutCh:
-				oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
-			case untrackedFilesCh <- untrackedFilesResponse{
-				untrackedFilesDiff: "",
-				err:                err,
-			}:
-			}
-			return
-		}
+    // go func that calculates the diff for the untracked files
+    go func() {
+        untrackedFiles, err := repo.calculateUntrackedFiles(ctx, contextDir)
+        if err != nil {
+            select {
+            case <-timeoutCh:
+                oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
+            case untrackedFilesCh <- untrackedFilesResponse{
+                untrackedFilesDiff: "",
+                err:                err,
+            }:
+            }
+            return
+        }
 
-		filteredUntrackedFiles := []string{}
-		for _, f := range untrackedFiles {
-			relpath := resolveRelativePath(filepath.Join(worktree.GetRoot(), f), contextDir)
-			shouldIgnore, err := r.ignorer(contextDir).Ignore(relpath)
-			if err != nil {
-				oktetoLog.Debugf("ignore error in GetDiffHash: %v", err)
-			}
-			if !shouldIgnore {
-				filteredUntrackedFiles = append(filteredUntrackedFiles, f)
-			} else {
-				oktetoLog.Debugf("skipping %v file change in GetDiffHash based on known ignore files", f)
-			}
+        if r.shouldIgnoreFiles {
+            worktree, err := repo.Worktree()
+            if err != nil {
+                oktetoLog.Debugf("Failed to get worktree, skipping calculation of files to ignore: %v", err)
+            } else {
+                filteredUntrackedFiles := []string{}
+                for _, f := range untrackedFiles {
+                    relpath := resolveRelativePath(filepath.Join(worktree.GetRoot(), f), contextDir)
+                    shouldIgnore, err := r.ignorer(contextDir).Ignore(relpath)
+                    if err != nil {
+                        oktetoLog.Debugf("ignore error in GetDiffHash: %v", err)
+                    }
+                    if !shouldIgnore {
+                        filteredUntrackedFiles = append(filteredUntrackedFiles, f)
+                    } else {
+                        oktetoLog.Debugf("skipping %v file change in GetDiffHash based on known ignore files", f)
+                    }
 
-		}
+                }
 
-		untrackedFilesContent, err := r.getUntrackedContent(ctx, filteredUntrackedFiles)
-		select {
-		case <-timeoutCh:
-			oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
-		case untrackedFilesCh <- untrackedFilesResponse{
-			untrackedFilesDiff: untrackedFilesContent,
-			err:                err,
-		}:
-		}
-	}()
+                untrackedFiles = filteredUntrackedFiles
+            }
+        }
 
-	diffResponse := <-diffCh
-	if diffResponse.err != nil {
-		return "", diffResponse.err
-	}
+        untrackedFilesContent, err := r.getUntrackedContent(ctx, untrackedFiles)
+        select {
+        case <-timeoutCh:
+            oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
+        case untrackedFilesCh <- untrackedFilesResponse{
+            untrackedFilesDiff: untrackedFilesContent,
+            err:                err,
+        }:
+        }
+    }()
 
-	untrackedFilesResponse := <-untrackedFilesCh
-	if untrackedFilesResponse.err != nil {
-		return "", untrackedFilesResponse.err
-	}
+    diffResponse := <-diffCh
+    if diffResponse.err != nil {
+        return "", diffResponse.err
+    }
 
-	hashFrom := fmt.Sprintf("%s-%s", diffResponse.diff, untrackedFilesResponse.untrackedFilesDiff)
-	oktetoLog.Infof("hashing diff: %s", hashFrom)
-	diffHash := sha256.Sum256([]byte(hashFrom))
-	return hex.EncodeToString(diffHash[:]), nil
+    untrackedFilesResponse := <-untrackedFilesCh
+    if untrackedFilesResponse.err != nil {
+        return "", untrackedFilesResponse.err
+    }
+
+    hashFrom := fmt.Sprintf("%s-%s", diffResponse.diff, untrackedFilesResponse.untrackedFilesDiff)
+    oktetoLog.Infof("hashing diff: %s", hashFrom)
+    diffHash := sha256.Sum256([]byte(hashFrom))
+    return hex.EncodeToString(diffHash[:]), nil
 }
 
 func (r gitRepoController) getUntrackedContent(ctx context.Context, files []string) (string, error) {
-	totalContent := ""
-	for _, file := range files {
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		default:
-			absPath := filepath.Join(r.path, file)
-			content, err := afero.ReadFile(r.fs, absPath)
-			if err != nil {
-				return "", fmt.Errorf("failed to read file '%s': %w", absPath, err)
-			}
-			totalContent += fmt.Sprintf("%s:%s\n", file, content)
-		}
-	}
-	return totalContent, nil
+    totalContent := ""
+    for _, file := range files {
+        select {
+        case <-ctx.Done():
+            return "", ctx.Err()
+        default:
+            absPath := filepath.Join(r.path, file)
+            content, err := afero.ReadFile(r.fs, absPath)
+            if err != nil {
+                return "", fmt.Errorf("failed to read file '%s': %w", absPath, err)
+            }
+            totalContent += fmt.Sprintf("%s:%s\n", file, content)
+        }
+    }
+    return totalContent, nil
 }
 
 func (r gitRepoController) calculateLatestDirSHA(ctx context.Context, contextDir string) (string, error) {
-	repo, err := r.repoGetter.get(r.path)
-	if err != nil {
-		return "", fmt.Errorf("failed to calculate latestDirCommit: failed to analyze git repo: %w", err)
-	}
+    repo, err := r.repoGetter.get(r.path)
+    if err != nil {
+        return "", fmt.Errorf("failed to calculate latestDirCommit: failed to analyze git repo: %w", err)
+    }
 
-	return repo.GetLatestSHA(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer))
+    return repo.GetLatestSHA(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
 }
 
 type repositoryGetterInterface interface {
-	get(path string) (gitRepositoryInterface, error)
+    get(path string) (gitRepositoryInterface, error)
 }
 
 type gitRepositoryGetter struct{}
 
 func (gitRepositoryGetter) get(path string) (gitRepositoryInterface, error) {
-	repo, err := FindTopLevelGitRepoFromPath(path)
-	if err != nil {
-		return nil, err
-	}
-	return oktetoGitRepository{
-		repo: repo,
-		root: path,
-	}, nil
+    repo, err := FindTopLevelGitRepoFromPath(path)
+    if err != nil {
+        return nil, err
+    }
+    return oktetoGitRepository{
+        repo: repo,
+        root: path,
+    }, nil
 }
 
 type oktetoGitRepository struct {
-	repo *git.Repository
-	root string
+    repo *git.Repository
+    root string
 }
 
 func (ogr oktetoGitRepository) Worktree() (gitWorktreeInterface, error) {
-	worktree, err := ogr.repo.Worktree()
-	if err != nil {
-		return nil, err
-	}
-	return oktetoGitWorktree{worktree: worktree}, nil
+    worktree, err := ogr.repo.Worktree()
+    if err != nil {
+        return nil, err
+    }
+    return oktetoGitWorktree{worktree: worktree}, nil
 }
 
 func (ogr oktetoGitRepository) Head() (*plumbing.Reference, error) {
-	return ogr.repo.Head()
+    return ogr.repo.Head()
 }
 
 func (ogr oktetoGitRepository) Log(o *git.LogOptions) (object.CommitIter, error) {
-	return ogr.repo.Log(o)
+    return ogr.repo.Log(o)
 }
 
 func (ogr oktetoGitRepository) calculateUntrackedFiles(ctx context.Context, contextDir string) ([]string, error) {
-	worktree, err := ogr.Worktree()
-	if err != nil {
-		return []string{}, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
-	}
+    worktree, err := ogr.Worktree()
+    if err != nil {
+        return []string{}, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
+    }
 
-	return worktree.ListUntrackedFiles(ctx, contextDir, NewLocalGit("git", &LocalExec{}, nil))
+    return worktree.ListUntrackedFiles(ctx, contextDir, NewLocalGit("git", &LocalExec{}, nil, false))
 }
 
 type oktetoGitWorktree struct {
-	worktree *git.Worktree
+    worktree *git.Worktree
 }
 
 func (ogr oktetoGitWorktree) GetRoot() string {
-	return ogr.worktree.Filesystem.Root()
+    return ogr.worktree.Filesystem.Root()
 }
 
 type oktetoGitStatus struct {
-	status git.Status
+    status git.Status
 }
 
 func (ogs oktetoGitStatus) IsClean() bool {
-	return ogs.status.IsClean()
+    return ogs.status.IsClean()
 }
 
 type gitRepositoryInterface interface {
-	Worktree() (gitWorktreeInterface, error)
-	Head() (*plumbing.Reference, error)
-	Log(o *git.LogOptions) (object.CommitIter, error)
-	GetLatestSHA(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
-	GetDiff(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
-	calculateUntrackedFiles(ctx context.Context, contextDir string) ([]string, error)
+    Worktree() (gitWorktreeInterface, error)
+    Head() (*plumbing.Reference, error)
+    Log(o *git.LogOptions) (object.CommitIter, error)
+    GetLatestSHA(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
+    GetDiff(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
+    calculateUntrackedFiles(ctx context.Context, contextDir string) ([]string, error)
 }
 
 type gitWorktreeInterface interface {
-	Status(context.Context, string, LocalGitInterface) (oktetoGitStatus, error)
-	GetRoot() string
-	ListUntrackedFiles(context.Context, string, LocalGitInterface) ([]string, error)
+    Status(context.Context, string, LocalGitInterface) (oktetoGitStatus, error)
+    GetRoot() string
+    ListUntrackedFiles(context.Context, string, LocalGitInterface) ([]string, error)
 }
 
 func (ogr oktetoGitWorktree) Status(ctx context.Context, repoRoot string, localGit LocalGitInterface) (oktetoGitStatus, error) {
-	// using git directly is faster, so we check if it's available
-	_, err := localGit.Exists()
-	if err != nil {
-		// git is not available, so we fall back on git-go
-		oktetoLog.Debug("Calculating git status: git is not installed, for better performances consider installing it")
-		status, err := ogr.worktree.Status()
-		if err != nil {
-			return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
-		}
+    // using git directly is faster, so we check if it's available
+    _, err := localGit.Exists()
+    if err != nil {
+        // git is not available, so we fall back on git-go
+        oktetoLog.Debug("Calculating git status: git is not installed, for better performances consider installing it")
+        status, err := ogr.worktree.Status()
+        if err != nil {
+            return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
+        }
 
-		return oktetoGitStatus{status: status}, nil
-	}
+        return oktetoGitStatus{status: status}, nil
+    }
 
-	status, err := localGit.Status(ctx, ogr.GetRoot(), repoRoot, 0)
-	if err != nil {
-		return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
-	}
+    status, err := localGit.Status(ctx, ogr.GetRoot(), repoRoot, 0)
+    if err != nil {
+        return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
+    }
 
-	return oktetoGitStatus{status: status}, nil
+    return oktetoGitStatus{status: status}, nil
 }
 
 func (ogr oktetoGitWorktree) ListUntrackedFiles(ctx context.Context, workdir string, localGit LocalGitInterface) ([]string, error) {
-	// using git directly is faster, so we check if it's available
-	_, err := localGit.Exists()
-	if err != nil {
-		// git is not available, so we fall back on git-go
-		oktetoLog.Debug("Calculating git untrackedFiles: git is not installed, for better performances consider installing it")
+    // using git directly is faster, so we check if it's available
+    _, err := localGit.Exists()
+    if err != nil {
+        // git is not available, so we fall back on git-go
+        oktetoLog.Debug("Calculating git untrackedFiles: git is not installed, for better performances consider installing it")
 
-		status, err := ogr.Status(ctx, ogr.GetRoot(), NewLocalGit("git", &LocalExec{}, nil))
-		if err != nil {
-			return []string{}, fmt.Errorf("failed to infer the git repo's status: %w", err)
-		}
+        status, err := ogr.Status(ctx, ogr.GetRoot(), NewLocalGit("git", &LocalExec{}, nil, false))
+        if err != nil {
+            return []string{}, fmt.Errorf("failed to infer the git repo's status: %w", err)
+        }
 
-		files := []string{}
-		for k, v := range status.status {
-			if v.Staging == git.Untracked {
-				files = append(files, k)
-			}
-		}
+        files := []string{}
+        for k, v := range status.status {
+            if v.Staging == git.Untracked {
+                files = append(files, k)
+            }
+        }
 
-		sort.Strings(files)
-		return files, nil
-	}
+        sort.Strings(files)
+        return files, nil
+    }
 
-	untrackedFiles, err := localGit.ListUntrackedFiles(ctx, ogr.GetRoot(), workdir, 0)
-	if err != nil {
-		return []string{}, fmt.Errorf("failed to get untrackedFiles: %w", err)
-	}
+    untrackedFiles, err := localGit.ListUntrackedFiles(ctx, ogr.GetRoot(), workdir, 0)
+    if err != nil {
+        return []string{}, fmt.Errorf("failed to get untrackedFiles: %w", err)
+    }
 
-	return untrackedFiles, nil
+    return untrackedFiles, nil
 }
 
 // GetLatestSHA calculates a SHA of a repo for the specified directory (dirpath). The result depends on having
@@ -525,78 +532,78 @@ func (ogr oktetoGitWorktree) ListUntrackedFiles(ctx context.Context, workdir str
 // - If git is not installed locally, it will use the latest commit of that directory.
 // - If git is installed it will get a SHA from the files tracked within that directory.
 func (ogr oktetoGitRepository) GetLatestSHA(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error) {
-	// using git directly is faster, so we check if it's available
-	_, err := localGit.Exists()
-	if err != nil {
-		// git is not available, so we fall back on git-go
-		oktetoLog.Debug("Calculating git latest commit: git is not installed, for better performances consider installing it")
-		cIter, err := ogr.Log(&git.LogOptions{
-			PathFilter: func(s string) bool {
-				return s == dirpath
-			},
-		})
-		if err != nil {
-			return "", fmt.Errorf("failed to get git log: %w", err)
-		}
-		commit := ""
-		err = cIter.ForEach(func(c *object.Commit) error {
-			commit = c.Hash.String()
-			return nil
-		})
-		if err != nil {
-			return "", fmt.Errorf("failed to get git log: %w", err)
-		}
-		return commit, nil
-	}
+    // using git directly is faster, so we check if it's available
+    _, err := localGit.Exists()
+    if err != nil {
+        // git is not available, so we fall back on git-go
+        oktetoLog.Debug("Calculating git latest commit: git is not installed, for better performances consider installing it")
+        cIter, err := ogr.Log(&git.LogOptions{
+            PathFilter: func(s string) bool {
+                return s == dirpath
+            },
+        })
+        if err != nil {
+            return "", fmt.Errorf("failed to get git log: %w", err)
+        }
+        commit := ""
+        err = cIter.ForEach(func(c *object.Commit) error {
+            commit = c.Hash.String()
+            return nil
+        })
+        if err != nil {
+            return "", fmt.Errorf("failed to get git log: %w", err)
+        }
+        return commit, nil
+    }
 
-	commit, err := localGit.GetDirContentSHA(ctx, ogr.root, dirpath, 0)
-	if err != nil {
-		return "", fmt.Errorf("failed to get git status: %w", err)
-	}
+    commit, err := localGit.GetDirContentSHA(ctx, ogr.root, dirpath, 0)
+    if err != nil {
+        return "", fmt.Errorf("failed to get git status: %w", err)
+    }
 
-	return commit, nil
+    return commit, nil
 }
 
 // GetDiff returns the diff between the current state of the repo and the last commit
 func (ogr oktetoGitRepository) GetDiff(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error) {
-	// using git directly is faster, so we check if it's available
-	_, err := localGit.Exists()
-	if err != nil {
-		return "", fmt.Errorf("failed to get git status: %w", err)
-	}
+    // using git directly is faster, so we check if it's available
+    _, err := localGit.Exists()
+    if err != nil {
+        return "", fmt.Errorf("failed to get git status: %w", err)
+    }
 
-	diff, err := localGit.Diff(ctx, ogr.root, dirpath, 0)
-	if err != nil {
-		return "", fmt.Errorf("failed to get git status: %w", err)
-	}
+    diff, err := localGit.Diff(ctx, ogr.root, dirpath, 0)
+    if err != nil {
+        return "", fmt.Errorf("failed to get git status: %w", err)
+    }
 
-	return diff, nil
+    return diff, nil
 }
 
 // FindTopLevelGitDir returns the top level git directory for the given working directory
 func FindTopLevelGitDir(workingDir string) (string, error) {
-	dir, err := filepath.Abs(workingDir)
-	if err != nil {
-		return "", fmt.Errorf("%w: invalid workind dir: %w", errFindingRepo, err)
-	}
+    dir, err := filepath.Abs(workingDir)
+    if err != nil {
+        return "", fmt.Errorf("%w: invalid workind dir: %w", errFindingRepo, err)
+    }
 
-	repo, err := FindTopLevelGitRepoFromPath(dir)
-	if err != nil {
-		return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
-	}
+    repo, err := FindTopLevelGitRepoFromPath(dir)
+    if err != nil {
+        return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
+    }
 
-	worktree, err := repo.Worktree()
-	if err != nil {
-		return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
-	}
+    worktree, err := repo.Worktree()
+    if err != nil {
+        return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
+    }
 
-	return worktree.Filesystem.Root(), nil
+    return worktree.Filesystem.Root(), nil
 }
 
 // FindTopLevelGitRepoFromPath returns the git repository for the given absolute path taking into parent folders
 func FindTopLevelGitRepoFromPath(path string) (*git.Repository, error) {
-	opts := &git.PlainOpenOptions{
-		DetectDotGit: true,
-	}
-	return git.PlainOpenWithOptions(path, opts)
+    opts := &git.PlainOpenOptions{
+        DetectDotGit: true,
+    }
+    return git.PlainOpenWithOptions(path, opts)
 }

--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -14,517 +14,517 @@
 package repository
 
 import (
-    "context"
-    "crypto/sha256"
-    "encoding/hex"
-    "errors"
-    "fmt"
-    "path/filepath"
-    "sort"
-    "strings"
-    "time"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
 
-    giturls "github.com/chainguard-dev/git-urls"
-    "github.com/go-git/go-git/v5"
-    "github.com/go-git/go-git/v5/plumbing"
-    "github.com/go-git/go-git/v5/plumbing/object"
-    "github.com/okteto/okteto/pkg/env"
-    "github.com/okteto/okteto/pkg/ignore"
-    oktetoLog "github.com/okteto/okteto/pkg/log"
-    "github.com/spf13/afero"
+	giturls "github.com/chainguard-dev/git-urls"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/okteto/okteto/pkg/env"
+	"github.com/okteto/okteto/pkg/ignore"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/spf13/afero"
 )
 
 const (
-    gitOperationTimeout = 5 * time.Second
+	gitOperationTimeout = 5 * time.Second
 )
 
 var (
-    errNotCleanRepo    = errors.New("repository is not clean")
-    errTimeoutExceeded = errors.New("timeout exceeded")
-    errFindingRepo     = errors.New("top level git repo directory cannot be found")
+	errNotCleanRepo    = errors.New("repository is not clean")
+	errTimeoutExceeded = errors.New("timeout exceeded")
+	errFindingRepo     = errors.New("top level git repo directory cannot be found")
 )
 
 type gitRepoController struct {
-    repoGetter        repositoryGetterInterface
-    fs                afero.Fs
-    ignorer           func(subpath string) ignore.Ignorer
-    path              string
-    shouldIgnoreFiles bool
+	repoGetter        repositoryGetterInterface
+	fs                afero.Fs
+	ignorer           func(subpath string) ignore.Ignorer
+	path              string
+	shouldIgnoreFiles bool
 }
 
 func newGitRepoController(path string) gitRepoController {
-    shouldIgnoreFiles := env.LoadBoolean("OKTETO_SMART_BUILDS_IGNORE_FILES_ENABLED")
-    return gitRepoController{
-        repoGetter: gitRepositoryGetter{},
-        path:       path,
-        fs:         afero.NewOsFs(),
-        ignorer: func(subpath string) ignore.Ignorer {
-            if !shouldIgnoreFiles {
-                return ignore.Never
-            }
-            return ignore.NewMultiIgnorer(
-                ignore.NewDockerIgnorer(filepath.Join(subpath, ".dockerignore")),
-            )
-        },
-        shouldIgnoreFiles: shouldIgnoreFiles,
-    }
+	shouldIgnoreFiles := env.LoadBoolean("OKTETO_SMART_BUILDS_IGNORE_FILES_ENABLED")
+	return gitRepoController{
+		repoGetter: gitRepositoryGetter{},
+		path:       path,
+		fs:         afero.NewOsFs(),
+		ignorer: func(subpath string) ignore.Ignorer {
+			if !shouldIgnoreFiles {
+				return ignore.Never
+			}
+			return ignore.NewMultiIgnorer(
+				ignore.NewDockerIgnorer(filepath.Join(subpath, ".dockerignore")),
+			)
+		},
+		shouldIgnoreFiles: shouldIgnoreFiles,
+	}
 }
 
 type cleanStatus struct {
-    err     error
-    isClean bool
+	err     error
+	isClean bool
 }
 
 func (r gitRepoController) getCurrentBranch() (string, error) {
-    repo, err := r.repoGetter.get(r.path)
-    if err != nil {
-        return "", fmt.Errorf("failed to analyze git repo: %w", err)
-    }
-    head, err := repo.Head()
-    if err != nil {
-        return "", fmt.Errorf("failed to analyze git repo: %w", err)
-    }
-    return head.Name().Short(), nil
+	repo, err := r.repoGetter.get(r.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
+	return head.Name().Short(), nil
 }
 
 func (r gitRepoController) calculateIsClean(ctx context.Context) (bool, error) {
-    repo, err := r.repoGetter.get(r.path)
-    if err != nil {
-        return false, fmt.Errorf("failed to analyze git repo: %w", err)
-    }
+	repo, err := r.repoGetter.get(r.path)
+	if err != nil {
+		return false, fmt.Errorf("failed to analyze git repo: %w", err)
+	}
 
-    worktree, err := repo.Worktree()
-    if err != nil {
-        return false, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
-    }
-    status, err := worktree.Status(ctx, "", NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
-    if err != nil {
-        return false, fmt.Errorf("failed to infer the git repo's status: %w", err)
-    }
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return false, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
+	}
+	status, err := worktree.Status(ctx, "", NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
+	if err != nil {
+		return false, fmt.Errorf("failed to infer the git repo's status: %w", err)
+	}
 
-    return status.IsClean(), nil
+	return status.IsClean(), nil
 }
 
 func (r gitRepoController) getRepoURL() (string, error) {
-    url, err := giturls.Parse(r.path)
-    if err != nil {
-        oktetoLog.Infof("could not parse url: %s", err)
-    }
-    if url.Scheme != "file" {
-        return r.sanitiseURL(url.String()), nil
-    }
+	url, err := giturls.Parse(r.path)
+	if err != nil {
+		oktetoLog.Infof("could not parse url: %s", err)
+	}
+	if url.Scheme != "file" {
+		return r.sanitiseURL(url.String()), nil
+	}
 
-    repo, err := FindTopLevelGitRepoFromPath(r.path)
-    if err != nil {
-        return "", fmt.Errorf("failed to analyze git repo: %w", err)
-    }
-    origin, err := repo.Remote("origin")
-    if err != nil {
-        if err != git.ErrRemoteNotFound {
-            return "", fmt.Errorf("failed to get the git repo's remote configuration: %w", err)
-        }
-    }
+	repo, err := FindTopLevelGitRepoFromPath(r.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
+	origin, err := repo.Remote("origin")
+	if err != nil {
+		if err != git.ErrRemoteNotFound {
+			return "", fmt.Errorf("failed to get the git repo's remote configuration: %w", err)
+		}
+	}
 
-    if origin != nil {
-        return r.sanitiseURL(origin.Config().URLs[0]), nil
-    }
+	if origin != nil {
+		return r.sanitiseURL(origin.Config().URLs[0]), nil
+	}
 
-    remotes, err := repo.Remotes()
-    if err != nil {
-        return "", fmt.Errorf("failed to get git repo's remote information: %w", err)
-    }
+	remotes, err := repo.Remotes()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git repo's remote information: %w", err)
+	}
 
-    if len(remotes) == 0 {
-        return "", fmt.Errorf("git repo doesn't have any remote")
-    }
+	if len(remotes) == 0 {
+		return "", fmt.Errorf("git repo doesn't have any remote")
+	}
 
-    return r.sanitiseURL(remotes[0].Config().URLs[0]), nil
+	return r.sanitiseURL(remotes[0].Config().URLs[0]), nil
 }
 
 func (r gitRepoController) sanitiseURL(u string) string {
-    url, err := giturls.Parse(u)
-    if err != nil {
-        oktetoLog.Infof("could not parse url: %s", err)
-        return u
-    }
-    url.Path = strings.Replace(url.Path, "//", "/", -1)
-    return url.String()
+	url, err := giturls.Parse(u)
+	if err != nil {
+		oktetoLog.Infof("could not parse url: %s", err)
+		return u
+	}
+	url.Path = strings.Replace(url.Path, "//", "/", -1)
+	return url.String()
 }
 
 // isClean checks if the repository have changes over the commit
 func (r gitRepoController) isClean(ctx context.Context) (bool, error) {
-    // We use context.TODO() in a few places to call isClean, so let's make sure
-    // we set proper internal timeouts to not leak goroutines
-    ctx, cancel := context.WithCancel(ctx)
-    defer cancel()
+	// We use context.TODO() in a few places to call isClean, so let's make sure
+	// we set proper internal timeouts to not leak goroutines
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-    timeoutCh := make(chan struct{})
-    ch := make(chan cleanStatus)
+	timeoutCh := make(chan struct{})
+	ch := make(chan cleanStatus)
 
-    go func() {
-        time.Sleep(time.Second)
-        close(timeoutCh)
-        cancel()
-        ch <- cleanStatus{errTimeoutExceeded, false}
-    }()
+	go func() {
+		time.Sleep(time.Second)
+		close(timeoutCh)
+		cancel()
+		ch <- cleanStatus{errTimeoutExceeded, false}
+	}()
 
-    go func() {
-        clean, err := r.calculateIsClean(ctx)
-        select {
-        case <-timeoutCh:
-        case ch <- cleanStatus{err, clean}:
-        }
-    }()
+	go func() {
+		clean, err := r.calculateIsClean(ctx)
+		select {
+		case <-timeoutCh:
+		case ch <- cleanStatus{err, clean}:
+		}
+	}()
 
-    s := <-ch
+	s := <-ch
 
-    if errors.Is(s.err, errTimeoutExceeded) {
-        oktetoLog.Debug("Timeout exceeded calculating git status: assuming dirty commit")
-    }
+	if errors.Is(s.err, errTimeoutExceeded) {
+		oktetoLog.Debug("Timeout exceeded calculating git status: assuming dirty commit")
+	}
 
-    return s.isClean, s.err
+	return s.isClean, s.err
 }
 
 // GetSHA returns the last commit sha of the repository
 func (r gitRepoController) getSHA() (string, error) {
-    isClean, err := r.isClean(context.TODO())
-    if err != nil {
-        return "", fmt.Errorf("%w: failed to check if repo is clean: %w", errNotCleanRepo, err)
-    }
-    if !isClean {
-        return "", errNotCleanRepo
-    }
-    repo, err := r.repoGetter.get(r.path)
-    if err != nil {
-        return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
-    }
-    head, err := repo.Head()
-    if err != nil {
-        return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
-    }
-    return head.Hash().String(), nil
+	isClean, err := r.isClean(context.TODO())
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to check if repo is clean: %w", errNotCleanRepo, err)
+	}
+	if !isClean {
+		return "", errNotCleanRepo
+	}
+	repo, err := r.repoGetter.get(r.path)
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to analyze git repo: %w", errNotCleanRepo, err)
+	}
+	return head.Hash().String(), nil
 }
 
 type commitResponse struct {
-    err    error
-    commit string
+	err    error
+	commit string
 }
 
 // GetLatestDirSHA It calculates a sha of the contextDir specified as parameter based on the content
 func (r gitRepoController) GetLatestDirSHA(contextDir string) (string, error) {
-    // We use context.TODO() in a few places to call isClean, so let's make sure
-    // we set proper internal timeouts to not leak goroutines
-    ctx, cancel := context.WithCancel(context.TODO())
-    defer cancel()
+	// We use context.TODO() in a few places to call isClean, so let's make sure
+	// we set proper internal timeouts to not leak goroutines
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-    timeoutCh := make(chan struct{})
-    ch := make(chan commitResponse)
+	timeoutCh := make(chan struct{})
+	ch := make(chan commitResponse)
 
-    go func() {
-        time.Sleep(gitOperationTimeout)
-        close(timeoutCh)
-        cancel()
-        ch <- commitResponse{
-            commit: "",
-            err:    errTimeoutExceeded,
-        }
-    }()
+	go func() {
+		time.Sleep(gitOperationTimeout)
+		close(timeoutCh)
+		cancel()
+		ch <- commitResponse{
+			commit: "",
+			err:    errTimeoutExceeded,
+		}
+	}()
 
-    go func() {
-        commit, err := r.calculateLatestDirSHA(ctx, contextDir)
-        select {
-        case <-timeoutCh:
-        case ch <- commitResponse{
-            commit: commit,
-            err:    err,
-        }:
-        }
-    }()
+	go func() {
+		commit, err := r.calculateLatestDirSHA(ctx, contextDir)
+		select {
+		case <-timeoutCh:
+		case ch <- commitResponse{
+			commit: commit,
+			err:    err,
+		}:
+		}
+	}()
 
-    s := <-ch
+	s := <-ch
 
-    if errors.Is(s.err, errTimeoutExceeded) {
-        oktetoLog.Debugf("Timeout exceeded calculating git commit for '%s': assuming dirty commit", contextDir)
-    }
+	if errors.Is(s.err, errTimeoutExceeded) {
+		oktetoLog.Debugf("Timeout exceeded calculating git commit for '%s': assuming dirty commit", contextDir)
+	}
 
-    return s.commit, s.err
+	return s.commit, s.err
 }
 
 type diffResponse struct {
-    err  error
-    diff string
+	err  error
+	diff string
 }
 
 type untrackedFilesResponse struct {
-    err                error
-    untrackedFilesDiff string
+	err                error
+	untrackedFilesDiff string
 }
 
 func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
-    // We use context.TODO() in a few places to call GetDiffHash, so let's make sure
-    // we set proper internal timeouts to not leak goroutines
-    ctx, cancel := context.WithCancel(context.TODO())
-    defer cancel()
+	// We use context.TODO() in a few places to call GetDiffHash, so let's make sure
+	// we set proper internal timeouts to not leak goroutines
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
 
-    timeoutCh := make(chan struct{})
-    diffCh := make(chan diffResponse)
-    untrackedFilesCh := make(chan untrackedFilesResponse)
+	timeoutCh := make(chan struct{})
+	diffCh := make(chan diffResponse)
+	untrackedFilesCh := make(chan untrackedFilesResponse)
 
-    repo, err := r.repoGetter.get(r.path)
-    if err != nil {
-        return "", fmt.Errorf("failed to analyze git repo: %w", err)
-    }
+	repo, err := r.repoGetter.get(r.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to analyze git repo: %w", err)
+	}
 
-    // go func that cancels the context after the timeout
-    go func() {
-        time.Sleep(gitOperationTimeout)
-        close(timeoutCh)
-        cancel()
-        diffCh <- diffResponse{
-            diff: "",
-            err:  errTimeoutExceeded,
-        }
-        untrackedFilesCh <- untrackedFilesResponse{
-            untrackedFilesDiff: "",
-            err:                errTimeoutExceeded,
-        }
-    }()
+	// go func that cancels the context after the timeout
+	go func() {
+		time.Sleep(gitOperationTimeout)
+		close(timeoutCh)
+		cancel()
+		diffCh <- diffResponse{
+			diff: "",
+			err:  errTimeoutExceeded,
+		}
+		untrackedFilesCh <- untrackedFilesResponse{
+			untrackedFilesDiff: "",
+			err:                errTimeoutExceeded,
+		}
+	}()
 
-    // go func that calculates the diff using git diff
-    go func() {
-        diff, err := repo.GetDiff(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
-        select {
-        case <-timeoutCh:
-            oktetoLog.Debug("Timeout exceeded calculating git diff: assuming dirty commit")
-        case diffCh <- diffResponse{
-            diff: diff,
-            err:  err,
-        }:
-        }
-    }()
+	// go func that calculates the diff using git diff
+	go func() {
+		diff, err := repo.GetDiff(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
+		select {
+		case <-timeoutCh:
+			oktetoLog.Debug("Timeout exceeded calculating git diff: assuming dirty commit")
+		case diffCh <- diffResponse{
+			diff: diff,
+			err:  err,
+		}:
+		}
+	}()
 
-    // go func that calculates the diff for the untracked files
-    go func() {
-        untrackedFiles, err := repo.calculateUntrackedFiles(ctx, contextDir)
-        if err != nil {
-            select {
-            case <-timeoutCh:
-                oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
-            case untrackedFilesCh <- untrackedFilesResponse{
-                untrackedFilesDiff: "",
-                err:                err,
-            }:
-            }
-            return
-        }
+	// go func that calculates the diff for the untracked files
+	go func() {
+		untrackedFiles, err := repo.calculateUntrackedFiles(ctx, contextDir)
+		if err != nil {
+			select {
+			case <-timeoutCh:
+				oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
+			case untrackedFilesCh <- untrackedFilesResponse{
+				untrackedFilesDiff: "",
+				err:                err,
+			}:
+			}
+			return
+		}
 
-        if r.shouldIgnoreFiles {
-            worktree, err := repo.Worktree()
-            if err != nil {
-                oktetoLog.Debugf("Failed to get worktree, skipping calculation of files to ignore: %v", err)
-            } else {
-                filteredUntrackedFiles := []string{}
-                for _, f := range untrackedFiles {
-                    relpath := resolveRelativePath(filepath.Join(worktree.GetRoot(), f), contextDir)
-                    shouldIgnore, err := r.ignorer(contextDir).Ignore(relpath)
-                    if err != nil {
-                        oktetoLog.Debugf("ignore error in GetDiffHash: %v", err)
-                    }
-                    if !shouldIgnore {
-                        filteredUntrackedFiles = append(filteredUntrackedFiles, f)
-                    } else {
-                        oktetoLog.Debugf("skipping %v file change in GetDiffHash based on known ignore files", f)
-                    }
+		if r.shouldIgnoreFiles {
+			worktree, err := repo.Worktree()
+			if err != nil {
+				oktetoLog.Debugf("Failed to get worktree, skipping calculation of files to ignore: %v", err)
+			} else {
+				filteredUntrackedFiles := []string{}
+				for _, f := range untrackedFiles {
+					relpath := resolveRelativePath(filepath.Join(worktree.GetRoot(), f), contextDir)
+					shouldIgnore, err := r.ignorer(contextDir).Ignore(relpath)
+					if err != nil {
+						oktetoLog.Debugf("ignore error in GetDiffHash: %v", err)
+					}
+					if !shouldIgnore {
+						filteredUntrackedFiles = append(filteredUntrackedFiles, f)
+					} else {
+						oktetoLog.Debugf("skipping %v file change in GetDiffHash based on known ignore files", f)
+					}
 
-                }
+				}
 
-                untrackedFiles = filteredUntrackedFiles
-            }
-        }
+				untrackedFiles = filteredUntrackedFiles
+			}
+		}
 
-        untrackedFilesContent, err := r.getUntrackedContent(ctx, untrackedFiles)
-        select {
-        case <-timeoutCh:
-            oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
-        case untrackedFilesCh <- untrackedFilesResponse{
-            untrackedFilesDiff: untrackedFilesContent,
-            err:                err,
-        }:
-        }
-    }()
+		untrackedFilesContent, err := r.getUntrackedContent(ctx, untrackedFiles)
+		select {
+		case <-timeoutCh:
+			oktetoLog.Debug("Timeout exceeded calculating git untracked files: assuming dirty commit")
+		case untrackedFilesCh <- untrackedFilesResponse{
+			untrackedFilesDiff: untrackedFilesContent,
+			err:                err,
+		}:
+		}
+	}()
 
-    diffResponse := <-diffCh
-    if diffResponse.err != nil {
-        return "", diffResponse.err
-    }
+	diffResponse := <-diffCh
+	if diffResponse.err != nil {
+		return "", diffResponse.err
+	}
 
-    untrackedFilesResponse := <-untrackedFilesCh
-    if untrackedFilesResponse.err != nil {
-        return "", untrackedFilesResponse.err
-    }
+	untrackedFilesResponse := <-untrackedFilesCh
+	if untrackedFilesResponse.err != nil {
+		return "", untrackedFilesResponse.err
+	}
 
-    hashFrom := fmt.Sprintf("%s-%s", diffResponse.diff, untrackedFilesResponse.untrackedFilesDiff)
-    oktetoLog.Infof("hashing diff: %s", hashFrom)
-    diffHash := sha256.Sum256([]byte(hashFrom))
-    return hex.EncodeToString(diffHash[:]), nil
+	hashFrom := fmt.Sprintf("%s-%s", diffResponse.diff, untrackedFilesResponse.untrackedFilesDiff)
+	oktetoLog.Infof("hashing diff: %s", hashFrom)
+	diffHash := sha256.Sum256([]byte(hashFrom))
+	return hex.EncodeToString(diffHash[:]), nil
 }
 
 func (r gitRepoController) getUntrackedContent(ctx context.Context, files []string) (string, error) {
-    totalContent := ""
-    for _, file := range files {
-        select {
-        case <-ctx.Done():
-            return "", ctx.Err()
-        default:
-            absPath := filepath.Join(r.path, file)
-            content, err := afero.ReadFile(r.fs, absPath)
-            if err != nil {
-                return "", fmt.Errorf("failed to read file '%s': %w", absPath, err)
-            }
-            totalContent += fmt.Sprintf("%s:%s\n", file, content)
-        }
-    }
-    return totalContent, nil
+	totalContent := ""
+	for _, file := range files {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+			absPath := filepath.Join(r.path, file)
+			content, err := afero.ReadFile(r.fs, absPath)
+			if err != nil {
+				return "", fmt.Errorf("failed to read file '%s': %w", absPath, err)
+			}
+			totalContent += fmt.Sprintf("%s:%s\n", file, content)
+		}
+	}
+	return totalContent, nil
 }
 
 func (r gitRepoController) calculateLatestDirSHA(ctx context.Context, contextDir string) (string, error) {
-    repo, err := r.repoGetter.get(r.path)
-    if err != nil {
-        return "", fmt.Errorf("failed to calculate latestDirCommit: failed to analyze git repo: %w", err)
-    }
+	repo, err := r.repoGetter.get(r.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to calculate latestDirCommit: failed to analyze git repo: %w", err)
+	}
 
-    return repo.GetLatestSHA(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
+	return repo.GetLatestSHA(ctx, contextDir, NewLocalGit("git", &LocalExec{}, r.ignorer, r.shouldIgnoreFiles))
 }
 
 type repositoryGetterInterface interface {
-    get(path string) (gitRepositoryInterface, error)
+	get(path string) (gitRepositoryInterface, error)
 }
 
 type gitRepositoryGetter struct{}
 
 func (gitRepositoryGetter) get(path string) (gitRepositoryInterface, error) {
-    repo, err := FindTopLevelGitRepoFromPath(path)
-    if err != nil {
-        return nil, err
-    }
-    return oktetoGitRepository{
-        repo: repo,
-        root: path,
-    }, nil
+	repo, err := FindTopLevelGitRepoFromPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return oktetoGitRepository{
+		repo: repo,
+		root: path,
+	}, nil
 }
 
 type oktetoGitRepository struct {
-    repo *git.Repository
-    root string
+	repo *git.Repository
+	root string
 }
 
 func (ogr oktetoGitRepository) Worktree() (gitWorktreeInterface, error) {
-    worktree, err := ogr.repo.Worktree()
-    if err != nil {
-        return nil, err
-    }
-    return oktetoGitWorktree{worktree: worktree}, nil
+	worktree, err := ogr.repo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	return oktetoGitWorktree{worktree: worktree}, nil
 }
 
 func (ogr oktetoGitRepository) Head() (*plumbing.Reference, error) {
-    return ogr.repo.Head()
+	return ogr.repo.Head()
 }
 
 func (ogr oktetoGitRepository) Log(o *git.LogOptions) (object.CommitIter, error) {
-    return ogr.repo.Log(o)
+	return ogr.repo.Log(o)
 }
 
 func (ogr oktetoGitRepository) calculateUntrackedFiles(ctx context.Context, contextDir string) ([]string, error) {
-    worktree, err := ogr.Worktree()
-    if err != nil {
-        return []string{}, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
-    }
+	worktree, err := ogr.Worktree()
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to infer the git repo's current worktree: %w", err)
+	}
 
-    return worktree.ListUntrackedFiles(ctx, contextDir, NewLocalGit("git", &LocalExec{}, nil, false))
+	return worktree.ListUntrackedFiles(ctx, contextDir, NewLocalGit("git", &LocalExec{}, nil, false))
 }
 
 type oktetoGitWorktree struct {
-    worktree *git.Worktree
+	worktree *git.Worktree
 }
 
 func (ogr oktetoGitWorktree) GetRoot() string {
-    return ogr.worktree.Filesystem.Root()
+	return ogr.worktree.Filesystem.Root()
 }
 
 type oktetoGitStatus struct {
-    status git.Status
+	status git.Status
 }
 
 func (ogs oktetoGitStatus) IsClean() bool {
-    return ogs.status.IsClean()
+	return ogs.status.IsClean()
 }
 
 type gitRepositoryInterface interface {
-    Worktree() (gitWorktreeInterface, error)
-    Head() (*plumbing.Reference, error)
-    Log(o *git.LogOptions) (object.CommitIter, error)
-    GetLatestSHA(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
-    GetDiff(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
-    calculateUntrackedFiles(ctx context.Context, contextDir string) ([]string, error)
+	Worktree() (gitWorktreeInterface, error)
+	Head() (*plumbing.Reference, error)
+	Log(o *git.LogOptions) (object.CommitIter, error)
+	GetLatestSHA(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
+	GetDiff(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error)
+	calculateUntrackedFiles(ctx context.Context, contextDir string) ([]string, error)
 }
 
 type gitWorktreeInterface interface {
-    Status(context.Context, string, LocalGitInterface) (oktetoGitStatus, error)
-    GetRoot() string
-    ListUntrackedFiles(context.Context, string, LocalGitInterface) ([]string, error)
+	Status(context.Context, string, LocalGitInterface) (oktetoGitStatus, error)
+	GetRoot() string
+	ListUntrackedFiles(context.Context, string, LocalGitInterface) ([]string, error)
 }
 
 func (ogr oktetoGitWorktree) Status(ctx context.Context, repoRoot string, localGit LocalGitInterface) (oktetoGitStatus, error) {
-    // using git directly is faster, so we check if it's available
-    _, err := localGit.Exists()
-    if err != nil {
-        // git is not available, so we fall back on git-go
-        oktetoLog.Debug("Calculating git status: git is not installed, for better performances consider installing it")
-        status, err := ogr.worktree.Status()
-        if err != nil {
-            return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
-        }
+	// using git directly is faster, so we check if it's available
+	_, err := localGit.Exists()
+	if err != nil {
+		// git is not available, so we fall back on git-go
+		oktetoLog.Debug("Calculating git status: git is not installed, for better performances consider installing it")
+		status, err := ogr.worktree.Status()
+		if err != nil {
+			return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
+		}
 
-        return oktetoGitStatus{status: status}, nil
-    }
+		return oktetoGitStatus{status: status}, nil
+	}
 
-    status, err := localGit.Status(ctx, ogr.GetRoot(), repoRoot, 0)
-    if err != nil {
-        return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
-    }
+	status, err := localGit.Status(ctx, ogr.GetRoot(), repoRoot, 0)
+	if err != nil {
+		return oktetoGitStatus{status: git.Status{}}, fmt.Errorf("failed to get git status: %w", err)
+	}
 
-    return oktetoGitStatus{status: status}, nil
+	return oktetoGitStatus{status: status}, nil
 }
 
 func (ogr oktetoGitWorktree) ListUntrackedFiles(ctx context.Context, workdir string, localGit LocalGitInterface) ([]string, error) {
-    // using git directly is faster, so we check if it's available
-    _, err := localGit.Exists()
-    if err != nil {
-        // git is not available, so we fall back on git-go
-        oktetoLog.Debug("Calculating git untrackedFiles: git is not installed, for better performances consider installing it")
+	// using git directly is faster, so we check if it's available
+	_, err := localGit.Exists()
+	if err != nil {
+		// git is not available, so we fall back on git-go
+		oktetoLog.Debug("Calculating git untrackedFiles: git is not installed, for better performances consider installing it")
 
-        status, err := ogr.Status(ctx, ogr.GetRoot(), NewLocalGit("git", &LocalExec{}, nil, false))
-        if err != nil {
-            return []string{}, fmt.Errorf("failed to infer the git repo's status: %w", err)
-        }
+		status, err := ogr.Status(ctx, ogr.GetRoot(), NewLocalGit("git", &LocalExec{}, nil, false))
+		if err != nil {
+			return []string{}, fmt.Errorf("failed to infer the git repo's status: %w", err)
+		}
 
-        files := []string{}
-        for k, v := range status.status {
-            if v.Staging == git.Untracked {
-                files = append(files, k)
-            }
-        }
+		files := []string{}
+		for k, v := range status.status {
+			if v.Staging == git.Untracked {
+				files = append(files, k)
+			}
+		}
 
-        sort.Strings(files)
-        return files, nil
-    }
+		sort.Strings(files)
+		return files, nil
+	}
 
-    untrackedFiles, err := localGit.ListUntrackedFiles(ctx, ogr.GetRoot(), workdir, 0)
-    if err != nil {
-        return []string{}, fmt.Errorf("failed to get untrackedFiles: %w", err)
-    }
+	untrackedFiles, err := localGit.ListUntrackedFiles(ctx, ogr.GetRoot(), workdir, 0)
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get untrackedFiles: %w", err)
+	}
 
-    return untrackedFiles, nil
+	return untrackedFiles, nil
 }
 
 // GetLatestSHA calculates a SHA of a repo for the specified directory (dirpath). The result depends on having
@@ -532,78 +532,78 @@ func (ogr oktetoGitWorktree) ListUntrackedFiles(ctx context.Context, workdir str
 // - If git is not installed locally, it will use the latest commit of that directory.
 // - If git is installed it will get a SHA from the files tracked within that directory.
 func (ogr oktetoGitRepository) GetLatestSHA(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error) {
-    // using git directly is faster, so we check if it's available
-    _, err := localGit.Exists()
-    if err != nil {
-        // git is not available, so we fall back on git-go
-        oktetoLog.Debug("Calculating git latest commit: git is not installed, for better performances consider installing it")
-        cIter, err := ogr.Log(&git.LogOptions{
-            PathFilter: func(s string) bool {
-                return s == dirpath
-            },
-        })
-        if err != nil {
-            return "", fmt.Errorf("failed to get git log: %w", err)
-        }
-        commit := ""
-        err = cIter.ForEach(func(c *object.Commit) error {
-            commit = c.Hash.String()
-            return nil
-        })
-        if err != nil {
-            return "", fmt.Errorf("failed to get git log: %w", err)
-        }
-        return commit, nil
-    }
+	// using git directly is faster, so we check if it's available
+	_, err := localGit.Exists()
+	if err != nil {
+		// git is not available, so we fall back on git-go
+		oktetoLog.Debug("Calculating git latest commit: git is not installed, for better performances consider installing it")
+		cIter, err := ogr.Log(&git.LogOptions{
+			PathFilter: func(s string) bool {
+				return s == dirpath
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to get git log: %w", err)
+		}
+		commit := ""
+		err = cIter.ForEach(func(c *object.Commit) error {
+			commit = c.Hash.String()
+			return nil
+		})
+		if err != nil {
+			return "", fmt.Errorf("failed to get git log: %w", err)
+		}
+		return commit, nil
+	}
 
-    commit, err := localGit.GetDirContentSHA(ctx, ogr.root, dirpath, 0)
-    if err != nil {
-        return "", fmt.Errorf("failed to get git status: %w", err)
-    }
+	commit, err := localGit.GetDirContentSHA(ctx, ogr.root, dirpath, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to get git status: %w", err)
+	}
 
-    return commit, nil
+	return commit, nil
 }
 
 // GetDiff returns the diff between the current state of the repo and the last commit
 func (ogr oktetoGitRepository) GetDiff(ctx context.Context, dirpath string, localGit LocalGitInterface) (string, error) {
-    // using git directly is faster, so we check if it's available
-    _, err := localGit.Exists()
-    if err != nil {
-        return "", fmt.Errorf("failed to get git status: %w", err)
-    }
+	// using git directly is faster, so we check if it's available
+	_, err := localGit.Exists()
+	if err != nil {
+		return "", fmt.Errorf("failed to get git status: %w", err)
+	}
 
-    diff, err := localGit.Diff(ctx, ogr.root, dirpath, 0)
-    if err != nil {
-        return "", fmt.Errorf("failed to get git status: %w", err)
-    }
+	diff, err := localGit.Diff(ctx, ogr.root, dirpath, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to get git status: %w", err)
+	}
 
-    return diff, nil
+	return diff, nil
 }
 
 // FindTopLevelGitDir returns the top level git directory for the given working directory
 func FindTopLevelGitDir(workingDir string) (string, error) {
-    dir, err := filepath.Abs(workingDir)
-    if err != nil {
-        return "", fmt.Errorf("%w: invalid workind dir: %w", errFindingRepo, err)
-    }
+	dir, err := filepath.Abs(workingDir)
+	if err != nil {
+		return "", fmt.Errorf("%w: invalid workind dir: %w", errFindingRepo, err)
+	}
 
-    repo, err := FindTopLevelGitRepoFromPath(dir)
-    if err != nil {
-        return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
-    }
+	repo, err := FindTopLevelGitRepoFromPath(dir)
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
+	}
 
-    worktree, err := repo.Worktree()
-    if err != nil {
-        return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
-    }
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return "", fmt.Errorf("%w: failed to find top level git repo: %w", errFindingRepo, err)
+	}
 
-    return worktree.Filesystem.Root(), nil
+	return worktree.Filesystem.Root(), nil
 }
 
 // FindTopLevelGitRepoFromPath returns the git repository for the given absolute path taking into parent folders
 func FindTopLevelGitRepoFromPath(path string) (*git.Repository, error) {
-    opts := &git.PlainOpenOptions{
-        DetectDotGit: true,
-    }
-    return git.PlainOpenWithOptions(path, opts)
+	opts := &git.PlainOpenOptions{
+		DetectDotGit: true,
+	}
+	return git.PlainOpenWithOptions(path, opts)
 }

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -373,7 +373,7 @@ func (lg *LocalGit) getDirContentSHAWithIgnore(ctx context.Context, gitPath, dir
 	defer func() {
 		err := lg.fs.Remove(f.Name())
 		if err != nil {
-			oktetoLog.Debugf("failed to close untracked file: %v", err)
+			oktetoLog.Debugf("failed to remove untracked file: %v", err)
 		}
 	}()
 

--- a/pkg/repository/local_git.go
+++ b/pkg/repository/local_git.go
@@ -147,21 +147,23 @@ type LocalGitInterface interface {
 }
 
 type LocalGit struct {
-	exec    CommandExecutor
-	ignorer func(subpath string) ignore.Ignorer
-	gitPath string
+	exec              CommandExecutor
+	ignorer           func(subpath string) ignore.Ignorer
+	gitPath           string
+	shouldIgnoreFiles bool
 }
 
-func NewLocalGit(gitPath string, exec CommandExecutor, ignorer func(path string) ignore.Ignorer) *LocalGit {
+func NewLocalGit(gitPath string, exec CommandExecutor, ignorer func(path string) ignore.Ignorer, shouldIgnoreFiles bool) *LocalGit {
 	if ignorer == nil {
 		ignorer = func(path string) ignore.Ignorer {
 			return ignore.Never
 		}
 	}
 	return &LocalGit{
-		gitPath: gitPath,
-		exec:    exec,
-		ignorer: ignorer,
+		gitPath:           gitPath,
+		exec:              exec,
+		ignorer:           ignorer,
+		shouldIgnoreFiles: shouldIgnoreFiles,
 	}
 }
 
@@ -286,6 +288,16 @@ func (lg *LocalGit) GetDirContentSHA(ctx context.Context, gitPath, dirPath strin
 		return "", errLocalGitCannotGetCommitTooManyAttempts
 	}
 
+	if lg.shouldIgnoreFiles {
+		return lg.getDirContentSHAWithIgnore(ctx, gitPath, dirPath, fixAttempt)
+	}
+
+	return lg.getDirContentSHAWithoutIgnore(ctx, gitPath, dirPath, fixAttempt)
+}
+
+// getDirContentSHAWithIgnore calculates the SHA of the content of the given directory using git ls-files and git hash-object taking into account
+// files to be ignored by the ignorer
+func (lg *LocalGit) getDirContentSHAWithIgnore(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
 	handleError := func(e error) (string, error) {
 		var exitError *exec.ExitError
 		errors.As(e, &exitError)
@@ -306,6 +318,7 @@ func (lg *LocalGit) GetDirContentSHA(ctx context.Context, gitPath, dirPath strin
 	filesRaw, err := lg.exec.RunCommand(ctx, dirPath, lg.gitPath, "--no-optional-locks", "ls-files", "-s")
 
 	if err != nil {
+		oktetoLog.Debugf("failed to list files in directory %s: %v", dirPath, err)
 		return handleError(err)
 	}
 
@@ -349,7 +362,34 @@ func (lg *LocalGit) GetDirContentSHA(ctx context.Context, gitPath, dirPath strin
 	output, err := lg.exec.RunPipeCommands(ctx, gitPath, "echo", []string{filteredLS}, lg.gitPath, hashObjectCmdArgs)
 
 	if err != nil {
+		oktetoLog.Debugf("failed to calculate hash of directory %s: %v", dirPath, err)
 		return handleError(err)
+	}
+	return string(output), nil
+}
+
+// getDirContentSHAWithoutIgnore calculates the SHA of the content of the given directory using git ls-files and git hash-object
+func (lg *LocalGit) getDirContentSHAWithoutIgnore(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
+	lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
+	hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
+
+	output, err := lg.exec.RunPipeCommands(ctx, gitPath, lg.gitPath, lsFilesCmdArgs, lg.gitPath, hashObjectCmdArgs)
+	if err != nil {
+		oktetoLog.Debugf("error getting dir content hash %s: %v", dirPath, err)
+		var exitError *exec.ExitError
+		errors.As(err, &exitError)
+		if exitError != nil {
+			exitErr := string(exitError.Stderr)
+			if strings.Contains(exitErr, "detected dubious ownership in repository") {
+				err = lg.FixDubiousOwnershipConfig(gitPath)
+				if err != nil {
+					return "", errLocalGitCannotGetStatusCannotRecover
+				}
+				fixAttempt++
+				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
+			}
+		}
+		return "", errLocalGitCannotGetStatusCannotRecover
 	}
 	return string(output), nil
 }
@@ -360,9 +400,42 @@ func (lg *LocalGit) Diff(ctx context.Context, gitPath, dirPath string, fixAttemp
 		return "", errLocalGitCannotGetCommitTooManyAttempts
 	}
 
+	if lg.shouldIgnoreFiles {
+		return lg.diffWithIgnore(ctx, gitPath, dirPath, fixAttempt)
+	}
+
+	return lg.diffWithoutIgnore(ctx, gitPath, dirPath, fixAttempt)
+}
+
+// diffWithoutIgnore calculates the diff of the repository at the given path
+func (lg *LocalGit) diffWithoutIgnore(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
+	output, err := lg.exec.RunCommand(ctx, gitPath, lg.gitPath, "--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath)
+	if err != nil {
+		oktetoLog.Debugf("error getting diff of directory %s: %v", dirPath, err)
+		var exitError *exec.ExitError
+		errors.As(err, &exitError)
+		if exitError != nil {
+			exitErr := string(exitError.Stderr)
+			if strings.Contains(exitErr, "detected dubious ownership in repository") {
+				err = lg.FixDubiousOwnershipConfig(gitPath)
+				if err != nil {
+					return "", errLocalGitCannotGetStatusCannotRecover
+				}
+				fixAttempt++
+				return lg.GetDirContentSHA(ctx, gitPath, dirPath, fixAttempt)
+			}
+		}
+		return "", errLocalGitCannotGetStatusCannotRecover
+	}
+	return string(output), nil
+}
+
+// diffWithIgnore calculates the diff of the repository at the given path taking into account files to be ignored by the ignorer
+func (lg *LocalGit) diffWithIgnore(ctx context.Context, gitPath, dirPath string, fixAttempt int) (string, error) {
 	rawOutput, err := lg.exec.RunCommand(ctx, dirPath, lg.gitPath, "--no-optional-locks", "diff", "--no-color", "HEAD", ".")
 
 	if err != nil {
+		oktetoLog.Debugf("error getting diff of directory %s: %v", dirPath, err)
 		var exitError *exec.ExitError
 		errors.As(err, &exitError)
 		if exitError != nil {
@@ -381,6 +454,7 @@ func (lg *LocalGit) Diff(ctx context.Context, gitPath, dirPath string, fixAttemp
 
 	files, _, err := gitdiff.Parse(bytes.NewReader(rawOutput))
 	if err != nil {
+		oktetoLog.Debugf("error parsing diff of directory %s: %v", dirPath, err)
 		return "", err
 	}
 
@@ -407,7 +481,7 @@ func (lg *LocalGit) Diff(ctx context.Context, gitPath, dirPath string, fixAttemp
 	return diff.String(), nil
 }
 
-// relpath removes dirPathToRemove from fullpath and returns the relative path
+// resolveRelativePath removes dirPathToRemove from absoluteFullpath and returns the relative path
 func resolveRelativePath(absoluteFullpath string, dirPathToRemove string) string {
 	relpath := strings.TrimPrefix(absoluteFullpath, dirPathToRemove)
 	return strings.TrimPrefix(relpath, string(filepath.Separator))

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -14,501 +14,502 @@
 package repository
 
 import (
-	"context"
-	"os/exec"
-	"runtime"
-	"testing"
-	"time"
+    "context"
+    "os/exec"
+    "path/filepath"
+    "runtime"
+    "testing"
+    "time"
 
-	"github.com/okteto/okteto/pkg/ignore"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
+    "github.com/okteto/okteto/pkg/ignore"
+    "github.com/spf13/afero"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/mock"
+    "github.com/stretchr/testify/require"
 )
 
 type mockLocalGit struct {
-	mock.Mock
+    mock.Mock
 }
 
 func (mlg *mockLocalGit) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-	args := mlg.Called(ctx, dir, name, arg)
-	return args.Get(0).([]byte), args.Error(1)
+    args := mlg.Called(ctx, dir, name, arg)
+    return args.Get(0).([]byte), args.Error(1)
 }
 
 func (mlg *mockLocalGit) LookPath(file string) (string, error) {
-	args := mlg.Called(file)
-	return args.String(0), args.Error(1)
+    args := mlg.Called(file)
+    return args.String(0), args.Error(1)
 }
 
 func (mlg *mockLocalGit) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-	args := mlg.Called(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
+    args := mlg.Called(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
 
-	return args.Get(0).([]byte), args.Error(1)
+    return args.Get(0).([]byte), args.Error(1)
 }
 
 type fakeIgnorer struct{}
 
 func (fi *fakeIgnorer) Ignore(path string) (bool, error) {
-	return path == "git/README.md", nil
+    return path == filepath.Join("git", "README.md"), nil
 }
 
 type mockLocalExec struct {
-	runCommand  func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
-	pipeCommand func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
-	lookPath    func(file string) (string, error)
+    runCommand  func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
+    pipeCommand func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
+    lookPath    func(file string) (string, error)
 }
 
 func (mle *mockLocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-	if mle.runCommand != nil {
-		return mle.runCommand(ctx, dir, name, arg...)
-	}
-	return nil, assert.AnError
+    if mle.runCommand != nil {
+        return mle.runCommand(ctx, dir, name, arg...)
+    }
+    return nil, assert.AnError
 }
 
 func (mle *mockLocalExec) LookPath(file string) (string, error) {
-	if mle.lookPath != nil {
-		return mle.lookPath(file)
-	}
-	return "", assert.AnError
+    if mle.lookPath != nil {
+        return mle.lookPath(file)
+    }
+    return "", assert.AnError
 }
 
 func (mle *mockLocalExec) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-	if mle.pipeCommand != nil {
-		return mle.pipeCommand(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
-	}
+    if mle.pipeCommand != nil {
+        return mle.pipeCommand(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
+    }
 
-	return nil, assert.AnError
+    return nil, assert.AnError
 }
 
 func TestLocalGit_Exists(t *testing.T) {
-	tests := []struct {
-		err      error
-		mockExec func() *mockLocalExec
-		name     string
-	}{
-		{
-			name: "git exists",
-			mockExec: func() *mockLocalExec {
-				return &mockLocalExec{
-					lookPath: func(file string) (string, error) {
-						return "/usr/bin/git", nil
-					},
-				}
-			},
-			err: nil,
-		},
-		{
-			name: "git not found",
-			mockExec: func() *mockLocalExec {
-				return &mockLocalExec{
-					lookPath: func(file string) (string, error) {
-						return "", assert.AnError
-					},
-				}
-			},
-			err: assert.AnError,
-		},
-	}
+    tests := []struct {
+        err      error
+        mockExec func() *mockLocalExec
+        name     string
+    }{
+        {
+            name: "git exists",
+            mockExec: func() *mockLocalExec {
+                return &mockLocalExec{
+                    lookPath: func(file string) (string, error) {
+                        return "/usr/bin/git", nil
+                    },
+                }
+            },
+            err: nil,
+        },
+        {
+            name: "git not found",
+            mockExec: func() *mockLocalExec {
+                return &mockLocalExec{
+                    lookPath: func(file string) (string, error) {
+                        return "", assert.AnError
+                    },
+                }
+            },
+            err: assert.AnError,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lg := NewLocalGit("git", tt.mockExec(), nil, false)
-			_, err := lg.Exists()
-			assert.ErrorIs(t, err, tt.err)
-		})
-	}
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            lg := NewLocalGit("git", tt.mockExec(), nil, false)
+            _, err := lg.Exists()
+            assert.ErrorIs(t, err, tt.err)
+        })
+    }
 }
 
 func TestLocalGit_FixDubiousOwnershipConfig(t *testing.T) {
-	tests := []struct {
-		err      error
-		mockExec func() *mockLocalExec
-		name     string
-	}{
-		{
-			name: "success",
-			mockExec: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
-						return []byte(""), nil
-					},
-				}
-			},
-			err: nil,
-		},
-		{
-			name: "failure",
-			mockExec: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			err: assert.AnError,
-		},
-	}
+    tests := []struct {
+        err      error
+        mockExec func() *mockLocalExec
+        name     string
+    }{
+        {
+            name: "success",
+            mockExec: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+                        return []byte(""), nil
+                    },
+                }
+            },
+            err: nil,
+        },
+        {
+            name: "failure",
+            mockExec: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            err: assert.AnError,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lg := NewLocalGit("git", tt.mockExec(), nil, false)
-			err := lg.FixDubiousOwnershipConfig("/test/dir")
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            lg := NewLocalGit("git", tt.mockExec(), nil, false)
+            err := lg.FixDubiousOwnershipConfig("/test/dir")
 
-			assert.ErrorIs(t, err, tt.err)
-		})
-	}
+            assert.ErrorIs(t, err, tt.err)
+        })
+    }
 }
 
 func TestLocalGit_Status(t *testing.T) {
-	tests := []struct {
-		expectedErr error
-		mock        func() *mockLocalExec
-		name        string
-		fixAttempts int
-	}{
-		{
-			name:        "success",
-			fixAttempts: 0,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return []byte("M modified-file.go"), nil
-					},
-				}
-			},
-			expectedErr: nil,
-		},
-		{
-			name:        "fail to parse git status output",
-			fixAttempts: 0,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return []byte("unexpected_output_in_git_status"), nil
-					},
-				}
-			},
-			expectedErr: errLocalGitInvalidStatusOutput,
-		},
-		{
-			name:        "recover from dubious ownership",
-			fixAttempts: 0,
-			mock: func() *mockLocalExec {
-				var currentFixAttempt int
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						if currentFixAttempt == 0 {
-							currentFixAttempt++
-							return nil, &exec.ExitError{
-								Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
-							}
-						}
+    tests := []struct {
+        expectedErr error
+        mock        func() *mockLocalExec
+        name        string
+        fixAttempts int
+    }{
+        {
+            name:        "success",
+            fixAttempts: 0,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return []byte("M modified-file.go"), nil
+                    },
+                }
+            },
+            expectedErr: nil,
+        },
+        {
+            name:        "fail to parse git status output",
+            fixAttempts: 0,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return []byte("unexpected_output_in_git_status"), nil
+                    },
+                }
+            },
+            expectedErr: errLocalGitInvalidStatusOutput,
+        },
+        {
+            name:        "recover from dubious ownership",
+            fixAttempts: 0,
+            mock: func() *mockLocalExec {
+                var currentFixAttempt int
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        if currentFixAttempt == 0 {
+                            currentFixAttempt++
+                            return nil, &exec.ExitError{
+                                Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+                            }
+                        }
 
-						return []byte(""), nil
+                        return []byte(""), nil
 
-					},
-				}
-			},
-			expectedErr: nil,
-		},
-		{
-			name:        "failure due to too many attempts",
-			fixAttempts: 2,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			expectedErr: errLocalGitCannotGetStatusTooManyAttempts,
-		},
-		{
-			name:        "cannot recover",
-			fixAttempts: 1,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			expectedErr: errLocalGitCannotGetStatusCannotRecover,
-		},
-	}
+                    },
+                }
+            },
+            expectedErr: nil,
+        },
+        {
+            name:        "failure due to too many attempts",
+            fixAttempts: 2,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            expectedErr: errLocalGitCannotGetStatusTooManyAttempts,
+        },
+        {
+            name:        "cannot recover",
+            fixAttempts: 1,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            expectedErr: errLocalGitCannotGetStatusCannotRecover,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lg := NewLocalGit("git", tt.mock(), nil, false)
-			_, err := lg.Status(context.Background(), "/test/dir", "", tt.fixAttempts)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            lg := NewLocalGit("git", tt.mock(), nil, false)
+            _, err := lg.Status(context.Background(), "/test/dir", "", tt.fixAttempts)
 
-			assert.ErrorIs(t, err, tt.expectedErr)
-		})
-	}
+            assert.ErrorIs(t, err, tt.expectedErr)
+        })
+    }
 }
 
 func Test_LocalExec_RunCommandWithContextCanceled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+    ctx, cancel := context.WithCancel(context.Background())
 
-	go func(cancel context.CancelFunc) {
-		time.Sleep(1 * time.Second)
-		cancel()
-	}(cancel)
+    go func(cancel context.CancelFunc) {
+        time.Sleep(1 * time.Second)
+        cancel()
+    }(cancel)
 
-	localExec := &LocalExec{}
-	got, err := localExec.RunCommand(ctx, t.TempDir(), "sleep", "3600")
+    localExec := &LocalExec{}
+    got, err := localExec.RunCommand(ctx, t.TempDir(), "sleep", "3600")
 
-	if runtime.GOOS != "windows" {
-		assert.EqualError(t, err, "signal: terminated")
-	} else {
-		assert.EqualError(t, err, "exit status 1")
-	}
-	assert.Equal(t, []byte(""), got)
+    if runtime.GOOS != "windows" {
+        assert.EqualError(t, err, "signal: terminated")
+    } else {
+        assert.EqualError(t, err, "exit status 1")
+    }
+    assert.Equal(t, []byte(""), got)
 }
 
 func Test_LocalExec_RunCommand(t *testing.T) {
-	ctx := context.Background()
+    ctx := context.Background()
 
-	localExec := &LocalExec{}
-	got, err := localExec.RunCommand(ctx, t.TempDir(), "echo", "okteto")
-	assert.NoError(t, err)
-	assert.Equal(t, "okteto\n", string(got))
+    localExec := &LocalExec{}
+    got, err := localExec.RunCommand(ctx, t.TempDir(), "echo", "okteto")
+    assert.NoError(t, err)
+    assert.Equal(t, "okteto\n", string(got))
 }
 
 func TestLocalGit_GetDirContentSHAWithError(t *testing.T) {
-	tests := []struct {
-		expectedErr error
-		mock        func() *mockLocalExec
-		name        string
-		fixAttempts int
-	}{
-		{
-			name:        "failure due to too many attempts",
-			fixAttempts: 2,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
-		},
-		{
-			name:        "cannot recover",
-			fixAttempts: 1,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			expectedErr: errLocalGitCannotGetStatusCannotRecover,
-		},
-	}
+    tests := []struct {
+        expectedErr error
+        mock        func() *mockLocalExec
+        name        string
+        fixAttempts int
+    }{
+        {
+            name:        "failure due to too many attempts",
+            fixAttempts: 2,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
+        },
+        {
+            name:        "cannot recover",
+            fixAttempts: 1,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            expectedErr: errLocalGitCannotGetStatusCannotRecover,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lg := NewLocalGit("git", tt.mock(), nil, false)
-			_, err := lg.GetDirContentSHA(context.Background(), "", "/test/dir", tt.fixAttempts)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            lg := NewLocalGit("git", tt.mock(), nil, false)
+            _, err := lg.GetDirContentSHA(context.Background(), "", "/test/dir", tt.fixAttempts)
 
-			assert.ErrorIs(t, err, tt.expectedErr)
-		})
-	}
+            assert.ErrorIs(t, err, tt.expectedErr)
+        })
+    }
 }
 
 func TestLocalGit_GetDirContentSHAWithoutIgnore(t *testing.T) {
-	dirPath := "/test/dir"
-	gitPath := "git"
-	lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
-	hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
-	localGit := &mockLocalGit{}
+    dirPath := "/test/dir"
+    gitPath := "git"
+    lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
+    hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
+    localGit := &mockLocalGit{}
 
-	localGit.On("RunPipeCommands", mock.Anything, gitPath, gitPath, lsFilesCmdArgs, gitPath, hashObjectCmdArgs).Return([]byte("very complex SHA"), nil)
+    localGit.On("RunPipeCommands", mock.Anything, gitPath, gitPath, lsFilesCmdArgs, gitPath, hashObjectCmdArgs).Return([]byte("very complex SHA"), nil)
 
-	lg := NewLocalGit(gitPath, localGit, nil, false)
+    lg := NewLocalGit(gitPath, localGit, nil, false)
 
-	output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
+    output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
 
-	localGit.AssertExpectations(t)
-	require.NoError(t, err)
-	require.Equal(t, "very complex SHA", output)
+    localGit.AssertExpectations(t)
+    require.NoError(t, err)
+    require.Equal(t, "very complex SHA", output)
 
 }
 
 func TestLocalGit_GetDirContentSHAWithIgnore(t *testing.T) {
-	dirPath := "/test/dir"
-	gitPath := "git"
-	localGit := &mockLocalGit{}
-	lsFilesOutput := `100644 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0	README.md
+    dirPath := "/test/dir"
+    gitPath := "git"
+    localGit := &mockLocalGit{}
+    lsFilesOutput := `100644 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0	README.md
 100644 f8d0d1b317c27e75dc328e1e33d2ac8ed257db44 0	main.go
 100644 a45c22d80f57524e6b605e842a48bde9c455c8f0 0	pkg/utils/helpers.go
 100644 2c9be049f5eb50b3c2d03de362e8f4d3e0b96fb4 0	cmd/root.go
 100644 8f7e0670619e3f6d83731c99df68307d5273b82c 0	.gitignore
 100755 f8d0d1b317c27e75dc328e1e33d2ac8ed257db44 0	scripts/build.sh`
-	ignorer := func(filename string) ignore.Ignorer {
-		return &fakeIgnorer{}
-	}
+    ignorer := func(filename string) ignore.Ignorer {
+        return &fakeIgnorer{}
+    }
 
-	localGit.On("RunCommand", mock.Anything, dirPath, gitPath, []string{"--no-optional-locks", "ls-files", "-s"}).Return([]byte(lsFilesOutput), nil)
+    localGit.On("RunCommand", mock.Anything, dirPath, gitPath, []string{"--no-optional-locks", "ls-files", "-s"}).Return([]byte(lsFilesOutput), nil)
 
-	localGit.On("RunCommand", mock.Anything, dirPath, gitPath, mock.Anything).Return([]byte("very complex SHA with ignorer"), nil)
+    localGit.On("RunCommand", mock.Anything, dirPath, gitPath, mock.Anything).Return([]byte("very complex SHA with ignorer"), nil)
 
-	lg := NewLocalGit(gitPath, localGit, ignorer, true)
-	lg.fs = afero.NewMemMapFs()
+    lg := NewLocalGit(gitPath, localGit, ignorer, true)
+    lg.fs = afero.NewMemMapFs()
 
-	output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
+    output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
 
-	localGit.AssertExpectations(t)
-	require.NoError(t, err)
-	require.Equal(t, "very complex SHA with ignorer", output)
+    localGit.AssertExpectations(t)
+    require.NoError(t, err)
+    require.Equal(t, "very complex SHA with ignorer", output)
 
 }
 
 func TestLocalGit_ListUntrackedFiles(t *testing.T) {
-	tests := []struct {
-		expectedErr   error
-		execMock      func() *mockLocalExec
-		name          string
-		expectedFiles []string
-		fixAttempt    int
-	}{
-		{
-			name:       "success",
-			fixAttempt: 0,
-			execMock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return []byte("file1.txt\nfile2.txt\nfile3.txt"), nil
-					},
-				}
-			},
-			expectedFiles: []string{"file1.txt", "file2.txt", "file3.txt"},
-			expectedErr:   nil,
-		},
-		{
-			name:       "failure - exit error",
-			fixAttempt: 0,
-			execMock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return nil, &exec.ExitError{
-							Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
-						}
-					},
-				}
-			},
-			expectedFiles: []string{},
-			expectedErr:   errLocalGitCannotGetStatusCannotRecover,
-		},
-		{
-			name:       "failure - fix attempt limit reached",
-			fixAttempt: 2,
-			execMock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return nil, &exec.ExitError{
-							Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
-						}
-					},
-				}
-			},
-			expectedFiles: []string{},
-			expectedErr:   errLocalGitCannotGetCommitTooManyAttempts,
-		},
-		{
-			name:       "failure - cannot recover",
-			fixAttempt: 1,
-			execMock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			expectedFiles: []string{},
-			expectedErr:   errLocalGitCannotGetStatusCannotRecover,
-		},
-	}
+    tests := []struct {
+        expectedErr   error
+        execMock      func() *mockLocalExec
+        name          string
+        expectedFiles []string
+        fixAttempt    int
+    }{
+        {
+            name:       "success",
+            fixAttempt: 0,
+            execMock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return []byte("file1.txt\nfile2.txt\nfile3.txt"), nil
+                    },
+                }
+            },
+            expectedFiles: []string{"file1.txt", "file2.txt", "file3.txt"},
+            expectedErr:   nil,
+        },
+        {
+            name:       "failure - exit error",
+            fixAttempt: 0,
+            execMock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return nil, &exec.ExitError{
+                            Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+                        }
+                    },
+                }
+            },
+            expectedFiles: []string{},
+            expectedErr:   errLocalGitCannotGetStatusCannotRecover,
+        },
+        {
+            name:       "failure - fix attempt limit reached",
+            fixAttempt: 2,
+            execMock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return nil, &exec.ExitError{
+                            Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+                        }
+                    },
+                }
+            },
+            expectedFiles: []string{},
+            expectedErr:   errLocalGitCannotGetCommitTooManyAttempts,
+        },
+        {
+            name:       "failure - cannot recover",
+            fixAttempt: 1,
+            execMock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            expectedFiles: []string{},
+            expectedErr:   errLocalGitCannotGetStatusCannotRecover,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lg := NewLocalGit("git", tt.execMock(), nil, false)
-			files, err := lg.ListUntrackedFiles(context.Background(), "/test/dir", "/test", tt.fixAttempt)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            lg := NewLocalGit("git", tt.execMock(), nil, false)
+            files, err := lg.ListUntrackedFiles(context.Background(), "/test/dir", "/test", tt.fixAttempt)
 
-			assert.Equal(t, tt.expectedFiles, files)
-			assert.ErrorIs(t, err, tt.expectedErr)
-		})
-	}
+            assert.Equal(t, tt.expectedFiles, files)
+            assert.ErrorIs(t, err, tt.expectedErr)
+        })
+    }
 }
 
 func TestLocalGit_GetDiffWithError(t *testing.T) {
-	tests := []struct {
-		expectedErr error
-		mock        func() *mockLocalExec
-		name        string
-		fixAttempts int
-	}{
-		{
-			name:        "failure due to too many attempts",
-			fixAttempts: 2,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
-		},
-		{
-			name:        "cannot recover",
-			fixAttempts: 1,
-			mock: func() *mockLocalExec {
-				return &mockLocalExec{
-					runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
-						return nil, assert.AnError
-					},
-				}
-			},
-			expectedErr: errLocalGitCannotGetStatusCannotRecover,
-		},
-	}
+    tests := []struct {
+        expectedErr error
+        mock        func() *mockLocalExec
+        name        string
+        fixAttempts int
+    }{
+        {
+            name:        "failure due to too many attempts",
+            fixAttempts: 2,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
+        },
+        {
+            name:        "cannot recover",
+            fixAttempts: 1,
+            mock: func() *mockLocalExec {
+                return &mockLocalExec{
+                    runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+                        return nil, assert.AnError
+                    },
+                }
+            },
+            expectedErr: errLocalGitCannotGetStatusCannotRecover,
+        },
+    }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			lg := NewLocalGit("git", tt.mock(), nil, false)
-			_, err := lg.Diff(context.Background(), "", "/test/dir", tt.fixAttempts)
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            lg := NewLocalGit("git", tt.mock(), nil, false)
+            _, err := lg.Diff(context.Background(), "", "/test/dir", tt.fixAttempts)
 
-			assert.ErrorIs(t, err, tt.expectedErr)
-		})
-	}
+            assert.ErrorIs(t, err, tt.expectedErr)
+        })
+    }
 }
 
 func TestLocalGit_GetDiffWithoutIgnore(t *testing.T) {
-	dirPath := "/test/dir"
-	gitPath := "git"
-	diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath}
-	localGit := &mockLocalGit{}
+    dirPath := "/test/dir"
+    gitPath := "git"
+    diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath}
+    localGit := &mockLocalGit{}
 
-	localGit.On("RunCommand", mock.Anything, gitPath, gitPath, diffCmdArgs).Return([]byte("very complex diff"), nil)
+    localGit.On("RunCommand", mock.Anything, gitPath, gitPath, diffCmdArgs).Return([]byte("very complex diff"), nil)
 
-	lg := NewLocalGit(gitPath, localGit, nil, false)
+    lg := NewLocalGit(gitPath, localGit, nil, false)
 
-	output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
+    output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
 
-	localGit.AssertExpectations(t)
-	require.NoError(t, err)
-	require.Equal(t, "very complex diff", output)
+    localGit.AssertExpectations(t)
+    require.NoError(t, err)
+    require.Equal(t, "very complex diff", output)
 }
 
 func TestLocalGit_GetDiffWithIgnore(t *testing.T) {
-	dirPath := "/test/dir"
-	gitPath := "git"
-	diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "HEAD", "."}
-	diffOutput := `diff --git a/README.md b/README.md
+    dirPath := "/test/dir"
+    gitPath := "git"
+    diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "HEAD", "."}
+    diffOutput := `diff --git a/README.md b/README.md
 index d14a7f3..3c9e1a0 100644
 --- a/README.md
 +++ b/README.md
@@ -550,7 +551,7 @@ index e69de29..b6fc4c3 100644
 +    fmt.Printf("Hello, %s!\n", name)
 +}
 +`
-	expectedOutput := `diff --git a/main.go b/main.go
+    expectedOutput := `diff --git a/main.go b/main.go
 index e69de29..b6fc4c3 100644
 --- a/main.go
 +++ b/main.go
@@ -572,18 +573,18 @@ index e69de29..b6fc4c3 100644
 +
 \ No newline at end of file
 `
-	localGit := &mockLocalGit{}
+    localGit := &mockLocalGit{}
 
-	localGit.On("RunCommand", mock.Anything, dirPath, gitPath, diffCmdArgs).Return([]byte(diffOutput), nil)
+    localGit.On("RunCommand", mock.Anything, dirPath, gitPath, diffCmdArgs).Return([]byte(diffOutput), nil)
 
-	ignorer := func(filename string) ignore.Ignorer {
-		return &fakeIgnorer{}
-	}
-	lg := NewLocalGit(gitPath, localGit, ignorer, true)
+    ignorer := func(filename string) ignore.Ignorer {
+        return &fakeIgnorer{}
+    }
+    lg := NewLocalGit(gitPath, localGit, ignorer, true)
 
-	output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
+    output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
 
-	localGit.AssertExpectations(t)
-	require.NoError(t, err)
-	require.Equal(t, expectedOutput, output)
+    localGit.AssertExpectations(t)
+    require.NoError(t, err)
+    require.Equal(t, expectedOutput, output)
 }

--- a/pkg/repository/local_git_test.go
+++ b/pkg/repository/local_git_test.go
@@ -14,502 +14,502 @@
 package repository
 
 import (
-    "context"
-    "os/exec"
-    "path/filepath"
-    "runtime"
-    "testing"
-    "time"
+	"context"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
 
-    "github.com/okteto/okteto/pkg/ignore"
-    "github.com/spf13/afero"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/mock"
-    "github.com/stretchr/testify/require"
+	"github.com/okteto/okteto/pkg/ignore"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockLocalGit struct {
-    mock.Mock
+	mock.Mock
 }
 
 func (mlg *mockLocalGit) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-    args := mlg.Called(ctx, dir, name, arg)
-    return args.Get(0).([]byte), args.Error(1)
+	args := mlg.Called(ctx, dir, name, arg)
+	return args.Get(0).([]byte), args.Error(1)
 }
 
 func (mlg *mockLocalGit) LookPath(file string) (string, error) {
-    args := mlg.Called(file)
-    return args.String(0), args.Error(1)
+	args := mlg.Called(file)
+	return args.String(0), args.Error(1)
 }
 
 func (mlg *mockLocalGit) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-    args := mlg.Called(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
+	args := mlg.Called(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
 
-    return args.Get(0).([]byte), args.Error(1)
+	return args.Get(0).([]byte), args.Error(1)
 }
 
 type fakeIgnorer struct{}
 
 func (fi *fakeIgnorer) Ignore(path string) (bool, error) {
-    return path == filepath.Join("git", "README.md"), nil
+	return path == filepath.Join("git", "README.md"), nil
 }
 
 type mockLocalExec struct {
-    runCommand  func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
-    pipeCommand func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
-    lookPath    func(file string) (string, error)
+	runCommand  func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error)
+	pipeCommand func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error)
+	lookPath    func(file string) (string, error)
 }
 
 func (mle *mockLocalExec) RunCommand(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-    if mle.runCommand != nil {
-        return mle.runCommand(ctx, dir, name, arg...)
-    }
-    return nil, assert.AnError
+	if mle.runCommand != nil {
+		return mle.runCommand(ctx, dir, name, arg...)
+	}
+	return nil, assert.AnError
 }
 
 func (mle *mockLocalExec) LookPath(file string) (string, error) {
-    if mle.lookPath != nil {
-        return mle.lookPath(file)
-    }
-    return "", assert.AnError
+	if mle.lookPath != nil {
+		return mle.lookPath(file)
+	}
+	return "", assert.AnError
 }
 
 func (mle *mockLocalExec) RunPipeCommands(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-    if mle.pipeCommand != nil {
-        return mle.pipeCommand(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
-    }
+	if mle.pipeCommand != nil {
+		return mle.pipeCommand(ctx, dir, cmd1, cmd1Args, cmd2, cmd2Args)
+	}
 
-    return nil, assert.AnError
+	return nil, assert.AnError
 }
 
 func TestLocalGit_Exists(t *testing.T) {
-    tests := []struct {
-        err      error
-        mockExec func() *mockLocalExec
-        name     string
-    }{
-        {
-            name: "git exists",
-            mockExec: func() *mockLocalExec {
-                return &mockLocalExec{
-                    lookPath: func(file string) (string, error) {
-                        return "/usr/bin/git", nil
-                    },
-                }
-            },
-            err: nil,
-        },
-        {
-            name: "git not found",
-            mockExec: func() *mockLocalExec {
-                return &mockLocalExec{
-                    lookPath: func(file string) (string, error) {
-                        return "", assert.AnError
-                    },
-                }
-            },
-            err: assert.AnError,
-        },
-    }
+	tests := []struct {
+		err      error
+		mockExec func() *mockLocalExec
+		name     string
+	}{
+		{
+			name: "git exists",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					lookPath: func(file string) (string, error) {
+						return "/usr/bin/git", nil
+					},
+				}
+			},
+			err: nil,
+		},
+		{
+			name: "git not found",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					lookPath: func(file string) (string, error) {
+						return "", assert.AnError
+					},
+				}
+			},
+			err: assert.AnError,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            lg := NewLocalGit("git", tt.mockExec(), nil, false)
-            _, err := lg.Exists()
-            assert.ErrorIs(t, err, tt.err)
-        })
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mockExec(), nil, false)
+			_, err := lg.Exists()
+			assert.ErrorIs(t, err, tt.err)
+		})
+	}
 }
 
 func TestLocalGit_FixDubiousOwnershipConfig(t *testing.T) {
-    tests := []struct {
-        err      error
-        mockExec func() *mockLocalExec
-        name     string
-    }{
-        {
-            name: "success",
-            mockExec: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
-                        return []byte(""), nil
-                    },
-                }
-            },
-            err: nil,
-        },
-        {
-            name: "failure",
-            mockExec: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            err: assert.AnError,
-        },
-    }
+	tests := []struct {
+		err      error
+		mockExec func() *mockLocalExec
+		name     string
+	}{
+		{
+			name: "success",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+						return []byte(""), nil
+					},
+				}
+			},
+			err: nil,
+		},
+		{
+			name: "failure",
+			mockExec: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			err: assert.AnError,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            lg := NewLocalGit("git", tt.mockExec(), nil, false)
-            err := lg.FixDubiousOwnershipConfig("/test/dir")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mockExec(), nil, false)
+			err := lg.FixDubiousOwnershipConfig("/test/dir")
 
-            assert.ErrorIs(t, err, tt.err)
-        })
-    }
+			assert.ErrorIs(t, err, tt.err)
+		})
+	}
 }
 
 func TestLocalGit_Status(t *testing.T) {
-    tests := []struct {
-        expectedErr error
-        mock        func() *mockLocalExec
-        name        string
-        fixAttempts int
-    }{
-        {
-            name:        "success",
-            fixAttempts: 0,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return []byte("M modified-file.go"), nil
-                    },
-                }
-            },
-            expectedErr: nil,
-        },
-        {
-            name:        "fail to parse git status output",
-            fixAttempts: 0,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return []byte("unexpected_output_in_git_status"), nil
-                    },
-                }
-            },
-            expectedErr: errLocalGitInvalidStatusOutput,
-        },
-        {
-            name:        "recover from dubious ownership",
-            fixAttempts: 0,
-            mock: func() *mockLocalExec {
-                var currentFixAttempt int
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        if currentFixAttempt == 0 {
-                            currentFixAttempt++
-                            return nil, &exec.ExitError{
-                                Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
-                            }
-                        }
+	tests := []struct {
+		expectedErr error
+		mock        func() *mockLocalExec
+		name        string
+		fixAttempts int
+	}{
+		{
+			name:        "success",
+			fixAttempts: 0,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return []byte("M modified-file.go"), nil
+					},
+				}
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "fail to parse git status output",
+			fixAttempts: 0,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return []byte("unexpected_output_in_git_status"), nil
+					},
+				}
+			},
+			expectedErr: errLocalGitInvalidStatusOutput,
+		},
+		{
+			name:        "recover from dubious ownership",
+			fixAttempts: 0,
+			mock: func() *mockLocalExec {
+				var currentFixAttempt int
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						if currentFixAttempt == 0 {
+							currentFixAttempt++
+							return nil, &exec.ExitError{
+								Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+							}
+						}
 
-                        return []byte(""), nil
+						return []byte(""), nil
 
-                    },
-                }
-            },
-            expectedErr: nil,
-        },
-        {
-            name:        "failure due to too many attempts",
-            fixAttempts: 2,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            expectedErr: errLocalGitCannotGetStatusTooManyAttempts,
-        },
-        {
-            name:        "cannot recover",
-            fixAttempts: 1,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            expectedErr: errLocalGitCannotGetStatusCannotRecover,
-        },
-    }
+					},
+				}
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "failure due to too many attempts",
+			fixAttempts: 2,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedErr: errLocalGitCannotGetStatusTooManyAttempts,
+		},
+		{
+			name:        "cannot recover",
+			fixAttempts: 1,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedErr: errLocalGitCannotGetStatusCannotRecover,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            lg := NewLocalGit("git", tt.mock(), nil, false)
-            _, err := lg.Status(context.Background(), "/test/dir", "", tt.fixAttempts)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mock(), nil, false)
+			_, err := lg.Status(context.Background(), "/test/dir", "", tt.fixAttempts)
 
-            assert.ErrorIs(t, err, tt.expectedErr)
-        })
-    }
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func Test_LocalExec_RunCommandWithContextCanceled(t *testing.T) {
-    ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 
-    go func(cancel context.CancelFunc) {
-        time.Sleep(1 * time.Second)
-        cancel()
-    }(cancel)
+	go func(cancel context.CancelFunc) {
+		time.Sleep(1 * time.Second)
+		cancel()
+	}(cancel)
 
-    localExec := &LocalExec{}
-    got, err := localExec.RunCommand(ctx, t.TempDir(), "sleep", "3600")
+	localExec := &LocalExec{}
+	got, err := localExec.RunCommand(ctx, t.TempDir(), "sleep", "3600")
 
-    if runtime.GOOS != "windows" {
-        assert.EqualError(t, err, "signal: terminated")
-    } else {
-        assert.EqualError(t, err, "exit status 1")
-    }
-    assert.Equal(t, []byte(""), got)
+	if runtime.GOOS != "windows" {
+		assert.EqualError(t, err, "signal: terminated")
+	} else {
+		assert.EqualError(t, err, "exit status 1")
+	}
+	assert.Equal(t, []byte(""), got)
 }
 
 func Test_LocalExec_RunCommand(t *testing.T) {
-    ctx := context.Background()
+	ctx := context.Background()
 
-    localExec := &LocalExec{}
-    got, err := localExec.RunCommand(ctx, t.TempDir(), "echo", "okteto")
-    assert.NoError(t, err)
-    assert.Equal(t, "okteto\n", string(got))
+	localExec := &LocalExec{}
+	got, err := localExec.RunCommand(ctx, t.TempDir(), "echo", "okteto")
+	assert.NoError(t, err)
+	assert.Equal(t, "okteto\n", string(got))
 }
 
 func TestLocalGit_GetDirContentSHAWithError(t *testing.T) {
-    tests := []struct {
-        expectedErr error
-        mock        func() *mockLocalExec
-        name        string
-        fixAttempts int
-    }{
-        {
-            name:        "failure due to too many attempts",
-            fixAttempts: 2,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
-        },
-        {
-            name:        "cannot recover",
-            fixAttempts: 1,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            expectedErr: errLocalGitCannotGetStatusCannotRecover,
-        },
-    }
+	tests := []struct {
+		expectedErr error
+		mock        func() *mockLocalExec
+		name        string
+		fixAttempts int
+	}{
+		{
+			name:        "failure due to too many attempts",
+			fixAttempts: 2,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
+		},
+		{
+			name:        "cannot recover",
+			fixAttempts: 1,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					pipeCommand: func(ctx context.Context, dir string, cmd1 string, cmd1Args []string, cmd2 string, cmd2Args []string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedErr: errLocalGitCannotGetStatusCannotRecover,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            lg := NewLocalGit("git", tt.mock(), nil, false)
-            _, err := lg.GetDirContentSHA(context.Background(), "", "/test/dir", tt.fixAttempts)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mock(), nil, false)
+			_, err := lg.GetDirContentSHA(context.Background(), "", "/test/dir", tt.fixAttempts)
 
-            assert.ErrorIs(t, err, tt.expectedErr)
-        })
-    }
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func TestLocalGit_GetDirContentSHAWithoutIgnore(t *testing.T) {
-    dirPath := "/test/dir"
-    gitPath := "git"
-    lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
-    hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
-    localGit := &mockLocalGit{}
+	dirPath := "/test/dir"
+	gitPath := "git"
+	lsFilesCmdArgs := []string{"--no-optional-locks", "ls-files", "-s", dirPath}
+	hashObjectCmdArgs := []string{"--no-optional-locks", "hash-object", "--stdin"}
+	localGit := &mockLocalGit{}
 
-    localGit.On("RunPipeCommands", mock.Anything, gitPath, gitPath, lsFilesCmdArgs, gitPath, hashObjectCmdArgs).Return([]byte("very complex SHA"), nil)
+	localGit.On("RunPipeCommands", mock.Anything, gitPath, gitPath, lsFilesCmdArgs, gitPath, hashObjectCmdArgs).Return([]byte("very complex SHA"), nil)
 
-    lg := NewLocalGit(gitPath, localGit, nil, false)
+	lg := NewLocalGit(gitPath, localGit, nil, false)
 
-    output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
+	output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
 
-    localGit.AssertExpectations(t)
-    require.NoError(t, err)
-    require.Equal(t, "very complex SHA", output)
+	localGit.AssertExpectations(t)
+	require.NoError(t, err)
+	require.Equal(t, "very complex SHA", output)
 
 }
 
 func TestLocalGit_GetDirContentSHAWithIgnore(t *testing.T) {
-    dirPath := "/test/dir"
-    gitPath := "git"
-    localGit := &mockLocalGit{}
-    lsFilesOutput := `100644 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0	README.md
+	dirPath := "/test/dir"
+	gitPath := "git"
+	localGit := &mockLocalGit{}
+	lsFilesOutput := `100644 e69de29bb2d1d6434b8b29ae775ad8c2e48c5391 0	README.md
 100644 f8d0d1b317c27e75dc328e1e33d2ac8ed257db44 0	main.go
 100644 a45c22d80f57524e6b605e842a48bde9c455c8f0 0	pkg/utils/helpers.go
 100644 2c9be049f5eb50b3c2d03de362e8f4d3e0b96fb4 0	cmd/root.go
 100644 8f7e0670619e3f6d83731c99df68307d5273b82c 0	.gitignore
 100755 f8d0d1b317c27e75dc328e1e33d2ac8ed257db44 0	scripts/build.sh`
-    ignorer := func(filename string) ignore.Ignorer {
-        return &fakeIgnorer{}
-    }
+	ignorer := func(filename string) ignore.Ignorer {
+		return &fakeIgnorer{}
+	}
 
-    localGit.On("RunCommand", mock.Anything, dirPath, gitPath, []string{"--no-optional-locks", "ls-files", "-s"}).Return([]byte(lsFilesOutput), nil)
+	localGit.On("RunCommand", mock.Anything, dirPath, gitPath, []string{"--no-optional-locks", "ls-files", "-s"}).Return([]byte(lsFilesOutput), nil)
 
-    localGit.On("RunCommand", mock.Anything, dirPath, gitPath, mock.Anything).Return([]byte("very complex SHA with ignorer"), nil)
+	localGit.On("RunCommand", mock.Anything, dirPath, gitPath, mock.Anything).Return([]byte("very complex SHA with ignorer"), nil)
 
-    lg := NewLocalGit(gitPath, localGit, ignorer, true)
-    lg.fs = afero.NewMemMapFs()
+	lg := NewLocalGit(gitPath, localGit, ignorer, true)
+	lg.fs = afero.NewMemMapFs()
 
-    output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
+	output, err := lg.GetDirContentSHA(context.Background(), gitPath, dirPath, 0)
 
-    localGit.AssertExpectations(t)
-    require.NoError(t, err)
-    require.Equal(t, "very complex SHA with ignorer", output)
+	localGit.AssertExpectations(t)
+	require.NoError(t, err)
+	require.Equal(t, "very complex SHA with ignorer", output)
 
 }
 
 func TestLocalGit_ListUntrackedFiles(t *testing.T) {
-    tests := []struct {
-        expectedErr   error
-        execMock      func() *mockLocalExec
-        name          string
-        expectedFiles []string
-        fixAttempt    int
-    }{
-        {
-            name:       "success",
-            fixAttempt: 0,
-            execMock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return []byte("file1.txt\nfile2.txt\nfile3.txt"), nil
-                    },
-                }
-            },
-            expectedFiles: []string{"file1.txt", "file2.txt", "file3.txt"},
-            expectedErr:   nil,
-        },
-        {
-            name:       "failure - exit error",
-            fixAttempt: 0,
-            execMock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return nil, &exec.ExitError{
-                            Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
-                        }
-                    },
-                }
-            },
-            expectedFiles: []string{},
-            expectedErr:   errLocalGitCannotGetStatusCannotRecover,
-        },
-        {
-            name:       "failure - fix attempt limit reached",
-            fixAttempt: 2,
-            execMock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return nil, &exec.ExitError{
-                            Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
-                        }
-                    },
-                }
-            },
-            expectedFiles: []string{},
-            expectedErr:   errLocalGitCannotGetCommitTooManyAttempts,
-        },
-        {
-            name:       "failure - cannot recover",
-            fixAttempt: 1,
-            execMock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            expectedFiles: []string{},
-            expectedErr:   errLocalGitCannotGetStatusCannotRecover,
-        },
-    }
+	tests := []struct {
+		expectedErr   error
+		execMock      func() *mockLocalExec
+		name          string
+		expectedFiles []string
+		fixAttempt    int
+	}{
+		{
+			name:       "success",
+			fixAttempt: 0,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return []byte("file1.txt\nfile2.txt\nfile3.txt"), nil
+					},
+				}
+			},
+			expectedFiles: []string{"file1.txt", "file2.txt", "file3.txt"},
+			expectedErr:   nil,
+		},
+		{
+			name:       "failure - exit error",
+			fixAttempt: 0,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, &exec.ExitError{
+							Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+						}
+					},
+				}
+			},
+			expectedFiles: []string{},
+			expectedErr:   errLocalGitCannotGetStatusCannotRecover,
+		},
+		{
+			name:       "failure - fix attempt limit reached",
+			fixAttempt: 2,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, &exec.ExitError{
+							Stderr: []byte("fatal: detected dubious ownership in repository at <path>"),
+						}
+					},
+				}
+			},
+			expectedFiles: []string{},
+			expectedErr:   errLocalGitCannotGetCommitTooManyAttempts,
+		},
+		{
+			name:       "failure - cannot recover",
+			fixAttempt: 1,
+			execMock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(ctx context.Context, dir string, name string, arg ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedFiles: []string{},
+			expectedErr:   errLocalGitCannotGetStatusCannotRecover,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            lg := NewLocalGit("git", tt.execMock(), nil, false)
-            files, err := lg.ListUntrackedFiles(context.Background(), "/test/dir", "/test", tt.fixAttempt)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.execMock(), nil, false)
+			files, err := lg.ListUntrackedFiles(context.Background(), "/test/dir", "/test", tt.fixAttempt)
 
-            assert.Equal(t, tt.expectedFiles, files)
-            assert.ErrorIs(t, err, tt.expectedErr)
-        })
-    }
+			assert.Equal(t, tt.expectedFiles, files)
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func TestLocalGit_GetDiffWithError(t *testing.T) {
-    tests := []struct {
-        expectedErr error
-        mock        func() *mockLocalExec
-        name        string
-        fixAttempts int
-    }{
-        {
-            name:        "failure due to too many attempts",
-            fixAttempts: 2,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
-        },
-        {
-            name:        "cannot recover",
-            fixAttempts: 1,
-            mock: func() *mockLocalExec {
-                return &mockLocalExec{
-                    runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
-                        return nil, assert.AnError
-                    },
-                }
-            },
-            expectedErr: errLocalGitCannotGetStatusCannotRecover,
-        },
-    }
+	tests := []struct {
+		expectedErr error
+		mock        func() *mockLocalExec
+		name        string
+		fixAttempts int
+	}{
+		{
+			name:        "failure due to too many attempts",
+			fixAttempts: 2,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedErr: errLocalGitCannotGetCommitTooManyAttempts,
+		},
+		{
+			name:        "cannot recover",
+			fixAttempts: 1,
+			mock: func() *mockLocalExec {
+				return &mockLocalExec{
+					runCommand: func(_ context.Context, _ string, _ string, _ ...string) ([]byte, error) {
+						return nil, assert.AnError
+					},
+				}
+			},
+			expectedErr: errLocalGitCannotGetStatusCannotRecover,
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            lg := NewLocalGit("git", tt.mock(), nil, false)
-            _, err := lg.Diff(context.Background(), "", "/test/dir", tt.fixAttempts)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lg := NewLocalGit("git", tt.mock(), nil, false)
+			_, err := lg.Diff(context.Background(), "", "/test/dir", tt.fixAttempts)
 
-            assert.ErrorIs(t, err, tt.expectedErr)
-        })
-    }
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func TestLocalGit_GetDiffWithoutIgnore(t *testing.T) {
-    dirPath := "/test/dir"
-    gitPath := "git"
-    diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath}
-    localGit := &mockLocalGit{}
+	dirPath := "/test/dir"
+	gitPath := "git"
+	diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "--", "HEAD", dirPath}
+	localGit := &mockLocalGit{}
 
-    localGit.On("RunCommand", mock.Anything, gitPath, gitPath, diffCmdArgs).Return([]byte("very complex diff"), nil)
+	localGit.On("RunCommand", mock.Anything, gitPath, gitPath, diffCmdArgs).Return([]byte("very complex diff"), nil)
 
-    lg := NewLocalGit(gitPath, localGit, nil, false)
+	lg := NewLocalGit(gitPath, localGit, nil, false)
 
-    output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
+	output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
 
-    localGit.AssertExpectations(t)
-    require.NoError(t, err)
-    require.Equal(t, "very complex diff", output)
+	localGit.AssertExpectations(t)
+	require.NoError(t, err)
+	require.Equal(t, "very complex diff", output)
 }
 
 func TestLocalGit_GetDiffWithIgnore(t *testing.T) {
-    dirPath := "/test/dir"
-    gitPath := "git"
-    diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "HEAD", "."}
-    diffOutput := `diff --git a/README.md b/README.md
+	dirPath := "/test/dir"
+	gitPath := "git"
+	diffCmdArgs := []string{"--no-optional-locks", "diff", "--no-color", "HEAD", "."}
+	diffOutput := `diff --git a/README.md b/README.md
 index d14a7f3..3c9e1a0 100644
 --- a/README.md
 +++ b/README.md
@@ -551,7 +551,7 @@ index e69de29..b6fc4c3 100644
 +    fmt.Printf("Hello, %s!\n", name)
 +}
 +`
-    expectedOutput := `diff --git a/main.go b/main.go
+	expectedOutput := `diff --git a/main.go b/main.go
 index e69de29..b6fc4c3 100644
 --- a/main.go
 +++ b/main.go
@@ -573,18 +573,18 @@ index e69de29..b6fc4c3 100644
 +
 \ No newline at end of file
 `
-    localGit := &mockLocalGit{}
+	localGit := &mockLocalGit{}
 
-    localGit.On("RunCommand", mock.Anything, dirPath, gitPath, diffCmdArgs).Return([]byte(diffOutput), nil)
+	localGit.On("RunCommand", mock.Anything, dirPath, gitPath, diffCmdArgs).Return([]byte(diffOutput), nil)
 
-    ignorer := func(filename string) ignore.Ignorer {
-        return &fakeIgnorer{}
-    }
-    lg := NewLocalGit(gitPath, localGit, ignorer, true)
+	ignorer := func(filename string) ignore.Ignorer {
+		return &fakeIgnorer{}
+	}
+	lg := NewLocalGit(gitPath, localGit, ignorer, true)
 
-    output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
+	output, err := lg.Diff(context.Background(), gitPath, dirPath, 0)
 
-    localGit.AssertExpectations(t)
-    require.NoError(t, err)
-    require.Equal(t, expectedOutput, output)
+	localGit.AssertExpectations(t)
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, output)
 }


### PR DESCRIPTION
# Proposed changes

After the changes introduced to ignore defined in `.dockerignore` files in the Smart Build logics [here](https://github.com/okteto/okteto/pull/4673), it turns out that for big repos with a lot of files, the command executed to calculate the SHA was failing, provoking that the image is built every time.

Even if there was a feature flag for the feature, the bug comes in a common place, so any could be affected independently of enabling the feature or not.

In this PR we are doing 2 things:
* Only change the logic to calculate things when the feature flag is enabled. If disabled, old logic would be executed (restored functions as they were before the changes in the Smart Builds logic). The idea of this is to prevent users which don't have the feature enabled to have some impact due to the new functionality
* Fix the way dir SHA is calculated to prevent that big repos can calculate it properly. We are creating a temporary file with the content of the `git ls-objects` command, to then, pass it to the `git hash-object` function, instead of doing a pipe as we were doing before

## How to validate

There are a couple of ways for validating it.

You need to play with the environment variable `OKTETO_SMART_BUILDS_IGNORE_FILES_ENABLED` to enable and disable.

When the environment variable `OKTETO_SMART_BUILDS_IGNORE_FILES_ENABLED` set to false, if you run a build using the log-level `debug` you will see how this command is executed: `/usr/bin/git --no-optional-locks ls-files -s <path-to-some-folder> | /usr/bin/git --no-optional-locks hash-object --stdin`. This is to calculate the SHA of the directory. 

Prior to this change, you can see how the following commands are executed:
* `/usr/bin/git --no-optional-locks ls-files -s`. To list all the files in the directory
* `echo <filtered output of previous command> | /usr/bin/git --no-optional-locks hash-object --stdin` To get the SHA

When the list of files was too long, it was generating an error, so image was being built always. With this PR, if the flag is disabled, we restore the original way of calculating the SHA, as no function to ignore files has to be applied, so no need to change the commands to execute.

Then, if you change the value of the environment variable `OKTETO_SMART_BUILDS_IGNORE_FILES_ENABLED` to true, and you see the logs, you will see now how the command to be used is different, fixing the issue when the repository has too many files.

You can see how now the command `/usr/bin/git --no-optional-locks ls-files -s` is executed first to get the list of files, and then, `/usr/bin/git --no-optional-locks hash-object <base-path>/.okteto/git-untracked-backend-1742893596755404000` to calculate the SHA of the directory. It is using a temporary file to store the filtered output of the `git ls-files` command to prevent the issue of passing a huge argument to the exec command

