### PR TITLE
Avoid to get an stuck channel to send a message to an unbuffered channel when timing out the list untracked files operation

### DIFF
--- a/pkg/repository/git.go
+++ b/pkg/repository/git.go
@@ -268,8 +268,8 @@ func (r gitRepoController) GetDiffHash(contextDir string) (string, error) {
 	defer cancel()
 
 	timeoutCh := make(chan struct{})
-	diffCh := make(chan diffResponse)
-	untrackedFilesCh := make(chan untrackedFilesResponse)
+	diffCh := make(chan diffResponse, 2)
+	untrackedFilesCh := make(chan untrackedFilesResponse, 2)
 
 	repo, err := r.repoGetter.get(r.path)
 	if err != nil {


### PR DESCRIPTION
# Proposed changes

We have to review how channels are being used in these operations, but we have seen this morning that in the case in which the diff operation ends successfully, but the untracked ones fails, the code within the goroutine in line 284 gets stuck because the diff channel was already read in line 357, and sending another event to an unbuffered channel would block the send operation, so the CLI gets stucked.

We never faced this because this happens when there is a huge list of untracked files, which is not common.

Until we review all this, we create a buffered channel of length 2, which is the maximum amount of messages we send in that flow, avoiding to get stuck by the send operation.

## How to validate

Try several times to build a repository with a lot of untracked files, so the operation times out. If you execute it with current version of the CLI, you will see that in some cases, the CLI gets stuck. But with the CLI built from this branch, that doesn't happen

