### PR TITLE
Add context command initialization in restart command

### DIFF
--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -86,6 +86,9 @@ func Restart(fs afero.Fs) *cobra.Command {
 			if len(dev.Services) == 0 {
 				return oktetoErrors.ErrNoServicesinOktetoManifest
 			}
+			if namespace == "" {
+				namespace = okteto.GetContext().Namespace
+			}
 
 			serviceName := ""
 			if len(args) > 0 {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -57,6 +57,10 @@ func Restart(fs afero.Fs) *cobra.Command {
 				return err
 			}
 
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Show: true, Namespace: namespace, Context: k8sContext}); err != nil {
+				return err
+			}
+
 			if !okteto.IsOkteto() {
 				if err := manifest.ValidateForCLIOnly(); err != nil {
 					return err


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

We were not initialising the context for the restart command making it fail if used by any user. This ensures the context is initialised and can create a k8s config for the client


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
