### PR TITLE
fix: start spinner when buidlkit fails to connect

### DIFF
--- a/pkg/build/buildkit/wait.go
+++ b/pkg/build/buildkit/wait.go
@@ -101,7 +101,6 @@ func (bw *Waiter) WaitUntilIsUp(ctx context.Context) error {
 	defer cancel()
 
 	sp := bw.logger.Out().Spinner("Waiting for BuildKit service to be ready...")
-	sp.Start()
 	defer sp.Stop()
 
 	startWaitingTime := time.Now()
@@ -113,6 +112,7 @@ func (bw *Waiter) WaitUntilIsUp(ctx context.Context) error {
 		default:
 			c, err := bw.buildkitClientFactory.GetBuildkitClient(ctx)
 			if err != nil {
+				sp.Start()
 				bw.logger.Infof("Failed to connect to BuildKit service: %v\n", err)
 				bw.logger.Infof("Retrying in %v...\n", bw.retryInterval)
 				bw.sleeper.Sleep(bw.retryInterval)
@@ -120,6 +120,7 @@ func (bw *Waiter) WaitUntilIsUp(ctx context.Context) error {
 			}
 			_, err = c.Info(ctx)
 			if err != nil {
+				sp.Start()
 				bw.logger.Infof("Failed to get BuildKit service info: %v\n", err)
 				bw.logger.Infof("Retrying in %v...\n", bw.retryInterval)
 				bw.sleeper.Sleep(bw.retryInterval)

--- a/pkg/log/io/spinner.go
+++ b/pkg/log/io/spinner.go
@@ -74,7 +74,9 @@ func (s *ttySpinner) Start() {
 
 // Stop stops the spinner
 func (s *ttySpinner) Stop() {
-	s.Spinner.Stop()
+	if s.Spinner != nil && s.Spinner.Active() {
+		s.Spinner.Stop()
+	}
 }
 
 // getMessage returns the spinner message


### PR DESCRIPTION
# Proposed changes

Show the waiting for buildkit connection only when it fails for first time. 

## How to validate

1. Run `export OKTETO_DISABLE_SPINNER=false`
1. Run `okteto build`
1. Check that the message is not shown (if buildkit is up and running) and the build happens correctly

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
