### PR TITLE
PROD-344: Add predefined Okteto environment variables to diverted pods, so it can be known at runtime time if they are in a diverted namespace or not

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,136 +14,142 @@
 package constants
 
 const (
-	// OktetoNameEnvVar defines if the command is running inside okteot
-	OktetoNameEnvVar = "OKTETO_NAME"
+        // OktetoNameEnvVar defines if the command is running inside okteot
+        OktetoNameEnvVar = "OKTETO_NAME"
 
-	// DevLabel indicates the deployment is in dev mode
-	DevLabel = "dev.okteto.com"
+        // DevLabel indicates the deployment is in dev mode
+        DevLabel = "dev.okteto.com"
 
-	// OktetoURLAnnotation indicates the okteto cluster public url
-	OktetoURLAnnotation = "dev.okteto.com/url"
+        // OktetoURLAnnotation indicates the okteto cluster public url
+        OktetoURLAnnotation = "dev.okteto.com/url"
 
-	// OktetoDevModeAnnotation indicates the development mode in use (sync or hybrid)
-	OktetoDevModeAnnotation = "dev.okteto.com/dev-mode"
+        // OktetoDevModeAnnotation indicates the development mode in use (sync or hybrid)
+        OktetoDevModeAnnotation = "dev.okteto.com/dev-mode"
 
-	// OktetoExtension identifies the okteto extension in kubeconfig files
-	OktetoExtension = "okteto"
+        // OktetoExtension identifies the okteto extension in kubeconfig files
+        OktetoExtension = "okteto"
 
-	// OktetoSkipConfigCredentialsUpdate prevents the kubernetes config from being updated
-	// with the okteto credentials
-	OktetoSkipConfigCredentialsUpdate = "OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE"
+        // OktetoSkipConfigCredentialsUpdate prevents the kubernetes config from being updated
+        // with the okteto credentials
+        OktetoSkipConfigCredentialsUpdate = "OKTETO_SKIP_CONFIG_CREDENTIALS_UPDATE"
 
-	// OktetoHomeEnvVar defines the path of okteto folder
-	OktetoHomeEnvVar = "OKTETO_HOME"
+        // OktetoHomeEnvVar defines the path of okteto folder
+        OktetoHomeEnvVar = "OKTETO_HOME"
 
-	// KubeConfigEnvVar defines the path where kubeconfig is stored
-	KubeConfigEnvVar = "KUBECONFIG"
+        // KubeConfigEnvVar defines the path where kubeconfig is stored
+        KubeConfigEnvVar = "KUBECONFIG"
 
-	// OktetoWithinDeployCommandContextEnvVar defines if an okteto command is executed by deploy command
-	OktetoWithinDeployCommandContextEnvVar = "OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT"
+        // OktetoWithinDeployCommandContextEnvVar defines if an okteto command is executed by deploy command
+        OktetoWithinDeployCommandContextEnvVar = "OKTETO_WITHIN_DEPLOY_COMMAND_CONTEXT"
 
-	// OktetoFolderEnvVar defines the path of okteto folder
-	OktetoFolderEnvVar = "OKTETO_FOLDER"
+        // OktetoFolderEnvVar defines the path of okteto folder
+        OktetoFolderEnvVar = "OKTETO_FOLDER"
 
-	// LastUpdatedAnnotation indicates update timestamp
-	LastUpdatedAnnotation = "dev.okteto.com/last-updated"
+        // LastUpdatedAnnotation indicates update timestamp
+        LastUpdatedAnnotation = "dev.okteto.com/last-updated"
 
-	// TimeFormat is the format to use when storing timestamps as a string
-	TimeFormat = "2006-01-02T15:04:05"
+        // TimeFormat is the format to use when storing timestamps as a string
+        TimeFormat = "2006-01-02T15:04:05"
 
-	// OktetoDeployRemote defines if deployment is executed remotely
-	OktetoDeployRemote = "OKTETO_DEPLOY_REMOTE"
+        // OktetoDeployRemote defines if deployment is executed remotely
+        OktetoDeployRemote = "OKTETO_DEPLOY_REMOTE"
 
-	// OktetoForceRemote defines whether a deploy/destroy operation is to be executed remotely
-	OktetoForceRemote = "OKTETO_FORCE_REMOTE"
+        // OktetoForceRemote defines whether a deploy/destroy operation is to be executed remotely
+        OktetoForceRemote = "OKTETO_FORCE_REMOTE"
 
-	// OktetoTlsCertBase64EnvVar defines the TLS certificate in base64 for --remote
-	OktetoTlsCertBase64EnvVar = "OKTETO_TLS_CERT_BASE64"
+        // OktetoTlsCertBase64EnvVar defines the TLS certificate in base64 for --remote
+        OktetoTlsCertBase64EnvVar = "OKTETO_TLS_CERT_BASE64"
 
-	// OktetoInternalServerNameEnvVar defines the internal server name for --remote
-	OktetoInternalServerNameEnvVar = "INTERNAL_SERVER_NAME"
+        // OktetoInternalServerNameEnvVar defines the internal server name for --remote
+        OktetoInternalServerNameEnvVar = "INTERNAL_SERVER_NAME"
 
-	// OktetoInvalidateCacheEnvVar defines a random number to invalidate the "--remote" cache
-	OktetoInvalidateCacheEnvVar = "OKTETO_INVALIDATE_CACHE"
+        // OktetoInvalidateCacheEnvVar defines a random number to invalidate the "--remote" cache
+        OktetoInvalidateCacheEnvVar = "OKTETO_INVALIDATE_CACHE"
 
-	// OktetoPipelineRunnerImage defines image to use for remote deployments if empty
-	OktetoPipelineRunnerImage = "okteto/pipeline-runner:1.0.2"
+        // OktetoPipelineRunnerImage defines image to use for remote deployments if empty
+        OktetoPipelineRunnerImage = "okteto/pipeline-runner:1.0.2"
 
-	// OktetoEnvFile defines the name for okteto env file
-	OktetoEnvFile = "OKTETO_ENV"
+        // OktetoEnvFile defines the name for okteto env file
+        OktetoEnvFile = "OKTETO_ENV"
 
-	// NamespaceStatusLabel label added to namespaces to indicate its status
-	NamespaceStatusLabel = "space.okteto.com/status"
+        // NamespaceStatusLabel label added to namespaces to indicate its status
+        NamespaceStatusLabel = "space.okteto.com/status"
 
-	// NamespaceStatusSleeping indicates that the namespace is sleeping
-	NamespaceStatusSleeping = "Sleeping"
+        // NamespaceStatusSleeping indicates that the namespace is sleeping
+        NamespaceStatusSleeping = "Sleeping"
 
-	// DevRegistry alias url for okteto registry
-	DevRegistry = "okteto.dev"
+        // DevRegistry alias url for okteto registry
+        DevRegistry = "okteto.dev"
 
-	// GlobalRegistry alias url for okteto global registry
-	GlobalRegistry = "okteto.global"
+        // GlobalRegistry alias url for okteto global registry
+        GlobalRegistry = "okteto.global"
 
-	// DefaultGlobalNamespace namespace where okteto app is running
-	DefaultGlobalNamespace = "okteto"
+        // DefaultGlobalNamespace namespace where okteto app is running
+        DefaultGlobalNamespace = "okteto"
 
-	// OktetoGitBranchEnvVar is the name of the Git branch currently being deployed.
-	OktetoGitBranchEnvVar = "OKTETO_GIT_BRANCH"
+        // OktetoGitBranchEnvVar is the name of the Git branch currently being deployed.
+        OktetoGitBranchEnvVar = "OKTETO_GIT_BRANCH"
 
-	// OktetoGitCommitEnvVar is the SHA1 hash of the last commit of the branch.
-	OktetoGitCommitEnvVar = "OKTETO_GIT_COMMIT"
+        // OktetoGitCommitEnvVar is the SHA1 hash of the last commit of the branch.
+        OktetoGitCommitEnvVar = "OKTETO_GIT_COMMIT"
 
-	// OktetoNamespaceLabel is the label used to identify the namespace where the resource lives
-	OktetoNamespaceLabel = "dev.okteto.com/namespace"
+        // OktetoNamespaceLabel is the label used to identify the namespace where the resource lives
+        OktetoNamespaceLabel = "dev.okteto.com/namespace"
 
-	// OktetoDivertNginxDriver is the divert driver for nginx
-	OktetoDivertNginxDriver = "nginx"
+        // OktetoDivertNginxDriver is the divert driver for nginx
+        OktetoDivertNginxDriver = "nginx"
 
-	// OktetoDivertIstioDriver is the divert driver for istio
-	OktetoDivertIstioDriver = "istio"
+        // OktetoDivertIstioDriver is the divert driver for istio
+        OktetoDivertIstioDriver = "istio"
 
-	// OktetoDivertBaggageHeader represents the baggage header
-	OktetoDivertBaggageHeader = "baggage"
+        // OktetoDivertBaggageHeader represents the baggage header
+        OktetoDivertBaggageHeader = "baggage"
 
-	// OktetoDivertHeaderName the default header name used by okteto to divert traffic
-	OktetoDivertHeaderName = "okteto-divert"
+        // OktetoDivertHeaderName the default header name used by okteto to divert traffic
+        OktetoDivertHeaderName = "okteto-divert"
 
-	// OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
-	OktetoDivertAnnotationTemplate = "divert.okteto.com/%s"
+        // OktetoDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+        OktetoDivertAnnotationTemplate = "divert.okteto.com/%s"
 
-	// OktetoDeprecatedDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
-	OktetoDeprecatedDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
+        // OktetoDeprecatedDivertAnnotationTemplate annotation for the okteto mutation webhook to divert a virtual service
+        OktetoDeprecatedDivertAnnotationTemplate = "divert.okteto.com/%s-%s"
 
-	// OktetoHybridModeFieldValue represents the hybrid mode field value
-	OktetoHybridModeFieldValue = "hybrid"
+        // OktetoHybridModeFieldValue represents the hybrid mode field value
+        OktetoHybridModeFieldValue = "hybrid"
 
-	// OktetoSyncModeFieldValue represents the sync mode field value
-	OktetoSyncModeFieldValue = "sync"
+        // OktetoSyncModeFieldValue represents the sync mode field value
+        OktetoSyncModeFieldValue = "sync"
 
-	// OktetoConfigMapVariablesField represents the field name related to variables seetion in config map
-	OktetoConfigMapVariablesField = "variables"
+        // OktetoConfigMapVariablesField represents the field name related to variables seetion in config map
+        OktetoConfigMapVariablesField = "variables"
 
-	// OktetoDependencyEnvsKey the key on the conqfig map that will store OKTETO_ENV values
-	OktetoDependencyEnvsKey = "dependencyEnvs"
+        // OktetoDependencyEnvsKey the key on the conqfig map that will store OKTETO_ENV values
+        OktetoDependencyEnvsKey = "dependencyEnvs"
 
-	// EnvironmentLabelKeyPrefix represents the prefix for the preview and pipeline labels
-	EnvironmentLabelKeyPrefix = "label.okteto.com"
+        // EnvironmentLabelKeyPrefix represents the prefix for the preview and pipeline labels
+        EnvironmentLabelKeyPrefix = "label.okteto.com"
 
-	// OktetoDeployableEnvVar Env variable containing the piece of Okteto manifest which is deployable in remote or local deploys
-	OktetoDeployableEnvVar = "OKTETO_DEPLOYABLE"
+        // OktetoDeployableEnvVar Env variable containing the piece of Okteto manifest which is deployable in remote or local deploys
+        OktetoDeployableEnvVar = "OKTETO_DEPLOYABLE"
 
-	// OktetoIsPreviewEnvVar Env variable containing a boolean indicating if the environment is a preview environment
-	OktetoIsPreviewEnvVar = "OKTETO_IS_PREVIEW_ENVIRONMENT"
+        // OktetoIsPreviewEnvVar Env variable containing a boolean indicating if the environment is a preview environment
+        OktetoIsPreviewEnvVar = "OKTETO_IS_PREVIEW_ENVIRONMENT"
 
-	// CIEnvVar Env variable defines if the environment is a CI environment
-	CIEnvVar = "CI"
+        // CIEnvVar Env variable defines if the environment is a CI environment
+        CIEnvVar = "CI"
 
-	// OktetoSshAgentHostnameEnvVar Env variable defining the hostname where the SSH Agent is listening
-	OktetoSshAgentHostnameEnvVar = "OKTETO_SSH_AGENT_HOSTNAME"
+        // OktetoSshAgentHostnameEnvVar Env variable defining the hostname where the SSH Agent is listening
+        OktetoSshAgentHostnameEnvVar = "OKTETO_SSH_AGENT_HOSTNAME"
 
-	// OktetoSshAgentPortEnvVar Env variable defining the port where the SSH Agent is listening
-	OktetoSshAgentPortEnvVar = "OKTETO_SSH_AGENT_PORT"
+        // OktetoSshAgentPortEnvVar Env variable defining the port where the SSH Agent is listening
+        OktetoSshAgentPortEnvVar = "OKTETO_SSH_AGENT_PORT"
 
-	// OktetoSshAgentSocketEnvVar Env variable defining the socket where the ssh-forwarder will listen
-	OktetoSshAgentSocketEnvVar = "OKTETO_SSH_AGENT_SOCKET"
+        // OktetoSshAgentSocketEnvVar Env variable defining the socket where the ssh-forwarder will listen
+        OktetoSshAgentSocketEnvVar = "OKTETO_SSH_AGENT_SOCKET"
+
+        // OktetoSharedEnvironmentEnvVar Env variable containing the namespace of the shared environment in divert
+        OktetoSharedEnvironmentEnvVar = "OKTETO_SHARED_ENVIRONMENT"
+
+        // OktetoDivertedEnvironmentEnvVar Env variable containing the namespace of the diverted environment in divert
+        OktetoDivertedEnvironmentEnvVar = "OKTETO_DIVERTED_ENVIRONMENT"
 )

--- a/pkg/divert/istio/divert.go
+++ b/pkg/divert/istio/divert.go
@@ -14,175 +14,195 @@
 package istio
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
 
-	"github.com/okteto/okteto/pkg/k8s/virtualservices"
-	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/model"
-	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
-	istioclientset "istio.io/client-go/pkg/clientset/versioned"
-	apiv1 "k8s.io/api/core/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/kubernetes"
+        "github.com/okteto/okteto/pkg/constants"
+        "github.com/okteto/okteto/pkg/k8s/virtualservices"
+        oktetoLog "github.com/okteto/okteto/pkg/log"
+        "github.com/okteto/okteto/pkg/model"
+        istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
+        istioclientset "istio.io/client-go/pkg/clientset/versioned"
+        apiv1 "k8s.io/api/core/v1"
+        k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+        "k8s.io/client-go/kubernetes"
 )
 
 const (
-	UPDATE_CONFLICT_RETRIES = 20
+        UPDATE_CONFLICT_RETRIES = 20
 )
 
 // Driver istio struct for the divert driver
 type Driver struct {
-	client      kubernetes.Interface
-	istioClient istioclientset.Interface
-	name        string
-	namespace   string
-	divert      model.DivertDeploy
+        client      kubernetes.Interface
+        istioClient istioclientset.Interface
+        name        string
+        namespace   string
+        divert      model.DivertDeploy
 }
 
 // DivertTransformation represents the annotation for the okteto mutation webhook to divert a virtual service
 type DivertTransformation struct {
-	Namespace string   `json:"namespace"`
-	Routes    []string `json:"routes,omitempty"`
+        Namespace string   `json:"namespace"`
+        Routes    []string `json:"routes,omitempty"`
 }
 
 func New(divert *model.DivertDeploy, name, namespace string, c kubernetes.Interface, ic istioclientset.Interface) *Driver {
-	return &Driver{
-		name:        name,
-		namespace:   namespace,
-		divert:      *divert,
-		client:      c,
-		istioClient: ic,
-	}
+        return &Driver{
+                name:        name,
+                namespace:   namespace,
+                divert:      *divert,
+                client:      c,
+                istioClient: ic,
+        }
 }
 
 func (d *Driver) Deploy(ctx context.Context) error {
-	for i := range d.divert.VirtualServices {
-		oktetoLog.Spinner(fmt.Sprintf("Diverting virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
-		oktetoLog.StartSpinner()
-		defer oktetoLog.StopSpinner()
-		if err := d.retryTranslateDivertVirtualService(ctx, d.divert.VirtualServices[i]); err != nil {
-			return err
-		}
-		oktetoLog.StopSpinner()
-		oktetoLog.Success("Virtual service '%s/%s' successfully diverted", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
-	}
+        for i := range d.divert.VirtualServices {
+                oktetoLog.Spinner(fmt.Sprintf("Diverting virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
+                oktetoLog.StartSpinner()
+                defer oktetoLog.StopSpinner()
+                if err := d.retryTranslateDivertVirtualService(ctx, d.divert.VirtualServices[i]); err != nil {
+                        return err
+                }
+                oktetoLog.StopSpinner()
+                oktetoLog.Success("Virtual service '%s/%s' successfully diverted", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
+        }
 
-	for i := range d.divert.Hosts {
-		select {
-		case <-ctx.Done():
-			oktetoLog.Infof("deployDivert context cancelled")
-			return ctx.Err()
-		default:
-			oktetoLog.Spinner(fmt.Sprintf("Diverting host %s/%s...", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService))
-			oktetoLog.StartSpinner()
-			defer oktetoLog.StopSpinner()
-			if err := d.retryTranslateDivertHost(ctx, d.divert.Hosts[i]); err != nil {
-				return err
-			}
-			oktetoLog.StopSpinner()
-			oktetoLog.Success("Host '%s/%s' successfully diverted", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService)
-		}
-	}
+        for i := range d.divert.Hosts {
+                select {
+                case <-ctx.Done():
+                        oktetoLog.Infof("deployDivert context cancelled")
+                        return ctx.Err()
+                default:
+                        oktetoLog.Spinner(fmt.Sprintf("Diverting host %s/%s...", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService))
+                        oktetoLog.StartSpinner()
+                        defer oktetoLog.StopSpinner()
+                        if err := d.retryTranslateDivertHost(ctx, d.divert.Hosts[i]); err != nil {
+                                return err
+                        }
+                        oktetoLog.StopSpinner()
+                        oktetoLog.Success("Host '%s/%s' successfully diverted", d.divert.Hosts[i].Namespace, d.divert.Hosts[i].VirtualService)
+                }
+        }
 
-	return nil
+        return nil
 }
 
 func (d *Driver) Destroy(ctx context.Context) error {
-	var err error
-	for i := range d.divert.VirtualServices {
-		oktetoLog.Spinner(fmt.Sprintf("Restoring virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
-		oktetoLog.StartSpinner()
-		defer oktetoLog.StopSpinner()
-		for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
-			vs, err := virtualservices.Get(ctx, d.divert.VirtualServices[i].Name, d.divert.VirtualServices[i].Namespace, d.istioClient)
-			if err != nil {
-				return err
-			}
-			restoredVS := d.restoreDivertVirtualService(vs)
+        var err error
+        for i := range d.divert.VirtualServices {
+                oktetoLog.Spinner(fmt.Sprintf("Restoring virtual service %s/%s...", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name))
+                oktetoLog.StartSpinner()
+                defer oktetoLog.StopSpinner()
+                for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
+                        vs, err := virtualservices.Get(ctx, d.divert.VirtualServices[i].Name, d.divert.VirtualServices[i].Namespace, d.istioClient)
+                        if err != nil {
+                                return err
+                        }
+                        restoredVS := d.restoreDivertVirtualService(vs)
 
-			err = virtualservices.Update(ctx, restoredVS, d.istioClient)
-			if err == nil {
-				oktetoLog.StopSpinner()
-				oktetoLog.Success("Virtual service '%s/%s' successfully restored", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
-				break
-			}
-			if !k8sErrors.IsConflict(err) {
-				return err
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+                        err = virtualservices.Update(ctx, restoredVS, d.istioClient)
+                        if err == nil {
+                                oktetoLog.StopSpinner()
+                                oktetoLog.Success("Virtual service '%s/%s' successfully restored", d.divert.VirtualServices[i].Namespace, d.divert.VirtualServices[i].Name)
+                                break
+                        }
+                        if !k8sErrors.IsConflict(err) {
+                                return err
+                        }
+                }
+                if err != nil {
+                        return err
+                }
+        }
+        return nil
 
 }
 
 func (d *Driver) UpdatePod(pod apiv1.PodSpec) apiv1.PodSpec {
-	return pod
+        // Add or update environment variables for all containers
+        for i := range pod.Containers {
+                updateEnvVar(&pod.Containers[i].Env, constants.OktetoSharedEnvironmentEnvVar, d.divert.Namespace)
+                updateEnvVar(&pod.Containers[i].Env, constants.OktetoDivertedEnvironmentEnvVar, d.namespace)
+        }
+        return pod
 }
 
 func (d *Driver) UpdateVirtualService(vs *istioNetworkingV1beta1.VirtualService) {
-	d.injectDivertHeader(vs)
+        d.injectDivertHeader(vs)
 }
 
 func (d *Driver) retryTranslateDivertVirtualService(ctx context.Context, divertVS model.DivertVirtualService) error {
-	var err error
-	for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
-		vs, err := virtualservices.Get(ctx, divertVS.Name, divertVS.Namespace, d.istioClient)
-		if err != nil {
-			return err
-		}
-		translatedVS, err := d.translateDivertVirtualService(vs, divertVS.Routes)
-		if err != nil {
-			return err
-		}
-		err = virtualservices.Update(ctx, translatedVS, d.istioClient)
-		if err == nil {
-			return nil
-		}
-		if !k8sErrors.IsConflict(err) {
-			return err
-		}
-	}
-	return err
+        var err error
+        for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
+                vs, err := virtualservices.Get(ctx, divertVS.Name, divertVS.Namespace, d.istioClient)
+                if err != nil {
+                        return err
+                }
+                translatedVS, err := d.translateDivertVirtualService(vs, divertVS.Routes)
+                if err != nil {
+                        return err
+                }
+                err = virtualservices.Update(ctx, translatedVS, d.istioClient)
+                if err == nil {
+                        return nil
+                }
+                if !k8sErrors.IsConflict(err) {
+                        return err
+                }
+        }
+        return err
 }
 
 func (d *Driver) retryTranslateDivertHost(ctx context.Context, divertHost model.DivertHost) error {
-	var err error
-	for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
-		vs, err := virtualservices.Get(ctx, divertHost.VirtualService, divertHost.Namespace, d.istioClient)
-		if err != nil {
-			return err
-		}
-		translatedVS := d.translateDivertHost(vs)
+        var err error
+        for retries := 0; retries < UPDATE_CONFLICT_RETRIES; retries++ {
+                vs, err := virtualservices.Get(ctx, divertHost.VirtualService, divertHost.Namespace, d.istioClient)
+                if err != nil {
+                        return err
+                }
+                translatedVS := d.translateDivertHost(vs)
 
-		devVS, err := virtualservices.Get(ctx, divertHost.VirtualService, d.namespace, d.istioClient)
-		if k8sErrors.IsNotFound(err) {
-			err = virtualservices.Create(ctx, translatedVS, d.istioClient)
-			if err == nil {
-				return nil
-			}
-			if k8sErrors.IsAlreadyExists(err) {
-				return nil
-			}
-			return err
-		}
+                devVS, err := virtualservices.Get(ctx, divertHost.VirtualService, d.namespace, d.istioClient)
+                if k8sErrors.IsNotFound(err) {
+                        err = virtualservices.Create(ctx, translatedVS, d.istioClient)
+                        if err == nil {
+                                return nil
+                        }
+                        if k8sErrors.IsAlreadyExists(err) {
+                                return nil
+                        }
+                        return err
+                }
 
-		if devVS.Labels[model.OktetoAutoCreateAnnotation] != "true" {
-			oktetoLog.Infof("Ignoring host '%s/%s', virtual service '%s/%s'", divertHost.Namespace, divertHost.VirtualService, d.namespace, divertHost.VirtualService)
-			return nil
-		}
+                if devVS.Labels[model.OktetoAutoCreateAnnotation] != "true" {
+                        oktetoLog.Infof("Ignoring host '%s/%s', virtual service '%s/%s'", divertHost.Namespace, divertHost.VirtualService, d.namespace, divertHost.VirtualService)
+                        return nil
+                }
 
-		translatedVS.ResourceVersion = devVS.ResourceVersion
-		err = virtualservices.Update(ctx, translatedVS, d.istioClient)
-		if err == nil {
-			return nil
-		}
-		if !k8sErrors.IsConflict(err) {
-			return err
-		}
-	}
-	return err
+                translatedVS.ResourceVersion = devVS.ResourceVersion
+                err = virtualservices.Update(ctx, translatedVS, d.istioClient)
+                if err == nil {
+                        return nil
+                }
+                if !k8sErrors.IsConflict(err) {
+                        return err
+                }
+        }
+        return err
+}
+
+// updateEnvVar adds or updates an environment variable in the given env var slice
+func updateEnvVar(envVars *[]apiv1.EnvVar, name, value string) {
+        for i := range *envVars {
+                if (*envVars)[i].Name == name {
+                        (*envVars)[i].Value = value
+                        return
+                }
+        }
+        *envVars = append(*envVars, apiv1.EnvVar{
+                Name:  name,
+                Value: value,
+        })
 }

--- a/pkg/divert/istio/divert_test.go
+++ b/pkg/divert/istio/divert_test.go
@@ -1,0 +1,258 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func Test_updateEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVars  []apiv1.EnvVar
+		envName  string
+		envValue string
+		expected []apiv1.EnvVar
+	}{
+		{
+			name:     "empty-env-vars",
+			envVars:  []apiv1.EnvVar{},
+			envName:  "TEST_VAR",
+			envValue: "test-value",
+			expected: []apiv1.EnvVar{
+				{
+					Name:  "TEST_VAR",
+					Value: "test-value",
+				},
+			},
+		},
+		{
+			name: "update-existing-var",
+			envVars: []apiv1.EnvVar{
+				{
+					Name:  "EXISTING_VAR",
+					Value: "existing-value",
+				},
+				{
+					Name:  "TEST_VAR",
+					Value: "old-value",
+				},
+			},
+			envName:  "TEST_VAR",
+			envValue: "new-value",
+			expected: []apiv1.EnvVar{
+				{
+					Name:  "EXISTING_VAR",
+					Value: "existing-value",
+				},
+				{
+					Name:  "TEST_VAR",
+					Value: "new-value",
+				},
+			},
+		},
+		{
+			name: "add-new-var",
+			envVars: []apiv1.EnvVar{
+				{
+					Name:  "EXISTING_VAR",
+					Value: "existing-value",
+				},
+			},
+			envName:  "NEW_VAR",
+			envValue: "new-value",
+			expected: []apiv1.EnvVar{
+				{
+					Name:  "EXISTING_VAR",
+					Value: "existing-value",
+				},
+				{
+					Name:  "NEW_VAR",
+					Value: "new-value",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envVars := tt.envVars
+			updateEnvVar(&envVars, tt.envName, tt.envValue)
+			assert.Equal(t, tt.expected, envVars)
+		})
+	}
+}
+
+func Test_UpdatePod(t *testing.T) {
+	tests := []struct {
+		name     string
+		podSpec  apiv1.PodSpec
+		expected apiv1.PodSpec
+		driver   *Driver
+	}{
+		{
+			name: "empty-pod",
+			podSpec: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name: "app",
+					},
+				},
+			},
+			expected: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name: "app",
+						Env: []apiv1.EnvVar{
+							{
+								Name:  "OKTETO_SHARED_ENVIRONMENT",
+								Value: "staging",
+							},
+							{
+								Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+								Value: "cindy",
+							},
+						},
+					},
+				},
+			},
+			driver: &Driver{
+				name:      "test",
+				namespace: "cindy",
+				divert: model.DivertDeploy{
+					Namespace: "staging",
+				},
+			},
+		},
+		{
+			name: "pod-with-existing-env-vars",
+			podSpec: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name: "app",
+						Env: []apiv1.EnvVar{
+							{
+								Name:  "EXISTING_VAR",
+								Value: "value",
+							},
+							{
+								Name:  "OKTETO_SHARED_ENVIRONMENT",
+								Value: "old-value",
+							},
+						},
+					},
+				},
+			},
+			expected: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name: "app",
+						Env: []apiv1.EnvVar{
+							{
+								Name:  "EXISTING_VAR",
+								Value: "value",
+							},
+							{
+								Name:  "OKTETO_SHARED_ENVIRONMENT",
+								Value: "staging",
+							},
+							{
+								Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+								Value: "cindy",
+							},
+						},
+					},
+				},
+			},
+			driver: &Driver{
+				name:      "test",
+				namespace: "cindy",
+				divert: model.DivertDeploy{
+					Namespace: "staging",
+				},
+			},
+		},
+		{
+			name: "pod-with-multiple-containers",
+			podSpec: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name: "app1",
+					},
+					{
+						Name: "app2",
+						Env: []apiv1.EnvVar{
+							{
+								Name:  "EXISTING_VAR",
+								Value: "value",
+							},
+						},
+					},
+				},
+			},
+			expected: apiv1.PodSpec{
+				Containers: []apiv1.Container{
+					{
+						Name: "app1",
+						Env: []apiv1.EnvVar{
+							{
+								Name:  "OKTETO_SHARED_ENVIRONMENT",
+								Value: "staging",
+							},
+							{
+								Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+								Value: "cindy",
+							},
+						},
+					},
+					{
+						Name: "app2",
+						Env: []apiv1.EnvVar{
+							{
+								Name:  "EXISTING_VAR",
+								Value: "value",
+							},
+							{
+								Name:  "OKTETO_SHARED_ENVIRONMENT",
+								Value: "staging",
+							},
+							{
+								Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+								Value: "cindy",
+							},
+						},
+					},
+				},
+			},
+			driver: &Driver{
+				name:      "test",
+				namespace: "cindy",
+				divert: model.DivertDeploy{
+					Namespace: "staging",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.driver.UpdatePod(tt.podSpec)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/divert/istio/virtualservices_test.go
+++ b/pkg/divert/istio/virtualservices_test.go
@@ -14,388 +14,390 @@
 package istio
 
 import (
-	"fmt"
-	"os"
-	"reflect"
-	"testing"
+        "fmt"
+        "os"
+        "reflect"
+        "testing"
 
-	"github.com/okteto/okteto/pkg/constants"
-	"github.com/okteto/okteto/pkg/model"
-	"github.com/okteto/okteto/pkg/okteto"
-	"github.com/okteto/okteto/pkg/types"
-	"github.com/stretchr/testify/assert"
-	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
-	istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+        "github.com/okteto/okteto/pkg/constants"
+        "github.com/okteto/okteto/pkg/model"
+        "github.com/okteto/okteto/pkg/okteto"
+        "github.com/okteto/okteto/pkg/types"
+        "github.com/stretchr/testify/assert"
+        istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
+        istioV1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMain(m *testing.M) {
-	okteto.CurrentStore = &okteto.ContextStore{
-		Contexts: map[string]*okteto.Context{
-			"test": {},
-		},
-		CurrentContext: "test",
-	}
-	os.Exit(m.Run())
+        okteto.CurrentStore = &okteto.ContextStore{
+                Contexts: map[string]*okteto.Context{
+                        "test": {},
+                },
+                CurrentContext: "test",
+        }
+        os.Exit(m.Run())
 }
 
-func Test_translateDivertVirtualService(t *testing.T) {
-	tests := []struct {
-		vs       *istioV1beta1.VirtualService
-		expected *istioV1beta1.VirtualService
-		name     string
-		routes   []string
-	}{
-		{
-			name: "add-divert-annotation",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-			},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-a",
-					Namespace: "staging",
-					Labels:    map[string]string{"l1": "v1"},
-					Annotations: map[string]string{
-						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy"}`,
-					},
-				},
-			},
-		},
-		{
-			name: "add-divert-annotation-with-routes",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-			},
-			routes: []string{"one-route", "another-route"},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-a",
-					Namespace: "staging",
-					Labels:    map[string]string{"l1": "v1"},
-					Annotations: map[string]string{
-						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy","routes":["one-route","another-route"]}`,
-					},
-				},
-			},
-		},
-	}
 
-	d := &Driver{
-		name:      "test",
-		namespace: "cindy",
-		divert: model.DivertDeploy{
-			VirtualServices: []model.DivertVirtualService{
-				{
-					Name:      "virtual-service-a",
-					Namespace: "staging",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := d.translateDivertVirtualService(tt.vs, tt.routes)
-			assert.NoError(t, err)
-			assert.Equal(t, result.Annotations, tt.expected.Annotations)
-		})
-	}
+
+func Test_translateDivertVirtualService(t *testing.T) {
+        tests := []struct {
+                vs       *istioV1beta1.VirtualService
+                expected *istioV1beta1.VirtualService
+                name     string
+                routes   []string
+        }{
+                {
+                        name: "add-divert-annotation",
+                        vs: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:        "service-a",
+                                        Namespace:   "staging",
+                                        Labels:      map[string]string{"l1": "v1"},
+                                        Annotations: map[string]string{"a1": "v1"},
+                                },
+                        },
+                        expected: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:      "service-a",
+                                        Namespace: "staging",
+                                        Labels:    map[string]string{"l1": "v1"},
+                                        Annotations: map[string]string{
+                                                "a1": "v1",
+                                                fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy"}`,
+                                        },
+                                },
+                        },
+                },
+                {
+                        name: "add-divert-annotation-with-routes",
+                        vs: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:        "service-a",
+                                        Namespace:   "staging",
+                                        Labels:      map[string]string{"l1": "v1"},
+                                        Annotations: map[string]string{"a1": "v1"},
+                                },
+                        },
+                        routes: []string{"one-route", "another-route"},
+                        expected: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:      "service-a",
+                                        Namespace: "staging",
+                                        Labels:    map[string]string{"l1": "v1"},
+                                        Annotations: map[string]string{
+                                                "a1": "v1",
+                                                fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy","routes":["one-route","another-route"]}`,
+                                        },
+                                },
+                        },
+                },
+        }
+
+        d := &Driver{
+                name:      "test",
+                namespace: "cindy",
+                divert: model.DivertDeploy{
+                        VirtualServices: []model.DivertVirtualService{
+                                {
+                                        Name:      "virtual-service-a",
+                                        Namespace: "staging",
+                                },
+                        },
+                },
+        }
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result, err := d.translateDivertVirtualService(tt.vs, tt.routes)
+                        assert.NoError(t, err)
+                        assert.Equal(t, result.Annotations, tt.expected.Annotations)
+                })
+        }
 }
 
 func Test_restoreDivertVirtualService(t *testing.T) {
-	tests := []struct {
-		vs       *istioV1beta1.VirtualService
-		expected *istioV1beta1.VirtualService
-		name     string
-	}{
-		{
-			name: "clean-divert-annotation",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-a",
-					Namespace: "staging",
-					Annotations: map[string]string{
-						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
-					},
-				},
-			},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-			},
-		},
-		{
-			name: "clean-deprecated-divert-annotation",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-a",
-					Namespace: "staging",
-					Annotations: map[string]string{
-						"a1": "v1",
-						fmt.Sprintf(constants.OktetoDeprecatedDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
-					},
-				},
-			},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        "service-a",
-					Namespace:   "staging",
-					Labels:      map[string]string{"l1": "v1"},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-			},
-		},
-	}
+        tests := []struct {
+                vs       *istioV1beta1.VirtualService
+                expected *istioV1beta1.VirtualService
+                name     string
+        }{
+                {
+                        name: "clean-divert-annotation",
+                        vs: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:      "service-a",
+                                        Namespace: "staging",
+                                        Annotations: map[string]string{
+                                                "a1": "v1",
+                                                fmt.Sprintf(constants.OktetoDivertAnnotationTemplate, "2615052508acbfaddeba0eeded4131631ea31a02"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
+                                        },
+                                },
+                        },
+                        expected: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:        "service-a",
+                                        Namespace:   "staging",
+                                        Labels:      map[string]string{"l1": "v1"},
+                                        Annotations: map[string]string{"a1": "v1"},
+                                },
+                        },
+                },
+                {
+                        name: "clean-deprecated-divert-annotation",
+                        vs: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:      "service-a",
+                                        Namespace: "staging",
+                                        Annotations: map[string]string{
+                                                "a1": "v1",
+                                                fmt.Sprintf(constants.OktetoDeprecatedDivertAnnotationTemplate, "cindy", "test"): `{"namespace":"cindy","header":{"name":"okteto-divert","match":"exact","value":"cindy"},"routes":null}`,
+                                        },
+                                },
+                        },
+                        expected: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:        "service-a",
+                                        Namespace:   "staging",
+                                        Labels:      map[string]string{"l1": "v1"},
+                                        Annotations: map[string]string{"a1": "v1"},
+                                },
+                        },
+                },
+        }
 
-	d := &Driver{
-		name:      "test",
-		namespace: "cindy",
-		divert: model.DivertDeploy{
-			VirtualServices: []model.DivertVirtualService{
-				{
-					Name:      "virtual-service-a",
-					Namespace: "staging",
-				},
-			},
-		},
-	}
+        d := &Driver{
+                name:      "test",
+                namespace: "cindy",
+                divert: model.DivertDeploy{
+                        VirtualServices: []model.DivertVirtualService{
+                                {
+                                        Name:      "virtual-service-a",
+                                        Namespace: "staging",
+                                },
+                        },
+                },
+        }
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := d.restoreDivertVirtualService(tt.vs)
-			assert.Equal(t, result.Annotations, tt.expected.Annotations)
-		})
-	}
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result := d.restoreDivertVirtualService(tt.vs)
+                        assert.Equal(t, result.Annotations, tt.expected.Annotations)
+                })
+        }
 }
 
 func Test_translateDivertHost(t *testing.T) {
-	tests := []struct {
-		vs       *istioV1beta1.VirtualService
-		expected *istioV1beta1.VirtualService
-		name     string
-	}{
-		{
-			name: "divert-host-service-same-namespace",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "service-a",
-					Namespace:       "staging",
-					Labels:          map[string]string{"l1": "v1"},
-					Annotations:     map[string]string{"a1": "v1"},
-					ResourceVersion: "version",
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-a",
-					Namespace: "cindy",
-					Labels: map[string]string{
-						"l1":                             "v1",
-						"dev.okteto.com/deployed-by":     "test",
-						model.OktetoAutoCreateAnnotation: "true",
-					},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a-cindy.demo.okteto.dev",
-						"service-a.cindy.svc.cluster.local",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Headers: &istioNetworkingV1beta1.Headers{
-								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Add: map[string]string{constants.OktetoDivertBaggageHeader: "okteto-divert=cindy"},
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "divert-host-service-different-namespace",
-			vs: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "service-a",
-					Namespace:       "staging",
-					Labels:          map[string]string{"l1": "v1"},
-					Annotations:     map[string]string{"a1": "v1"},
-					ResourceVersion: "version",
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a.staging.svc.cluster.local",
-						"service-a.staging.com",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging2.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: &istioV1beta1.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "service-a",
-					Namespace: "cindy",
-					Labels: map[string]string{
-						"l1":                             "v1",
-						"dev.okteto.com/deployed-by":     "test",
-						model.OktetoAutoCreateAnnotation: "true",
-					},
-					Annotations: map[string]string{"a1": "v1"},
-				},
-				Spec: istioNetworkingV1beta1.VirtualService{
-					Gateways: []string{"ingress-http"},
-					Hosts: []string{
-						"service-a-cindy.demo.okteto.dev",
-						"service-a.cindy.svc.cluster.local",
-					},
-					Http: []*istioNetworkingV1beta1.HTTPRoute{
-						{
-							Name: "ingress-gateway-http-app-service",
-							Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
-								{
-									Gateways: []string{"ingress-http"},
-									Port:     80,
-								},
-							},
-							Headers: &istioNetworkingV1beta1.Headers{
-								Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
-									Add: map[string]string{constants.OktetoDivertBaggageHeader: "okteto-divert=cindy"},
-								},
-							},
-							Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
-								{
-									Destination: &istioNetworkingV1beta1.Destination{
-										Host: "service-a.staging2.svc.cluster.local",
-										Port: &istioNetworkingV1beta1.PortSelector{
-											Number: 80,
-										},
-										Subset: "stable",
-									},
-									Weight: 100,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+        tests := []struct {
+                vs       *istioV1beta1.VirtualService
+                expected *istioV1beta1.VirtualService
+                name     string
+        }{
+                {
+                        name: "divert-host-service-same-namespace",
+                        vs: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:            "service-a",
+                                        Namespace:       "staging",
+                                        Labels:          map[string]string{"l1": "v1"},
+                                        Annotations:     map[string]string{"a1": "v1"},
+                                        ResourceVersion: "version",
+                                },
+                                Spec: istioNetworkingV1beta1.VirtualService{
+                                        Gateways: []string{"ingress-http"},
+                                        Hosts: []string{
+                                                "service-a.staging.svc.cluster.local",
+                                                "service-a.staging.com",
+                                        },
+                                        Http: []*istioNetworkingV1beta1.HTTPRoute{
+                                                {
+                                                        Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
+                                                        Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
+                                                                {
+                                                                        Gateways: []string{"ingress-http"},
+                                                                        Port:     80,
+                                                                },
+                                                        },
+                                                        Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
+                                                                {
+                                                                        Destination: &istioNetworkingV1beta1.Destination{
+                                                                                Host: "service-a",
+                                                                                Port: &istioNetworkingV1beta1.PortSelector{
+                                                                                        Number: 80,
+                                                                                },
+                                                                                Subset: "stable",
+                                                                        },
+                                                                        Weight: 100,
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        expected: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:      "service-a",
+                                        Namespace: "cindy",
+                                        Labels: map[string]string{
+                                                "l1":                             "v1",
+                                                "dev.okteto.com/deployed-by":     "test",
+                                                model.OktetoAutoCreateAnnotation: "true",
+                                        },
+                                        Annotations: map[string]string{"a1": "v1"},
+                                },
+                                Spec: istioNetworkingV1beta1.VirtualService{
+                                        Gateways: []string{"ingress-http"},
+                                        Hosts: []string{
+                                                "service-a-cindy.demo.okteto.dev",
+                                                "service-a.cindy.svc.cluster.local",
+                                        },
+                                        Http: []*istioNetworkingV1beta1.HTTPRoute{
+                                                {
+                                                        Name: "ingress-gateway-http-app-service",
+                                                        Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
+                                                                {
+                                                                        Gateways: []string{"ingress-http"},
+                                                                        Port:     80,
+                                                                },
+                                                        },
+                                                        Headers: &istioNetworkingV1beta1.Headers{
+                                                                Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
+                                                                        Add: map[string]string{constants.OktetoDivertBaggageHeader: "okteto-divert=cindy"},
+                                                                },
+                                                        },
+                                                        Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
+                                                                {
+                                                                        Destination: &istioNetworkingV1beta1.Destination{
+                                                                                Host: "service-a.staging.svc.cluster.local",
+                                                                                Port: &istioNetworkingV1beta1.PortSelector{
+                                                                                        Number: 80,
+                                                                                },
+                                                                                Subset: "stable",
+                                                                        },
+                                                                        Weight: 100,
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                },
+                {
+                        name: "divert-host-service-different-namespace",
+                        vs: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:            "service-a",
+                                        Namespace:       "staging",
+                                        Labels:          map[string]string{"l1": "v1"},
+                                        Annotations:     map[string]string{"a1": "v1"},
+                                        ResourceVersion: "version",
+                                },
+                                Spec: istioNetworkingV1beta1.VirtualService{
+                                        Gateways: []string{"ingress-http"},
+                                        Hosts: []string{
+                                                "service-a.staging.svc.cluster.local",
+                                                "service-a.staging.com",
+                                        },
+                                        Http: []*istioNetworkingV1beta1.HTTPRoute{
+                                                {
+                                                        Name: "okteto-divert-cindy-ingress-gateway-http-app-service",
+                                                        Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
+                                                                {
+                                                                        Gateways: []string{"ingress-http"},
+                                                                        Port:     80,
+                                                                },
+                                                        },
+                                                        Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
+                                                                {
+                                                                        Destination: &istioNetworkingV1beta1.Destination{
+                                                                                Host: "service-a.staging2.svc.cluster.local",
+                                                                                Port: &istioNetworkingV1beta1.PortSelector{
+                                                                                        Number: 80,
+                                                                                },
+                                                                                Subset: "stable",
+                                                                        },
+                                                                        Weight: 100,
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        expected: &istioV1beta1.VirtualService{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:      "service-a",
+                                        Namespace: "cindy",
+                                        Labels: map[string]string{
+                                                "l1":                             "v1",
+                                                "dev.okteto.com/deployed-by":     "test",
+                                                model.OktetoAutoCreateAnnotation: "true",
+                                        },
+                                        Annotations: map[string]string{"a1": "v1"},
+                                },
+                                Spec: istioNetworkingV1beta1.VirtualService{
+                                        Gateways: []string{"ingress-http"},
+                                        Hosts: []string{
+                                                "service-a-cindy.demo.okteto.dev",
+                                                "service-a.cindy.svc.cluster.local",
+                                        },
+                                        Http: []*istioNetworkingV1beta1.HTTPRoute{
+                                                {
+                                                        Name: "ingress-gateway-http-app-service",
+                                                        Match: []*istioNetworkingV1beta1.HTTPMatchRequest{
+                                                                {
+                                                                        Gateways: []string{"ingress-http"},
+                                                                        Port:     80,
+                                                                },
+                                                        },
+                                                        Headers: &istioNetworkingV1beta1.Headers{
+                                                                Request: &istioNetworkingV1beta1.Headers_HeaderOperations{
+                                                                        Add: map[string]string{constants.OktetoDivertBaggageHeader: "okteto-divert=cindy"},
+                                                                },
+                                                        },
+                                                        Route: []*istioNetworkingV1beta1.HTTPRouteDestination{
+                                                                {
+                                                                        Destination: &istioNetworkingV1beta1.Destination{
+                                                                                Host: "service-a.staging2.svc.cluster.local",
+                                                                                Port: &istioNetworkingV1beta1.PortSelector{
+                                                                                        Number: 80,
+                                                                                },
+                                                                                Subset: "stable",
+                                                                        },
+                                                                        Weight: 100,
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                },
+        }
 
-	d := &Driver{
-		name:      "test",
-		namespace: "cindy",
-		divert: model.DivertDeploy{
-			VirtualServices: []model.DivertVirtualService{
-				{
-					Name:      "virtual-service-a",
-					Namespace: "staging",
-				},
-			},
-		},
-	}
-	okteto.AddOktetoContext("test", &types.User{Registry: "registry.demo.okteto.dev"}, "okteto", "cyndy")
+        d := &Driver{
+                name:      "test",
+                namespace: "cindy",
+                divert: model.DivertDeploy{
+                        VirtualServices: []model.DivertVirtualService{
+                                {
+                                        Name:      "virtual-service-a",
+                                        Namespace: "staging",
+                                },
+                        },
+                },
+        }
+        okteto.AddOktetoContext("test", &types.User{Registry: "registry.demo.okteto.dev"}, "okteto", "cyndy")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := d.translateDivertHost(tt.vs)
-			assert.Equal(t, result.ResourceVersion, "")
-			assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
-			assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
-			assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
-			for i := range tt.expected.Spec.Http {
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
-				assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
-			}
-		})
-	}
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result := d.translateDivertHost(tt.vs)
+                        assert.Equal(t, result.ResourceVersion, "")
+                        assert.True(t, reflect.DeepEqual(result.ObjectMeta, tt.expected.ObjectMeta))
+                        assert.True(t, reflect.DeepEqual(result.Spec.Hosts, tt.expected.Spec.Hosts))
+                        assert.True(t, reflect.DeepEqual(result.Spec.Gateways, tt.expected.Spec.Gateways))
+                        for i := range tt.expected.Spec.Http {
+                                assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Headers, tt.expected.Spec.Http[i].Headers))
+                                assert.True(t, reflect.DeepEqual(result.Spec.Http[i].Route, tt.expected.Spec.Http[i].Route))
+                        }
+                })
+        }
 }

--- a/pkg/divert/nginx/divert.go
+++ b/pkg/divert/nginx/divert.go
@@ -14,78 +14,100 @@
 package nginx
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
 
-	oktetoLog "github.com/okteto/okteto/pkg/log"
-	"github.com/okteto/okteto/pkg/model"
-	istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
-	apiv1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
+        "github.com/okteto/okteto/pkg/constants"
+        oktetoLog "github.com/okteto/okteto/pkg/log"
+        "github.com/okteto/okteto/pkg/model"
+        istioNetworkingV1beta1 "istio.io/api/networking/v1beta1"
+        apiv1 "k8s.io/api/core/v1"
+        "k8s.io/client-go/kubernetes"
 )
 
 // Driver nginx struct for the divert driver
 type Driver struct {
-	client    kubernetes.Interface
-	cache     *cache
-	name      string
-	namespace string
-	divert    model.DivertDeploy
+        client    kubernetes.Interface
+        cache     *cache
+        name      string
+        namespace string
+        divert    model.DivertDeploy
 }
 
 func New(divert *model.DivertDeploy, name, namespace string, c kubernetes.Interface) *Driver {
-	return &Driver{
-		name:      name,
-		namespace: namespace,
-		divert:    *divert,
-		client:    c,
-	}
+        return &Driver{
+                name:      name,
+                namespace: namespace,
+                divert:    *divert,
+                client:    c,
+        }
 }
 
 func (d *Driver) Deploy(ctx context.Context) error {
-	oktetoLog.Spinner(fmt.Sprintf("Diverting namespace %s...", d.divert.Namespace))
-	oktetoLog.StartSpinner()
-	defer oktetoLog.StopSpinner()
-	if err := d.initCache(ctx); err != nil {
-		return err
-	}
-	for name, in := range d.cache.divertIngresses {
-		select {
-		case <-ctx.Done():
-			oktetoLog.Infof("deployDivert context cancelled")
-			return ctx.Err()
-		default:
-			oktetoLog.Spinner(fmt.Sprintf("Diverting ingress %s/%s...", in.Namespace, in.Name))
-			oktetoLog.StartSpinner()
-			defer oktetoLog.StopSpinner()
-			if err := d.divertIngress(ctx, name); err != nil {
-				return err
-			}
-			oktetoLog.StopSpinner()
-			oktetoLog.Success("Ingress '%s/%s' successfully diverted", in.Namespace, in.Name)
-		}
-	}
-	return nil
+        oktetoLog.Spinner(fmt.Sprintf("Diverting namespace %s...", d.divert.Namespace))
+        oktetoLog.StartSpinner()
+        defer oktetoLog.StopSpinner()
+        if err := d.initCache(ctx); err != nil {
+                return err
+        }
+        for name, in := range d.cache.divertIngresses {
+                select {
+                case <-ctx.Done():
+                        oktetoLog.Infof("deployDivert context cancelled")
+                        return ctx.Err()
+                default:
+                        oktetoLog.Spinner(fmt.Sprintf("Diverting ingress %s/%s...", in.Namespace, in.Name))
+                        oktetoLog.StartSpinner()
+                        defer oktetoLog.StopSpinner()
+                        if err := d.divertIngress(ctx, name); err != nil {
+                                return err
+                        }
+                        oktetoLog.StopSpinner()
+                        oktetoLog.Success("Ingress '%s/%s' successfully diverted", in.Namespace, in.Name)
+                }
+        }
+        return nil
 }
 
 // Destroy implements from the interface diver.Driver
 // nolint:unparam
 func (d *Driver) Destroy(_ context.Context) error {
-	oktetoLog.Success("Divert from '%s' successfully destroyed", d.divert.Namespace)
-	return nil
+        oktetoLog.Success("Divert from '%s' successfully destroyed", d.divert.Namespace)
+        return nil
 }
 
 func (d *Driver) UpdatePod(pod apiv1.PodSpec) apiv1.PodSpec {
-	if pod.DNSConfig == nil {
-		pod.DNSConfig = &apiv1.PodDNSConfig{}
-	}
-	if pod.DNSConfig.Searches == nil {
-		pod.DNSConfig.Searches = []string{}
-	}
-	searches := []string{fmt.Sprintf("%s.svc.cluster.local", d.divert.Namespace)}
-	searches = append(searches, pod.DNSConfig.Searches...)
-	pod.DNSConfig.Searches = searches
-	return pod
+        if pod.DNSConfig == nil {
+                pod.DNSConfig = &apiv1.PodDNSConfig{}
+        }
+        if pod.DNSConfig.Searches == nil {
+                pod.DNSConfig.Searches = []string{}
+        }
+        searches := []string{fmt.Sprintf("%s.svc.cluster.local", d.divert.Namespace)}
+        searches = append(searches, pod.DNSConfig.Searches...)
+        pod.DNSConfig.Searches = searches
+
+        // Add or update environment variables for all containers
+        for i := range pod.Containers {
+                updateEnvVar(&pod.Containers[i].Env, constants.OktetoSharedEnvironmentEnvVar, d.divert.Namespace)
+                updateEnvVar(&pod.Containers[i].Env, constants.OktetoDivertedEnvironmentEnvVar, d.namespace)
+        }
+
+        return pod
 }
 
 func (d *Driver) UpdateVirtualService(vs *istioNetworkingV1beta1.VirtualService) {}
+
+// updateEnvVar adds or updates an environment variable in the given env var slice
+func updateEnvVar(envVars *[]apiv1.EnvVar, name, value string) {
+        for i := range *envVars {
+                if (*envVars)[i].Name == name {
+                        (*envVars)[i].Value = value
+                        return
+                }
+        }
+        *envVars = append(*envVars, apiv1.EnvVar{
+                Name:  name,
+                Value: value,
+        })
+}

--- a/pkg/divert/nginx/divert_test.go
+++ b/pkg/divert/nginx/divert_test.go
@@ -14,422 +14,670 @@
 package nginx
 
 import (
-	"context"
-	"testing"
+        "context"
+        "testing"
 
-	"github.com/okteto/okteto/pkg/model"
-	"github.com/stretchr/testify/assert"
-	apiv1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+        "github.com/okteto/okteto/pkg/model"
+        "github.com/stretchr/testify/assert"
+        apiv1 "k8s.io/api/core/v1"
+        networkingv1 "k8s.io/api/networking/v1"
+        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+        "k8s.io/client-go/kubernetes/fake"
 )
 
+func Test_updateEnvVar(t *testing.T) {
+        tests := []struct {
+                name     string
+                envVars  []apiv1.EnvVar
+                envName  string
+                envValue string
+                expected []apiv1.EnvVar
+        }{
+                {
+                        name:     "empty-env-vars",
+                        envVars:  []apiv1.EnvVar{},
+                        envName:  "TEST_VAR",
+                        envValue: "test-value",
+                        expected: []apiv1.EnvVar{
+                                {
+                                        Name:  "TEST_VAR",
+                                        Value: "test-value",
+                                },
+                        },
+                },
+                {
+                        name: "update-existing-var",
+                        envVars: []apiv1.EnvVar{
+                                {
+                                        Name:  "EXISTING_VAR",
+                                        Value: "existing-value",
+                                },
+                                {
+                                        Name:  "TEST_VAR",
+                                        Value: "old-value",
+                                },
+                        },
+                        envName:  "TEST_VAR",
+                        envValue: "new-value",
+                        expected: []apiv1.EnvVar{
+                                {
+                                        Name:  "EXISTING_VAR",
+                                        Value: "existing-value",
+                                },
+                                {
+                                        Name:  "TEST_VAR",
+                                        Value: "new-value",
+                                },
+                        },
+                },
+                {
+                        name: "add-new-var",
+                        envVars: []apiv1.EnvVar{
+                                {
+                                        Name:  "EXISTING_VAR",
+                                        Value: "existing-value",
+                                },
+                        },
+                        envName:  "NEW_VAR",
+                        envValue: "new-value",
+                        expected: []apiv1.EnvVar{
+                                {
+                                        Name:  "EXISTING_VAR",
+                                        Value: "existing-value",
+                                },
+                                {
+                                        Name:  "NEW_VAR",
+                                        Value: "new-value",
+                                },
+                        },
+                },
+        }
+
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        envVars := tt.envVars
+                        updateEnvVar(&envVars, tt.envName, tt.envValue)
+                        assert.Equal(t, tt.expected, envVars)
+                })
+        }
+}
+
+func Test_UpdatePod(t *testing.T) {
+        tests := []struct {
+                name     string
+                podSpec  apiv1.PodSpec
+                expected apiv1.PodSpec
+                driver   *Driver
+        }{
+                {
+                        name: "empty-pod",
+                        podSpec: apiv1.PodSpec{
+                                Containers: []apiv1.Container{
+                                        {
+                                                Name: "app",
+                                        },
+                                },
+                        },
+                        expected: apiv1.PodSpec{
+                                Containers: []apiv1.Container{
+                                        {
+                                                Name: "app",
+                                                Env: []apiv1.EnvVar{
+                                                        {
+                                                                Name:  "OKTETO_SHARED_ENVIRONMENT",
+                                                                Value: "staging",
+                                                        },
+                                                        {
+                                                                Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+                                                                Value: "cindy",
+                                                        },
+                                                },
+                                        },
+                                },
+                                DNSConfig: &apiv1.PodDNSConfig{
+                                        Searches: []string{"staging.svc.cluster.local"},
+                                },
+                        },
+                        driver: &Driver{
+                                name:      "test",
+                                namespace: "cindy",
+                                divert: model.DivertDeploy{
+                                        Namespace: "staging",
+                                },
+                        },
+                },
+                {
+                        name: "pod-with-existing-env-vars",
+                        podSpec: apiv1.PodSpec{
+                                Containers: []apiv1.Container{
+                                        {
+                                                Name: "app",
+                                                Env: []apiv1.EnvVar{
+                                                        {
+                                                                Name:  "EXISTING_VAR",
+                                                                Value: "value",
+                                                        },
+                                                        {
+                                                                Name:  "OKTETO_SHARED_ENVIRONMENT",
+                                                                Value: "old-value",
+                                                        },
+                                                },
+                                        },
+                                },
+                                DNSConfig: &apiv1.PodDNSConfig{
+                                        Searches: []string{"existing-search"},
+                                },
+                        },
+                        expected: apiv1.PodSpec{
+                                Containers: []apiv1.Container{
+                                        {
+                                                Name: "app",
+                                                Env: []apiv1.EnvVar{
+                                                        {
+                                                                Name:  "EXISTING_VAR",
+                                                                Value: "value",
+                                                        },
+                                                        {
+                                                                Name:  "OKTETO_SHARED_ENVIRONMENT",
+                                                                Value: "staging",
+                                                        },
+                                                        {
+                                                                Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+                                                                Value: "cindy",
+                                                        },
+                                                },
+                                        },
+                                },
+                                DNSConfig: &apiv1.PodDNSConfig{
+                                        Searches: []string{"staging.svc.cluster.local", "existing-search"},
+                                },
+                        },
+                        driver: &Driver{
+                                name:      "test",
+                                namespace: "cindy",
+                                divert: model.DivertDeploy{
+                                        Namespace: "staging",
+                                },
+                        },
+                },
+                {
+                        name: "pod-with-multiple-containers",
+                        podSpec: apiv1.PodSpec{
+                                Containers: []apiv1.Container{
+                                        {
+                                                Name: "app1",
+                                        },
+                                        {
+                                                Name: "app2",
+                                                Env: []apiv1.EnvVar{
+                                                        {
+                                                                Name:  "EXISTING_VAR",
+                                                                Value: "value",
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        expected: apiv1.PodSpec{
+                                Containers: []apiv1.Container{
+                                        {
+                                                Name: "app1",
+                                                Env: []apiv1.EnvVar{
+                                                        {
+                                                                Name:  "OKTETO_SHARED_ENVIRONMENT",
+                                                                Value: "staging",
+                                                        },
+                                                        {
+                                                                Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+                                                                Value: "cindy",
+                                                        },
+                                                },
+                                        },
+                                        {
+                                                Name: "app2",
+                                                Env: []apiv1.EnvVar{
+                                                        {
+                                                                Name:  "EXISTING_VAR",
+                                                                Value: "value",
+                                                        },
+                                                        {
+                                                                Name:  "OKTETO_SHARED_ENVIRONMENT",
+                                                                Value: "staging",
+                                                        },
+                                                        {
+                                                                Name:  "OKTETO_DIVERTED_ENVIRONMENT",
+                                                                Value: "cindy",
+                                                        },
+                                                },
+                                        },
+                                },
+                                DNSConfig: &apiv1.PodDNSConfig{
+                                        Searches: []string{"staging.svc.cluster.local"},
+                                },
+                        },
+                        driver: &Driver{
+                                name:      "test",
+                                namespace: "cindy",
+                                divert: model.DivertDeploy{
+                                        Namespace: "staging",
+                                },
+                        },
+                },
+        }
+
+        for _, tt := range tests {
+                t.Run(tt.name, func(t *testing.T) {
+                        result := tt.driver.UpdatePod(tt.podSpec)
+                        assert.Equal(t, tt.expected, result)
+                })
+        }
+}
+
 func Test_divertIngresses(t *testing.T) {
-	ctx := context.Background()
-	i1 := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "i1",
-			Namespace: "cindy",
-			Labels: map[string]string{
-				model.DeployedByLabel: "test",
-				"l1":                  "v1",
-			},
-			Annotations: map[string]string{
-				"a1":                                    "v1",
-				model.OktetoDivertedNamespaceAnnotation: "staging",
-				model.OktetoDivertHeaderAnnotation:      "cindy",
-			},
-		},
-		Spec: networkingv1.IngressSpec{
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: "i1-cindy.okteto.dev",
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "s1",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			TLS: []networkingv1.IngressTLS{
-				{
-					Hosts: []string{"i1-cindy.okteto.dev"},
-				},
-			},
-		},
-	}
-	expectedI1 := i1.DeepCopy()
-	di1 := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "i1",
-			Namespace: "staging",
-			Labels: map[string]string{
-				model.DeployedByLabel: "staging",
-				"l1":                  "v2",
-			},
-			Annotations: map[string]string{"a1": "v2"},
-		},
-		Spec: networkingv1.IngressSpec{
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: "i1-cstaging.okteto.dev",
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "s1",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			TLS: []networkingv1.IngressTLS{
-				{
-					Hosts: []string{"i1-staging.okteto.dev"},
-				},
-			},
-		},
-	}
+        ctx := context.Background()
+        i1 := &networkingv1.Ingress{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "i1",
+                        Namespace: "cindy",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "test",
+                                "l1":                  "v1",
+                        },
+                        Annotations: map[string]string{
+                                "a1":                                    "v1",
+                                model.OktetoDivertedNamespaceAnnotation: "staging",
+                                model.OktetoDivertHeaderAnnotation:      "cindy",
+                        },
+                },
+                Spec: networkingv1.IngressSpec{
+                        Rules: []networkingv1.IngressRule{
+                                {
+                                        Host: "i1-cindy.okteto.dev",
+                                        IngressRuleValue: networkingv1.IngressRuleValue{
+                                                HTTP: &networkingv1.HTTPIngressRuleValue{
+                                                        Paths: []networkingv1.HTTPIngressPath{
+                                                                {
+                                                                        Backend: networkingv1.IngressBackend{
+                                                                                Service: &networkingv1.IngressServiceBackend{
+                                                                                        Name: "s1",
+                                                                                },
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        TLS: []networkingv1.IngressTLS{
+                                {
+                                        Hosts: []string{"i1-cindy.okteto.dev"},
+                                },
+                        },
+                },
+        }
+        expectedI1 := i1.DeepCopy()
+        di1 := &networkingv1.Ingress{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "i1",
+                        Namespace: "staging",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "staging",
+                                "l1":                  "v2",
+                        },
+                        Annotations: map[string]string{"a1": "v2"},
+                },
+                Spec: networkingv1.IngressSpec{
+                        Rules: []networkingv1.IngressRule{
+                                {
+                                        Host: "i1-cstaging.okteto.dev",
+                                        IngressRuleValue: networkingv1.IngressRuleValue{
+                                                HTTP: &networkingv1.HTTPIngressRuleValue{
+                                                        Paths: []networkingv1.HTTPIngressPath{
+                                                                {
+                                                                        Backend: networkingv1.IngressBackend{
+                                                                                Service: &networkingv1.IngressServiceBackend{
+                                                                                        Name: "s1",
+                                                                                },
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        TLS: []networkingv1.IngressTLS{
+                                {
+                                        Hosts: []string{"i1-staging.okteto.dev"},
+                                },
+                        },
+                },
+        }
 
-	i2 := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "i2",
-			Namespace: "cindy",
-			Labels: map[string]string{
-				model.DeployedByLabel: "test",
-				"l1":                  "v1",
-			},
-			Annotations: map[string]string{
-				model.OktetoAutoCreateAnnotation:        "true",
-				model.OktetoDivertedNamespaceAnnotation: "staging",
-				"a1":                                    "v1",
-			},
-		},
-		Spec: networkingv1.IngressSpec{
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: "i2-cindy.okteto.dev",
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "s2",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			TLS: []networkingv1.IngressTLS{
-				{
-					Hosts: []string{"i2-cindy.okteto.dev"},
-				},
-			},
-		},
-	}
-	expectedI2 := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "i2",
-			Namespace: "cindy",
-			Labels: map[string]string{
-				model.DeployedByLabel: "test",
-				"l1":                  "v2",
-			},
-			Annotations: map[string]string{
-				model.OktetoAutoCreateAnnotation:        "true",
-				model.OktetoDivertedNamespaceAnnotation: "staging",
-				model.OktetoDivertHeaderAnnotation:      "cindy",
-				"a1":                                    "v2",
-			},
-		},
-		Spec: networkingv1.IngressSpec{
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: "i2-cindy.okteto.dev",
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "s2",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			TLS: []networkingv1.IngressTLS{
-				{
-					Hosts: []string{"i2-cindy.okteto.dev"},
-				},
-			},
-		},
-	}
-	di2 := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "i2",
-			Namespace: "staging",
-			Labels: map[string]string{
-				model.DeployedByLabel: "staging",
-				"l1":                  "v2",
-			},
-			Annotations: map[string]string{"a1": "v2"},
-		},
-		Spec: networkingv1.IngressSpec{
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: "i2-staging.okteto.dev",
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "s2",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			TLS: []networkingv1.IngressTLS{
-				{
-					Hosts: []string{"i2-staging.okteto.dev"},
-				},
-			},
-		},
-	}
+        i2 := &networkingv1.Ingress{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "i2",
+                        Namespace: "cindy",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "test",
+                                "l1":                  "v1",
+                        },
+                        Annotations: map[string]string{
+                                model.OktetoAutoCreateAnnotation:        "true",
+                                model.OktetoDivertedNamespaceAnnotation: "staging",
+                                "a1":                                    "v1",
+                        },
+                },
+                Spec: networkingv1.IngressSpec{
+                        Rules: []networkingv1.IngressRule{
+                                {
+                                        Host: "i2-cindy.okteto.dev",
+                                        IngressRuleValue: networkingv1.IngressRuleValue{
+                                                HTTP: &networkingv1.HTTPIngressRuleValue{
+                                                        Paths: []networkingv1.HTTPIngressPath{
+                                                                {
+                                                                        Backend: networkingv1.IngressBackend{
+                                                                                Service: &networkingv1.IngressServiceBackend{
+                                                                                        Name: "s2",
+                                                                                },
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        TLS: []networkingv1.IngressTLS{
+                                {
+                                        Hosts: []string{"i2-cindy.okteto.dev"},
+                                },
+                        },
+                },
+        }
+        expectedI2 := &networkingv1.Ingress{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "i2",
+                        Namespace: "cindy",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "test",
+                                "l1":                  "v2",
+                        },
+                        Annotations: map[string]string{
+                                model.OktetoAutoCreateAnnotation:        "true",
+                                model.OktetoDivertedNamespaceAnnotation: "staging",
+                                model.OktetoDivertHeaderAnnotation:      "cindy",
+                                "a1":                                    "v2",
+                        },
+                },
+                Spec: networkingv1.IngressSpec{
+                        Rules: []networkingv1.IngressRule{
+                                {
+                                        Host: "i2-cindy.okteto.dev",
+                                        IngressRuleValue: networkingv1.IngressRuleValue{
+                                                HTTP: &networkingv1.HTTPIngressRuleValue{
+                                                        Paths: []networkingv1.HTTPIngressPath{
+                                                                {
+                                                                        Backend: networkingv1.IngressBackend{
+                                                                                Service: &networkingv1.IngressServiceBackend{
+                                                                                        Name: "s2",
+                                                                                },
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        TLS: []networkingv1.IngressTLS{
+                                {
+                                        Hosts: []string{"i2-cindy.okteto.dev"},
+                                },
+                        },
+                },
+        }
+        di2 := &networkingv1.Ingress{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "i2",
+                        Namespace: "staging",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "staging",
+                                "l1":                  "v2",
+                        },
+                        Annotations: map[string]string{"a1": "v2"},
+                },
+                Spec: networkingv1.IngressSpec{
+                        Rules: []networkingv1.IngressRule{
+                                {
+                                        Host: "i2-staging.okteto.dev",
+                                        IngressRuleValue: networkingv1.IngressRuleValue{
+                                                HTTP: &networkingv1.HTTPIngressRuleValue{
+                                                        Paths: []networkingv1.HTTPIngressPath{
+                                                                {
+                                                                        Backend: networkingv1.IngressBackend{
+                                                                                Service: &networkingv1.IngressServiceBackend{
+                                                                                        Name: "s2",
+                                                                                },
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        TLS: []networkingv1.IngressTLS{
+                                {
+                                        Hosts: []string{"i2-staging.okteto.dev"},
+                                },
+                        },
+                },
+        }
 
-	expectedI3 := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "i3",
-			Namespace: "cindy",
-			Labels: map[string]string{
-				model.DeployedByLabel: "test",
-				"l1":                  "v2",
-			},
-			Annotations: map[string]string{
-				model.OktetoAutoCreateAnnotation:        "true",
-				model.OktetoDivertedNamespaceAnnotation: "staging",
-				model.OktetoDivertHeaderAnnotation:      "cindy",
-				"a1":                                    "v2",
-			},
-		},
-		Spec: networkingv1.IngressSpec{
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: "i3-cindy.okteto.dev",
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "s3",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			TLS: []networkingv1.IngressTLS{
-				{
-					Hosts: []string{"i3-cindy.okteto.dev"},
-				},
-			},
-		},
-	}
-	di3 := &networkingv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "i3",
-			Namespace: "staging",
-			Labels: map[string]string{
-				model.DeployedByLabel: "staging",
-				"l1":                  "v2",
-			},
-			Annotations: map[string]string{"a1": "v2"},
-		},
-		Spec: networkingv1.IngressSpec{
-			Rules: []networkingv1.IngressRule{
-				{
-					Host: "i3-staging.okteto.dev",
-					IngressRuleValue: networkingv1.IngressRuleValue{
-						HTTP: &networkingv1.HTTPIngressRuleValue{
-							Paths: []networkingv1.HTTPIngressPath{
-								{
-									Backend: networkingv1.IngressBackend{
-										Service: &networkingv1.IngressServiceBackend{
-											Name: "s3",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			TLS: []networkingv1.IngressTLS{
-				{
-					Hosts: []string{"i3-staging.okteto.dev"},
-				},
-			},
-		},
-	}
+        expectedI3 := &networkingv1.Ingress{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "i3",
+                        Namespace: "cindy",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "test",
+                                "l1":                  "v2",
+                        },
+                        Annotations: map[string]string{
+                                model.OktetoAutoCreateAnnotation:        "true",
+                                model.OktetoDivertedNamespaceAnnotation: "staging",
+                                model.OktetoDivertHeaderAnnotation:      "cindy",
+                                "a1":                                    "v2",
+                        },
+                },
+                Spec: networkingv1.IngressSpec{
+                        Rules: []networkingv1.IngressRule{
+                                {
+                                        Host: "i3-cindy.okteto.dev",
+                                        IngressRuleValue: networkingv1.IngressRuleValue{
+                                                HTTP: &networkingv1.HTTPIngressRuleValue{
+                                                        Paths: []networkingv1.HTTPIngressPath{
+                                                                {
+                                                                        Backend: networkingv1.IngressBackend{
+                                                                                Service: &networkingv1.IngressServiceBackend{
+                                                                                        Name: "s3",
+                                                                                },
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        TLS: []networkingv1.IngressTLS{
+                                {
+                                        Hosts: []string{"i3-cindy.okteto.dev"},
+                                },
+                        },
+                },
+        }
+        di3 := &networkingv1.Ingress{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "i3",
+                        Namespace: "staging",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "staging",
+                                "l1":                  "v2",
+                        },
+                        Annotations: map[string]string{"a1": "v2"},
+                },
+                Spec: networkingv1.IngressSpec{
+                        Rules: []networkingv1.IngressRule{
+                                {
+                                        Host: "i3-staging.okteto.dev",
+                                        IngressRuleValue: networkingv1.IngressRuleValue{
+                                                HTTP: &networkingv1.HTTPIngressRuleValue{
+                                                        Paths: []networkingv1.HTTPIngressPath{
+                                                                {
+                                                                        Backend: networkingv1.IngressBackend{
+                                                                                Service: &networkingv1.IngressServiceBackend{
+                                                                                        Name: "s3",
+                                                                                },
+                                                                        },
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                        TLS: []networkingv1.IngressTLS{
+                                {
+                                        Hosts: []string{"i3-staging.okteto.dev"},
+                                },
+                        },
+                },
+        }
 
-	s1 := &apiv1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "s1",
-			Namespace: "cindy",
-			Labels: map[string]string{
-				model.DeployedByLabel: "test",
-				"l1":                  "v1",
-			},
-			Annotations: map[string]string{"a1": "v1"},
-		},
-		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeClusterIP,
-			Ports: []apiv1.ServicePort{
-				{
-					Name: "port-cindy",
-					Port: 8080,
-				},
-			},
-			ClusterIP:  "my-ip",
-			ClusterIPs: []string{"my-ip"},
-			Selector:   map[string]string{"l1": "v1"},
-		},
-	}
-	ds1 := &apiv1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "s1",
-			Namespace: "staging",
-			Labels: map[string]string{
-				model.DeployedByLabel: "staging",
-				"l1":                  "v2",
-			},
-			Annotations: map[string]string{"a1": "v2"},
-		},
-		Spec: apiv1.ServiceSpec{
-			Type:         apiv1.ServiceTypeExternalName,
-			ExternalName: "s1.staging.svc.cluster.local",
-		},
-	}
+        s1 := &apiv1.Service{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "s1",
+                        Namespace: "cindy",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "test",
+                                "l1":                  "v1",
+                        },
+                        Annotations: map[string]string{"a1": "v1"},
+                },
+                Spec: apiv1.ServiceSpec{
+                        Type: apiv1.ServiceTypeClusterIP,
+                        Ports: []apiv1.ServicePort{
+                                {
+                                        Name: "port-cindy",
+                                        Port: 8080,
+                                },
+                        },
+                        ClusterIP:  "my-ip",
+                        ClusterIPs: []string{"my-ip"},
+                        Selector:   map[string]string{"l1": "v1"},
+                },
+        }
+        ds1 := &apiv1.Service{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "s1",
+                        Namespace: "staging",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "staging",
+                                "l1":                  "v2",
+                        },
+                        Annotations: map[string]string{"a1": "v2"},
+                },
+                Spec: apiv1.ServiceSpec{
+                        Type:         apiv1.ServiceTypeExternalName,
+                        ExternalName: "s1.staging.svc.cluster.local",
+                },
+        }
 
-	s2 := &apiv1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "s2",
-			Namespace: "cindy",
-			Labels: map[string]string{
-				model.DeployedByLabel: "test",
-				"l1":                  "v1",
-			},
-			Annotations: map[string]string{
-				model.OktetoAutoCreateAnnotation: "true",
-				"a1":                             "v1",
-			},
-		},
-		Spec: apiv1.ServiceSpec{
-			Type: apiv1.ServiceTypeClusterIP,
-			Ports: []apiv1.ServicePort{
-				{
-					Name: "port-cindy",
-					Port: 8080,
-				},
-			},
-			ClusterIP:  apiv1.ClusterIPNone,
-			ClusterIPs: nil,
-			Selector:   nil,
-		},
-	}
+        s2 := &apiv1.Service{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "s2",
+                        Namespace: "cindy",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "test",
+                                "l1":                  "v1",
+                        },
+                        Annotations: map[string]string{
+                                model.OktetoAutoCreateAnnotation: "true",
+                                "a1":                             "v1",
+                        },
+                },
+                Spec: apiv1.ServiceSpec{
+                        Type: apiv1.ServiceTypeClusterIP,
+                        Ports: []apiv1.ServicePort{
+                                {
+                                        Name: "port-cindy",
+                                        Port: 8080,
+                                },
+                        },
+                        ClusterIP:  apiv1.ClusterIPNone,
+                        ClusterIPs: nil,
+                        Selector:   nil,
+                },
+        }
 
-	ds2 := &apiv1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "s2",
-			Namespace: "staging",
-			Labels: map[string]string{
-				model.DeployedByLabel: "staging",
-				"l1":                  "v2",
-			},
-			Annotations: map[string]string{"a1": "v2"},
-		},
-		Spec: apiv1.ServiceSpec{
-			Type:         apiv1.ServiceTypeExternalName,
-			ExternalName: "s2.staging.svc.cluster.local",
-		},
-	}
+        ds2 := &apiv1.Service{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      "s2",
+                        Namespace: "staging",
+                        Labels: map[string]string{
+                                model.DeployedByLabel: "staging",
+                                "l1":                  "v2",
+                        },
+                        Annotations: map[string]string{"a1": "v2"},
+                },
+                Spec: apiv1.ServiceSpec{
+                        Type:         apiv1.ServiceTypeExternalName,
+                        ExternalName: "s2.staging.svc.cluster.local",
+                },
+        }
 
-	c := fake.NewSimpleClientset(i1, i2, di1, di2, di3, s1, s2, ds1, ds2)
-	m := &model.Manifest{
-		Name: "test",
-		Deploy: &model.DeployInfo{
-			Divert: &model.DivertDeploy{
-				Namespace: "staging",
-			},
-		},
-	}
+        c := fake.NewSimpleClientset(i1, i2, di1, di2, di3, s1, s2, ds1, ds2)
+        m := &model.Manifest{
+                Name: "test",
+                Deploy: &model.DeployInfo{
+                        Divert: &model.DivertDeploy{
+                                Namespace: "staging",
+                        },
+                },
+        }
 
-	d := &Driver{client: c, name: m.Name, namespace: "cindy", divert: *m.Deploy.Divert}
-	err := d.Deploy(ctx)
-	assert.NoError(t, err)
+        d := &Driver{client: c, name: m.Name, namespace: "cindy", divert: *m.Deploy.Divert}
+        err := d.Deploy(ctx)
+        assert.NoError(t, err)
 
-	resultI1, err := c.NetworkingV1().Ingresses("cindy").Get(ctx, "i1", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, expectedI1, resultI1)
-	resultS1, err := c.CoreV1().Services("cindy").Get(ctx, "s1", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, s1, resultS1)
+        resultI1, err := c.NetworkingV1().Ingresses("cindy").Get(ctx, "i1", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, expectedI1, resultI1)
+        resultS1, err := c.CoreV1().Services("cindy").Get(ctx, "s1", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, s1, resultS1)
 
-	resultI2, err := c.NetworkingV1().Ingresses("cindy").Get(ctx, "i2", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, expectedI2, resultI2)
+        resultI2, err := c.NetworkingV1().Ingresses("cindy").Get(ctx, "i2", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, expectedI2, resultI2)
 
-	resultI3, err := c.NetworkingV1().Ingresses("cindy").Get(ctx, "i3", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, expectedI3, resultI3)
+        resultI3, err := c.NetworkingV1().Ingresses("cindy").Get(ctx, "i3", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, expectedI3, resultI3)
 
-	// Eliminate elements from the cache to force RCs
-	d.cache.developerIngresses = map[string]*networkingv1.Ingress{}
-	d.cache.developerServices = map[string]*apiv1.Service{}
-	err = d.Deploy(ctx)
-	assert.NoError(t, err)
+        // Eliminate elements from the cache to force RCs
+        d.cache.developerIngresses = map[string]*networkingv1.Ingress{}
+        d.cache.developerServices = map[string]*apiv1.Service{}
+        err = d.Deploy(ctx)
+        assert.NoError(t, err)
 
-	resultI1, err = c.NetworkingV1().Ingresses("cindy").Get(ctx, "i1", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, expectedI1, resultI1)
-	resultS1, err = c.CoreV1().Services("cindy").Get(ctx, "s1", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, s1, resultS1)
+        resultI1, err = c.NetworkingV1().Ingresses("cindy").Get(ctx, "i1", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, expectedI1, resultI1)
+        resultS1, err = c.CoreV1().Services("cindy").Get(ctx, "s1", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, s1, resultS1)
 
-	resultI2, err = c.NetworkingV1().Ingresses("cindy").Get(ctx, "i2", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, expectedI2, resultI2)
+        resultI2, err = c.NetworkingV1().Ingresses("cindy").Get(ctx, "i2", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, expectedI2, resultI2)
 
-	resultI3, err = c.NetworkingV1().Ingresses("cindy").Get(ctx, "i3", metav1.GetOptions{})
-	assert.NoError(t, err)
-	assert.Equal(t, expectedI3, resultI3)
+        resultI3, err = c.NetworkingV1().Ingresses("cindy").Get(ctx, "i3", metav1.GetOptions{})
+        assert.NoError(t, err)
+        assert.Equal(t, expectedI3, resultI3)
 }


### PR DESCRIPTION
PROD-344

## Description

This PR adds two environment variables to the divert drivers (nginx and istio) to provide information about the shared and diverted environments:

* OKTETO_SHARED_ENVIRONMENT: Contains the namespace of the shared environment (d.divert.Namespace)
* OKTETO_DIVERTED_ENVIRONMENT: Contains the namespace of the diverted environment (d.namespace)

### Changes made:

1. Added two new constants in pkg/constants/constants.go:
   - OktetoSharedEnvironmentEnvVar
   - OktetoDivertedEnvironmentEnvVar

2. Modified the UpdatePod function in both divert drivers:
   - pkg/divert/nginx/divert.go
   - pkg/divert/istio/divert.go

3. Added a helper function updateEnvVar to both drivers to handle adding or updating environment variables.

4. Added comprehensive unit tests for both drivers:
   - Test_updateEnvVar: Tests the helper function
   - Test_UpdatePod: Tests the main functionality with various scenarios

### Testing:
- Added unit tests for all new functionality
- All existing tests continue to pass

This change will allow applications running in diverted environments to be aware of both the shared and diverted namespaces, which can be useful for various integration scenarios.