### PR TITLE
Option 1:Adds a new spinner when is checking if a image has been built

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -263,7 +263,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 
 			// We only check that the image is built in the global registry if the noCache option is not set
 			if !options.NoCache && ob.smartBuildCtrl.IsEnabled() {
-				imageChecker := getImageChecker(ob.Config, ob.Registry, ob.smartBuildCtrl, ob.ioCtrl.Logger())
+				imageChecker := getImageChecker(ob.Config, ob.Registry, ob.smartBuildCtrl, ob.ioCtrl)
 				cacheHitDurationStart := time.Now()
 
 				buildHash := ob.smartBuildCtrl.GetBuildHash(buildSvcInfo, svcToBuild)
@@ -450,7 +450,7 @@ func validateServices(buildSection build.ManifestBuild, svcsToBuild []string) er
 	return nil
 }
 
-func getImageChecker(cfg oktetoBuilderConfigInterface, registry registryImageCheckerInterface, sbc smartBuildController, logger loggerInfo) imageCheckerInterface {
+func getImageChecker(cfg oktetoBuilderConfigInterface, registry registryImageCheckerInterface, sbc smartBuildController, ioCtrl *io.Controller) imageCheckerInterface {
 	tagger := newImageTagger(cfg, sbc)
-	return newImageChecker(cfg, registry, tagger, logger)
+	return newImageChecker(cfg, registry, tagger, ioCtrl)
 }

--- a/cmd/build/v2/imagechecker_test.go
+++ b/cmd/build/v2/imagechecker_test.go
@@ -37,7 +37,8 @@ func Test_checkIfBuildHashIsBuilt(t *testing.T) {
 		{
 			name: "empty build hash",
 			imageChecker: &imageChecker{
-				logger: io.NewIOController().Logger(),
+				logger:  io.NewIOController().Logger(),
+				outCtrl: io.NewIOController().Out(),
 			},
 			expectedTag:   "",
 			expectedBuilt: false,
@@ -51,7 +52,8 @@ func Test_checkIfBuildHashIsBuilt(t *testing.T) {
 				lookupReferenceWithDigest: func(_ string, _ registryImageCheckerInterface) (string, error) {
 					return "", oktetoErrors.ErrNotFound
 				},
-				logger: io.NewIOController().Logger(),
+				logger:  io.NewIOController().Logger(),
+				outCtrl: io.NewIOController().Out(),
 			},
 			manifestName:  "manifest",
 			serviceName:   "service",
@@ -62,7 +64,8 @@ func Test_checkIfBuildHashIsBuilt(t *testing.T) {
 		{
 			name: "error getting SHA from registry",
 			imageChecker: &imageChecker{
-				logger: io.NewIOController().Logger(),
+				logger:  io.NewIOController().Logger(),
+				outCtrl: io.NewIOController().Out(),
 				tagger: imageTagger{
 					cfg: &fakeConfig{},
 				},
@@ -87,7 +90,8 @@ func Test_checkIfBuildHashIsBuilt(t *testing.T) {
 				lookupReferenceWithDigest: func(_ string, _ registryImageCheckerInterface) (string, error) {
 					return "image-tag-from-registry", nil
 				},
-				logger: io.NewIOController().Logger(),
+				logger:  io.NewIOController().Logger(),
+				outCtrl: io.NewIOController().Out(),
 			},
 			manifestName:  "manifest",
 			serviceName:   "service",

--- a/cmd/build/v2/services.go
+++ b/cmd/build/v2/services.go
@@ -105,7 +105,7 @@ func (bc *OktetoBuilder) checkServiceToBuildDuringDeploy(service string, manifes
 		buildInfo.Image = ""
 	}
 
-	imageChecker := getImageChecker(bc.Config, bc.Registry, bc.smartBuildCtrl, bc.ioCtrl.Logger())
+	imageChecker := getImageChecker(bc.Config, bc.Registry, bc.smartBuildCtrl, bc.ioCtrl)
 	imageWithDigest, err := imageChecker.getImageDigestReferenceForServiceDeploy(manifest.Name, service, buildInfo)
 	if oktetoErrors.IsNotFound(err) {
 		bc.ioCtrl.Logger().Debug("image not found, building image")


### PR DESCRIPTION
# Proposed changes

Fixes DEV-861

This PR has been created with cindy.

Adds a new spinner when is checking if a image has been built

## How to validate

1. Run okteto build with a bad connection
2. Run okteto build with a repo that has several build

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
