### PR TITLE
Add git binary for the dockerfile image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN curl -sLf --retry 3 -o helm.tar.gz \
     && /tmp/helm version
 
 # Stage 3.4: Download and compress git (Version control system)
-FROM debian:stable-slim AS git-builder
+FROM debian:bookworm-slim AS git-builder
 
 ARG GIT_VERSION="2.42.0"
 ENV CC=gcc


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-893

Add static git to the final image so it can be used by the okteto cli for smartbuilds

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
