### PR TITLE
Option 2: add spinner forchecking services

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -234,6 +234,10 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				ob.ioCtrl.SetStage(fmt.Sprintf("Building service %s", svcToBuild))
 			}
 
+			sp := ob.ioCtrl.Out().Spinner(fmt.Sprintf("Checking if image '%s' is already built", svcToBuild))
+			sp.Start()
+			defer sp.Stop()
+
 			buildSvcInfo := buildManifest[svcToBuild]
 
 			// create the meta pointer and append it to the analytics slice
@@ -291,6 +295,8 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 			if !ob.oktetoContext.IsOktetoCluster() && buildSvcInfo.Image == "" {
 				return fmt.Errorf("'build.%s.image' is required if your context doesn't have Okteto installed", svcToBuild)
 			}
+
+			sp.Stop()
 			buildDurationStart := time.Now()
 			imageTag, err := ob.buildServiceImages(ctx, options.Manifest, svcToBuild, options)
 			buildkitRunner, ok := ob.Builder.BuildRunner.(*buildCmd.OktetoBuilder)

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -278,8 +278,6 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				meta.CacheHitDuration = time.Since(cacheHitDurationStart)
 
 				if isBuilt {
-					ob.ioCtrl.Out().Infof("Okteto Smart Builds is skipping build of '%s' because it's already built from cache.", svcToBuild)
-
 					imageWithDigest, err := ob.smartBuildCtrl.CloneGlobalImageToDev(imageWithDigest, buildSvcInfo.Image)
 					if err != nil {
 						return err
@@ -288,6 +286,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 					ob.SetServiceEnvVars(svcToBuild, imageWithDigest)
 					builtImagesControl[svcToBuild] = true
 					meta.Success = true
+					ob.ioCtrl.Out().Infof("Okteto Smart Builds is skipping build of '%s' because it's already built from cache.", svcToBuild)
 					continue
 				}
 			}

--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -234,7 +234,7 @@ func (ob *OktetoBuilder) Build(ctx context.Context, options *types.BuildOptions)
 				ob.ioCtrl.SetStage(fmt.Sprintf("Building service %s", svcToBuild))
 			}
 
-			sp := ob.ioCtrl.Out().Spinner(fmt.Sprintf("Checking if image '%s' is already built", svcToBuild))
+			sp := ob.ioCtrl.Out().Spinner(fmt.Sprintf("Checking if image '%s' is already built...", svcToBuild))
 			sp.Start()
 			defer sp.Stop()
 

--- a/cmd/build/v2/smartbuild/hasher_test.go
+++ b/cmd/build/v2/smartbuild/hasher_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/pkg/build"
+	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -82,7 +83,7 @@ func TestServiceHasher_HashProjectCommit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			wdGetter := fakeWorkingDirGetter{}
-			sh := newServiceHasher(tt.repoCtrl, afero.NewMemMapFs(), wdGetter)
+			sh := newServiceHasher(tt.repoCtrl, afero.NewMemMapFs(), wdGetter, io.NewIOController())
 			hash, err := sh.hashProjectCommit(&build.Info{})
 			assert.Equal(t, tt.expectedHash, hash)
 			assert.ErrorIs(t, err, tt.expectedErr)
@@ -225,6 +226,7 @@ func TestServiceHasher_HashBuildContextWithError(t *testing.T) {
 				},
 				serviceShaCache: map[string]string{},
 				wdGetter:        tt.wdGetter,
+				ioCtrl:          io.NewIOController(),
 			}
 
 			repoController.On("GetLatestDirSHA", tt.expectedBuildContext).Return(tt.dirSHA, tt.errSHA)

--- a/cmd/build/v2/smartbuild/smartbuild.go
+++ b/cmd/build/v2/smartbuild/smartbuild.go
@@ -65,7 +65,7 @@ func NewSmartBuildCtrl(repo repositoryInterface, registry registryController, fs
 	return &Ctrl{
 		gitRepo:            repo,
 		isEnabled:          isEnabled,
-		hasher:             newServiceHasher(repo, fs, wdGetter),
+		hasher:             newServiceHasher(repo, fs, wdGetter, ioCtrl),
 		registryController: registry,
 		ioCtrl:             ioCtrl,
 	}

--- a/cmd/build/v2/smartbuild/smartbuild_test.go
+++ b/cmd/build/v2/smartbuild/smartbuild_test.go
@@ -315,7 +315,7 @@ func Test_getBuildHashFromCommit(t *testing.T) {
 			got, err := newServiceHasher(fakeConfigRepo{
 				sha: tc.input.repo.sha,
 				err: tc.input.repo.err,
-			}, afero.NewMemMapFs(), wdGetter).hashProjectCommit(tc.input.buildInfo)
+			}, afero.NewMemMapFs(), wdGetter, io.NewIOController()).hashProjectCommit(tc.input.buildInfo)
 			assert.ErrorIs(t, err, tc.expectedErr)
 			if tc.expected != "" {
 				expectedHash := sha256.Sum256([]byte(tc.expected))


### PR DESCRIPTION
# Proposed changes

Fixes DEV-861

This PR has been created with cindy.

Adds a new spinner when is checking if a image has been built

## How to validate

1. Run okteto build with a bad connection
2. Run okteto build with a repo that has several build

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
