### PR TITLE
feat: add destroy with dependencies on CLI

### DIFF
--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -273,7 +273,7 @@ If you need to destroy external resources (like s3 buckets or other Cloud resour
 	cmd.Flags().StringVar(&options.Name, "name", "", "the name of the Development Environment")
 	cmd.Flags().StringVarP(&options.ManifestPath, "file", "f", "", "the path to the Okteto Manifest")
 	cmd.Flags().BoolVarP(&options.DestroyVolumes, "volumes", "v", false, "remove persistent volumes")
-	cmd.Flags().BoolVarP(&options.DestroyDependencies, "dependencies", "d", false, "destroy dependencies")
+	cmd.Flags().BoolVar(&options.DestroyDependencies, "dependencies", false, "destroy repositories in the 'dependencies' section")
 	cmd.Flags().BoolVar(&options.ForceDestroy, "force-destroy", false, "forces the development environment to be destroyed even if there is an error executing the custom destroy commands defined in the manifest")
 	cmd.Flags().StringVarP(&options.Namespace, "namespace", "n", "", "overwrite the namespace where the development environment was deployed")
 	cmd.Flags().StringVarP(&options.K8sContext, "context", "c", "", "context where the development environment was deployed")

--- a/internal/test/client/pipeline.go
+++ b/internal/test/client/pipeline.go
@@ -59,7 +59,7 @@ func (fc *FakePipelineClient) WaitForActionToFinish(_ context.Context, _, _, _ s
 }
 
 // Destroy destroys a pipeline
-func (fc *FakePipelineClient) Destroy(_ context.Context, _, _ string, _ bool) (*types.GitDeployResponse, error) {
+func (fc *FakePipelineClient) Destroy(_ context.Context, _, _ string, _, _ bool) (*types.GitDeployResponse, error) {
 	return fc.responses.DestroyResponse, fc.responses.DestroyErr
 }
 

--- a/pkg/okteto/pipeline.go
+++ b/pkg/okteto/pipeline.go
@@ -252,6 +252,7 @@ func (c *pipelineClient) Destroy(ctx context.Context, name, namespace string, de
 		"dependencies":   graphql.Boolean(destroyDependencies),
 	}
 	err := mutate(ctx, &mutation, queryVariables, c.client)
+	response = mutation.Response
 	if err != nil {
 		if strings.Contains(err.Error(), "Unknown argument \"dependencies\" on field \"destroyGitRepository\" of type \"Mutation\"") {
 			mutationWithoutDependencies := &destroyPipelineMutation{}
@@ -264,19 +265,18 @@ func (c *pipelineClient) Destroy(ctx context.Context, name, namespace string, de
 		} else {
 			return nil, fmt.Errorf("failed to deploy pipeline: %w", err)
 		}
-		gitDeployResponse.Action = &types.Action{
-			ID:     string(response.Action.Id),
-			Name:   string(response.Action.Name),
-			Status: string(response.Action.Status),
-		}
-		gitDeployResponse.GitDeploy = &types.GitDeploy{
-			ID:         string(response.GitDeploy.Id),
-			Name:       string(response.GitDeploy.Name),
-			Repository: string(response.GitDeploy.Repository),
-			Status:     string(response.GitDeploy.Status),
-		}
 	}
-
+	gitDeployResponse.Action = &types.Action{
+		ID:     string(response.Action.Id),
+		Name:   string(response.Action.Name),
+		Status: string(response.Action.Status),
+	}
+	gitDeployResponse.GitDeploy = &types.GitDeploy{
+		ID:         string(response.GitDeploy.Id),
+		Name:       string(response.GitDeploy.Name),
+		Repository: string(response.GitDeploy.Repository),
+		Status:     string(response.GitDeploy.Status),
+	}
 	oktetoLog.Infof("destroy pipeline: %+v", gitDeployResponse.GitDeploy.Status)
 	return gitDeployResponse, nil
 }

--- a/pkg/okteto/pipeline_test.go
+++ b/pkg/okteto/pipeline_test.go
@@ -398,7 +398,7 @@ func TestDestroyPipeline(t *testing.T) {
 			input: input{
 				client: &fakeGraphQLMultipleCallsClient{
 					mutationResult: []interface{}{
-						&destroyPipelineWithVolumesMutation{
+						&destroyPipelineMutation{
 							Response: destroyPipelineResponse{
 								Action: actionStruct{
 									Id:     "test",
@@ -440,7 +440,7 @@ func TestDestroyPipeline(t *testing.T) {
 			input: input{
 				client: &fakeGraphQLMultipleCallsClient{
 					mutationResult: []interface{}{
-						&destroyPipelineWithoutVolumesMutation{
+						&destroyPipelineMutation{
 							Response: destroyPipelineResponse{
 								Action: actionStruct{
 									Id:     "test",

--- a/pkg/okteto/pipeline_test.go
+++ b/pkg/okteto/pipeline_test.go
@@ -483,7 +483,7 @@ func TestDestroyPipeline(t *testing.T) {
 			pc := pipelineClient{
 				client: tc.input.client,
 			}
-			response, err := pc.Destroy(context.Background(), tc.input.name, "", tc.input.destroyVolumes)
+			response, err := pc.Destroy(context.Background(), tc.input.name, "", tc.input.destroyVolumes, false)
 			assert.ErrorIs(t, err, tc.expected.err)
 			assert.Equal(t, tc.expected.response, response)
 		})

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -67,7 +67,7 @@ type PreviewInterface interface {
 type PipelineInterface interface {
 	Deploy(ctx context.Context, opts PipelineDeployOptions) (*GitDeployResponse, error)
 	WaitForActionToFinish(ctx context.Context, pipelineName, namespace, actionName string, timeout time.Duration) error
-	Destroy(ctx context.Context, name, namespace string, destroyVolumes bool) (*GitDeployResponse, error)
+	Destroy(ctx context.Context, name, namespace string, destroyVolumes, destroyDependencies bool) (*GitDeployResponse, error)
 	GetResourcesStatus(ctx context.Context, name, namespace string) (map[string]string, error)
 	GetByName(ctx context.Context, name, namespace string) (*GitDeploy, error)
 	WaitForActionProgressing(ctx context.Context, pipelineName, namespace, actionName string, timeout time.Duration) error


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-941

Adds the ability to run `okteto pipeline destroy --dependencies` from the CLI and call the correct graphql endpoint

## How to validate

With a cluster that has the correct configuration and CLI

1. Run okteto pipeline deploy on a repo that has dependencies in the manifest
1. Run okteto pipeline destroy --dependencies
1. Check that the devenvs have been eliminated

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
