### PR TITLE
feat: enhance deploy and destroy pipelines with dependency handling

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -706,7 +706,6 @@ func (dc *Command) deployDependencies(ctx context.Context, deployOptions *Option
 	for depName, dep := range deployOptions.Manifest.Dependencies {
 		oktetoLog.Information("Deploying dependency  '%s'", depName)
 		oktetoLog.SetStage(fmt.Sprintf("Deploying dependency %s", depName))
-
 		if err := validator.CheckReservedVarName(dep.Variables); err != nil {
 			return err
 		}
@@ -730,6 +729,7 @@ func (dc *Command) deployDependencies(ctx context.Context, deployOptions *Option
 			Timeout:      dep.GetTimeout(deployOptions.Timeout),
 			SkipIfExists: !deployOptions.Dependencies,
 			Namespace:    okteto.GetContext().Namespace,
+			IsDependency: true,
 		}
 
 		if err := dc.PipelineCMD.ExecuteDeployPipeline(ctx, pipOpts); err != nil {
@@ -746,6 +746,7 @@ func (dc *Command) deployDependencies(ctx context.Context, deployOptions *Option
 				}
 			}
 		}
+		oktetoLog.SetStage("")
 	}
 	oktetoLog.SetStage("")
 	return nil

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -529,6 +529,7 @@ func (dc *destroyCommand) destroyDependencies(ctx context.Context, opts *Options
 			Name:           depName,
 			DestroyVolumes: opts.DestroyVolumes,
 			Namespace:      okteto.GetContext().Namespace,
+			IsDependency:   true,
 		}
 		pipelineCmd, err := dc.getPipelineDestroyer()
 		if err != nil {

--- a/cmd/pipeline/deploy.go
+++ b/cmd/pipeline/deploy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/devenvironment"
+	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/configmaps"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -66,6 +67,7 @@ type deployFlags struct {
 	skipIfExists         bool
 	reuseParams          bool
 	redeployDependencies bool
+	dependenciesIsSet    bool
 }
 
 // DeployOptions represents options for deploy pipeline command
@@ -82,6 +84,8 @@ type DeployOptions struct {
 	SkipIfExists         bool
 	ReuseParams          bool
 	RedeployDependencies bool
+	IsDependency         bool
+	DependenciesIsSet    bool
 }
 
 func deploy(ctx context.Context) *cobra.Command {
@@ -93,7 +97,7 @@ func deploy(ctx context.Context) *cobra.Command {
 		Example: `To run the deploy without the Okteto CLI wait for its completion, use the '--wait=false' flag:
 okteto pipeline deploy --wait=false`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
+			flags.dependenciesIsSet = cmd.Flags().Changed("dependencies")
 			if err := validator.CheckReservedVariablesNameOption(flags.variables); err != nil {
 				return err
 			}
@@ -142,6 +146,7 @@ okteto pipeline deploy --wait=false`,
 
 // ExecuteDeployPipeline executes deploy pipeline given a set of options
 func (pc *Command) ExecuteDeployPipeline(ctx context.Context, opts *DeployOptions) error {
+	opts.RedeployDependencies = shouldRedeployDependencies(opts)
 	if err := opts.setDefaults(); err != nil {
 		return fmt.Errorf("could not set default values for options: %w", err)
 	}
@@ -170,7 +175,7 @@ func (pc *Command) ExecuteDeployPipeline(ctx context.Context, opts *DeployOption
 		}
 	}
 
-	if opts.SkipIfExists && exists {
+	if !opts.RedeployDependencies && opts.SkipIfExists && exists {
 		if cfg.Data["status"] == pipeline.DeployedStatus {
 			oktetoLog.Success("Skipping repository '%s' because it's already deployed", opts.Name)
 			return nil
@@ -247,6 +252,26 @@ func (pc *Command) ExecuteDeployPipeline(ctx context.Context, opts *DeployOption
 
 	oktetoLog.Success("Repository '%s' successfully deployed", opts.Name)
 	return nil
+}
+
+// shouldRedeployDependencies determines if the pipeline should redeploy dependencies
+// default behavior is set by cluster config, but can be overridden by the user using the flag --dependencies
+func shouldRedeployDependencies(opts *DeployOptions) bool {
+	isForceRedeployDependenciesSetInOktetoInstance := env.LoadBoolean(constants.OktetoForceRedeployDependencies)
+	isInsideDependency := env.LoadBoolean(constants.OktetoIsDependencyEnvVar)
+	if !isInsideDependency && isForceRedeployDependenciesSetInOktetoInstance {
+		// the user forces --dependencies=false
+		if opts.DependenciesIsSet && !opts.RedeployDependencies {
+			return false
+		}
+		return true
+	}
+
+	if isInsideDependency {
+		return false
+	}
+
+	return opts.RedeployDependencies
 }
 
 type envSetter func(name, value string) error
@@ -440,6 +465,7 @@ func (f deployFlags) toOptions() *DeployOptions {
 		Labels:               f.labels,
 		ReuseParams:          f.reuseParams,
 		RedeployDependencies: f.redeployDependencies,
+		DependenciesIsSet:    f.dependenciesIsSet,
 	}
 }
 
@@ -516,6 +542,7 @@ func (o *DeployOptions) toPipelineDeployClientOptions() (types.PipelineDeployOpt
 		Namespace:            o.Namespace,
 		Labels:               o.Labels,
 		RedeployDependencies: o.RedeployDependencies,
+		IsDependency:         o.IsDependency,
 	}, nil
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -152,4 +152,13 @@ const (
 
 	// OktetoDivertedEnvironmentEnvVar Env variable containing the namespace of the diverted environment in divert
 	OktetoDivertedEnvironmentEnvVar = "OKTETO_DIVERTED_ENVIRONMENT"
+
+	// OktetoForceRedeployDependencies defines whether a deploy operation should redeploy dependencies
+	OktetoForceRedeployDependencies = "OKTETO_FORCE_DEPLOY_DEPENDENCIES_FLAG"
+
+	// OktetoForceDestroyDependencies defines whether a destroy operation should destroy dependencies
+	OktetoForceDestroyDependencies = "OKTETO_FORCE_DESTROY_DEPENDENCIES_FLAG"
+
+	// OktetoIsDependencyEnvVar defines if the command is executed inside a dependency
+	OktetoIsDependencyEnvVar = "OKTETO_IS_DEPENDENCY"
 )

--- a/pkg/okteto/pipeline_test.go
+++ b/pkg/okteto/pipeline_test.go
@@ -483,7 +483,7 @@ func TestDestroyPipeline(t *testing.T) {
 			pc := pipelineClient{
 				client: tc.input.client,
 			}
-			response, err := pc.Destroy(context.Background(), tc.input.name, "", tc.input.destroyVolumes, false)
+			response, err := pc.Destroy(context.Background(), tc.input.name, "", tc.input.destroyVolumes, false, false)
 			assert.ErrorIs(t, err, tc.expected.err)
 			assert.Equal(t, tc.expected.response, response)
 		})

--- a/pkg/types/gitdeploy.go
+++ b/pkg/types/gitdeploy.go
@@ -23,6 +23,7 @@ type PipelineDeployOptions struct {
 	Namespace            string
 	Labels               []string
 	RedeployDependencies bool
+	IsDependency         bool
 }
 
 // SpaceBody top body answer

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -67,7 +67,7 @@ type PreviewInterface interface {
 type PipelineInterface interface {
 	Deploy(ctx context.Context, opts PipelineDeployOptions) (*GitDeployResponse, error)
 	WaitForActionToFinish(ctx context.Context, pipelineName, namespace, actionName string, timeout time.Duration) error
-	Destroy(ctx context.Context, name, namespace string, destroyVolumes, destroyDependencies bool) (*GitDeployResponse, error)
+	Destroy(ctx context.Context, name, namespace string, destroyVolumes, destroyDependencies, isDependency bool) (*GitDeployResponse, error)
 	GetResourcesStatus(ctx context.Context, name, namespace string) (map[string]string, error)
 	GetByName(ctx context.Context, name, namespace string) (*GitDeploy, error)
 	WaitForActionProgressing(ctx context.Context, pipelineName, namespace, actionName string, timeout time.Duration) error


### PR DESCRIPTION
- Added support for managing dependencies in both deploy and destroy commands.
- Introduced flags to control redeployment and destruction of dependencies.
- Updated pipeline mutations to include an `isDependency` argument for better context handling.
- Enhanced logging and error handling for dependency operations.

This update improves the flexibility and control over dependency management during pipeline operations.

# Proposed changes

Fixes DEV-961

This PR fixes the infinite redeployment when the setting is activated in the backend 

## How to validate

1. Using a cluster set the redeploy dependencies to true and try running `okteto pipeline deploy/destroy` with dependencies and without them 

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
