### PR TITLE
Fix okteto preview deploy --log-output json command

### DIFF
--- a/pkg/okteto/stream.go
+++ b/pkg/okteto/stream.go
@@ -71,6 +71,10 @@ func handlerPipelineLogLine(line string) bool {
 		if pLog.Stage == "done" && pLog.Message == "EOF" {
 			return true
 		}
+		// Set the stage before printing to ensure proper JSON formatting
+		if pLog.Stage != "" {
+			oktetoLog.SetStage(pLog.Stage)
+		}
 		oktetoLog.Println(pLog.Message)
 		return false
 	}
@@ -79,10 +83,16 @@ func handlerPipelineLogLine(line string) bool {
 		if pLog.Stage == "done" && pLog.Message == "EOF" {
 			return true
 		}
+		// Set the stage before printing to ensure proper JSON formatting
+		if pLog.Stage != "" {
+			oktetoLog.SetStage(pLog.Stage)
+		}
 		oktetoLog.Println(pLog.Message)
 	}
 	return false
 }
+
+
 
 // DestroyAllLogs retrieves logs from the pipeline provided and prints them, returns error
 func (c *streamClient) DestroyAllLogs(ctx context.Context, namespace string) error {


### PR DESCRIPTION
Fixes [PROD-290](https://okteto.atlassian.net/browse/PROD-290) issue where the `okteto preview deploy --log-output json` doesn't output anything. 


# Okteto Agent Fleets generated text below here

The issue was that the handlerPipelineLogLine function in pkg/okteto/stream.go was not setting the log stage before printing messages. When --log-output json is specified, the logs need to be formatted as JSON with the proper stage information.

The fix sets the stage using oktetoLog.SetStage() before calling oktetoLog.Println(), ensuring that the JSON writer properly formats the output with stage information.

# Proposed changes

Fixes # (issue)

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1.
1.
1.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
