### PR TITLE
fix: wait until sync completes to run services

### DIFF
--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -173,8 +173,11 @@ func (up *upContext) activate() error {
 	}
 
 	dd := newDevDeployer(up.Translations, k8sClient)
-	if err := dd.deployDevServices(ctx); err != nil {
-		return err
+	// if servicesUpWait is not set, we need to deploy the dev services because they will be deployed with the main dev
+	if dd.servicesUpWait {
+		if err := dd.deployDevServices(ctx); err != nil {
+			return err
+		}
 	}
 
 	// success means all context is ready to run the activation
@@ -301,6 +304,12 @@ func (up *upContext) createDevContainer(ctx context.Context, app apps.App, creat
 	dd := newDevDeployer(trMap, k8sClient)
 	if err := dd.deployMainDev(ctx); err != nil {
 		return err
+	}
+	// if servicesUpWait is not set, we need to deploy the dev services because they will be deployed with the main dev
+	if !dd.servicesUpWait {
+		if err := dd.deployDevServices(ctx); err != nil {
+			return err
+		}
 	}
 
 	if create {

--- a/cmd/up/activate.go
+++ b/cmd/up/activate.go
@@ -173,7 +173,7 @@ func (up *upContext) activate() error {
 	}
 
 	dd := newDevDeployer(up.Translations, k8sClient)
-	// if servicesUpWait is not set, we need to deploy the dev services because they will be deployed with the main dev
+	// if servicesUpWait is set, we need to deploy the dev services because they won't be deployed with the main dev
 	if dd.servicesUpWait {
 		if err := dd.deployDevServices(ctx); err != nil {
 			return err

--- a/cmd/up/devdeployer.go
+++ b/cmd/up/devdeployer.go
@@ -62,24 +62,11 @@ func newDevDeployer(translations map[string]*apps.Translation, k8sClient kuberne
 
 // deployMainDev deploys the main dev
 func (dd *devDeployer) deployMainDev(ctx context.Context) error {
-
-	err := dd.deploy(ctx, dd.mainTranslation)
-	if err != nil {
-		return err
-	}
-
-	if !dd.servicesUpWait {
-		return dd.deployDevServices(ctx)
-	}
-	return nil
+	return dd.deploy(ctx, dd.mainTranslation)
 }
 
 // deployDevServices deploys the dev services
 func (dd *devDeployer) deployDevServices(ctx context.Context) error {
-	if !dd.servicesUpWait {
-		return nil
-	}
-
 	for _, tr := range dd.devTranslations {
 		annotations := tr.DevApp.TemplateObjectMeta().Annotations
 		if annotations == nil {

--- a/cmd/up/devdeployer.go
+++ b/cmd/up/devdeployer.go
@@ -1,0 +1,78 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"context"
+
+	"github.com/okteto/okteto/pkg/k8s/apps"
+	"github.com/okteto/okteto/pkg/model"
+	"k8s.io/client-go/kubernetes"
+)
+
+type devDeployer struct {
+	translations map[string]*apps.Translation
+	k8sClient    kubernetes.Interface
+
+	mainTranslation *apps.Translation
+	devTranslations []*apps.Translation
+}
+
+// newDevDeployer creates a new devDeployer
+func newDevDeployer(translations map[string]*apps.Translation, k8sClient kubernetes.Interface) *devDeployer {
+	var mainTranslation *apps.Translation
+	devTranslations := make([]*apps.Translation, 0)
+
+	for _, translation := range translations {
+		if translation.MainDev == translation.Dev {
+			mainTranslation = translation
+		} else {
+			devTranslations = append(devTranslations, translation)
+		}
+	}
+
+	return &devDeployer{
+		translations:    translations,
+		k8sClient:       k8sClient,
+		mainTranslation: mainTranslation,
+		devTranslations: devTranslations,
+	}
+}
+
+// deployMainDev deploys the main dev
+func (dd *devDeployer) deployMainDev(ctx context.Context) error {
+	return dd.deploy(ctx, dd.mainTranslation)
+}
+
+// deployDevServices deploys the dev services
+func (dd *devDeployer) deployDevServices(ctx context.Context) error {
+	for _, tr := range dd.devTranslations {
+		if err := dd.deploy(ctx, tr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// deploy replaces the devApp and the app
+func (dd *devDeployer) deploy(ctx context.Context, tr *apps.Translation) error {
+	delete(tr.DevApp.ObjectMeta().Annotations, model.DeploymentRevisionAnnotation)
+	if err := tr.DevApp.Deploy(ctx, dd.k8sClient); err != nil {
+		return err
+	}
+	if err := tr.App.Deploy(ctx, dd.k8sClient); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/up/devdeployer_test.go
+++ b/cmd/up/devdeployer_test.go
@@ -1,0 +1,165 @@
+package up
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/okteto/okteto/pkg/k8s/apps"
+	"github.com/okteto/okteto/pkg/model"
+)
+
+type MockApp struct {
+	mock.Mock
+	apps.App
+}
+
+func (m *MockApp) Deploy(ctx context.Context, k8sClient kubernetes.Interface) error {
+	args := m.Called(ctx, k8sClient)
+	return args.Error(0)
+}
+
+func (m *MockApp) ObjectMeta() metav1.ObjectMeta {
+	args := m.Called()
+	return args.Get(0).(metav1.ObjectMeta)
+}
+
+func TestDevDeployer_DeployMainDev_Success(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewSimpleClientset()
+
+	devApp := &MockApp{}
+	devApp.On("Deploy", ctx, k8sClient).Return(nil)
+	devApp.On("ObjectMeta").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{
+			model.DeploymentRevisionAnnotation: "1",
+		},
+	})
+
+	d := &model.Dev{
+		Name: "main",
+	}
+	translations := map[string]*apps.Translation{
+		"main": {
+			MainDev: d,
+			Dev:     d,
+			DevApp:  devApp,
+			App:     devApp,
+		},
+	}
+	deployer := newDevDeployer(translations, k8sClient)
+
+	err := deployer.deployMainDev(ctx)
+	assert.NoError(t, err)
+
+	devApp.AssertExpectations(t)
+}
+
+func TestDevDeployer_DeployMainDev_DeployError(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewSimpleClientset()
+
+	devApp := &MockApp{}
+	devApp.On("Deploy", ctx, k8sClient).Return(errors.New("deploy error"))
+	devApp.On("ObjectMeta").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{
+			model.DeploymentRevisionAnnotation: "1",
+		},
+	})
+
+	d := &model.Dev{
+		Name: "main",
+	}
+
+	translations := map[string]*apps.Translation{
+		"main": {
+			MainDev: d,
+			Dev:     d,
+			DevApp:  devApp,
+			App:     devApp,
+		},
+	}
+
+	deployer := newDevDeployer(translations, k8sClient)
+
+	err := deployer.deployMainDev(ctx)
+	assert.Error(t, err)
+
+	devApp.AssertExpectations(t)
+}
+
+func TestDevDeployer_DeployDevServices_Success(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewSimpleClientset()
+
+	devApp := &MockApp{}
+	devApp.On("Deploy", ctx, k8sClient).Return(nil)
+	devApp.On("ObjectMeta").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{
+			model.DeploymentRevisionAnnotation: "1",
+		},
+	})
+
+	app := &MockApp{}
+	app.On("Deploy", ctx, k8sClient).Return(nil)
+
+	translations := map[string]*apps.Translation{
+		"svc1": {
+			MainDev: &model.Dev{
+				Name: "main",
+			},
+			Dev: &model.Dev{
+				Name: "svc1",
+			},
+			DevApp: devApp,
+			App:    app,
+		},
+	}
+
+	deployer := newDevDeployer(translations, k8sClient)
+
+	err := deployer.deployDevServices(ctx)
+	assert.NoError(t, err)
+
+	devApp.AssertExpectations(t)
+	app.AssertExpectations(t)
+}
+
+func TestDevDeployer_DeployDevServices_DeployError(t *testing.T) {
+	ctx := context.Background()
+	k8sClient := fake.NewSimpleClientset()
+
+	devApp := &MockApp{}
+	devApp.On("Deploy", ctx, k8sClient).Return(errors.New("deploy error"))
+	devApp.On("ObjectMeta").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{
+			model.DeploymentRevisionAnnotation: "1",
+		},
+	})
+
+	translations := map[string]*apps.Translation{
+		"svc1": {
+			MainDev: &model.Dev{
+				Name: "main",
+			},
+			Dev: &model.Dev{
+				Name: "svc1",
+			},
+			DevApp: devApp,
+			App:    &MockApp{},
+		},
+	}
+
+	deployer := newDevDeployer(translations, k8sClient)
+
+	err := deployer.deployDevServices(ctx)
+	assert.Error(t, err)
+
+	devApp.AssertExpectations(t)
+}

--- a/cmd/up/devdeployer_test.go
+++ b/cmd/up/devdeployer_test.go
@@ -42,6 +42,11 @@ func (m *MockApp) ObjectMeta() metav1.ObjectMeta {
 	return args.Get(0).(metav1.ObjectMeta)
 }
 
+func (m *MockApp) TemplateObjectMeta() metav1.ObjectMeta {
+	args := m.Called()
+	return args.Get(0).(metav1.ObjectMeta)
+}
+
 func TestDevDeployer_DeployMainDev_Success(t *testing.T) {
 	ctx := context.Background()
 	k8sClient := fake.NewSimpleClientset()
@@ -117,6 +122,9 @@ func TestDevDeployer_DeployDevServices_Success(t *testing.T) {
 			model.DeploymentRevisionAnnotation: "1",
 		},
 	})
+	devApp.On("TemplateObjectMeta").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{},
+	})
 
 	app := &MockApp{}
 	app.On("Deploy", ctx, k8sClient).Return(nil)
@@ -135,6 +143,7 @@ func TestDevDeployer_DeployDevServices_Success(t *testing.T) {
 	}
 
 	deployer := newDevDeployer(translations, k8sClient)
+	deployer.servicesUpWait = true
 
 	err := deployer.deployDevServices(ctx)
 	assert.NoError(t, err)
@@ -154,6 +163,9 @@ func TestDevDeployer_DeployDevServices_DeployError(t *testing.T) {
 			model.DeploymentRevisionAnnotation: "1",
 		},
 	})
+	devApp.On("TemplateObjectMeta").Return(metav1.ObjectMeta{
+		Annotations: map[string]string{},
+	})
 
 	translations := map[string]*apps.Translation{
 		"svc1": {
@@ -169,6 +181,7 @@ func TestDevDeployer_DeployDevServices_DeployError(t *testing.T) {
 	}
 
 	deployer := newDevDeployer(translations, k8sClient)
+	deployer.servicesUpWait = true
 
 	err := deployer.deployDevServices(ctx)
 	assert.Error(t, err)

--- a/cmd/up/devdeployer_test.go
+++ b/cmd/up/devdeployer_test.go
@@ -1,3 +1,16 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package up
 
 import (
@@ -5,14 +18,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/okteto/okteto/pkg/k8s/apps"
+	"github.com/okteto/okteto/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/okteto/okteto/pkg/k8s/apps"
-	"github.com/okteto/okteto/pkg/model"
 )
 
 type MockApp struct {

--- a/integration/up/deployment_test.go
+++ b/integration/up/deployment_test.go
@@ -54,6 +54,21 @@ dev:
       sync:
       - .:/usr/src/app
 `
+	deploymentManifestV2Exec = `
+dev:
+  e2etest:
+    image: python:alpine
+    command:
+    - sh
+    - -c
+    - "echo -n $VAR > var.html && python -m http.server 8080"
+    workdir: /usr/src/app
+    sync:
+    - .:/usr/src/app
+    forward:
+    - 8084:8080
+`
+
 	k8sManifestTemplate = `
 apiVersion: apps/v1
 kind: Deployment

--- a/integration/up/deployment_test.go
+++ b/integration/up/deployment_test.go
@@ -49,6 +49,10 @@ dev:
     - .:/usr/src/app
     forward:
     - 8084:8080
+    services:
+    - name: e2etest-other
+      sync:
+      - .:/usr/src/app
 `
 	k8sManifestTemplate = `
 apiVersion: apps/v1
@@ -94,6 +98,50 @@ spec:
   selector:
     app: e2etest
 `
+	anotherK8sManifestTemplate = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2etest-other
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: e2etest-other
+  template:
+    metadata:
+      labels:
+        app: e2etest-other
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: test
+        image: python:alpine
+        ports:
+        - containerPort: 8080
+        workingDir: /usr/src/app
+        env:
+        - name: VAR
+          value: value1
+        command:
+          - sh
+          - -c
+          - "echo -n $VAR > var.html && python -m http.server 8080"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2etest-other
+  annotations:
+    dev.okteto.com/auto-ingress: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - name: e2etest-other
+    port: 8080
+  selector:
+    app: e2etest-other
+`
 )
 
 func TestUpDeploymentV2(t *testing.T) {
@@ -121,6 +169,7 @@ func TestUpDeploymentV2(t *testing.T) {
 	log.Printf("original 'index.html' content: %s", testNamespace)
 
 	require.NoError(t, writeFile(filepath.Join(dir, "deployment.yml"), k8sManifestTemplate))
+	require.NoError(t, writeFile(filepath.Join(dir, "deployment-other.yml"), anotherK8sManifestTemplate))
 	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), deploymentManifestV2))
 	require.NoError(t, writeFile(filepath.Join(dir, ".stignore"), stignoreContent))
 
@@ -133,7 +182,19 @@ func TestUpDeploymentV2(t *testing.T) {
 	require.NoError(t, commands.RunKubectlApply(kubectlBinary, kubectlOpts))
 	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOpts, 1, timeout))
 
+	kubectlOptsOther := &commands.KubectlOptions{
+		Namespace:  testNamespace,
+		File:       filepath.Join(dir, "deployment-other.yml"),
+		Name:       "e2etest-other",
+		ConfigFile: filepath.Join(dir, ".kube", "config"),
+	}
+	require.NoError(t, commands.RunKubectlApply(kubectlBinary, kubectlOptsOther))
+	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOptsOther, 1, timeout))
+
 	originalDeployment, err := integration.GetDeployment(context.Background(), testNamespace, "e2etest", c)
+	require.NoError(t, err)
+
+	originalDeploymentService, err := integration.GetDeployment(context.Background(), testNamespace, "e2etest-other", c)
 	require.NoError(t, err)
 
 	upOptions := &commands.UpOptions{
@@ -154,6 +215,7 @@ func TestUpDeploymentV2(t *testing.T) {
 		ConfigFile: filepath.Join(dir, ".kube", "config"),
 	}
 	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOpts, 1, timeout))
+	require.NoError(t, integration.WaitForDeployment(kubectlBinary, kubectlOptsOther, 1, timeout))
 
 	varLocalEndpoint := "http://localhost:8084/var.html"
 	indexLocalEndpoint := "http://localhost:8084/index.html"
@@ -209,6 +271,7 @@ func TestUpDeploymentV2(t *testing.T) {
 
 	// Test that original hasn't change
 	require.NoError(t, compareDeployment(context.Background(), originalDeployment, c))
+	require.NoError(t, compareDeployment(context.Background(), originalDeploymentService, c))
 	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
 

--- a/integration/up/exec_test.go
+++ b/integration/up/exec_test.go
@@ -107,7 +107,7 @@ func TestExec(t *testing.T) {
 	log.Printf("original 'index.html' content: %s", testNamespace)
 
 	require.NoError(t, writeFile(filepath.Join(dir, "deployment.yml"), k8sManifestTemplate))
-	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), deploymentManifestV2))
+	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), deploymentManifestV2Exec))
 	require.NoError(t, writeFile(filepath.Join(dir, ".stignore"), stignoreContent))
 
 	kubectlOpts := &commands.KubectlOptions{


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes PROD-293

**Problem:**
We were not waiting for the sync to complete on the `dev[svcname].services`. When syncing large files or multiple files, this caused the service commands to execute before synchronization was finished, leading to failures and undesired behaviors.

**Solution:**
This PR fixes the issue by splitting the deployment of the dev environments into two separate steps: mainDev and services. We deploy the mainDev, synchronise the files and then start the rest of the services. This ensures that synchronization completes before the service commands run.


## How to validate

1. Using https://github.com/jLopezbarb/test-services
1. Create a big file, for example using dd: `dd if=/dev/zero of=bigfile.txt bs=1024k count=1024`
1. Run `okteto up`
1. Check that the web service could not start
1. Run again using this branch

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
