### PR TITLE
fix(test): create /okteto/artifacts dir (PROD-377)

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -106,6 +106,9 @@ RUN \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts $HOME/.ssh/known_hosts" >> $HOME/.ssh/config && \
   /okteto/bin/okteto remote-run {{ .Command }} --log-output=json --server-name="${{ .InternalServerName }}" {{ .CommandFlags }}{{ if eq .Command "test" }} || true{{ end }}
 
+{{ if gt (len .Artifacts) 0 -}}
+RUN mkdir -p /okteto/artifacts
+{{ end -}}
 {{range $key, $artifact := .Artifacts }}
 RUN if [ -e /okteto/src/{{$artifact.Path}} ]; then \
     mkdir -p $(dirname /okteto/artifacts/{{$artifact.Destination}}) && \

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -426,6 +426,7 @@ RUN \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts $HOME/.ssh/known_hosts" >> $HOME/.ssh/config && \
   /okteto/bin/okteto remote-run test --log-output=json --server-name="$INTERNAL_SERVER_NAME" --name "test" || true
 
+RUN mkdir -p /okteto/artifacts
 
 RUN if [ -e /okteto/src/coverage.txt ]; then \
     mkdir -p $(dirname /okteto/artifacts/coverage.txt) && \


### PR DESCRIPTION
Signed-off-by: Javier Provecho Fernández (Okteto) <jpf@okteto.com>

# Proposed changes

Fixes PROD-377

This PR ensures the /okteto/artifact directory is created when artifacts are defined. It also fixes a bug where the operation failed if the test command didn’t produce content, resulting in a missing folder.

## How to validate

Create the following Okteto manifest:

```yaml
test:
  foo:
    image: alpine
    context: this
    commands:
    - echo hello world
    artifacts:
    - there.txt
```

Run `okteto test` and observe the following error:

```
 x  The image '' is not accessible or it does not exist
```

Run `okteto test -l debug` to get more details:

```
error on stage [stage-2 1/1] COPY --from=runner /okteto/artifacts/ /: failed to calculate checksum of ref REDACTED: "/okteto/artifacts": not found
```

Apply the changes from this PR and run the command again. Confirm that the errors no longer appear.