### PR TITLE
Avoid build error messages on okteto test execution

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -403,10 +403,10 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		testMetadata.Success = err == nil
 		testAnalytics = append(testAnalytics, &testMetadata)
 		if err != nil {
-			hint := `Please verify test container definition.
+			hint := `Please verify the specified image is accesible.
     You can use --log-level flag to get additional output.`
 			if len(test.Artifacts) > 0 {
-				hint = `Please verify test container definition and review if expected artifacts are being generated.
+				hint = `Please verify the specified image is accesible and review if expected artifacts are being generated.
     You can use --log-level flag to get additional output.`
 			}
 

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -29,6 +29,7 @@ import (
 	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/cmd/utils"
 	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/okteto/okteto/pkg/build/buildkit"
 	buildCMD "github.com/okteto/okteto/pkg/cmd/build"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
@@ -403,6 +404,12 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		testMetadata.Success = err == nil
 		testAnalytics = append(testAnalytics, &testMetadata)
 		if err != nil {
+			// If it is a commandErr, it means that there were an error on the tests itself, so we should return that error directly
+			var cmdErr buildkit.CommandErr
+			if errors.As(err, &cmdErr) {
+				return metadata, err
+			}
+
 			hint := `Please verify the specified image is accesible.
     You can use --log-level flag to get additional output.`
 			if len(test.Artifacts) > 0 {
@@ -412,7 +419,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 
 			ioCtrl.Logger().Infof("error executing test container: %v", err)
 			err = oktetoErrors.UserError{
-				E:    fmt.Errorf("Error executing test container '%s'", name),
+				E:    fmt.Errorf("error executing test container '%s'", name),
 				Hint: hint,
 			}
 			return metadata, err

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -403,6 +403,18 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 		testMetadata.Success = err == nil
 		testAnalytics = append(testAnalytics, &testMetadata)
 		if err != nil {
+			hint := `Please verify test container definition.
+    You can use --log-level flag to get additional output.`
+			if len(test.Artifacts) > 0 {
+				hint = `Please verify test container definition and review if expected artifacts are being generated.
+    You can use --log-level flag to get additional output.`
+			}
+
+			ioCtrl.Logger().Infof("error executing test container: %v", err)
+			err = oktetoErrors.UserError{
+				E:    fmt.Errorf("Error executing test container '%s'", name),
+				Hint: hint,
+			}
 			return metadata, err
 		}
 		oktetoLog.Success("Test container '%s' passed", name)


### PR DESCRIPTION
# Proposed changes

On `okteto test`, when it fails due to some problem with BuildKit (bad Dockerfile for example) we are showing the error coming from the buildkit underlying layers, which usually mention build operations or similar, that doesn't make sense for test execution.

For that reason, I'm changing to show a generic error when okteto test execution fails unexpectedly indicating that the test execution of the test container failed, with a hint to review the image and artifacts, and a reminder for using `log-level` flag to get additional output.

In the case of getting a `CommandErr`, we just return that error, as that represents an error in the test execution itself.

As part of this, I also added some changes in `pkg/build/buildkit/errors.go` to not consider the error `failed to calculate checksum of ref xxxx: "xxx": not found` as some lack of permissions getting the image. I added an extra check to return the error as it is in that case instead of completely replace it.

In the of having `artifacts` defined in the test container, this is the error we return now

<img width="887" alt="Screenshot 2025-06-20 at 13 38 52" src="https://github.com/user-attachments/assets/a356fb5e-02f6-4b32-abce-a81962f5d470" />

If there is no artifacts defined, this is the error we display

<img width="560" alt="Screenshot 2025-06-20 at 13 40 10" src="https://github.com/user-attachments/assets/3759b995-aca9-4240-a226-00a1d272786b" />

In case of a failure in the test itself, we keep returning the same:

<img width="453" alt="Screenshot 2025-06-20 at 13 41 05" src="https://github.com/user-attachments/assets/fdbd7b5c-7837-4e84-b5b9-8f8aaf69e77d" />


## How to validate

Define a test container with an artifact that is not generated by the commands, for example:

```yaml
test:
  backend:
    image: okteto/golang:1
    context: backend
    caches:
      - /go/
      - /root/.cache/
    commands:
      - echo "foo"
    artifacts:
      - foo.txt
```
It should fail with the generic error I'm adding. Before, it was failing with a misleading error: `The image '' is not accessible or it does not exist`

Define a test container with a non-existent image, for example:

```yaml
test:
  backend:
    image: okteto/foo:1
    context: backend
    caches:
      - /go/
      - /root/.cache/
    commands:
      - echo "foo"
```

It should fail with the generic error I'm adding.

Define a test container with a failed command to make sure we are failing in the same way we used to do:

```
test:
  backend:
    image: okteto/golang:1
    context: backend
    caches:
      - /go/
      - /root/.cache/
    commands:
      - asdgasfga
```

It should fail with the same error than without my changes.

