### PR TITLE
Don't build images on deploy command if the calculation of images to build is an empty list

### DIFF
--- a/cmd/deploy/build.go
+++ b/cmd/deploy/build.go
@@ -32,7 +32,7 @@ func buildImages(ctx context.Context, builder builderInterface, cmapHandler Conf
 	oktetoManifestServicesWithBuild := setDifference(allServicesWithBuildSection, stackServicesWithBuild) // Warning: this way of getting the oktetoManifestServicesWithBuild is highly dependent on the manifest struct as it is now. We are assuming that: *okteto* manifest build = manifest build - stack build section
 	servicesToDeployWithBuild := setIntersection(allServicesWithBuildSection, sliceToSet(deployOptions.StackServicesToDeploy))
 	// We need to build:
-	// - All the services that have a build section defined in the *okteto* manifest
+	// - All the services that have a build section defined in the *okteto* manifest, and are not overriding the build of a service defined in the stack
 	// - Services from *deployOptions.servicesToDeploy* that have a build section
 
 	servicesToBuildSet := setUnion(oktetoManifestServicesWithBuild, servicesToDeployWithBuild)
@@ -56,6 +56,11 @@ func buildImages(ctx context.Context, builder builderInterface, cmapHandler Conf
 			}
 		}
 	} else {
+		// If there are no images to build, we just return early as we don't need to do anything
+		if len(servicesToBuildSet) == 0 {
+			return nil
+		}
+
 		buildOptions := &types.BuildOptions{
 			EnableStages: true,
 			Manifest:     deployOptions.Manifest,

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -170,13 +170,17 @@ type fakeV2Builder struct {
 	buildErr             error
 	buildOptionsStorage  *types.BuildOptions
 	servicesAlreadyBuilt []string
+
+	mock.Mock
 }
 
-func (b *fakeV2Builder) Build(_ context.Context, buildOptions *types.BuildOptions) error {
+func (b *fakeV2Builder) Build(ctx context.Context, buildOptions *types.BuildOptions) error {
 	if b.buildErr != nil {
 		return b.buildErr
 	}
 	b.buildOptionsStorage = buildOptions
+
+	b.Called(ctx, buildOptions)
 	return nil
 }
 


### PR DESCRIPTION
# Proposed changes

On deploy command, we are calculating which images have to be built. It might happen that there are not images to build e.g. no build section defined, or deploying just a subset of services from a compose with  using public images. In that case, internal logic within the build function was considering that all the images had to be built. In most of the cases that wouldn't generate issues, but in other cases it would generate unnecessary builds.

For example, having a compose file like this:

```yaml
services:
  foo:
    image: nginx
    volumes:
    - ./foo:/data
  bar:
    image: nginx
  baz:
    image: nginx
```

and the following okteto manifest:

```yaml
deploy:
  compose:
    file: file.yml
    services: [bar, baz]
```

The Okteto manifest is considering to deploy 2 services that directly use a public image and there is no need to build.

If you deploy that manifest, you will see how the `foo` image is being built even if it is not necessary.

## How to validate

Using the scenario described above,  execute `okteto deploy` and see that `foo` image is not being build. Add that service within `deploy.compose.services`, execute it, and see how the image is now build. (it is expected that the build of `foo` fails because the folder `foo` doesn't exist

Without these changes, the first deploy would have triggered the deploy, and it shouldn't
