### PR TITLE
feat: add variable expansion for ServicesToDeploy

### DIFF
--- a/pkg/model/serializer.go
+++ b/pkg/model/serializer.go
@@ -969,8 +969,12 @@ func (s *ServicesToDeploy) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	var rawString string
 	err := unmarshal(&rawString)
 	if err == nil {
+		expanded, err := env.ExpandEnv(rawString)
+		if err != nil {
+			return err
+		}
 		*s = ServicesToDeploy{
-			rawString,
+			expanded,
 		}
 		return nil
 	}
@@ -979,7 +983,15 @@ func (s *ServicesToDeploy) UnmarshalYAML(unmarshal func(interface{}) error) erro
 	var servicesToDeployHolder servicesToDeployRaw
 	err = unmarshal(&servicesToDeployHolder)
 	if err == nil {
-		*s = ServicesToDeploy(servicesToDeployHolder)
+		servicesToDeploy := ServicesToDeploy{}
+		for _, service := range servicesToDeployHolder {
+			expanded, err := env.ExpandEnv(service)
+			if err != nil {
+				return err
+			}
+			servicesToDeploy = append(servicesToDeploy, expanded)
+		}
+		*s = servicesToDeploy
 		return nil
 	}
 	return err


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

- Introduced a comprehensive set of unit tests for the ServicesToDeploy unmarshalling functionality.
- Tests cover various scenarios including single string services, arrays of services, and handling of environment variables with defaults.
- Added cases for error handling with broken syntax and invalid data types to ensure robustness.

## How to validate

1. Using the following `okteto.yml` and `docker compose`
```yaml
# docker-compose.yml
services:
  api:
    image: nginx
```
```yaml
# okteto.yml
deploy:
  compose:
    file: docker-compose.yml
    services:
      - ${SERVICE}
```
2. Export the variable `SERVICE`: `export SERVICE=api`
3. Run `okteto deploy`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
