### PR TITLE
reduce severity of JSON parsing error log, and skip parsing when the log is empty

### DIFF
--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -148,7 +148,7 @@ func (t *trace) update(ss *client.SolveStatus) error {
 
 func (t *trace) display(progress string) {
 	for _, v := range t.ongoing {
-		if t.isTransferringContext(v.name) {
+		if isTransferringContext(v.name) {
 			if v.currentTransferedContext != 0 {
 				currentLoadedCtx := units.Bytes(v.currentTransferedContext)
 				if t.showCtxAdvice && currentLoadedCtx > largeContextThreshold {
@@ -158,7 +158,7 @@ func (t *trace) display(progress string) {
 				oktetoLog.Spinner(fmt.Sprintf("Synchronizing context: %.2f", currentLoadedCtx))
 			}
 		}
-		if t.hasCommandLogs(v) {
+		if hasCommandLogs(v) {
 			switch progress {
 			case DeployOutputModeOnBuild:
 				oktetoLog.Spinner("Deploying your development environment...")
@@ -218,16 +218,6 @@ func (t *trace) display(progress string) {
 	}
 }
 
-func (t trace) isTransferringContext(name string) bool {
-	isInternal := strings.HasPrefix(name, "[internal]")
-	isLoadingCtx := strings.Contains(name, "load build")
-	return isInternal && isLoadingCtx
-}
-
-func (t trace) hasCommandLogs(v *vertexInfo) bool {
-	return len(v.logs) != 0
-}
-
 func (t *trace) removeCompletedSteps() {
 	for k, v := range t.ongoing {
 		if v.completed {
@@ -244,6 +234,16 @@ func (t *trace) removeCompletedSteps() {
 			delete(t.ongoing, k)
 		}
 	}
+}
+
+func hasCommandLogs(v *vertexInfo) bool {
+	return len(v.logs) != 0
+}
+
+func isTransferringContext(name string) bool {
+	isInternal := strings.HasPrefix(name, "[internal]")
+	isLoadingCtx := strings.Contains(name, "load build")
+	return isInternal && isLoadingCtx
 }
 
 type vertexInfo struct {

--- a/pkg/cmd/build/logger.go
+++ b/pkg/cmd/build/logger.go
@@ -169,9 +169,13 @@ func (t *trace) display(progress string) {
 			}
 
 			for _, log := range v.logs {
+				if log == "" {
+					continue
+				}
+
 				var text oktetoLog.JSONLogFormat
 				if err := json.Unmarshal([]byte(log), &text); err != nil {
-					oktetoLog.Infof("could not parse %s: %s", log, err)
+					oktetoLog.Debugf("could not parse %s: %s", log, err)
 					continue
 				}
 				if text.Stage == "" {


### PR DESCRIPTION
# Proposed changes

Fixes # https://okteto.atlassian.net/browse/PROD-397

Reduce  the severity of JSON parsing error log, and skip parsing when the log is empty

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Check out a repo with a lot of images
1. `okteto build`
1. Observe the logs for failures

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
