### PR TITLE
Enhance DestroyPreview functionality to include timeout parameter

### DIFF
--- a/cmd/preview/destroy.go
+++ b/cmd/preview/destroy.go
@@ -101,7 +101,7 @@ func (c destroyPreviewCommand) executeDestroyPreview(ctx context.Context, opts *
 	oktetoLog.StartSpinner()
 	defer oktetoLog.StopSpinner()
 
-	if err := c.okClient.Previews().Destroy(ctx, opts.name); err != nil {
+	if err := c.okClient.Previews().Destroy(ctx, opts.name, int(opts.timeout.Seconds())); err != nil {
 		if oktetoErrors.IsNotFound(err) {
 			oktetoLog.Information("Preview environment '%s' not found.", opts.name)
 			return nil

--- a/internal/test/client/preview.go
+++ b/internal/test/client/preview.go
@@ -61,7 +61,7 @@ func (c *FakePreviewsClient) GetResourcesStatus(_ context.Context, _, _ string) 
 	return c.response.ResourceStatus, c.response.ErrResources
 }
 
-func (c *FakePreviewsClient) Destroy(_ context.Context, _ string) error {
+func (c *FakePreviewsClient) Destroy(_ context.Context, _ string, _ int) error {
 	if c.response.ErrDestroyPreview != nil {
 		return c.response.ErrDestroyPreview
 	}

--- a/pkg/okteto/preview_test.go
+++ b/pkg/okteto/preview_test.go
@@ -281,7 +281,7 @@ func TestDestroyPreview(t *testing.T) {
 			pc := previewClient{
 				client: tc.input.client,
 			}
-			err := pc.Destroy(context.Background(), tc.input.name)
+			err := pc.Destroy(context.Background(), tc.input.name, 0)
 			assert.ErrorIs(t, err, tc.expected.err)
 		})
 	}

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -58,7 +58,7 @@ type PreviewInterface interface {
 	List(ctx context.Context, labels []string) ([]Preview, error)
 	DeployPreview(ctx context.Context, name, scope, repository, branch, sourceUrl, filename string, variables []Variable, labels []string, redeployDependencies bool) (*PreviewResponse, error)
 	GetResourcesStatus(ctx context.Context, previewName, devName string) (map[string]string, error)
-	Destroy(ctx context.Context, previewName string) error
+	Destroy(ctx context.Context, previewName string, timeout int) error
 	ListEndpoints(ctx context.Context, previewName string) ([]Endpoint, error)
 	Get(ctx context.Context, previewName string) (*Preview, error)
 }


### PR DESCRIPTION
# Proposed changes

Fixes DEV-980

- Updated the Destroy method in the preview client to accept a timeout parameter, allowing for more flexible preview destruction.
- Modified related interfaces and test cases to accommodate the new timeout argument.
- Adjusted error handling in the Destroy method to manage cases where the timeout argument is not recognized.

This change improves the usability of the DestroyPreview feature by enabling users to specify a timeout for the operation.

## How to validate

I run `okteto preview deploy 10m` on the repo https://github.com/jLopezbarb/movies/tree/jlo/destroy-10m  and then `okteto preview deploy 10m` and got as result:
```
Waiting for 6 min
Tue Jul 22 14:50:32 UTC 2025
completed
Tue Jul 22 14:56:32 UTC 2025
```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
