### PR TITLE
Improved error handling when the backend returns a 401 error, to force a new login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -177,7 +177,6 @@ require (
 )
 
 require (
-	github.com/argoproj/argo-rollouts v1.8.3
 	github.com/bluekeyes/go-gitdiff v0.8.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/heimdalr/dag v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,6 @@ github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOL
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argoproj/argo-rollouts v1.8.3 h1:blbtQva4IK9r6gFh+dWkCrLnFdPOWiv9ubQYu36qeaA=
-github.com/argoproj/argo-rollouts v1.8.3/go.mod h1:kCAUvIfMGfOyVf3lvQbBt0nqQn4Pd+zB5/YwKv+UBa8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ import (
 )
 
 func init() {
+	cobra.EnableTraverseRunHooks = true
 	oktetoLog.SetLevel("warn") // TODO: Remove when we fully move to ioController
 	var b [16]byte
 	_, err := cryptoRand.Read(b[:])

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 
@@ -57,9 +56,7 @@ var serverName string
 var strictTLSOnce sync.Once
 var errURLNotSet = errors.New("the okteto URL is not set")
 
-const unauthorizedTokenPattern = `^non-200 OK status code: 401 Unauthorized body: "fail to find user with token [A-Za-z0-9]+: not-authorized\\n"$`
-
-var unauthorizedTokenRegex = regexp.MustCompile(unauthorizedTokenPattern)
+const unauthorizedTokenPrefix = `non-200 OK status code: 401 Unauthorized body: "fail to find user with token`
 
 // graphqlClientInterface contains the functions that a graphqlClient must have
 type graphqlClientInterface interface {
@@ -350,6 +347,8 @@ func parseOktetoURLWithPath(u, path string) (string, error) {
 }
 
 func translateAPIErr(err error) error {
+	oktetoLog.Debugf("returnedAPI error: %s", err.Error())
+
 	e := strings.TrimPrefix(err.Error(), "graphql: ")
 	switch e {
 	case "not-authorized":
@@ -374,7 +373,7 @@ func translateAPIErr(err error) error {
 		return oktetoErrors.ErrNamespaceNotFound
 
 	default:
-		if unauthorizedTokenRegex.MatchString(err.Error()) {
+		if strings.HasPrefix(err.Error(), unauthorizedTokenPrefix) {
 			return fmt.Errorf(oktetoErrors.ErrNotLogged, GetContext().Name)
 		}
 


### PR DESCRIPTION
# Proposed changes

Fixes # (issue)

Change the condition to consider when an API error is because of an unauthorized error. We were just handling when the error string returned by the backend was `not-authorized` but there are other cases like `not-found`. They key here is that it should be an unauthorized error when the backend returns a 401 error, and that happens when the error string contains: `non-200 OK status code: 401 Unauthorized body`. That means that the backend returned a 401 error.

If that happens, the function should return the error `ErrNotLogged`, so when that happens in the context command, it will retrigger a new login flow, regenerating the local token.

As part of this, I did a change to make sure that the flag `log-level` works also for `context` commands. It wasn't working because the log level is being changed on the function `PersistentPreRun` from the main command, but the context command was overriding that function, and by default, cobra only executes the first function in the chain. I set `EnableTraverseRunHooks` to `true`, so it executes all the functions in the chain

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1. Execute `okteto ctx use` for one Okteto instance
2. Go to the UI in that instance, and refresh the login token
3. If you try to execute any CLI command, you will see how it fails
4. Now, build the code from this branch, and execute `okteto context`. You will see how it will say that the token is invalid and it will regenerate one, and it will trigger the login flow
