### PR TITLE
Add unit test for CreateDev function and fix TargetPort type in Service translation

### DIFF
--- a/pkg/k8s/services/translate.go
+++ b/pkg/k8s/services/translate.go
@@ -49,7 +49,7 @@ func translate(dev *model.Dev, namespace string) *apiv1.Service {
 				{
 					Name:       dev.Name,
 					Port:       8080,
-					TargetPort: intstr.IntOrString{StrVal: "8080"},
+					TargetPort: intstr.IntOrString{IntVal: 8080},
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

- Introduced a new test, TestCreateDev, to validate the CreateDev function's behavior, ensuring it correctly creates a service in the specified namespace.
- Updated the TargetPort type in the Service translation from string to integer for proper Kubernetes compatibility.

This enhances test coverage and corrects a potential issue in service configuration.

## How to validate

1. run okteto up on k8s 1.33 in minikube with a autocreate

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
