### PR TITLE
Added debug message when compose parsing fails 

### DIFF
--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -367,6 +367,9 @@ func getManifestFromFile(cwd, manifestPath string, fs afero.Fs) (*Manifest, erro
 			if errors.Is(stackErr, oktetoErrors.ErrServiceEmpty) {
 				return nil, stackErr
 			}
+
+			// We just log the error in this case to not lose the stackErr. Before that, we are returning it
+			oktetoLog.Debugf("there was an error loading compose file(s): %v", stackErr)
 			// if not return original manifest err
 			return nil, err
 		}

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -369,7 +369,7 @@ func getManifestFromFile(cwd, manifestPath string, fs afero.Fs) (*Manifest, erro
 			}
 
 			// We just log the error in this case to not lose the stackErr. Before that, we are returning it
-			oktetoLog.Debugf("there was an error loading compose file(s): %v", stackErr)
+			oktetoLog.Infof("there was an error loading compose file(s): %v", stackErr)
 			// if not return original manifest err
 			return nil, err
 		}


### PR DESCRIPTION
# Proposed changes

When we use the flag `-f` to specify a file, and that file is a compose, we are silently ignoring the error returned by `LoadStack` in all the cases except in 2 specific cases. We return the original error returning from parsing the file as Okteto Manifest. And it seems to be done on purpose.

Instead of returning the stackErr, which would require to think about the flow and the experience offered, I'm just adding a log to not lose it, and facilitate the troubleshooting when that happens.

For example, if you have a compose like this one:

```
services:
  mysql:
    environment:
      FOO: "hellow"
      FOO: "world"
    image: 'mysql:8.0.28-oracle'
    ports:
    - '3306:3306'
```

and you execute `okteto deploy -f <path-to-compose>`, you will get an error similar to this one:

```
 x  Your Okteto Manifest is not valid, please check the following errors:
     - line 1: field 'services' is not a property of the okteto manifest
    Check out the Okteto Manifest docs at: https://www.okteto.com/docs/reference/okteto-manifest
```

And if you add debug logs, you don't get a different error, making hard to troubleshoot it.

With my changes, the debug logs would print something like this:

```
DEBU[0001] there was an error loading compose file(s): Invalid compose manifest:
    - line 5: key "FOO" already set in map
    See https://okteto.com/docs/reference/docker-compose/ for details
```

## How to validate

1. Create a compose file like the one mentioned above
2. Execute `okteto deploy -f <path-to-compose> --log-level=debug` with an official CLI release, and you will see how you don't see any specific error or something telling you what is going on
3. Compile this branch
4. Execute the same command, and you will see the log message indicating the error
