### PR TITLE
DEV-1107: Initialize the divert deployer in the command struct for up and test commands

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -36,6 +36,7 @@ import (
 	"github.com/okteto/okteto/pkg/dag"
 	"github.com/okteto/okteto/pkg/deployable"
 	"github.com/okteto/okteto/pkg/devenvironment"
+	"github.com/okteto/okteto/pkg/divert"
 	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/filesystem"
@@ -51,6 +52,7 @@ import (
 	"github.com/okteto/okteto/pkg/validator"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 )
 
 type Options struct {
@@ -273,6 +275,9 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			K8sLogger:          k8sLogger,
 			IsRemote:           env.LoadBoolean(constants.OktetoDeployRemote),
 			RunningInInstaller: config.RunningInInstaller(),
+			DivertDeployerGetter: func(d *model.DivertDeploy, name, namespace string, c kubernetes.Interface) (deployCMD.DivertDeployer, error) {
+				return divert.New(d, name, namespace, c)
+			},
 		}
 		// runInRemote is not set at init, its left default to false and calculated by deployCMD.ShouldRunInRemote
 		opts := &deployCMD.Options{

--- a/cmd/up/deploy.go
+++ b/cmd/up/deploy.go
@@ -23,6 +23,7 @@ import (
 	pipelineCMD "github.com/okteto/okteto/cmd/pipeline"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/cmd/pipeline"
+	"github.com/okteto/okteto/pkg/divert"
 	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
@@ -87,6 +88,9 @@ func NewDevEnvDeployerManager(up *upContext, ioCtrl *io.Controller, k8sLogger *i
 				EndpointGetter:    deploy.NewEndpointGetter,
 				AnalyticsTracker:  up.analyticsTracker,
 				IoCtrl:            ioCtrl,
+				DivertDeployerGetter: func(d *model.DivertDeploy, name, namespace string, c kubernetes.Interface) (deploy.DivertDeployer, error) {
+					return divert.New(d, name, namespace, c)
+				},
 			}
 			return c, nil
 		},


### PR DESCRIPTION
# Proposed changes

DEV-1107

Regression introduced in [this PR](https://github.com/okteto/okteto/pull/4701). I had added a new field in a struct, but it wasn't being initialized in the case of `okteto up` and `okteto test` commands when they have to deploy. This PR is initializing correctly the struct in both cases

I tested it on my dev environment for the case of nginx, and I created a new cluster with istio installed to test the istio scenario. Both cases work fine. I tested executing `okteto up` and `okteto test` with deploy flags. I was not able to reproduce the crash anymore after those changes
