### PR TITLE
DEV-1079: Added logic to remove Divert resources when services are not longer in the diverted namespace

### DIFF
--- a/pkg/divert/nginx/cache.go
+++ b/pkg/divert/nginx/cache.go
@@ -16,6 +16,7 @@ package nginx
 import (
 	"context"
 
+	"github.com/okteto/okteto/pkg/divert/k8s"
 	apiv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +27,7 @@ type cache struct {
 	divertServices     map[string]*apiv1.Service
 	developerIngresses map[string]*networkingv1.Ingress
 	developerServices  map[string]*apiv1.Service
+	divertResources    map[string]*k8s.Divert
 }
 
 func (d *Driver) initCache(ctx context.Context) error {
@@ -34,6 +36,7 @@ func (d *Driver) initCache(ctx context.Context) error {
 		divertServices:     map[string]*apiv1.Service{},
 		developerIngresses: map[string]*networkingv1.Ingress{},
 		developerServices:  map[string]*apiv1.Service{},
+		divertResources:    map[string]*k8s.Divert{},
 	}
 	// Init ingress cache for diverted namespace
 	iList, err := d.client.NetworkingV1().Ingresses(d.divert.Namespace).List(ctx, metav1.ListOptions{})
@@ -69,6 +72,14 @@ func (d *Driver) initCache(ctx context.Context) error {
 	}
 	for i := range sList.Items {
 		d.cache.developerServices[sList.Items[i].Name] = &sList.Items[i]
+	}
+
+	divList, err := d.divertManager.List(ctx, d.namespace)
+	if err != nil {
+		return err
+	}
+	for i := range divList {
+		d.cache.divertResources[divList[i].Name] = divList[i]
 	}
 
 	return nil

--- a/pkg/divert/nginx/divert.go
+++ b/pkg/divert/nginx/divert.go
@@ -197,7 +197,6 @@ func (d *Driver) deployDivertResources(ctx context.Context) error {
 
 // deleteOrphanDiverts checks for divert resources that are not associated with any developer service, and deletes them.
 func (d *Driver) deleteOrphanDiverts(ctx context.Context) error {
-	// We check if we need to delete some divert resource
 	divertToDelete := make([]string, 0)
 	for _, div := range d.cache.divertResources {
 		if _, ok := d.cache.developerServices[div.Spec.Service]; ok {

--- a/pkg/divert/nginx/divert_test.go
+++ b/pkg/divert/nginx/divert_test.go
@@ -37,6 +37,16 @@ func (f *fakeDivertManager) CreateOrUpdate(ctx context.Context, d *k8s.Divert) e
 	return args.Error(0)
 }
 
+func (f *fakeDivertManager) List(ctx context.Context, namespace string) ([]*k8s.Divert, error) {
+	args := f.Called(ctx, namespace)
+	return args.Get(0).([]*k8s.Divert), args.Error(1)
+}
+
+func (f *fakeDivertManager) Delete(ctx context.Context, name, namespace string) error {
+	args := f.Called(ctx, name, namespace)
+	return args.Error(0)
+}
+
 func Test_updateEnvVar(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -802,6 +812,7 @@ func Test_divertIngresses(t *testing.T) {
 	dm := &fakeDivertManager{}
 
 	dm.On("CreateOrUpdate", mock.Anything, mock.Anything).Return(nil).Times(2)
+	dm.On("List", mock.Anything, "cindy").Return([]*k8s.Divert{}, nil).Times(2)
 
 	d := &Driver{client: c, name: m.Name, namespace: "cindy", divert: *m.Deploy.Divert, divertManager: dm}
 	err := d.Deploy(ctx)


### PR DESCRIPTION
# Proposed changes

DEV-1079

Follow up PR of https://github.com/okteto/okteto/pull/4755 where I include code to delete "orphan" divert resources. Understanding "orphan" as divert resources pointing to a services no longer in the diverted namespace. This could happen in case of a redeploy or manually deletion of services in that namespace

I tested on my test cluster deploying 5 services, making sure 5 divert resources are created, and then, delete 1 service, redeploy the dev environment (making sure the deleted service is not deployed), and verifying that 4 divert resources were present after that
