### PR TITLE
Changed themock in a couple of tests to use mock.Anything instead of the context

### DIFF
--- a/pkg/divert/nginx/divert_test.go
+++ b/pkg/divert/nginx/divert_test.go
@@ -1127,8 +1127,8 @@ func Test_deleteOrphanDiverts_Success(t *testing.T) {
 	}
 
 	dm := &fakeDivertManager{}
-	dm.On("Delete", ctx, "divert2", "cindy").Return(nil).Once()
-	dm.On("Delete", ctx, "divert3", "cindy").Return(nil).Once()
+	dm.On("Delete", mock.Anything, "divert2", "cindy").Return(nil).Once()
+	dm.On("Delete", mock.Anything, "divert3", "cindy").Return(nil).Once()
 
 	d := &Driver{
 		namespace:     "cindy",
@@ -1143,7 +1143,7 @@ func Test_deleteOrphanDiverts_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	dm.AssertExpectations(t)
-	dm.AssertNotCalled(t, "Delete", ctx, "divert1", "cindy")
+	dm.AssertNotCalled(t, "Delete", mock.Anything, "divert1", "cindy")
 }
 
 func Test_deleteOrphanDiverts_NoOrphans(t *testing.T) {
@@ -1229,8 +1229,8 @@ func Test_deleteOrphanDiverts_DeleteError(t *testing.T) {
 	developerServices := map[string]*apiv1.Service{}
 
 	dm := &fakeDivertManager{}
-	dm.On("Delete", ctx, "divert1", "cindy").Return(nil).Once()
-	dm.On("Delete", ctx, "divert2", "cindy").Return(fmt.Errorf("delete error")).Once()
+	dm.On("Delete", mock.Anything, "divert1", "cindy").Return(nil).Once()
+	dm.On("Delete", mock.Anything, "divert2", "cindy").Return(fmt.Errorf("delete error")).Once()
 
 	d := &Driver{
 		namespace:     "cindy",


### PR DESCRIPTION
# Proposed changes

There was a test execution where one test failed without modified the piece of code that is being tested: https://app.circleci.com/pipelines/github/okteto/okteto/17114/workflows/8768ebaf-4714-48b2-8488-8166a2a0c008/jobs/70970.

Checking the test and the code, I don't see anything obvious about why this might be failing. The only thing I can think of is that the context changes somehow during execution, not matching with the expectations set in the test. For that reason, I'm changing the ctx parameter to be `mock.Anything` in the expectations, as I don't want to verify the context being passed
