### PR TITLE
fix: update golangci to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ orbs:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.7.3
+      - image: okteto/golang-ci:2.8.0
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ orbs:
 executors:
   golang-ci:
     docker:
-      - image: okteto/golang-ci:2.8.0
+      - image: okteto/golang-ci:2.8.1
     environment:
       OKTETO_CONTEXT: https://staging.okteto.dev
       OKTETO_APPS_SUBDOMAIN: staging.dev.okteto.net

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,13 +68,13 @@ linters:
 formatters:
   enable:
     - gci
-  # settings for gci:
-  # settings:
-  #   gci:
-  #     sections:
-  #       - standard
-  #       - default
-  #       - prefix(github.com/tu/org/tu-proyecto)
+    # settings for gci:
+    # settings:
+    #   gci:
+    #     sections:
+    #       - standard
+    #       - default
+    #       - prefix(github.com/tu/org/tu-proyecto)
 
 issues:
   include:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: '2'
 
 run:
   modules-download-mode: readonly
@@ -65,10 +65,9 @@ linters:
     - revive
     - staticcheck # replace with "gosimple"
 
-
 formatters:
   enable:
-  - gci
+    - gci
   # settings for gci:
   # settings:
   #   gci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,7 +70,7 @@ linters:
 
 formatters:
   enable:
-    - gci
+  - gci
   # settings opcionales para gci:
   # settings:
   #   gci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,6 @@ linters-settings:
   errcheck:
     check-type-assertions: true
     check-blank: true
-  tenv:
-    all: true # <- queda inofensivo si lo dejas, pero puedes borrar toda esta sección si quieres
   goheader:
     values:
       regexp:
@@ -61,17 +59,17 @@ linters:
 
   disable:
     # We need to revisit this. For now, we're disabling the following linters until we fix the issues they raise.
-    - copyloopvar # reemplaza a "exportloopref"
+    - copyloopvar # replace with "exportloopref"
     - errcheck
     - mnd
     - revive
-    - staticcheck # reemplaza a "gosimple"
+    - staticcheck # replace with "gosimple"
 
 
 formatters:
   enable:
   - gci
-  # settings opcionales para gci:
+  # settings for gci:
   # settings:
   #   gci:
   #     sections:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   modules-download-mode: readonly
 
@@ -7,41 +9,19 @@ output:
 
 linters-settings:
   unparam:
-    # Inspect exported functions.
-    #
-    # Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    #
     check-exported: true
   errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
     check-type-assertions: true
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
-    # Such cases aren't reported by default.
-    # Default: false
     check-blank: true
   tenv:
-    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
+    all: true # <- queda inofensivo si lo dejas, pero puedes borrar toda esta sección si quieres
   goheader:
     values:
       regexp:
         YEAR: 2023|2024|2025
     template-path: .copyright-header.tmpl
   mnd:
-    checks:
-      - argument
-      - case
-      - condition
-      # - operation
-      # - return
-      # - assign
+    checks: [argument, case, condition]
     ignored-functions:
       - '\.NewWriter'
       - '\.NewTabWriter'
@@ -59,19 +39,13 @@ linters-settings:
     rules:
       - name: exported
 
-# All possible linters can be found https://golangci-lint.run/usage/linters/
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - typecheck
     - govet
     - ineffassign
     - unused
     - unparam
-    - tenv
     - tparallel
-    - gci
     - goheader
     - unconvert
     - predeclared
@@ -79,30 +53,39 @@ linters:
     - asasalint
     - bidichk
     - decorder
-    - exportloopref
     - makezero
-    - mnd
     - musttag
     - bodyclose
     - durationcheck
     - exhaustive
+
+  disable:
+    # We need to revisit this. For now, we're disabling the following linters until we fix the issues they raise.
+    - copyloopvar # reemplaza a "exportloopref"
+    - errcheck
+    - mnd
     - revive
+    - staticcheck # reemplaza a "gosimple"
+
+
+formatters:
+  enable:
+    - gci
+  # settings opcionales para gci:
+  # settings:
+  #   gci:
+  #     sections:
+  #       - standard
+  #       - default
+  #       - prefix(github.com/tu/org/tu-proyecto)
 
 issues:
   include:
-    - EXC0014 # EXC0014 revive: comment on exported (.+) should be of the form "(.+)..."
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+    - EXC0014 # revive: comment on exported...
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0
-
   exclude-rules:
     - path: '(.+)_test\.go'
-      linters:
-        - errcheck
-    - linters:
-        - unparam
-      # exclude from linting the custom implementation for "MarshalYAML"
+      linters: [errcheck]
+    - linters: [unparam]
       text: 'MarshalYAML()'


### PR DESCRIPTION
Update to golangci v2:

Followed https://golangci-lint.run/docs/product/migration-guide/