### PR TITLE
Fix flaky test Test_deleteOrphanDiverts_DeleteError

### DIFF
--- a/pkg/divert/nginx/divert_test.go
+++ b/pkg/divert/nginx/divert_test.go
@@ -1229,8 +1229,16 @@ func Test_deleteOrphanDiverts_DeleteError(t *testing.T) {
 	developerServices := map[string]*apiv1.Service{}
 
 	dm := &fakeDivertManager{}
-	dm.On("Delete", mock.Anything, "divert1", "cindy").Return(nil).Once()
-	dm.On("Delete", mock.Anything, "divert2", "cindy").Return(fmt.Errorf("delete error")).Once()
+	isExpectedDivert := func(arg interface{}) bool {
+		divertName := arg.(string)
+		return divertName == "divert1" || divertName == "divert2"
+	}
+	isExpectedNamespace := func(arg interface{}) bool {
+		namespace := arg.(string)
+		return namespace == "cindy"
+	}
+	dm.On("Delete", mock.Anything, mock.MatchedBy(isExpectedDivert), mock.MatchedBy(isExpectedNamespace)).Return(nil).Once()
+	dm.On("Delete", mock.Anything, mock.MatchedBy(isExpectedDivert), mock.MatchedBy(isExpectedNamespace)).Return(fmt.Errorf("delete error")).Once()
 
 	d := &Driver{
 		namespace:     "cindy",


### PR DESCRIPTION
# Proposed changes

The problem comes in the sorting of maps. It is not deterministic in golang, so even I was defining always `divert1` first, and `divert2` second, they could be processed in different order. As I was always failing when `divert2` was deleted, when that divert object was being considered first, the test was failing because it was expecting a second call, but it never happened.

I'm changing it to keep validating that the parameters are always fine, and making sure that is always the second call to Delete the one that i failing, so we ensure the function is always called twice

