### PR TITLE
Change prettier pre-commit to a local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,8 @@
 # https://pre-commit.com/
 default_stages: [pre-commit, pre-push]
 default_language_version:
-  # force all unspecified Python hooks to run python3
   python: python3
+  node: 22.19.0
 minimum_pre_commit_version: '3.2.0'
 repos:
   - repo: meta
@@ -12,6 +12,15 @@ repos:
         name: run identity check
       - id: check-hooks-apply
         name: run check-hooks-apply
+  - repo: local
+    hooks:
+      - id: prettier
+        name: run prettier
+        description: format files with prettier
+        entry: prettier --write '**/*.json' '**/*.md' '**/*.yaml' '**/*.yml'
+        files: \.(json|md|ya?ml)$
+        language: node
+        additional_dependencies: ['prettier@3.6.2']
   # general checks for the repository
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -58,14 +67,6 @@ repos:
         name: run codespell
         description: Check Spelling with codespell
         entry: codespell -L ba,flate,ges,indx,keypair,splitted,vertexes --exclude-file=go.sum
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        name: run prettier
-        description: Format files with prettier
-        exclude: schema.json
 
   # yaml files check
   - repo: https://github.com/adrienverge/yamllint

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 .github/**
 /docs/**
 integration/validate/manifests/invalid-syntax.yml
+schema.json


### PR DESCRIPTION
The old prettier hook repository has been archived for over a year:

https://github.com/pre-commit/mirrors-prettier

Use the most current versions of Node.js and prettier:

https://www.npmjs.com/package/prettier

https://nodejs.org/en/download

prettier uses an ignore file to exclude files so add "schema.json"

You can see a prettier local hook that I added to mruby here:

https://github.com/mruby/mruby/blob/master/.pre-commit-config.yaml#L22

# Proposed changes

Fixes # (issue)

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## How to validate

Please provide step-by-step instructions to replicate your validation scenario. For bug fixes, detail how to reproduce both the bug and its fix, along with any observations.

1.
1.
1.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
