### PR TITLE
Fix Cache tests

### DIFF
--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -387,6 +387,7 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			Manifest:                    manifest,
 			Command:                     remote.TestCommand,
 			ContextAbsolutePathOverride: ctxCwd,
+			TestName:                    name,
 			Caches:                      test.Caches,
 			IgnoreRules:                 testIgnoreRules,
 			Artifacts:                   test.Artifacts,

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -100,7 +100,7 @@ RUN echo "${{ .InvalidateCacheArgName }}" > /etc/.oktetocachekey
 RUN okteto registrytoken install --force --log-output=json
 
 RUN \
-  {{range $key, $path := .Caches }}--mount=type=cache,target={{$path}},sharing=private {{end}}\
+  {{range $key, $path := .Caches }}--mount=type=cache,id={{$.ManifestName}}-{{$.TestName}}-{{$key}},target={{$path}},sharing=private {{end}}\
   --mount=type=secret,id=known_hosts \
   --mount=type=secret,id={{ .SSHAgentSocketArgName }},env=SSH_AUTH_SOCK \
   mkdir -p $HOME/.ssh && echo "UserKnownHostsFile=/run/secrets/known_hosts $HOME/.ssh/known_hosts" >> $HOME/.ssh/config && \
@@ -177,6 +177,8 @@ type Params struct {
 	CommandFlags []string
 	Caches       []string
 	Hosts        []model.Host
+	// TestName is the name of the test container, used for cache isolation
+	TestName string
 	// IgnoreRules are the ignoring rules added to this build execution.
 	// Rules follow the .dockerignore syntax as defined in:
 	// https://docs.docker.com/build/building/context/#syntax
@@ -220,6 +222,8 @@ type dockerfileTemplateProperties struct {
 	SSHAgentPort                 string
 	SSHAgentSocketArgName        string
 	Caches                       []string
+	TestName                     string
+	ManifestName                 string
 	Artifacts                    []model.Artifact
 }
 
@@ -422,6 +426,8 @@ func (r *Runner) createDockerfile(tmpDir string, params *Params) (string, error)
 		OktetoCommandSpecificEnvVars: params.OktetoCommandSpecificEnvVars,
 		Command:                      params.Command,
 		Caches:                       params.Caches,
+		TestName:                     params.TestName,
+		ManifestName:                 params.Manifest.Name,
 		Artifacts:                    params.Artifacts,
 		SSHAgentHostname:             params.SSHAgentHostname,
 		SSHAgentHostnameArgName:      constants.OktetoSshAgentHostnameEnvVar,

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -584,10 +584,10 @@ func TestDockerfileWithCache(t *testing.T) {
 	require.Equal(t, filepath.Clean("/test/myDockerfile"), dockerfileName)
 	d, err := afero.ReadFile(fs, dockerfileName)
 	require.NoError(t, err)
-	
+
 	// Verify that each cache has a unique ID based on manifest name, test name, and cache index
 	for i, cache := range caches {
-		expectedID := fmt.Sprintf("test-manifest-unit-test-%d", i)
+		expectedID := fmt.Sprintf("-test-manifest-unit-test-%d", i)
 		pattern := fmt.Sprintf("--mount=type=cache,id=%s,target=%s", expectedID, cache)
 		ok, err := regexp.MatchString(pattern, string(d))
 		require.NoError(t, err)
@@ -611,7 +611,7 @@ func TestCacheIsolationBetweenTestContexts(t *testing.T) {
 		generateSocketName: nameGenerator.GenerateName,
 	}
 	caches := []string{"/root/.cache", "/go/pkg/mod"}
-	
+
 	// Test case 1: manifest1, test1
 	manifest1 := &model.Manifest{Name: "app1"}
 	dockerfile1, err := rdc.createDockerfile("/test1", &Params{
@@ -621,7 +621,7 @@ func TestCacheIsolationBetweenTestContexts(t *testing.T) {
 		Manifest:       manifest1,
 	})
 	require.NoError(t, err)
-	
+
 	// Test case 2: manifest1, test2 (different test context)
 	dockerfile2, err := rdc.createDockerfile("/test2", &Params{
 		Caches:         caches,
@@ -630,7 +630,7 @@ func TestCacheIsolationBetweenTestContexts(t *testing.T) {
 		Manifest:       manifest1,
 	})
 	require.NoError(t, err)
-	
+
 	// Test case 3: manifest2, test1 (different manifest)
 	manifest2 := &model.Manifest{Name: "app2"}
 	dockerfile3, err := rdc.createDockerfile("/test3", &Params{
@@ -640,7 +640,7 @@ func TestCacheIsolationBetweenTestContexts(t *testing.T) {
 		Manifest:       manifest2,
 	})
 	require.NoError(t, err)
-	
+
 	// Read all dockerfiles
 	d1, err := afero.ReadFile(fs, dockerfile1)
 	require.NoError(t, err)
@@ -648,32 +648,32 @@ func TestCacheIsolationBetweenTestContexts(t *testing.T) {
 	require.NoError(t, err)
 	d3, err := afero.ReadFile(fs, dockerfile3)
 	require.NoError(t, err)
-	
+
 	// Verify that each test context generates unique cache IDs
 	for i, cache := range caches {
 		// Expected cache IDs for each context
-		expectedID1 := fmt.Sprintf("app1-unit-%d", i)
-		expectedID2 := fmt.Sprintf("app1-integration-%d", i)
-		expectedID3 := fmt.Sprintf("app2-unit-%d", i)
-		
+		expectedID1 := fmt.Sprintf("-app1-unit-%d", i)
+		expectedID2 := fmt.Sprintf("-app1-integration-%d", i)
+		expectedID3 := fmt.Sprintf("-app2-unit-%d", i)
+
 		// Verify dockerfile1 has app1-unit cache IDs
 		pattern1 := fmt.Sprintf("--mount=type=cache,id=%s,target=%s", expectedID1, cache)
 		ok, err := regexp.MatchString(pattern1, string(d1))
 		require.NoError(t, err)
 		require.True(t, ok, "Dockerfile1 should have cache ID %s", expectedID1)
-		
+
 		// Verify dockerfile2 has app1-integration cache IDs
 		pattern2 := fmt.Sprintf("--mount=type=cache,id=%s,target=%s", expectedID2, cache)
 		ok, err = regexp.MatchString(pattern2, string(d2))
 		require.NoError(t, err)
 		require.True(t, ok, "Dockerfile2 should have cache ID %s", expectedID2)
-		
+
 		// Verify dockerfile3 has app2-unit cache IDs
 		pattern3 := fmt.Sprintf("--mount=type=cache,id=%s,target=%s", expectedID3, cache)
 		ok, err = regexp.MatchString(pattern3, string(d3))
 		require.NoError(t, err)
 		require.True(t, ok, "Dockerfile3 should have cache ID %s", expectedID3)
-		
+
 		// Ensure that the cache IDs are different between contexts
 		require.NotEqual(t, expectedID1, expectedID2, "Cache IDs should be different between test contexts")
 		require.NotEqual(t, expectedID1, expectedID3, "Cache IDs should be different between manifests")

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -586,9 +586,8 @@ func TestDockerfileWithCache(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify that each cache has a unique ID based on manifest name, test name, and cache index
-	for i, cache := range caches {
-		expectedID := fmt.Sprintf("-test-manifest-unit-test-%d", i)
-		pattern := fmt.Sprintf("--mount=type=cache,id=%s,target=%s", expectedID, cache)
+	for _, cache := range caches {
+		pattern := fmt.Sprintf("--mount=type=cache,id=\\w+,target=%s", cache)
 		ok, err := regexp.MatchString(pattern, string(d))
 		require.NoError(t, err)
 		require.True(t, ok, "Expected cache mount pattern not found: %s", pattern)


### PR DESCRIPTION
# Proposed changes

Fixes DEV-1069

Add a new id based on repositoryHash/manifestname/testname/testidx in order to generate a unique id and fix the cache in the remote 
Fix the tests accordingly

## How to validate

Run a okteto test with two tests contianers sharing the same cache like for example one caching node modules and then using it in the next one

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
