### PR TITLE
Jlo/add cache id in run cmds

### DIFF
--- a/cmd/build/v2/build.go
+++ b/cmd/build/v2/build.go
@@ -373,7 +373,7 @@ func (bc *OktetoBuilder) buildSvcFromDockerfile(ctx context.Context, manifest *m
 		return "", fmt.Errorf("error expanding build args from service '%s': %w", svcName, err)
 	}
 
-	buildOptions := buildCmd.OptsFromBuildInfo(manifest.Name, svcName, buildSvcInfo, options, bc.Registry, bc.oktetoContext)
+	buildOptions := buildCmd.OptsFromBuildInfo(manifest, svcName, buildSvcInfo, options, bc.Registry, bc.oktetoContext)
 
 	if err := bc.Builder.Build(ctx, buildOptions); err != nil {
 		return "", err

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -171,6 +171,14 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			},
 			isOkteto: true,
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Image: "okteto.dev/movies-service:okteto",
+						},
+					},
+				},
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
 				BuildArgs:  []string{namespaceEnvVar.String()},
@@ -182,6 +190,12 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			buildInfo:   &build.Info{},
 			isOkteto:    false,
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {},
+					},
+				},
 				OutputMode: oktetoLog.TTYFormat,
 				BuildArgs:  []string{},
 			},
@@ -211,6 +225,24 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			},
 			isOkteto: true,
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Context:    serviceContext,
+							Dockerfile: serviceDockerfile,
+							Image:      "okteto.dev/movies-service:okteto",
+							Target:     "build",
+							CacheFrom:  []string{"cache-image"},
+							Args: build.Args{
+								{
+									Name:  "arg1",
+									Value: "value1",
+								},
+							},
+						},
+					},
+				},
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
 				File:       filepath.Join(dir, serviceContext, serviceDockerfile),
@@ -251,6 +283,30 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			},
 			isOkteto: true,
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Context:    serviceContext,
+							Image:      "okteto.dev/movies-service:okteto",
+							Dockerfile: serviceDockerfile,
+							Target:     "build",
+							CacheFrom:  []string{"cache-image"},
+							Args: build.Args{
+								{
+									Name:  "arg1",
+									Value: "value1",
+								},
+							},
+							VolumesToInclude: []build.VolumeMounts{
+								{
+									LocalPath:  "a",
+									RemotePath: "b",
+								},
+							},
+						},
+					},
+				},
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/movies-service:okteto",
 				File:       filepath.Join(dir, serviceContext, serviceDockerfile),
@@ -293,6 +349,29 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 			},
 			isOkteto: true,
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Image:      "okteto.dev/mycustomimage:dev",
+							Context:    serviceContext,
+							Dockerfile: serviceDockerfile,
+							Target:     "build",
+							CacheFrom:  []string{"cache-image"},
+							Args: build.Args{
+								namespaceEnvVar,
+								{
+									Name:  "arg1",
+									Value: "value1",
+								},
+							},
+							Secrets: map[string]string{
+								"mysecret": "source",
+							},
+							ExportCache: []string{"export-image"},
+						},
+					},
+				},
 				OutputMode: oktetoLog.TTYFormat,
 				Tag:        "okteto.dev/mycustomimage:dev",
 				File:       filepath.Join(dir, serviceContext, serviceDockerfile),
@@ -321,6 +400,14 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				repo:             "movies-service",
 			},
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Image: "okteto.dev/movies-service:okteto",
+						},
+					},
+				},
 				BuildArgs:  []string{namespaceEnvVar.String()},
 				Platform:   "linux/amd64",
 				Tag:        "okteto.dev/movies-service:okteto",
@@ -343,6 +430,14 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				repo:             "movies-service",
 			},
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Image: "okteto.dev/movies-service:okteto",
+						},
+					},
+				},
 				BuildArgs: []string{
 					namespaceEnvVar.String(),
 					"arg1=value1",
@@ -374,6 +469,20 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				repo:             "movies-service",
 			},
 			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Image: "okteto.dev/movies-service:okteto",
+							Args: build.Args{
+								{
+									Name:  "arg1",
+									Value: "value2",
+								},
+							},
+						},
+					},
+				},
 				BuildArgs: []string{
 					namespaceEnvVar.String(),
 					"arg1=",
@@ -403,7 +512,7 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				},
 			}
 
-			result := OptsFromBuildInfo(manifest.Name, tt.serviceName, manifest.Build[tt.serviceName], tt.initialOpts, &tt.mr, okCtx)
+			result := OptsFromBuildInfo(manifest, tt.serviceName, manifest.Build[tt.serviceName], tt.initialOpts, &tt.mr, okCtx)
 			require.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/cmd/build/file_test.go
+++ b/pkg/cmd/build/file_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_translateOktetoRegistryImage(t *testing.T) {
@@ -77,6 +78,49 @@ func Test_translateOktetoRegistryImage(t *testing.T) {
 			if got := translateOktetoRegistryImage(tt.input, okCtx); got != tt.want {
 				t.Errorf("registry.translateOktetoRegistryImage = %v,  want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestTranslateCacheHandler(t *testing.T) {
+	projectHash := "abc123"
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no RUN command",
+			input:    "COPY . .",
+			expected: "COPY . .",
+		},
+		{
+			name:     "RUN without cache mount",
+			input:    "RUN echo hello",
+			expected: "RUN echo hello",
+		},
+		{
+			name:     "RUN with cache mount and id already present",
+			input:    "RUN --mount=type=cache,id=mycache,target=/root/.cache pip install -r requirements.txt",
+			expected: "RUN --mount=type=cache,id=mycache,target=/root/.cache pip install -r requirements.txt",
+		},
+		{
+			name:     "RUN with cache mount but no id, with target",
+			input:    "RUN --mount=type=cache,target=/root/.cache pip install -r requirements.txt",
+			expected: "RUN --mount=id=abc123-/root/.cache,type=cache,target=/root/.cache pip install -r requirements.txt",
+		},
+		{
+			name:     "RUN with cache mount but no id, without target",
+			input:    "RUN --mount=type=cache pip install -r requirements.txt",
+			expected: "RUN --mount=id=abc123,type=cache pip install -r requirements.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := translateCacheHandler(tt.input, projectHash)
+			assert.Equal(t, tt.expected, output)
 		})
 	}
 }

--- a/pkg/cmd/build/translator.go
+++ b/pkg/cmd/build/translator.go
@@ -218,8 +218,8 @@ func (cmt cacheMountTranslator) translate(line string) string {
 
 	// Find all mount definitions
 	matches := cmt.mountRegex.FindAllStringSubmatch(result, -1)
-
 	for _, match := range matches {
+
 		if len(match) < 2 {
 			continue
 		}

--- a/pkg/cmd/build/translator.go
+++ b/pkg/cmd/build/translator.go
@@ -167,18 +167,24 @@ type cacheMountTranslator struct {
 	cacheMountRegex    *regexp.Regexp
 	hasIDRegex         *regexp.Regexp
 	targetExtractRegex *regexp.Regexp
+	mountRegex         *regexp.Regexp
+	targetRegex        *regexp.Regexp
 }
 
 func newCacheMountTranslator(repo, dockerfilePath, target string) cacheMountTranslator {
 	cacheMountRegex := regexp.MustCompile(`^RUN.*--mount=.*type=cache`)
 	hasIDRegex := regexp.MustCompile(`^RUN.*--mount=[^ ]*id=`)
 	targetExtractRegex := regexp.MustCompile(`--mount=[^ ]*target=([^, ]+)`)
+	mountRegex := regexp.MustCompile(`--mount=([^[:space:]]+)`)
+	targetRegex := regexp.MustCompile(`target=([^,\s]+)`)
 
 	return cacheMountTranslator{
 		projectHash:        generateProjectHash(repo, dockerfilePath, target),
 		cacheMountRegex:    cacheMountRegex,
 		hasIDRegex:         hasIDRegex,
 		targetExtractRegex: targetExtractRegex,
+		mountRegex:         mountRegex,
+		targetRegex:        targetRegex,
 	}
 }
 
@@ -207,15 +213,46 @@ func (cmt cacheMountTranslator) translate(line string) string {
 		return line
 	}
 
-	target := ""
-	if matches := cmt.targetExtractRegex.FindStringSubmatch(line); len(matches) > 1 {
-		target = matches[1]
+	// Find all --mount= occurrences and process them individually
+	result := line
+
+	// Find all mount definitions
+	matches := cmt.mountRegex.FindAllStringSubmatch(result, -1)
+
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+
+		fullMount := match[0]   // --mount=type=cache,target=...
+		mountParams := match[1] // type=cache,target=...
+
+		// Check if this is a cache mount
+		if !strings.Contains(mountParams, "type=cache") {
+			continue
+		}
+
+		// Check if it already has an id
+		if strings.Contains(mountParams, "id=") {
+			continue
+		}
+
+		// Extract target from this specific mount
+		target := ""
+		if targetMatch := cmt.targetRegex.FindStringSubmatch(mountParams); len(targetMatch) > 1 {
+			target = targetMatch[1]
+		}
+
+		// Generate unique ID for this mount
+		id := cmt.projectHash
+		if target != "" {
+			id = fmt.Sprintf("%s-%s", cmt.projectHash, target)
+		}
+
+		// Replace this specific mount with the one that includes the ID
+		newMount := fmt.Sprintf("--mount=id=%s,%s", id, mountParams)
+		result = strings.Replace(result, fullMount, newMount, 1)
 	}
 
-	id := cmt.projectHash
-	if target != "" {
-		id = fmt.Sprintf("%s-%s", cmt.projectHash, target)
-	}
-	// Otherwise, insert id=<projectHash> into the mount
-	return strings.ReplaceAll(line, "--mount=", fmt.Sprintf("--mount=id=%s,", id))
+	return result
 }

--- a/pkg/cmd/build/translator.go
+++ b/pkg/cmd/build/translator.go
@@ -1,0 +1,217 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/okteto/okteto/pkg/config"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/registry"
+)
+
+const (
+	tmpFilePrefix = "buildkit-"
+)
+
+type opener interface {
+	Open(file string) (io.ReadWriter, error)
+}
+
+type fileOpener struct{}
+
+func (fileOpener) Open(file string) (io.ReadWriter, error) {
+	return os.Open(file)
+}
+
+type NameWriter interface {
+	Name() string
+	io.Writer
+}
+
+type tmpFileCreator interface {
+	Create(dir string) (string, error)
+}
+type osTmpFileCreator struct{}
+
+func (osTmpFileCreator) Create(dir string) (string, error) {
+	file, err := os.CreateTemp(dir, tmpFilePrefix)
+	if err != nil {
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		return "", err
+	}
+	return file.Name(), nil
+}
+
+type DockerfileTranslator struct {
+	opener         opener
+	tmpFileCreator tmpFileCreator
+	tmpFolder      string
+	tmpFileName    string
+	translators    []translator
+}
+
+func newDockerfileTranslator(okCtx OktetoContextInterface, repoURL, dockerfilePath, target string) (*DockerfileTranslator, error) {
+
+	dockerfileTmpFolder := filepath.Join(config.GetOktetoHome(), ".dockerfile")
+	if err := os.MkdirAll(dockerfileTmpFolder, 0700); err != nil {
+		return nil, fmt.Errorf("failed to create %s: %w", dockerfileTmpFolder, err)
+	}
+
+	return &DockerfileTranslator{
+		opener:         fileOpener{},
+		tmpFileCreator: osTmpFileCreator{},
+		tmpFolder:      dockerfileTmpFolder,
+		translators: []translator{
+			newRegistryTranslator(okCtx),
+			newCacheMountTranslator(repoURL, dockerfilePath, target),
+		},
+	}, nil
+}
+
+func (dt *DockerfileTranslator) translate(filename string) error {
+	readerFile, err := dt.opener.Open(filename)
+	if err != nil {
+		return err
+	}
+
+	dt.tmpFileName, err = dt.tmpFileCreator.Create(dt.tmpFolder)
+	if err != nil {
+		return err
+	}
+
+	writerFile, err := dt.opener.Open(dt.tmpFileName)
+	if err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(readerFile)
+	datawriter := bufio.NewWriter(writerFile)
+	defer datawriter.Flush()
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		result := line
+		for _, translator := range dt.translators {
+			result = translator.translate(result)
+		}
+
+		_, err := datawriter.WriteString(result + "\n")
+		if err != nil {
+			return fmt.Errorf("failed to write dockerfile: %w", err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type translator interface {
+	translate(line string) string
+}
+
+type registryTranslator struct {
+	replacer        registry.Replacer
+	userNs          string
+	globalNamespace string
+}
+
+func newRegistryTranslator(okCtx OktetoContextInterface) registryTranslator {
+	globalNamespace := constants.DefaultGlobalNamespace
+	ctxGlobalNamespace := okCtx.GetGlobalNamespace()
+	if ctxGlobalNamespace != "" {
+		globalNamespace = ctxGlobalNamespace
+	}
+
+	return registryTranslator{
+		replacer:        registry.NewRegistryReplacer(GetRegistryConfigFromOktetoConfig(okCtx)),
+		userNs:          okCtx.GetNamespace(),
+		globalNamespace: globalNamespace,
+	}
+}
+
+func (rt registryTranslator) translate(line string) string {
+	if strings.Contains(line, constants.DevRegistry) {
+		result := rt.replacer.Replace(line, constants.DevRegistry, rt.userNs)
+		return result
+	}
+
+	if strings.Contains(line, constants.GlobalRegistry) {
+		result := rt.replacer.Replace(line, constants.GlobalRegistry, rt.globalNamespace)
+		return result
+	}
+	return line
+}
+
+type cacheMountTranslator struct {
+	projectHash string
+}
+
+func newCacheMountTranslator(repo, dockerfilePath, target string) cacheMountTranslator {
+	return cacheMountTranslator{
+		projectHash: generateProjectHash(repo, dockerfilePath, target),
+	}
+}
+
+func generateProjectHash(repositoryURL, manifestName, path string) string {
+	// Create input string for hashing
+	input := fmt.Sprintf("%s-%s-%s", repositoryURL, manifestName, path)
+
+	// Generate SHA256 hash
+	hasher := sha256.New()
+	hasher.Write([]byte(input))
+	hash := hasher.Sum(nil)
+
+	// Return first 12 characters of hex hash for readability
+	return hex.EncodeToString(hash)[:12]
+}
+
+func (cmt cacheMountTranslator) translate(line string) string {
+	// Check if this RUN command has a cache mount
+	hasCacheMount, err := regexp.MatchString(`^RUN.*--mount=.*type=cache`, line)
+	if err != nil || !hasCacheMount {
+		return line
+	}
+
+	// If an id is already defined, leave unchanged
+	hasID, err := regexp.MatchString(`^RUN.*--mount=[^ ]*id=`, line)
+	if err == nil && hasID {
+		return line
+	}
+
+	target := ""
+	re := regexp.MustCompile(`--mount=[^ ]*target=([^, ]+)`)
+	if matches := re.FindStringSubmatch(line); len(matches) > 1 {
+		target = matches[1]
+	}
+
+	id := cmt.projectHash
+	if target != "" {
+		id = fmt.Sprintf("%s-%s", cmt.projectHash, target)
+	}
+	// Otherwise, insert id=<projectHash> into the mount
+	return strings.ReplaceAll(line, "--mount=", fmt.Sprintf("--mount=id=%s,", id))
+}

--- a/pkg/cmd/build/translator_test.go
+++ b/pkg/cmd/build/translator_test.go
@@ -423,6 +423,8 @@ func TestNewCacheMountTranslator(t *testing.T) {
 			assert.NotNil(t, cmt.cacheMountRegex)
 			assert.NotNil(t, cmt.hasIDRegex)
 			assert.NotNil(t, cmt.targetExtractRegex)
+			assert.NotNil(t, cmt.mountRegex)
+			assert.NotNil(t, cmt.targetRegex)
 		})
 	}
 }
@@ -557,6 +559,11 @@ func TestCacheMountTranslator_Translate(t *testing.T) {
 			name:     "leaves RUN with secret mount unchanged",
 			input:    "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret",
 			expected: "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret",
+		},
+		{
+			name:     "handles multiple cache mounts in single RUN command",
+			input:    "RUN --mount=type=cache,target=./.eslintcache --mount=type=cache,target=./.yarn/cache,sharing=private --mount=type=cache,target=./node_modules,sharing=private yarn install --immutable",
+			expected: "RUN --mount=id=abcdef123456-./.eslintcache,type=cache,target=./.eslintcache --mount=id=abcdef123456-./.yarn/cache,type=cache,target=./.yarn/cache,sharing=private --mount=id=abcdef123456-./node_modules,type=cache,target=./node_modules,sharing=private yarn install --immutable",
 		},
 	}
 

--- a/pkg/cmd/build/translator_test.go
+++ b/pkg/cmd/build/translator_test.go
@@ -1,0 +1,767 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Mock implementations for testing
+type mockOpener struct {
+	files      map[string]*mockFile
+	shouldFail bool
+}
+
+type mockFile struct {
+	content string
+	pos     int
+}
+
+func (mf *mockFile) Read(p []byte) (n int, err error) {
+	if mf.pos >= len(mf.content) {
+		return 0, io.EOF
+	}
+	n = copy(p, mf.content[mf.pos:])
+	mf.pos += n
+	return n, nil
+}
+
+func (mf *mockFile) Write(p []byte) (n int, err error) {
+	mf.content += string(p)
+	return len(p), nil
+}
+
+func (mf *mockFile) Close() error {
+	return nil
+}
+
+func newMockFile(content string) *mockFile {
+	return &mockFile{content: content, pos: 0}
+}
+
+func (mo *mockOpener) Open(file string) (io.ReadWriteCloser, error) {
+	if mo.shouldFail {
+		return nil, fmt.Errorf("mock open error")
+	}
+	if f, exists := mo.files[file]; exists {
+		return f, nil
+	}
+	// Create a new empty file if it doesn't exist
+	mo.files[file] = newMockFile("")
+	return mo.files[file], nil
+}
+
+type mockTmpFileCreator struct {
+	shouldFail bool
+	fileName   string
+}
+
+func (mtfc *mockTmpFileCreator) Create(dir string) (string, error) {
+	if mtfc.shouldFail {
+		return "", fmt.Errorf("mock tmp file creation error")
+	}
+	return mtfc.fileName, nil
+}
+
+type mockOktetoContext struct {
+	namespace       string
+	globalNamespace string
+	registryURL     string
+}
+
+func (moc *mockOktetoContext) GetCurrentName() string                            { return "test" }
+func (moc *mockOktetoContext) GetNamespace() string                              { return moc.namespace }
+func (moc *mockOktetoContext) GetGlobalNamespace() string                        { return moc.globalNamespace }
+func (moc *mockOktetoContext) GetCurrentBuilder() string                         { return "test" }
+func (moc *mockOktetoContext) GetCurrentCertStr() string                         { return "" }
+func (moc *mockOktetoContext) GetCurrentCfg() *clientcmdapi.Config               { return nil }
+func (moc *mockOktetoContext) GetCurrentToken() string                           { return "" }
+func (moc *mockOktetoContext) GetCurrentUser() string                            { return "" }
+func (moc *mockOktetoContext) ExistsContext() bool                               { return true }
+func (moc *mockOktetoContext) IsOktetoCluster() bool                             { return true }
+func (moc *mockOktetoContext) IsInsecure() bool                                  { return false }
+func (moc *mockOktetoContext) UseContextByBuilder()                              {}
+func (moc *mockOktetoContext) GetTokenByContextName(name string) (string, error) { return "", nil }
+func (moc *mockOktetoContext) GetRegistryURL() string                            { return moc.registryURL }
+
+type mockReplacerConfig struct {
+	registryURL string
+}
+
+func (mrc *mockReplacerConfig) GetRegistryURL() string {
+	return mrc.registryURL
+}
+
+func TestNewDockerfileTranslator(t *testing.T) {
+	tests := []struct {
+		name                    string
+		okCtx                   OktetoContextInterface
+		repoURL                 string
+		dockerfilePath          string
+		target                  string
+		expectedTranslatorCount int
+	}{
+		{
+			name: "successful creation with default global namespace",
+			okCtx: &mockOktetoContext{
+				namespace:       "test-ns",
+				globalNamespace: "",
+				registryURL:     "registry.example.com",
+			},
+			repoURL:                 "https://github.com/test/repo",
+			dockerfilePath:          "Dockerfile",
+			target:                  "prod",
+			expectedTranslatorCount: 2,
+		},
+		{
+			name: "successful creation with custom global namespace",
+			okCtx: &mockOktetoContext{
+				namespace:       "user-ns",
+				globalNamespace: "custom-global",
+				registryURL:     "registry.example.com",
+			},
+			repoURL:                 "https://github.com/test/repo",
+			dockerfilePath:          "Dockerfile",
+			target:                  "dev",
+			expectedTranslatorCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dt, err := newDockerfileTranslator(tt.okCtx, tt.repoURL, tt.dockerfilePath, tt.target)
+
+			require.NoError(t, err)
+			require.NotNil(t, dt)
+			require.Len(t, dt.translators, tt.expectedTranslatorCount)
+			require.NotEmpty(t, dt.tmpFolder)
+		})
+	}
+}
+
+func TestDockerfileTranslator_Translate(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputContent    string
+		expectedOutput  string
+		setupTranslator func() *DockerfileTranslator
+	}{
+		{
+			name:           "simple dockerfile with no translations needed",
+			inputContent:   "FROM ubuntu:20.04\nRUN echo hello",
+			expectedOutput: "FROM ubuntu:20.04\nRUN echo hello\n",
+			setupTranslator: func() *DockerfileTranslator {
+				mockOpener := &mockOpener{
+					files: make(map[string]*mockFile),
+				}
+				mockOpener.files["input.dockerfile"] = newMockFile("FROM ubuntu:20.04\nRUN echo hello")
+
+				return &DockerfileTranslator{
+					opener:         mockOpener,
+					tmpFileCreator: &mockTmpFileCreator{fileName: "temp.dockerfile"},
+					tmpFolder:      "/tmp",
+					translators:    []translator{}, // No translators
+				}
+			},
+		},
+		{
+			name:           "dockerfile with dev registry translation",
+			inputContent:   fmt.Sprintf("FROM %s/myimage:latest", constants.DevRegistry),
+			expectedOutput: "FROM registry.example.com/test-ns/myimage:latest\n",
+			setupTranslator: func() *DockerfileTranslator {
+				mockOpener := &mockOpener{
+					files: make(map[string]*mockFile),
+				}
+				mockOpener.files["input.dockerfile"] = newMockFile(fmt.Sprintf("FROM %s/myimage:latest", constants.DevRegistry))
+
+				registryTranslator := registryTranslator{
+					replacer:        registry.NewRegistryReplacer(&mockReplacerConfig{registryURL: "registry.example.com"}),
+					userNs:          "test-ns",
+					globalNamespace: "okteto",
+				}
+
+				return &DockerfileTranslator{
+					opener:         mockOpener,
+					tmpFileCreator: &mockTmpFileCreator{fileName: "temp.dockerfile"},
+					tmpFolder:      "/tmp",
+					translators:    []translator{registryTranslator},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dt := tt.setupTranslator()
+
+			err := dt.translate("input.dockerfile")
+			require.NoError(t, err)
+
+			// Check the output content
+			outputFile := dt.opener.(*mockOpener).files[dt.tmpFileName]
+			require.NotNil(t, outputFile)
+			assert.Equal(t, tt.expectedOutput, outputFile.content)
+		})
+	}
+}
+
+func TestDockerfileTranslator_Translate_Failures(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupTranslator func() *DockerfileTranslator
+		filename        string
+		expectedError   string
+	}{
+		{
+			name: "opener fails to open input file",
+			setupTranslator: func() *DockerfileTranslator {
+				return &DockerfileTranslator{
+					opener:         &mockOpener{shouldFail: true},
+					tmpFileCreator: &mockTmpFileCreator{fileName: "temp.dockerfile"},
+					tmpFolder:      "/tmp",
+					translators:    []translator{},
+				}
+			},
+			filename:      "nonexistent.dockerfile",
+			expectedError: "mock open error",
+		},
+		{
+			name: "tmp file creator fails",
+			setupTranslator: func() *DockerfileTranslator {
+				mockOpener := &mockOpener{
+					files: make(map[string]*mockFile),
+				}
+				mockOpener.files["input.dockerfile"] = newMockFile("FROM ubuntu:20.04")
+
+				return &DockerfileTranslator{
+					opener:         mockOpener,
+					tmpFileCreator: &mockTmpFileCreator{shouldFail: true},
+					tmpFolder:      "/tmp",
+					translators:    []translator{},
+				}
+			},
+			filename:      "input.dockerfile",
+			expectedError: "mock tmp file creation error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dt := tt.setupTranslator()
+
+			err := dt.translate(tt.filename)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+func TestNewRegistryTranslator(t *testing.T) {
+	tests := []struct {
+		name                    string
+		okCtx                   OktetoContextInterface
+		expectedUserNs          string
+		expectedGlobalNamespace string
+	}{
+		{
+			name: "with custom global namespace",
+			okCtx: &mockOktetoContext{
+				namespace:       "user-namespace",
+				globalNamespace: "custom-global",
+				registryURL:     "registry.example.com",
+			},
+			expectedUserNs:          "user-namespace",
+			expectedGlobalNamespace: "custom-global",
+		},
+		{
+			name: "with empty global namespace defaults to okteto",
+			okCtx: &mockOktetoContext{
+				namespace:       "test-ns",
+				globalNamespace: "",
+				registryURL:     "registry.example.com",
+			},
+			expectedUserNs:          "test-ns",
+			expectedGlobalNamespace: constants.DefaultGlobalNamespace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := newRegistryTranslator(tt.okCtx)
+
+			assert.Equal(t, tt.expectedUserNs, rt.userNs)
+			assert.Equal(t, tt.expectedGlobalNamespace, rt.globalNamespace)
+			assert.NotNil(t, rt.replacer)
+		})
+	}
+}
+
+func TestRegistryTranslator_Translate(t *testing.T) {
+	rt := registryTranslator{
+		replacer:        registry.NewRegistryReplacer(&mockReplacerConfig{registryURL: "registry.example.com"}),
+		userNs:          "test-ns",
+		globalNamespace: "global-ns",
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "translates dev registry",
+			input:    fmt.Sprintf("FROM %s/myimage:latest", constants.DevRegistry),
+			expected: "FROM registry.example.com/test-ns/myimage:latest",
+		},
+		{
+			name:     "translates global registry",
+			input:    fmt.Sprintf("FROM %s/shared:v1.0", constants.GlobalRegistry),
+			expected: "FROM registry.example.com/global-ns/shared:v1.0",
+		},
+		{
+			name:     "handles dev registry at start of line",
+			input:    fmt.Sprintf("%s/builder:latest", constants.DevRegistry),
+			expected: "registry.example.com/test-ns/builder:latest",
+		},
+		{
+			name:     "handles dev registry with whitespace prefix",
+			input:    fmt.Sprintf("COPY --from %s/builder:latest /app .", constants.DevRegistry),
+			expected: "COPY --from registry.example.com/test-ns/builder:latest /app .",
+		},
+		{
+			name:     "leaves non-okteto registries unchanged",
+			input:    "FROM docker.io/ubuntu:20.04",
+			expected: "FROM docker.io/ubuntu:20.04",
+		},
+		{
+			name:     "leaves standard docker hub image unchanged",
+			input:    "FROM ubuntu:20.04",
+			expected: "FROM ubuntu:20.04",
+		},
+		{
+			name:     "leaves private registry image unchanged",
+			input:    "FROM private.registry.com/myapp:latest",
+			expected: "FROM private.registry.com/myapp:latest",
+		},
+		{
+			name:     "leaves empty line unchanged",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "leaves comment line unchanged",
+			input:    "# This is a comment",
+			expected: "# This is a comment",
+		},
+		{
+			name:     "leaves run command without registry unchanged",
+			input:    "RUN apt-get update",
+			expected: "RUN apt-get update",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := rt.translate(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewCacheMountTranslator(t *testing.T) {
+	tests := []struct {
+		name               string
+		repo               string
+		dockerfilePath     string
+		target             string
+		expectedHashLength int
+	}{
+		{
+			name:               "creates translator with valid project hash",
+			repo:               "https://github.com/test/repo",
+			dockerfilePath:     "Dockerfile",
+			target:             "production",
+			expectedHashLength: 12,
+		},
+		{
+			name:               "different inputs produce different hashes",
+			repo:               "https://github.com/different/repo",
+			dockerfilePath:     "Dockerfile.dev",
+			target:             "development",
+			expectedHashLength: 12,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmt := newCacheMountTranslator(tt.repo, tt.dockerfilePath, tt.target)
+
+			assert.NotEmpty(t, cmt.projectHash)
+			assert.Len(t, cmt.projectHash, tt.expectedHashLength)
+			assert.NotNil(t, cmt.cacheMountRegex)
+			assert.NotNil(t, cmt.hasIDRegex)
+			assert.NotNil(t, cmt.targetExtractRegex)
+		})
+	}
+}
+
+func TestGenerateProjectHash(t *testing.T) {
+	tests := []struct {
+		name               string
+		repositoryURL      string
+		manifestName       string
+		path               string
+		expectedHashLength int
+		comparisonInputs   []string
+		shouldBeDifferent  bool
+	}{
+		{
+			name:               "generates consistent hash for same inputs",
+			repositoryURL:      "https://github.com/test/repo",
+			manifestName:       "Dockerfile",
+			path:               "production",
+			expectedHashLength: 12,
+			comparisonInputs:   []string{"https://github.com/test/repo", "Dockerfile", "production"},
+			shouldBeDifferent:  false,
+		},
+		{
+			name:               "different repos produce different hashes",
+			repositoryURL:      "https://github.com/different/repo",
+			manifestName:       "Dockerfile",
+			path:               "production",
+			expectedHashLength: 12,
+			comparisonInputs:   []string{"https://github.com/test/repo", "Dockerfile", "production"},
+			shouldBeDifferent:  true,
+		},
+		{
+			name:               "different paths produce different hashes",
+			repositoryURL:      "https://github.com/test/repo",
+			manifestName:       "Dockerfile",
+			path:               "development",
+			expectedHashLength: 12,
+			comparisonInputs:   []string{"https://github.com/test/repo", "Dockerfile", "production"},
+			shouldBeDifferent:  true,
+		},
+		{
+			name:               "handles empty values",
+			repositoryURL:      "",
+			manifestName:       "",
+			path:               "",
+			expectedHashLength: 12,
+			comparisonInputs:   []string{"https://github.com/test/repo", "Dockerfile", "production"},
+			shouldBeDifferent:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := generateProjectHash(tt.repositoryURL, tt.manifestName, tt.path)
+
+			assert.Len(t, hash, tt.expectedHashLength)
+			assert.NotEmpty(t, hash)
+
+			// Test consistency
+			hash2 := generateProjectHash(tt.repositoryURL, tt.manifestName, tt.path)
+			assert.Equal(t, hash, hash2)
+
+			// Test comparison
+			comparisonHash := generateProjectHash(tt.comparisonInputs[0], tt.comparisonInputs[1], tt.comparisonInputs[2])
+			assert.Equal(t, tt.shouldBeDifferent, hash != comparisonHash)
+		})
+	}
+}
+
+func TestCacheMountTranslator_Translate(t *testing.T) {
+	cmt := newCacheMountTranslator("https://github.com/test/repo", "Dockerfile", "prod")
+	// Override projectHash for predictable test results
+	cmt.projectHash = "abcdef123456"
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "adds id to cache mount without target",
+			input:    "RUN --mount=type=cache apt-get update",
+			expected: "RUN --mount=id=abcdef123456,type=cache apt-get update",
+		},
+		{
+			name:     "adds id with target to cache mount",
+			input:    "RUN --mount=type=cache,target=/root/.cache pip install -r requirements.txt",
+			expected: "RUN --mount=id=abcdef123456-/root/.cache,type=cache,target=/root/.cache pip install -r requirements.txt",
+		},
+		{
+			name:     "handles complex cache mount with multiple parameters",
+			input:    "RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update",
+			expected: "RUN --mount=id=abcdef123456-/var/cache/apt,type=cache,target=/var/cache/apt,sharing=locked apt-get update",
+		},
+		{
+			name:     "handles cache mount with quoted target",
+			input:    `RUN --mount=type=cache,target="/go/pkg/mod" go mod download`,
+			expected: `RUN --mount=id=abcdef123456-"/go/pkg/mod",type=cache,target="/go/pkg/mod" go mod download`,
+		},
+		{
+			name:     "leaves non-RUN command unchanged",
+			input:    "FROM ubuntu:20.04",
+			expected: "FROM ubuntu:20.04",
+		},
+		{
+			name:     "leaves RUN without cache mount unchanged",
+			input:    "RUN apt-get update",
+			expected: "RUN apt-get update",
+		},
+		{
+			name:     "leaves cache mount with existing id unchanged",
+			input:    "RUN --mount=type=cache,id=custom-id,target=/cache apt-get update",
+			expected: "RUN --mount=type=cache,id=custom-id,target=/cache apt-get update",
+		},
+		{
+			name:     "leaves RUN with different mount type unchanged",
+			input:    "RUN --mount=type=bind,source=.,target=/app ls",
+			expected: "RUN --mount=type=bind,source=.,target=/app ls",
+		},
+		{
+			name:     "leaves empty line unchanged",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "leaves comment line unchanged",
+			input:    "# Install dependencies",
+			expected: "# Install dependencies",
+		},
+		{
+			name:     "leaves RUN with secret mount unchanged",
+			input:    "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret",
+			expected: "RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cmt.translate(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestOsTmpFileCreator_Create(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupTmpDir func(*testing.T) string
+	}{
+		{
+			name: "creates temp file with correct prefix",
+			setupTmpDir: func(t *testing.T) string {
+				return t.TempDir()
+			},
+		},
+		{
+			name: "creates temp file in nested directory",
+			setupTmpDir: func(t *testing.T) string {
+				baseDir := t.TempDir()
+				nestedDir := filepath.Join(baseDir, "nested")
+				require.NoError(t, os.MkdirAll(nestedDir, 0755))
+				return nestedDir
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creator := osTmpFileCreator{}
+			tmpDir := tt.setupTmpDir(t)
+
+			filename, err := creator.Create(tmpDir)
+			require.NoError(t, err)
+
+			// Verify file was created with correct prefix and location
+			assert.True(t, strings.HasPrefix(filepath.Base(filename), tmpFilePrefix))
+			assert.True(t, strings.HasPrefix(filename, tmpDir))
+
+			// Verify file exists and can be written to
+			file, err := os.OpenFile(filename, os.O_RDWR, 0644)
+			require.NoError(t, err)
+			defer file.Close()
+
+			_, err = file.WriteString("test content")
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestFileOpener_Open(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		setupFile func(*testing.T, string) string
+	}{
+		{
+			name:    "opens existing file with content",
+			content: "test content",
+			setupFile: func(t *testing.T, content string) string {
+				tmpFile, err := os.CreateTemp(t.TempDir(), "test-")
+				require.NoError(t, err)
+
+				_, err = tmpFile.WriteString(content)
+				require.NoError(t, err)
+				require.NoError(t, tmpFile.Close())
+
+				return tmpFile.Name()
+			},
+		},
+		{
+			name:    "opens empty file",
+			content: "",
+			setupFile: func(t *testing.T, content string) string {
+				tmpFile, err := os.CreateTemp(t.TempDir(), "empty-")
+				require.NoError(t, err)
+				require.NoError(t, tmpFile.Close())
+
+				return tmpFile.Name()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opener := fileOpener{}
+			filename := tt.setupFile(t, tt.content)
+			defer os.Remove(filename)
+
+			file, err := opener.Open(filename)
+			require.NoError(t, err)
+			defer file.Close()
+
+			// Verify we can read from it
+			content, err := io.ReadAll(file)
+			require.NoError(t, err)
+			assert.Equal(t, tt.content, string(content))
+
+			// Verify we can close it
+			err = file.Close()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestFileOpener_Open_Failures(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+	}{
+		{
+			name:     "nonexistent file returns error",
+			filePath: "/nonexistent/file/path",
+		},
+		{
+			name:     "invalid file path returns error",
+			filePath: "/invalid\x00path/file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opener := fileOpener{}
+
+			_, err := opener.Open(tt.filePath)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestDockerfileTranslator_Integration(t *testing.T) {
+	tests := []struct {
+		name                 string
+		dockerfileContent    string
+		okCtx                OktetoContextInterface
+		repoURL              string
+		target               string
+		expectedContains     []string
+		expectedCacheMountID bool
+	}{
+		{
+			name: "simple dockerfile translation",
+			dockerfileContent: `FROM ubuntu:20.04
+RUN --mount=type=cache,target=/var/cache/apt apt-get update
+FROM alpine:latest`,
+			okCtx: &mockOktetoContext{
+				namespace:       "user-ns",
+				globalNamespace: "global-ns",
+				registryURL:     "registry.example.com",
+			},
+			repoURL: "https://github.com/test/repo",
+			target:  "prod",
+			expectedContains: []string{
+				"FROM ubuntu:20.04",
+				"FROM alpine:latest",
+			},
+			expectedCacheMountID: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
+
+			err := os.WriteFile(dockerfilePath, []byte(tt.dockerfileContent), 0644)
+			require.NoError(t, err)
+
+			inputContent, err := os.ReadFile(dockerfilePath)
+			require.NoError(t, err)
+			require.NotEmpty(t, string(inputContent))
+			t.Logf("Input Dockerfile content: %q", string(inputContent))
+
+			dt, err := newDockerfileTranslator(tt.okCtx, tt.repoURL, dockerfilePath, tt.target)
+			require.NoError(t, err)
+
+			err = dt.translate(dockerfilePath)
+			require.NoError(t, err)
+
+			require.NotEmpty(t, dt.tmpFileName, "temporary file name should be set after translation")
+			t.Logf("Temporary file created: %s", dt.tmpFileName)
+
+			_, err = os.Stat(dt.tmpFileName)
+			require.NoError(t, err, "temporary file should exist")
+
+			translatedContent, err := os.ReadFile(dt.tmpFileName)
+			require.NoError(t, err)
+			defer os.Remove(dt.tmpFileName)
+
+			translatedStr := string(translatedContent)
+			t.Logf("Translated content: %q", translatedStr)
+
+			assert.NotEmpty(t, translatedStr, "translated content should not be empty")
+
+			for _, expected := range tt.expectedContains {
+				assert.Contains(t, translatedStr, expected, "should contain: %s", expected)
+			}
+
+			assert.Equal(t, tt.expectedCacheMountID, strings.Contains(translatedStr, "--mount=id="), "cache mount ID should be present")
+		})
+	}
+}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-1150

Refactor the translation of the Dockerfile so it can be tested.
Adds a new translation for the cache mounting:
If `mount type=cache && not contains id` we set it based on repo, folder and target

## How to validate

1. Use the following Dockerfiles:
``` Dockerile
# frontend
FROM okteto/node:20 as runner

USER 0

ARG AAA

COPY . /okteto/src
WORKDIR /okteto/src

ENV OKTETO_SMART_BUILDS_ENABLED="true"

ENV CI=true

RUN --mount=type=cache,target=./.eslintcache --mount=type=cache,target=./.yarn/cache,sharing=private --mount=type=cache,target=./node_modules,sharing=private yarn install --immutable
```
```Dockerfile
# backend
FROM node:24-slim as runner

USER 0

ARG AAA

COPY . /okteto/src
WORKDIR /okteto/src

ENV OKTETO_SMART_BUILDS_ENABLED="true"

ENV CI=true

RUN --mount=type=cache,target=./node_modules npm install
```
2. Build frontend using `okteto build` on its folder 
3. Build backend using `okteto build` on its folder
4. Create a new change on the frontend folder
5. Build frontend using `okteto build` on its folder 
6. See no error

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
