### PR TITLE
fix: nil pointer exception in build

### DIFF
--- a/pkg/filesystem/file.go
+++ b/pkg/filesystem/file.go
@@ -84,7 +84,8 @@ func CopyFile(from, to string) error {
 // FileExistsAndNotDir checks if the file exists, and it's not a dir
 func FileExistsAndNotDir(path string, fs afero.Fs) bool {
 	info, err := fs.Stat(path)
-	if err != nil && os.IsNotExist(err) {
+	if err != nil {
+		oktetoLog.Infof("failed to check if %s is a file: %s", path, err)
 		return false
 	}
 	return !info.IsDir()


### PR DESCRIPTION
# Proposed changes

Fixes DEV-721

Fixes a panic when the context does not exist. 

<img width="673" height="52" alt="Screenshot 2025-10-02 at 17 46 50" src="https://github.com/user-attachments/assets/c807f2da-7723-432a-ad4f-6a38e9250525" />


## How to validate

1. Create the following okteto manifest
```yaml
build:
  piipi:
    context: Dockerfile
```
2. Create the following Dockefile:
```Dockerfile
FROM alpine
```
3. Run `okteto build`

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
