### PR TITLE
refactor: rename release-external job to release-brew-formula and add…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,7 +484,7 @@ jobs:
       - run: *init-gcloud
       - run: 'gsutil -m -h "Cache-Control: no-store" -h "Content-Type: text/x-sh" cp ./scripts/get-okteto.sh gs://get.okteto.com/get-okteto.sh'
 
-  release-external:
+  release-brew-formula:
     executor: golang-ci
     steps:
       - checkout
@@ -503,6 +503,16 @@ jobs:
             ./scripts/update_homebrew_formula.sh $CIRCLE_TAG $sha $sha_arm
             pushd homebrew-cli
             git push git@github.com:okteto/homebrew-cli.git master
+
+  release-gh-actions:
+    executor: golang-ci
+    steps:
+      - checkout
+      - run: *init-gcloud
+      - add_ssh_keys:
+          fingerprints:
+            # This key belongs to oktetobot user in GitHub
+            - SHA256:+wgdECJJEEyF/iyl8Y8EV/tpOEQIv6zZ/0LRqRChS18
       - run:
           name: Auto-update-actions
           command: ./scripts/ci/release-github-actions.sh $CIRCLE_TAG
@@ -785,7 +795,16 @@ workflows:
             tags:
               only:
                 - *release-regex
-      - release-external:
+      - release-gh-actions:
+          context: GKE
+          requires:
+            - release-job
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+      - release-brew-formula:
           context: GKE
           requires:
             - release-job


### PR DESCRIPTION
… release-gh-actions job

# Proposed changes

Fixes DEV-1086

- Updated the CircleCI configuration to rename the 'release-external' job to 'release-brew-formula'.
- Introduced a new job 'release-gh-actions' to handle GitHub Actions releases, including SSH key management and artifact attachment.
- Adjusted workflow to include the new 'release-gh-actions' job with appropriate filters for tag releases.`11

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
