### PR TITLE
refactor: enhance namespace destruction logic in localDestroyAllCommand

### DIFF
--- a/cmd/destroy/all.go
+++ b/cmd/destroy/all.go
@@ -182,7 +182,7 @@ func (lda *localDestroyAllCommand) checkAllResourcesDestroyed(ctx context.Contex
 	for _, cfg := range cfgList.Items {
 		for l := range cfg.GetLabels() {
 			if _, ok := resourcesLabels[l]; ok {
-				return fmt.Errorf("some resources where not destroyed")
+				return fmt.Errorf("some resources were not destroyed")
 			}
 		}
 	}


### PR DESCRIPTION
# Proposed changes

Fixes DEV-1046

- Introduced a new constant for the ticker duration during the destruction process.
- Improved the waitForNamespaceDestroyAllToComplete method to ensure comprehensive checks for resource destruction.
- Added a new checkAllResourcesDestroyed method to verify that all resources, including configmaps, are properly removed after the destruction operation.


## How to validate

1. Run `okteto destroy --all` several times and check that it always finishes


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
