### PR TITLE
Updated the checkout method for circle jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
     executor: golang-ci
     steps:
       - checkout:
-          method: blobless
+          method: full
       - restore_cache:
           keys:
             - v4-pkg-cache-{{ checksum "go.sum" }}


### PR DESCRIPTION
# Proposed changes

CircleCI announced that on November 3rd they will change the default mode of cloning when using the `checkout` step in the jobs definition. https://circleci.com/changelog/default-method-used-to-checkout-code-from-your-repository-is-changing-on-nov/.

They will start using `blobless` (in case you want to know what it means: https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/) instead of `full`. I was reviewing the different jobs to set the right checkout mode. There were a couple of them I wasn't sure, but as we don't have a huge repo, if we clone it fully as we were doing now, it wouldn't be a problem
