### PR TITLE
Default to okteto/okteto image hosted in GitHub Packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,7 +468,7 @@ jobs:
       - run: *docker-login
       - run: *github-packages-login
       - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG" "linux/amd64,linux/arm64"
-      - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress okteto/okteto:$CIRCLE_TAG
+      - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress ghcr.io/okteto/okteto:$CIRCLE_TAG
 
   push-image-dev:
     executor: golang-ci
@@ -478,7 +478,7 @@ jobs:
       - run: *docker-login
       - run: *github-packages-login
       - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG",dev "linux/amd64,linux/arm64"
-      - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress okteto/okteto:dev
+      - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress ghcr.io/okteto/okteto:dev
 
   push-image-master:
     executor: golang-ci
@@ -488,7 +488,7 @@ jobs:
       - run: *docker-login
       - run: *github-packages-login
       - run: ./scripts/ci/push-image.sh "master" "linux/amd64,linux/arm64"
-      - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress okteto/okteto:master
+      - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress ghcr.io/okteto/okteto:master
 
   upload-static-job:
     executor: golang-ci

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -134,10 +134,10 @@ For eg: [https://downloads.okteto.com/cli/2.2.2/okteto-Darwin-x86_64](https://do
 
 The same artifacts are also uploaded to the Github release assets and can be downloaded from there.
 
-Alongside the release artifacts, a docker image is automatically created for each release and pushed to [hub.docker.com/r/okteto/okteto](https://hub.docker.com/r/okteto/okteto):
+Alongside the release artifacts, a docker image is automatically created for each release and pushed to [GitHub Packages](https://github.com/orgs/okteto/packages/container/package/okteto):
 
 ```sh
-docker pull okteto/okteto:2.2.2
+docker pull ghcr.io/okteto/okteto:3.15.0
 ```
 
 #### Pull Request Labels

--- a/pkg/config/image.go
+++ b/pkg/config/image.go
@@ -45,7 +45,7 @@ const (
 	oktetoCLIImageTemplate = "%s:%s"
 
 	// oktetoCliRepository defines the okteto cli repository
-	oktetoCliRepository = "okteto/okteto"
+	oktetoCliRepository = "ghcr.io/okteto/okteto"
 )
 
 type ImageConfig struct {

--- a/pkg/config/image_test.go
+++ b/pkg/config/image_test.go
@@ -89,14 +89,14 @@ func TestGetCliImage(t *testing.T) {
 			name:          "No env vars set, valid VersionString",
 			envVars:       map[string]string{},
 			versionString: "1.2.3",
-			expectedImage: "okteto/okteto:1.2.3",
+			expectedImage: "ghcr.io/okteto/okteto:1.2.3",
 			expectedLogs:  []string{"using okteto cli image (from cli version): 1.2.3"},
 		},
 		{
 			name:          "No env vars set, invalid VersionString",
 			envVars:       map[string]string{},
 			versionString: "invalidversion",
-			expectedImage: "okteto/okteto:master",
+			expectedImage: "ghcr.io/okteto/okteto:master",
 			expectedLogs:  []string{"invalid version string: invalidversion, using latest"},
 		},
 	}
@@ -114,7 +114,7 @@ func TestGetCliImage(t *testing.T) {
 					}
 					return ""
 				},
-				cliRepository: "okteto/okteto",
+				cliRepository: "ghcr.io/okteto/okteto",
 			}
 
 			image := c.GetCliImage()
@@ -147,7 +147,7 @@ func TestClusterCliRepositoryOverridesDefault(t *testing.T) {
 			name:          "Empty ClusterCliRepository uses default",
 			clusterRepo:   "",
 			versionString: "1.2.3",
-			expectedImage: "okteto/okteto:1.2.3",
+			expectedImage: "ghcr.io/okteto/okteto:1.2.3",
 		},
 	}
 

--- a/pkg/registry/image_test.go
+++ b/pkg/registry/image_test.go
@@ -49,9 +49,9 @@ func TestExpandRegistry(t *testing.T) {
 				config: fakeImageConfig{
 					isOkteto: false,
 				},
-				image: "okteto/okteto:latest",
+				image: "ghcr.io/okteto/okteto:latest",
 			},
-			expected: "okteto/okteto:latest",
+			expected: "ghcr.io/okteto/okteto:latest",
 		},
 		{
 			name: "no need to expand registry - Okteto",
@@ -59,9 +59,9 @@ func TestExpandRegistry(t *testing.T) {
 				config: fakeImageConfig{
 					isOkteto: true,
 				},
-				image: "okteto/okteto:latest",
+				image: "ghcr.io/okteto/okteto:latest",
 			},
-			expected: "okteto/okteto:latest",
+			expected: "ghcr.io/okteto/okteto:latest",
 		},
 		{
 			name: "okteto dev should expansion - Okteto",

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -271,7 +271,7 @@ func TestCreateDockerfile(t *testing.T) {
 			expected: expected{
 				dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
 				dockerfileContent: `
-FROM okteto/okteto:master as okteto-cli
+FROM ghcr.io/okteto/okteto:master as okteto-cli
 
 FROM test-image as runner
 
@@ -369,7 +369,7 @@ COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 			expected: expected{
 				dockerfileName: filepath.Clean("/test/Dockerfile.test"),
 				dockerfileContent: `
-FROM okteto/okteto:master as okteto-cli
+FROM ghcr.io/okteto/okteto:master as okteto-cli
 
 FROM test-image as runner
 
@@ -464,7 +464,7 @@ COPY --from=runner /okteto/artifacts/ /
 			expected: expected{
 				dockerfileName: filepath.Clean("/test/Dockerfile.deploy"),
 				dockerfileContent: `
-FROM okteto/okteto:master as okteto-cli
+FROM ghcr.io/okteto/okteto:master as okteto-cli
 
 FROM test-image as runner
 

--- a/scripts/ci/release-github-actions.sh
+++ b/scripts/ci/release-github-actions.sh
@@ -137,8 +137,8 @@ for repo in "${repos[@]}"; do
 
     # Modify Dockerfile
     if [[ -f Dockerfile ]]; then
-        echo "Updating Dockerfile to use okteto/okteto:${RELEASE_TAG}"
-        sed -i.bak -E 's|(FROM okteto/okteto:)[^ ]*|\1'"${RELEASE_TAG}"'|g' Dockerfile
+        echo "Updating Dockerfile to use ghcr.io/okteto/okteto:${RELEASE_TAG}"
+        sed -i.bak -E 's|(FROM ghcr\.io/okteto/okteto:)[^ ]*|\1'"${RELEASE_TAG}"'|g' Dockerfile
         rm Dockerfile.bak
 
         echo "Dockerfile changes:"
@@ -213,17 +213,17 @@ for repo in "${repos[@]}"; do
     update_tag_if_greater "latest"
     update_tag_if_greater "stable"
 
-    # Revert Dockerfile to use okteto/okteto:master
-    echo "Reverting Dockerfile to use okteto/okteto:master"
+    # Revert Dockerfile to use ghcr.io/okteto/okteto:master
+    echo "Reverting Dockerfile to use ghcr.io/okteto/okteto:master"
     if [[ -f Dockerfile ]]; then
-        sed -i.bak -E 's|(FROM okteto/okteto:)[^ ]*|\1master|g' Dockerfile
+        sed -i.bak -E 's|(FROM ghcr\.io/okteto/okteto:)[^ ]*|\1master|g' Dockerfile
         rm Dockerfile.bak
 
         echo "Dockerfile changes:"
         git --no-pager diff Dockerfile
 
         git add Dockerfile
-        git commit -m "Update Dockerfile to use okteto/okteto:master" || echo "No changes to commit in repository '$repo'."
+        git commit -m "Update Dockerfile to use ghcr.io/okteto/okteto:master" || echo "No changes to commit in repository '$repo'."
     else
         echo "Warning: Dockerfile not found in repository '$repo'. Skipping Dockerfile update to master."
     fi


### PR DESCRIPTION
## Summary

Migrates the default Okteto CLI image registry from Docker Hub (okteto/okteto) to GitHub Packages (ghcr.io/okteto/okteto).

## Changes

This PR updates all references to the Okteto CLI image across the codebase to use the new GitHub Packages registry:

  - CI Configuration (.circleci/config.yml): Updated Trivy security scans for tagged releases, dev builds, and master builds to use ghcr.io/okteto/okteto
  - Documentation (docs/RELEASE.md): Updated release documentation to reference GitHub Packages with correct pull command examples
  - Image Configuration (pkg/config/image.go): Changed default CLI repository constant from okteto/okteto to ghcr.io/okteto/okteto
  - Tests: Updated test expectations across multiple packages:
  - Release Scripts (scripts/ci/release-github-actions.sh): Updated GitHub Actions release automation to:
    - Use ghcr.io/okteto/okteto when updating Dockerfiles for releases
    - Properly revert to ghcr.io/okteto/okteto:master after creating releases
