### PR TITLE
fix(log): mask platform env vars (DEV-1266)

### DIFF
--- a/cmd/destroy/local.go
+++ b/cmd/destroy/local.go
@@ -57,6 +57,10 @@ func (ld *localDestroyCommand) Destroy(ctx context.Context, opts *Options) error
 
 		for k, v := range deployable.GetPlatformEnvironment(ctx) {
 			vars = append(vars, fmt.Sprintf("%s=%s", k, v))
+			// Always mask cloud credentials from execution environment
+			if v != "" {
+				oktetoLog.AddMaskedWord(v)
+			}
 		}
 		params := deployable.DestroyParameters{
 			Name:         opts.Name,

--- a/pkg/deployable/deploy.go
+++ b/pkg/deployable/deploy.go
@@ -270,6 +270,10 @@ func (r *DeployRunner) RunDeploy(ctx context.Context, params DeployParameters) e
 		)
 		for k, v := range GetPlatformEnvironment(ctx) {
 			params.Variables = append(params.Variables, fmt.Sprintf("%s=%s", k, v))
+			// Always mask cloud credentials from execution environment
+			if strings.TrimSpace(v) != "" {
+				oktetoLog.AddMaskedWord(v)
+			}
 		}
 	}
 	oktetoLog.EnableMasking()

--- a/pkg/deployable/destroy.go
+++ b/pkg/deployable/destroy.go
@@ -46,6 +46,10 @@ func (dr *DestroyRunner) RunDestroy(ctx context.Context, params DestroyParameter
 
 	for k, v := range GetPlatformEnvironment(ctx) {
 		params.Variables = append(params.Variables, fmt.Sprintf("%s=%s", k, v))
+		// Always mask cloud credentials from execution environment
+		if v != "" {
+			oktetoLog.AddMaskedWord(v)
+		}
 	}
 
 	for _, command := range params.Deployable.Commands {

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -49,6 +49,10 @@ func (dr *TestRunner) RunTest(ctx context.Context, params TestParameters) error 
 
 	for k, v := range GetPlatformEnvironment(ctx) {
 		params.Variables = append(params.Variables, fmt.Sprintf("%s=%s", k, v))
+		// Always mask cloud credentials from execution environment
+		if v != "" {
+			oktetoLog.AddMaskedWord(v)
+		}
 	}
 
 	envStepper := NewEnvStepper(oktetoEnvFile.Name())


### PR DESCRIPTION
# Proposed changes

Fixes [DEV-1266](https://okteto.atlassian.net/browse/DEV-1266)

This change ensures that all platform environment variables are always masked in logs during remote execution operations.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

[DEV-1266]: https://okteto.atlassian.net/browse/DEV-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ