### PR TITLE
Ignore discovery errors for "metrics.k8s.io/v1beta1" and "custom.metr…

### DIFF
--- a/pkg/k8s/namespaces/namespace.go
+++ b/pkg/k8s/namespaces/namespace.go
@@ -282,7 +282,7 @@ func newTrip(restConfig *rest.Config, opts *Options) (*Trip, error) {
 func (t *Trip) wander(ctx context.Context, traveler Traveler) error {
 	_, apis, err := t.k8s.Discovery().ServerGroupsAndResources()
 	if err != nil {
-		//only return the err when is NOT GroupDiscoveryFailedError and NOT relative to metrics.k8s.io or custom.metrics.k8s.io
+		// only return the err when is NOT GroupDiscoveryFailedError and NOT relative to metrics.k8s.io or custom.metrics.k8s.io
 		groupErr, ok := err.(*discovery.ErrGroupDiscoveryFailed)
 		if !ok {
 			return err
@@ -353,7 +353,7 @@ func (t *Trip) listAll(ctx context.Context, traveler Traveler, client dynamic.Re
 	}
 	defer t.sem.Release(1)
 
-	pager := pager.New(pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
+	pager := pager.New(pager.SimplePageFunc(func(_ metav1.ListOptions) (runtime.Object, error) {
 		objs, err := client.List(ctx, t.list)
 		return objs, err
 	}))

--- a/pkg/k8s/namespaces/namespace_test.go
+++ b/pkg/k8s/namespaces/namespace_test.go
@@ -386,7 +386,7 @@ func (*fakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourc
 func (*fakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
 }
-func (*fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+func (*fakeDiscovery) ServerResourcesForGroupVersion(_ string) (*metav1.APIResourceList, error) {
 	return nil, nil
 }
 func (*fakeDiscovery) ServerVersion() (*version.Info, error) {
@@ -558,7 +558,7 @@ func Test_wander(t *testing.T) {
 				sem:       semaphore.NewWeighted(10),
 			}
 
-			err := trip.wander(ctx, TravelerFunc(func(obj runtime.Object) error {
+			err := trip.wander(ctx, TravelerFunc(func(_ runtime.Object) error {
 				return nil
 			}))
 


### PR DESCRIPTION
While working on https://okteto.atlassian.net/browse/DEV-1206, I realized that the Okteto CLI doesn't handle this case for "metrics.k8s.io/v1beta1" yet. I scale down the metrics server in a dedicated cluster (using the catalog!) and run `okteto destroy` and got this error:
<img width="1209" height="58" alt="Screenshot 2025-12-16 at 06 36 36" src="https://github.com/user-attachments/assets/a2027ffe-2710-45e6-b55f-0af80f71ade0" />

I followed a similar approach as [the one we follow in the backend](https://github.com/okteto/app/blob/master/backend/pkg/k8s/namespaces/world.go#L103) to ignore discovery errors in "metrics.k8s.io/v1beta1" and "custom.metrics.k8s.io/v1beta2".

I was able to repro the issue scaling down the metrics server and the buildkit metrics adapter, respectively, and confirmed the issue is gone after the fix