### PR TITLE
fix: only use incluster when env var activated

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -112,6 +112,9 @@ func GetBuildkitConnector(okCtx OktetoContextInterface, logger *io.Controller) B
 // shouldUseInClusterConnector returns true when running inside an Okteto-managed environment
 // where we can connect directly to BuildKit via pod IP
 func shouldUseInClusterConnector() bool {
+	if !env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, false) {
+		return false
+	}
 	return env.LoadBoolean(constants.OktetoDeployRemote) || // Remote commands (deploy --remote, destroy --remote, test)
 		config.RunningInInstaller() || // Pipeline installer
 		env.LoadBoolean(constants.OktetoManagedPodEnvVar) // Pods in managed namespaces

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -931,70 +931,89 @@ func Test_setOutputMode(t *testing.T) {
 
 func Test_shouldUseInClusterConnector(t *testing.T) {
 	tests := []struct {
-		name            string
-		envDeployRemote string
-		envInInstaller  string
-		envManagedPod   string
-		expected        bool
+		name                 string
+		envBuildQueueEnabled string
+		envDeployRemote      string
+		envInInstaller       string
+		envManagedPod        string
+		expected             bool
 	}{
 		{
 			name:     "no env vars set - returns false",
 			expected: false,
 		},
 		{
-			name:            "OKTETO_DEPLOY_REMOTE=true - returns true",
-			envDeployRemote: "true",
-			expected:        true,
+			name:                 "build queue disabled - returns false even with OKTETO_DEPLOY_REMOTE=true",
+			envBuildQueueEnabled: "false",
+			envDeployRemote:      "true",
+			expected:             false,
 		},
 		{
-			name:            "OKTETO_DEPLOY_REMOTE=false - returns false",
-			envDeployRemote: "false",
-			expected:        false,
+			name:                 "OKTETO_DEPLOY_REMOTE=true - returns true",
+			envBuildQueueEnabled: "true",
+			envDeployRemote:      "true",
+			expected:             true,
 		},
 		{
-			name:           "OKTETO_IN_INSTALLER=true - returns true",
-			envInInstaller: "true",
-			expected:       true,
+			name:                 "OKTETO_DEPLOY_REMOTE=false - returns false",
+			envBuildQueueEnabled: "true",
+			envDeployRemote:      "false",
+			expected:             false,
 		},
 		{
-			name:           "OKTETO_IN_INSTALLER=false - returns false",
-			envInInstaller: "false",
-			expected:       false,
+			name:                 "OKTETO_IN_INSTALLER=true - returns true",
+			envBuildQueueEnabled: "true",
+			envInInstaller:       "true",
+			expected:             true,
 		},
 		{
-			name:          "OKTETO_MANAGED_POD=true - returns true",
-			envManagedPod: "true",
-			expected:      true,
+			name:                 "OKTETO_IN_INSTALLER=false - returns false",
+			envBuildQueueEnabled: "true",
+			envInInstaller:       "false",
+			expected:             false,
 		},
 		{
-			name:          "OKTETO_MANAGED_POD=false - returns false",
-			envManagedPod: "false",
-			expected:      false,
+			name:                 "OKTETO_MANAGED_POD=true - returns true",
+			envBuildQueueEnabled: "true",
+			envManagedPod:        "true",
+			expected:             true,
 		},
 		{
-			name:            "multiple env vars set - returns true if any is true",
-			envDeployRemote: "false",
-			envInInstaller:  "false",
-			envManagedPod:   "true",
-			expected:        true,
+			name:                 "OKTETO_MANAGED_POD=false - returns false",
+			envBuildQueueEnabled: "true",
+			envManagedPod:        "false",
+			expected:             false,
 		},
 		{
-			name:            "all env vars false - returns false",
-			envDeployRemote: "false",
-			envInInstaller:  "false",
-			envManagedPod:   "false",
-			expected:        false,
+			name:                 "multiple env vars set - returns true if any is true",
+			envBuildQueueEnabled: "true",
+			envDeployRemote:      "false",
+			envInInstaller:       "false",
+			envManagedPod:        "true",
+			expected:             true,
+		},
+		{
+			name:                 "all env vars false - returns false",
+			envBuildQueueEnabled: "true",
+			envDeployRemote:      "false",
+			envInInstaller:       "false",
+			envManagedPod:        "false",
+			expected:             false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clear all env vars first
+			t.Setenv(OktetoBuildQueueEnabledEnvVar, "")
 			t.Setenv(constants.OktetoDeployRemote, "")
 			t.Setenv("OKTETO_IN_INSTALLER", "")
 			t.Setenv(constants.OktetoManagedPodEnvVar, "")
 
 			// Set the specific env vars for this test
+			if tt.envBuildQueueEnabled != "" {
+				t.Setenv(OktetoBuildQueueEnabledEnvVar, tt.envBuildQueueEnabled)
+			}
 			if tt.envDeployRemote != "" {
 				t.Setenv(constants.OktetoDeployRemote, tt.envDeployRemote)
 			}


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes Issue with the incluster connector. It was being activated when the env var was unset. 


## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
