### PR TITLE
Update and upgrade the pre-commit config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,12 +35,10 @@
 /.editorconfig
 /.gitignore
 /.golangci.yml
-/.mdlrc
 /.pre-commit-config.yaml
 /.prettierrc
 /.prettierignore
 /.stignore
-/.yaml-lint.yml
 
 # Okteto specific files (not needed inside the container)
 /.oktetoignore

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,9 +1,29 @@
-rules '~MD007', '~MD013', '~MD024', '~MD025', '~MD026', '~MD033', '~MD040', '~MD041'
 # MD007 ul-indent - Unordered list indentation
+MD007: false
+
 # MD013 line-length - Line length
+MD013: false
+
 # MD024 no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024: false
+
 # MD025 single-title/single-h1 - Multiple top-level headings in the same document
+MD025: false
+
 # MD026 no-trailing-punctuation - Trailing punctuation in heading
+MD026: false
+
 # MD033 no-inline-html - Inline HTML
+MD033: false
+
+# MD034/no-bare-urls Bare URL used
+MD034: false
+
 # MD040 fenced-code-language - Fenced code blocks should have a language specified
+MD040: false
+
 # MD041 first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041: false
+
+# MD059/descriptive-link-text Link text should be descriptive
+MD059: false

--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,6 +1,5 @@
 ---
 # https://yamllint.readthedocs.io/en/stable/index.html
-# yamllint --strict -c .yaml-lint.yml .
 
 extends: default
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 default_stages: [pre-commit, pre-push]
 default_language_version:
   python: python3
-  node: 22.19.0
+  node: 24.12.0
 minimum_pre_commit_version: '3.2.0'
 repos:
   - repo: meta
@@ -20,14 +20,18 @@ repos:
         entry: prettier --write '**/*.json' '**/*.md' '**/*.yaml' '**/*.yml'
         files: \.(json|md|ya?ml)$
         language: node
-        additional_dependencies: ['prettier@3.6.2']
-  # general checks for the repository
+        pass_filenames: false
+        additional_dependencies: ['prettier@3.7.4']
+
+  # check for secrets
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.28.0
+    rev: v8.30.0
     hooks:
       - id: gitleaks
         name: run gitleaks
         description: detect hardcoded secrets with gitleaks
+
+  # general checks for the repository
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -54,17 +58,6 @@ repos:
       - id: trailing-whitespace
         exclude: ^\.github/pull_request_template\.md$
 
-  # shell and markdown checks
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 3.0.0
-    hooks:
-      - id: shellcheck
-        name: run shellcheck
-        exclude: ^samples/|^scripts/ci/push-image.sh
-      - id: markdownlint
-        name: run markdownlint
-        exclude: ^samples/
-
   # check spelling though all the repository
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
@@ -74,6 +67,27 @@ repos:
         description: Check Spelling with codespell
         entry: codespell -L ba,flate,ges,indx,keypair,splitted,vertexes --exclude-file=go.sum
 
+  # markdown checks
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        name: run markdownlint
+        description: check Markdown files with markdownlint
+        args: [--config=.github/linters/.markdown-lint.yml]
+        exclude: ^samples/
+        types: [markdown]
+        files: \.md$
+
+  # shell checks
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        name: run shellcheck
+        description: check Shell scripts with shellcheck
+        exclude: ^samples/|^scripts/ci/push-image.sh
+
   # yaml files check
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.37.1
@@ -81,7 +95,7 @@ repos:
       - id: yamllint
         name: run yamllint
         description: Check YAML files with yamllint
-        entry: yamllint --strict -c .yaml-lint.yml
+        args: [--strict, -c=.github/linters/.yaml-lint.yml]
         types: [yaml]
-        files: \.(ya?ml)$
+        files: \.ya?ml$
         exclude: ^integration/validate/manifests/invalid-syntax\.yml$

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Today, most developers try to either run parts of the infrastructure locally or 
 
 Okteto enables development inside a container, providing a seamless IDE and tool integration as if you were working locally but with the resources of a remote cluster. When you run `okteto up` your Kubernetes deployment is replaced by a Development Container that contains your development tools (e.g. maven and jdk, or npm, python, go compiler, debuggers, etc). This development container can use any [docker image](https://okteto.com/docs/development/images/). The development container inherits the same secrets, configmaps, volumes or any other configuration value of the original Kubernetes deployment.
 
-<img align="left" src="images/how-does-it-work.png">
+<img align="left" src="images/how-does-it-work.png" alt="How does it work">
 
 The end result is a remote cluster that is seen by your IDE and tools as a local filesystem/environment. You keep writing code on your local IDE and as soon as you save a file, the change goes to the development container, and your application instantly updates (taking advantage of any hot-reload mechanism you already have). This whole process happens in an instant. No docker images need to be created and no Kubernetes manifests need to be applied to the cluster.
 
@@ -116,6 +116,6 @@ You can also join us in the [#okteto](https://kubernetes.slack.com/messages/CM1Q
 ### Thanks to all our contributors!
 
 <a href="https://github.com/okteto/okteto/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=okteto/okteto" />
+  <img src="https://contrib.rocks/image?repo=okteto/okteto" alt="Contributors Avatars" />
 </a>
 <!--  https://contrib.rocks -->


### PR DESCRIPTION
# Proposed changes

We need to remove `jumanjihouse` hooks since that repo has not been updated for 4 years

https://github.com/jumanjihouse/pre-commit-hooks

Updates all libraries and removes outdated hooks and replaces with maintained hooks.

https://nodejs.org/en/download

https://www.npmjs.com/package/prettier

Switched to newer npm based Markdown linter:

https://github.com/DavidAnson/markdownlint

https://github.com/igorshubovych/markdownlint-cli

Switched to new shell check library

https://github.com/shellcheck-py/shellcheck-py

which is maintained by the pre-commit devs

Moved linter files to common directory which cleans up the repo root.

Used `pass_filenames: false` for the prettier hook to stop prettier from doing multiple passes through the files since it finds its own files with an `entry` point

## How to validate

Run pre-commit locally and tests pass.

`pre-commit run --all-files`


