### PR TITLE
fix: update default behavior for build queue flag

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -102,7 +102,7 @@ func GetBuildkitConnector(okCtx OktetoContextInterface, logger *io.Controller) B
 		return newInClusterConnectorWithFallback(okCtx, logger)
 	}
 
-	if env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, false) {
+	if env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, true) {
 		return newPortForwarderWithFallback(okCtx, logger)
 	}
 
@@ -112,7 +112,7 @@ func GetBuildkitConnector(okCtx OktetoContextInterface, logger *io.Controller) B
 // shouldUseInClusterConnector returns true when running inside an Okteto-managed environment
 // where we can connect directly to BuildKit via pod IP
 func shouldUseInClusterConnector() bool {
-	if !env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, false) {
+	if !env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, true) {
 		return false
 	}
 	return env.LoadBoolean(constants.OktetoDeployRemote) || // Remote commands (deploy --remote, destroy --remote, test)


### PR DESCRIPTION
# Proposed changes

 Changes the default value of `OKTETO_BUILD_QUEUE_ENABLED` from `false` to `true`, enabling the build queue by default for all users.

## Connector Selection Behavior

  With this change, the buildkit connector selection now defaults to:

  1. **InClusterConnector** - when running inside Okteto (remote commands, installer, or managed pods) with build queue enabled
  2. **PortForwarder** - for local CLI execution (new default behavior)
  3. **IngressConnector** - only when explicitly disabled via `OKTETO_BUILD_QUEUE_ENABLED=false`



## Backward Compatibility
  Users can still disable the build queue by explicitly setting:
  ```bash
  export OKTETO_BUILD_QUEUE_ENABLED=false
```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
