### PR TITLE
Optimize BuildKit queue waiting strategy to prioritize early queue positions with faster refresh rates.

### DIFF
--- a/pkg/build/buildkit/connector/incluster.go
+++ b/pkg/build/buildkit/connector/incluster.go
@@ -184,7 +184,7 @@ func (ic *InClusterConnector) assignBuildkitPod(ctx context.Context) (string, er
 
 		// Calculate wait duration as min(queue position, exponential backoff)
 		// This prioritizes early queue positions with faster refresh rates
-		waitDuration := min(time.Duration(response.QueuePosition)* time.Second, pollInterval)
+		waitDuration := min(time.Duration(response.QueuePosition)*time.Second, pollInterval)
 
 		select {
 		case <-time.After(waitDuration):

--- a/pkg/build/buildkit/connector/portforward.go
+++ b/pkg/build/buildkit/connector/portforward.go
@@ -221,7 +221,7 @@ func (pf *PortForwarder) assignBuildkitPod(ctx context.Context) (string, error) 
 
 		// Calculate wait duration as min(queue position, exponential backoff)
 		// This prioritizes early queue positions with faster refresh rates
-		waitDuration := min(time.Duration(response.QueuePosition)* time.Second, pollInterval)
+		waitDuration := min(time.Duration(response.QueuePosition)*time.Second, pollInterval)
 
 		select {
 		case <-time.After(waitDuration):


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

# Proposed changes

Fixes DEV-1279

Modified the queue polling logic in both portforward and incluster connectors to use min(queue position, exponential backoff) instead of only exponential backoff.

### Before:
  - All requests waited using exponential backoff: 1s → 2s → 4s → 8s → 10s (max)
  - Position 1 in queue would wait 8s on the 4th iteration

### After:
  - Wait duration is min(queue position * 1 second, exponential backoff)
  - Position 1 in queue always waits only 1 second
  - Position 2 in queue always waits only 2 seconds
  - Position 10+ waits up to 10 seconds (capped by exponential backoff max)

### Benefits

  1. Faster lock acquisition: Requests at the front of the queue refresh faster and obtain BuildKit pods more quickly
  2. Reduced latency: First in queue experiences minimal waiting time between checks
  3. Backpressure maintained: Later queue positions still benefit from exponential backoff to avoid overwhelming the API
  4. Fair prioritization: Queue position directly influences refresh rate, ensuring FIFO order is respected

### Impact

  - Users at the front of the queue will experience faster BuildKit pod assignment
  - Overall queue throughput improves as early positions don't wait unnecessarily long
  - No breaking changes to API or behavior, only optimization of timing

## Test plan

1. Saturate all buildkits
2. Run another build with debug enabled
3. Check that the build is retrying each second

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
