### PR TITLE
Use helm4 if OKTETO_HELM_4_ENABLED is true

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -164,4 +164,7 @@ const (
 
 	// OkteoManagedPodEnvVar defines if the pod is executed inside a ns managed by okteto
 	OktetoManagedPodEnvVar = "OKTETO_MANAGED_POD"
+
+	// OktetoHelm4EnabledEnvVar defines if Helm 4 should be used as the default helm binary
+	OktetoHelm4EnabledEnvVar = "OKTETO_HELM_4_ENABLED"
 )

--- a/pkg/deployable/destroy.go
+++ b/pkg/deployable/destroy.go
@@ -52,6 +52,11 @@ func (dr *DestroyRunner) RunDestroy(ctx context.Context, params DestroyParameter
 		}
 	}
 
+	// Setup helm version based on environment variable
+	if err := setupHelmVersion(); err != nil {
+		return err
+	}
+
 	for _, command := range params.Deployable.Commands {
 		oktetoLog.Information("Running '%s'", command.Name)
 		lastCommandName = command.Name

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -55,6 +55,11 @@ func (dr *TestRunner) RunTest(ctx context.Context, params TestParameters) error 
 		}
 	}
 
+	// Setup helm version based on environment variable
+	if err := setupHelmVersion(); err != nil {
+		return err
+	}
+
 	envStepper := NewEnvStepper(oktetoEnvFile.Name())
 	envStepper.WithFS(dr.Fs)
 


### PR DESCRIPTION
Implements https://okteto.atlassian.net/browse/DEV-1280 for remote operations.

When `OKTETO_HELM_4_ENABLED` is set to true, Helm 4 is used as the default helm binary. When set to false, Helm 3 is used. If not defined, no copy operation occurs and the `helm` binary is the default install in the Dockerfile.                                                                    