### PR TITLE
fix multiple log with same value on buildkit

### DIFF
--- a/cmd/deploy/cfghandler.go
+++ b/cmd/deploy/cfghandler.go
@@ -32,7 +32,7 @@ import (
 // or an okteto destroy directly
 type ConfigMapHandler interface {
 	TranslateConfigMapAndDeploy(context.Context, *pipeline.CfgData) (*apiv1.ConfigMap, error)
-	UpdateConfigMap(context.Context, *apiv1.ConfigMap, *pipeline.CfgData, error, bool) error
+	UpdateConfigMap(context.Context, *apiv1.ConfigMap, *pipeline.CfgData, error) error
 	UpdateEnvsFromCommands(context.Context, string, string, []string) error
 	GetDependencyBuildEnvVars(context.Context, string, string) (map[string]string, error)
 	SetBuildEnvVars(context.Context, string, string, map[string]string) error
@@ -74,15 +74,13 @@ func (ch *defaultConfigMapHandler) GetConfigmapVariablesEncoded(ctx context.Cont
 	return pipeline.GetConfigmapVariablesEncoded(ctx, name, namespace, c)
 }
 
-func (ch *defaultConfigMapHandler) UpdateConfigMap(ctx context.Context, cfg *apiv1.ConfigMap, data *pipeline.CfgData, errMain error, logError bool) error {
+func (ch *defaultConfigMapHandler) UpdateConfigMap(ctx context.Context, cfg *apiv1.ConfigMap, data *pipeline.CfgData, errMain error) error {
 	c, _, err := ch.k8sClientProvider.ProvideWithLogger(okteto.GetContext().Cfg, ch.k8slogger)
 	if err != nil {
 		return err
 	}
 	if errMain != nil {
-		if logError {
-			oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, errMain.Error())
-		}
+		oktetoLog.AddToBuffer(oktetoLog.ErrorLevel, errMain.Error())
 		data.Status = pipeline.ErrorStatus
 	}
 	if err := pipeline.UpdateConfigMap(ctx, cfg, data, c); err != nil {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -441,7 +441,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	os.Setenv(constants.OktetoNameEnvVar, deployOptions.Name)
 
 	if err := dc.deployDependencies(ctx, deployOptions); err != nil {
-		if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err, true); errStatus != nil {
+		if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); errStatus != nil {
 			return errStatus
 		}
 		return err
@@ -452,7 +452,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 	}
 
 	if err := buildImages(ctx, dc.Builder, dc.CfgMapHandler, deployOptions); err != nil {
-		if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err, false); errStatus != nil {
+		if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); errStatus != nil {
 			return errStatus
 		}
 		return err
@@ -490,7 +490,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		if hasDeployed {
 			if deployOptions.Wait {
 				if err := dc.DeployWaiter.wait(ctx, deployOptions); err != nil {
-					if err := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err, true); err != nil {
+					if err := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); err != nil {
 						oktetoLog.Infof("could not update configmap with timeout error: %s", err)
 						return err
 					}
@@ -514,7 +514,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		data.Status = pipeline.DeployedStatus
 	}
 
-	if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err, true); errStatus != nil {
+	if errStatus := dc.CfgMapHandler.UpdateConfigMap(ctx, cfg, data, err); errStatus != nil {
 		return errStatus
 	}
 


### PR DESCRIPTION
# Proposed changes

Fixes DEV-1283

There were several logs duplicated. One per iteration on the waiting spininner which was resolved by just rewriting when the message change and another one for the build error message. This last one was fixed by not adding to the configmap the error and letting the error be written by the last error. I didn't want to affect other parts of the code so I added a new param to the function 

## How to validate

1. Saturate the queue
1. Run a okteto deploy that times out on the queue
1. See that there is no duplication

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
