### PR TITLE
DEV-1295: Disable buildkit queue by default

### DIFF
--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -104,7 +104,7 @@ func GetBuildkitConnector(okCtx OktetoContextInterface, logger *io.Controller) B
 		return newInClusterConnectorWithFallback(okCtx, logger)
 	}
 
-	if env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, true) {
+	if env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, false) {
 		return newPortForwarderWithFallback(okCtx, logger)
 	}
 
@@ -114,7 +114,7 @@ func GetBuildkitConnector(okCtx OktetoContextInterface, logger *io.Controller) B
 // shouldUseInClusterConnector returns true when running inside an Okteto-managed environment
 // where we can connect directly to BuildKit via pod IP
 func shouldUseInClusterConnector() bool {
-	if !env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, true) {
+	if !env.LoadBooleanOrDefault(OktetoBuildQueueEnabledEnvVar, false) {
 		return false
 	}
 	return env.LoadBoolean(constants.OktetoDeployRemote) || // Remote commands (deploy --remote, destroy --remote, test)


### PR DESCRIPTION
# Proposed changes

DEV-1295

As discussed in the daily, we are going to disable by default the BuildKit queue for now.

