### PR TITLE
feat: enhance transient error handling in IsRetryable function

### DIFF
--- a/pkg/build/buildkit/errors.go
+++ b/pkg/build/buildkit/errors.go
@@ -172,6 +172,8 @@ func IsRetryable(err error) bool {
 		return true
 	case strings.Contains(err.Error(), "Canceled") && strings.Contains(err.Error(), "context canceled"):
 		return true
+	case strings.Contains(err.Error(), "NotFound") && strings.Contains(err.Error(), "no such job"):
+		return true
 
 	default:
 		return false

--- a/pkg/build/buildkit/errors_test.go
+++ b/pkg/build/buildkit/errors_test.go
@@ -223,6 +223,11 @@ func Test_isTransientError(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "contains 'NotFound' and 'no such job'",
+			err:      fmt.Errorf("rpc error: code = NotFound desc = no such job"),
+			expected: true,
+		},
+		{
 			name:     "contains other error",
 			err:      fmt.Errorf("some other error"),
 			expected: false,


### PR DESCRIPTION
Added support for recognizing errors that contain both 'NotFound' and 'no such job' as transient errors in the IsRetryable function. Updated unit tests to validate this new behavior, ensuring comprehensive coverage for error handling scenarios.

# Proposed changes

BuildKit occasionally fails with transient "no such job" errors:                                                                              
                                                                                                                                                
```
Error building service 'app': build failed: failed to receive status: rpc error: code = NotFound desc = no such job 0kazrj8ts32ism0erw979bpvg 
```                                                                                                                                                

These errors occur when BuildKit loses track of a build job.

## Solution                                                                                                                                      
                                                                                                                                                
  Add "no such job" errors to the list of retryable BuildKit errors in IsRetryable().                                                           
                                                                                                                                                
  The retry logic checks for both:                                                                                                              
  - "NotFound" - The gRPC error code/message                                                                                                    
  - "no such job" - The specific error condition   

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
