### PR TITLE
chore: add Renovate configuration for dependency management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "includePaths": [
+    "go.mod",
+    "tools/go.mod"
+  ],
   "extends": [
     "config:recommended",
     ":enableVulnerabilityAlertsWithLabel(security)"
@@ -9,7 +13,7 @@
   "commitMessagePrefix": "chore(deps):",
   "automerge": false,
   "platformAutomerge": false,
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 5,
   "prHourlyLimit": 1,
   "rebaseWhen": "conflicted",
   "enabledManagers": ["gomod"],
@@ -33,10 +37,9 @@
       "enabled": false
     },
     {
-      "description": "Manage Go toolchain version updates as a group",
+      "description": "Default: ungrouped Go dependencies update on Fridays",
       "matchManagers": ["gomod"],
-      "matchDepTypes": ["golang"],
-      "groupName": "go toolchain"
+      "schedule": ["on friday"]
     },
     {
       "description": "Label PRs for the main module",
@@ -53,22 +56,46 @@
     {
       "description": "Kubernetes ecosystem - must stay in sync",
       "matchPackagePrefixes": ["k8s.io/"],
-      "groupName": "kubernetes"
+      "groupName": "kubernetes",
+      "schedule": ["on monday"]
     },
     {
-      "description": "Docker ecosystem - must stay in sync",
+      "description": "Docker & container ecosystem - must stay in sync",
       "matchPackagePrefixes": ["github.com/docker/"],
-      "groupName": "docker"
+      "matchPackageNames": [
+        "github.com/google/go-containerregistry",
+        "github.com/moby/term"
+      ],
+      "groupName": "docker",
+      "schedule": ["on tuesday"]
     },
     {
       "description": "Go stdlib extensions",
-      "matchPackagePrefixes": ["golang.org/x/", "google.golang.org/"],
-      "groupName": "golang-stdlib-extensions"
+      "matchPackagePrefixes": ["golang.org/x/", "google.golang.org/", "gopkg.in/"],
+      "groupName": "golang-stdlib-extensions",
+      "schedule": ["on wednesday"]
     },
     {
-      "description": "Wait 7 days before updating to avoid broken releases",
+      "description": "CLI framework & logging",
+      "matchPackageNames": [
+        "github.com/spf13/cobra",
+        "github.com/spf13/afero",
+        "github.com/sirupsen/logrus",
+        "github.com/fatih/color",
+        "github.com/briandowns/spinner",
+        "github.com/cheggaaa/pb/v3",
+        "github.com/manifoldco/promptui",
+        "github.com/vbauerster/mpb/v7",
+        "github.com/juju/ansiterm",
+        "github.com/pkg/errors"
+      ],
+      "groupName": "cli-and-logging",
+      "schedule": ["on thursday"]
+    },
+    {
+      "description": "Wait 30 days before updating to avoid broken releases",
       "matchUpdateTypes": ["patch", "minor", "major"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "30 days"
     }
   ]
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,27 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily run at 04:00 UTC. Renovate schedules in .github/renovate.json decide what PRs to open/update.
+    - cron: "0 4 * * *"
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v44.2.5
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATEBOT_GITHUB_TOKEN }}
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
# Proposed changes

Introduces renovate.json to automate Go dependency updates for both the main module (go.mod) and the internal tools module (tools/go.mod).

  **Update strategy**: one PR open at a time — each update is reviewed and merged before the next is proposed. A 7-day minimum release age applies to all updates to avoid broken or yanked releases.

  **Grouped ecosystems** — packages that must stay on compatible versions with each other are updated in a single PR:
  - k8s.io/* — Kubernetes packages share types and expect matching versions across the ecosystem
  - github.com/docker/* — Docker CLI and daemon packages are tightly coupled
  - golang.org/x/* and google.golang.org/* — Go stdlib extensions share internal dependencies

**Individual PRs** for all other direct dependencies (e.g. cobra, logrus, go-git), since they are independent of each other.

  **Security**: vulnerability alerts bypass the queue and open an immediate PR labeled security, regardless of schedule or concurrent limits.

  **Excluded**: github.com/moby/buildkit — the repo uses the github.com/okteto/buildkit fork via a replace directive.

  **Monthly maintenance**: go mod tidy runs once a month to clean up stale go.sum entries without changing any versions.

## How to validate

  1. Merge this PR and install the Renovate GitHub App on the repository if not
  already installed
  2. Trigger a Renovate run from the Dependency Dashboard issue it creates, or
  wait for the next scheduled run (weekdays 9–17h Madrid time)
  3. Verify the first PR targets a direct dependency in go.mod or tools/go.mod,
  not an indirect one
  4. Verify the PR has labels dependencies, go, and release/internal
  5. Merge it and confirm the next PR only appears after the previous one is merged (serial behavior)
  6. Verify that grouped packages (e.g. all k8s.io/*) are bumped together in a single PR

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines
