### PR TITLE
fix: update kubectl, helm4, kustomize to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Base image versions - Centralized version control for easier updates
 # Kubernetes tools (kubectl, Helm 3, Helm 4, kustomize)
-ARG KUBECTL_VERSION=1.34.3
+ARG KUBECTL_VERSION=1.34.4
 ARG HELM3_VERSION=3.20.0
-ARG HELM4_VERSION=4.1.0
-ARG KUSTOMIZE_VERSION=5.8.0
+ARG HELM4_VERSION=4.1.1
+ARG KUSTOMIZE_VERSION=5.8.1
 # Okteto components
 
 ARG SYNCTHING_VERSION=2.0.14


### PR DESCRIPTION
## Summary

NOT all CRITICAL/HIGH vulnerabilities have been fixed — the remaining ones have no upstream fixes available yet (external binaries not yet rebuilt with patched Go versions).

**Fixed in this PR:**
- ✅ helm4 `4.1.0 → 4.1.1` — fixes CVE-2025-68121 CRITICAL (rebuilt with Go 1.25.7)
- ✅ kubectl `1.34.3 → 1.34.4` — fixes CVE-2025-61726, CVE-2025-61728, CVE-2025-61730 (3× HIGH)
- kustomize `5.8.0 → 5.8.1` — latest patch release (no CVE change; v5.8.1 still built with Go 1.24.0)

## Before

```
usr/bin-image/bin/syncthing  Total: 2 (HIGH: 1, CRITICAL: 1)
usr/local/bin/helm           Total: 1 (HIGH: 0, CRITICAL: 1)
usr/local/bin/helm3          Total: 1 (HIGH: 0, CRITICAL: 1)
usr/local/bin/helm4          Total: 1 (HIGH: 0, CRITICAL: 1)
usr/local/bin/kubectl        Total: 4 (HIGH: 3, CRITICAL: 1)
usr/local/bin/kustomize      Total: 8 (HIGH: 7, CRITICAL: 1)
usr/local/bin/okteto         Total: 0
Total: 5 CRITICAL, 11 HIGH
```

## After

```
usr/bin-image/bin/syncthing  Total: 2 (HIGH: 1*, CRITICAL: 1)
usr/local/bin/helm           Total: 1 (HIGH: 0, CRITICAL: 1)
usr/local/bin/helm3          Total: 1 (HIGH: 0, CRITICAL: 1)
usr/local/bin/helm4          Total: 0  ✅
usr/local/bin/kubectl        Total: 1 (HIGH: 0, CRITICAL: 1)
usr/local/bin/kustomize      Total: 8 (HIGH: 7, CRITICAL: 1)
usr/local/bin/okteto         Total: 0
Total: 4 CRITICAL, 8 HIGH
```

\* CVE-2017-1000420 in syncthing is a **false positive** — it affects syncthing ≤0.14.33; we use v2.0.14.

## Remaining unfixable CVEs (no upstream fix available)

| CVE | Severity | Component | Needs |
|-----|----------|-----------|-------|
| CVE-2025-68121 | CRITICAL | syncthing, helm, helm3, kubectl, kustomize | Go 1.25.7 / 1.24.13 |
| CVE-2025-22874 | HIGH | kustomize | Go 1.24.4 |
| CVE-2025-47907 | HIGH | kustomize | Go 1.24.6 |
| CVE-2025-58183 | HIGH | kustomize | Go 1.24.8 |
| CVE-2025-61726 | HIGH | kustomize | Go 1.24.12 |
| CVE-2025-61728 | HIGH | kustomize | Go 1.24.12 |
| CVE-2025-61729 | HIGH | kustomize | Go 1.24.11 |
| CVE-2025-61730 | HIGH | kustomize | Go 1.24.12 |

All remaining CVEs require upstream projects (kustomize, helm3, syncthing, kubectl) to release new versions compiled with Go ≥1.24.13 or ≥1.25.7.

## Test plan
- [x] Docker image built successfully
- [x] `okteto version` works in container
- [x] `kubectl version --client` shows v1.34.4
- [x] `helm4 version` shows v4.1.1 (Go 1.25.7)
- [x] `kustomize version` shows v5.8.1
- [x] `make lint` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)