### PR TITLE
feat: support dev mode on Argo Rollouts

### DIFF
--- a/cmd/up/autodown.go
+++ b/cmd/up/autodown.go
@@ -44,6 +44,7 @@ type autoDownRunner struct {
 	k8sLogger        *io.K8sLogger
 	analyticsTracker analyticsTrackerInterface
 	downCmd          downCmdRunner
+	getApp           func(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Interface, isRetry bool) (apps.App, bool, error)
 }
 
 type downCmdRunner interface {
@@ -62,6 +63,7 @@ func newAutoDown(ioCtrl *io.Controller, k8sLogger *io.K8sLogger, at analyticsTra
 		k8sLogger:        k8sLogger,
 		analyticsTracker: at,
 		downCmd:          downCmd,
+		getApp:           utils.GetApp,
 	}
 }
 
@@ -75,7 +77,12 @@ func (a *autoDownRunner) run(ctx context.Context, dev *model.Dev, namespace, man
 	sp := a.ioCtrl.Out().Spinner("Running okteto down...")
 	sp.Start()
 	defer sp.Stop()
-	app, _, err := utils.GetApp(ctx, dev, namespace, k8sClient, false)
+	getApp := a.getApp
+	if getApp == nil {
+		getApp = utils.GetApp
+	}
+
+	app, _, err := getApp(ctx, dev, namespace, k8sClient, false)
 	if err != nil {
 		if !oktetoErrors.IsNotFound(err) {
 			return err

--- a/cmd/up/autodown_test.go
+++ b/cmd/up/autodown_test.go
@@ -17,13 +17,19 @@ import (
 	"context"
 	"testing"
 
+	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutsfake "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/k8s/apps"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 )
 
 type mockAnalyticsTracker struct {
@@ -199,4 +205,57 @@ func TestAutoDownRunner_Run_WithAppNotFound(t *testing.T) {
 	// Should not error as not found is handled gracefully
 	assert.ErrorIs(t, err, assert.AnError)
 	at.AssertExpectations(t)
+}
+
+func TestAutoDownRunner_Run_WithRolloutApp(t *testing.T) {
+	ioCtrl := io.NewIOController()
+	k8sLogger := io.NewK8sLogger()
+	at := &mockAnalyticsTracker{}
+	downCmd := &mockDownCmdRunner{}
+	downCmd.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	dev := &model.Dev{
+		Name:      "test-dev",
+		Container: "main",
+	}
+	namespace := "test-namespace"
+
+	rollout := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dev.Name,
+			Namespace: namespace,
+			UID:       "rollout-uid",
+		},
+		Spec: rolloutsv1alpha1.RolloutSpec{
+			Replicas: ptr.To(int32(1)),
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "main",
+							Image: "image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ad := &autoDownRunner{
+		autoDown:         true,
+		ioCtrl:           ioCtrl,
+		k8sLogger:        k8sLogger,
+		analyticsTracker: at,
+		downCmd:          downCmd,
+		getApp: func(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Interface, isRetry bool) (apps.App, bool, error) {
+			return apps.NewRolloutApp(rollout.DeepCopy(), rolloutsfake.NewSimpleClientset(rollout.DeepCopy())), false, nil
+		},
+	}
+
+	fakeK8sClient := fake.NewSimpleClientset()
+
+	err := ad.run(context.Background(), dev, namespace, "test-manifest", fakeK8sClient)
+
+	assert.NoError(t, err)
+	downCmd.AssertExpectations(t)
 }

--- a/cmd/up/devdeployer.go
+++ b/cmd/up/devdeployer.go
@@ -84,6 +84,7 @@ func (dd *devDeployer) deployDevServices(ctx context.Context) error {
 // deploy replaces the devApp and the app
 func (dd *devDeployer) deploy(ctx context.Context, tr *apps.Translation) error {
 	delete(tr.DevApp.ObjectMeta().Annotations, model.DeploymentRevisionAnnotation)
+	delete(tr.DevApp.ObjectMeta().Annotations, model.OktetoRevisionAnnotation)
 	if err := tr.DevApp.Deploy(ctx, dd.k8sClient); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 )
 
 require (
-	cloud.google.com/go v0.112.0 // indirect
-	cloud.google.com/go/storage v1.36.0 // indirect
+	cloud.google.com/go v0.112.2 // indirect
+	cloud.google.com/go/storage v1.39.1 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
@@ -96,7 +96,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
@@ -154,7 +154,7 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	google.golang.org/api v0.162.0 // indirect
+	google.golang.org/api v0.223.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
@@ -171,6 +171,7 @@ require (
 )
 
 require (
+	github.com/argoproj/argo-rollouts v1.9.0
 	github.com/bluekeyes/go-gitdiff v0.8.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/heimdalr/dag v1.4.0
@@ -185,6 +186,8 @@ require (
 )
 
 require (
+	cloud.google.com/go/auth v0.15.0 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	github.com/STARRY-S/zip v0.2.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
@@ -232,8 +235,8 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/gnostic-models v0.7.0
-	github.com/google/s2a-go v0.1.7 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
+	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/in-toto/in-toto-golang v0.9.0 // indirect
 	github.com/mholt/archives v0.0.0-20241129155617-ff6062f60091

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ cloud.google.com/go v0.104.0/go.mod h1:OO6xxXdJyvuJPcEPBLN9BJPD+jep5G1+2U5B5gkRY
 cloud.google.com/go v0.105.0/go.mod h1:PrLgOJNe5nfE9UMxKxgXj4mD3voiP+YQ6gdt6KMFOKM=
 cloud.google.com/go v0.107.0/go.mod h1:wpc2eNrD7hXUTy8EKS10jkxpZBjASrORK7goS+3YX2I=
 cloud.google.com/go v0.110.0/go.mod h1:SJnCLqQ0FCFGSZMUNUf84MV3Aia54kn7pi8st7tMzaY=
-cloud.google.com/go v0.112.0 h1:tpFCD7hpHFlQ8yPwT3x+QeXqc2T6+n6T+hmABHfDUSM=
-cloud.google.com/go v0.112.0/go.mod h1:3jEEVwZ/MHU4djK5t5RHuKOA/GbLddgTdVubX1qnPD4=
+cloud.google.com/go v0.112.2 h1:ZaGT6LiG7dBzi6zNOvVZwacaXlmf3lRqnC4DQzqyRQw=
+cloud.google.com/go v0.112.2/go.mod h1:iEqjp//KquGIJV/m+Pk3xecgKNhV+ry+vVTsy4TbDms=
 cloud.google.com/go/accessapproval v1.4.0/go.mod h1:zybIuC3KpDOvotz59lFe5qxRZx6C75OtwbisN56xYB4=
 cloud.google.com/go/accessapproval v1.5.0/go.mod h1:HFy3tuiGvMdcd/u+Cu5b9NkO1pEICJ46IR82PoUdplw=
 cloud.google.com/go/accessapproval v1.6.0/go.mod h1:R0EiYnwV5fsRFiKZkPHr6mwyk2wxUJ30nL4j2pcFY2E=
@@ -99,6 +99,10 @@ cloud.google.com/go/assuredworkloads v1.7.0/go.mod h1:z/736/oNmtGAyU47reJgGN+KVo
 cloud.google.com/go/assuredworkloads v1.8.0/go.mod h1:AsX2cqyNCOvEQC8RMPnoc0yEarXQk6WEKkxYfL6kGIo=
 cloud.google.com/go/assuredworkloads v1.9.0/go.mod h1:kFuI1P78bplYtT77Tb1hi0FMxM0vVpRC7VVoJC3ZoT0=
 cloud.google.com/go/assuredworkloads v1.10.0/go.mod h1:kwdUQuXcedVdsIaKgKTp9t0UJkE5+PAVNhdQm4ZVq2E=
+cloud.google.com/go/auth v0.15.0 h1:Ly0u4aA5vG/fsSsxu98qCQBemXtAtJf+95z9HK+cxps=
+cloud.google.com/go/auth v0.15.0/go.mod h1:WJDGqZ1o9E9wKIL+IwStfyn/+s59zl4Bi+1KQNVXLZ8=
+cloud.google.com/go/auth/oauth2adapt v0.2.7 h1:/Lc7xODdqcEw8IrZ9SvwnlLX6j9FHQM74z6cBk9Rw6M=
+cloud.google.com/go/auth/oauth2adapt v0.2.7/go.mod h1:NTbTTzfvPl1Y3V1nPpOgl2w6d/FjO7NNUQaWSox6ZMc=
 cloud.google.com/go/automl v1.5.0/go.mod h1:34EjfoFGMZ5sgJ9EoLsRtdPSNZLcfflJR39VbVNS2M0=
 cloud.google.com/go/automl v1.6.0/go.mod h1:ugf8a6Fx+zP0D59WLhqgTDsQI9w07o64uf/Is3Nh5p8=
 cloud.google.com/go/automl v1.7.0/go.mod h1:RL9MYCCsJEOmt0Wf3z9uzG0a7adTT1fe+aObgSpkCt8=
@@ -533,8 +537,8 @@ cloud.google.com/go/storage v1.23.0/go.mod h1:vOEEDNFnciUMhBeT6hsJIn3ieU5cFRmzeL
 cloud.google.com/go/storage v1.27.0/go.mod h1:x9DOL8TK/ygDUMieqwfhdpQryTeEkhGKMi80i/iqR2s=
 cloud.google.com/go/storage v1.28.1/go.mod h1:Qnisd4CqDdo6BGs2AD5LLnEsmSQ80wQ5ogcBBKhU86Y=
 cloud.google.com/go/storage v1.29.0/go.mod h1:4puEjyTKnku6gfKoTfNOU/W+a9JyuVNxjpS5GBrB8h4=
-cloud.google.com/go/storage v1.36.0 h1:P0mOkAcaJxhCTvAkMhxMfrTKiNcub4YmmPBtlhAyTr8=
-cloud.google.com/go/storage v1.36.0/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
+cloud.google.com/go/storage v1.39.1 h1:MvraqHKhogCOTXTlct/9C3K3+Uy2jBmFYb3/Sp6dVtY=
+cloud.google.com/go/storage v1.39.1/go.mod h1:xK6xZmxZmo+fyP7+DEF6FhNc24/JAe95OLyOHCXFH1o=
 cloud.google.com/go/storagetransfer v1.5.0/go.mod h1:dxNzUopWy7RQevYFHewchb29POFv3/AaBgnhqzqiK0w=
 cloud.google.com/go/storagetransfer v1.6.0/go.mod h1:y77xm4CQV/ZhFZH75PLEXY0ROiS7Gh6pSKrM8dJyg6I=
 cloud.google.com/go/storagetransfer v1.7.0/go.mod h1:8Giuj1QNb1kfLAiWM1bN6dHzfdlDAVC9rv9abHot2W4=
@@ -651,6 +655,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/argoproj/argo-rollouts v1.9.0 h1:bXgBpwCByXyAUcgBnyP0fxkSW2CEot78InTFjFlag5g=
+github.com/argoproj/argo-rollouts v1.9.0/go.mod h1:jOalqf2kDSmCp7eQpFF4i3kHnlEqNE/Yjwz1q7CpPIU=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
@@ -978,8 +984,8 @@ github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
-github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
+github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
+github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -991,8 +997,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY
 github.com/googleapis/enterprise-certificate-proxy v0.2.0/go.mod h1:8C0jb7/mgJe/9KK8Lm7X9ctZC2t60YyIpYEI16jx0Qg=
 github.com/googleapis/enterprise-certificate-proxy v0.2.1/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
 github.com/googleapis/enterprise-certificate-proxy v0.2.3/go.mod h1:AwSRAtLfXpU5Nm3pW+v7rGDHp09LsPtGY9MduiEsR9k=
-github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
-github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
+github.com/googleapis/enterprise-certificate-proxy v0.3.4 h1:XYIDZApgAnrN1c855gTgghdIA6Stxb52D5RnLI1SLyw=
+github.com/googleapis/enterprise-certificate-proxy v0.3.4/go.mod h1:YKe7cfqYXjKGpGvmSg28/fFvhNzinZQm8DGnaburhGA=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -1004,8 +1010,8 @@ github.com/googleapis/gax-go/v2 v2.5.1/go.mod h1:h6B0KMMFNtI2ddbGJn3T3ZbwkeT6yqE
 github.com/googleapis/gax-go/v2 v2.6.0/go.mod h1:1mjbznJAPHFpesgE5ucqfYEscaz5kMdcIDwU/6+DDoY=
 github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57QpBWsYpwqHJx8=
 github.com/googleapis/gax-go/v2 v2.7.1/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
-github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
-github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
+github.com/googleapis/gax-go/v2 v2.14.1 h1:hb0FFeiPaQskmvakKu5EbCbpntQn48jyHuvrkurSS/Q=
+github.com/googleapis/gax-go/v2 v2.14.1/go.mod h1:Hb/NubMaVM88SrNkvl8X/o8XWwDJEPqouaLeN2IUxoA=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
@@ -1780,8 +1786,9 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
+golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.3/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=
@@ -1849,8 +1856,8 @@ google.golang.org/api v0.108.0/go.mod h1:2Ts0XTHNVWxypznxWOYUeI4g3WdP9Pk2Qk58+a/
 google.golang.org/api v0.110.0/go.mod h1:7FC4Vvx1Mooxh8C5HWjzZHcavuS2f6pmJpZx60ca7iI=
 google.golang.org/api v0.111.0/go.mod h1:qtFHvU9mhgTJegR31csQ+rwxyUTHOKFqCKWp1J0fdw0=
 google.golang.org/api v0.114.0/go.mod h1:ifYI2ZsFK6/uGddGfAD5BMxlnkBqCmqHSDUVi45N5Yg=
-google.golang.org/api v0.162.0 h1:Vhs54HkaEpkMBdgGdOT2P6F0csGG/vxDS0hWHJzmmps=
-google.golang.org/api v0.162.0/go.mod h1:6SulDkfoBIg4NFmCuZ39XeeAgSHCPecfSUuDyYlAHs0=
+google.golang.org/api v0.223.0 h1:JUTaWEriXmEy5AhvdMgksGGPEFsYfUKaPEYXd4c3Wvc=
+google.golang.org/api v0.223.0/go.mod h1:C+RS7Z+dDwds2b+zoAk5hN/eSfsiCn0UDrYof/M4d2M=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/pkg/k8s/apps/crud.go
+++ b/pkg/k8s/apps/crud.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"time"
 
+	rolloutsclientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/env"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/k8s/deployments"
+	k8srollouts "github.com/okteto/okteto/pkg/k8s/rollouts"
 	"github.com/okteto/okteto/pkg/k8s/statefulsets"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
@@ -37,6 +39,19 @@ type ErrApplicationNotFound struct {
 func (e ErrApplicationNotFound) Error() string {
 	return fmt.Sprintf("the application '%s' referred by your okteto manifest doesn't exist", e.Name)
 }
+
+var newRolloutsClient = func() (rolloutsclientset.Interface, error) {
+	if okteto.GetContext().Cfg == nil {
+		return nil, oktetoErrors.ErrNotFound
+	}
+
+	rc, _, err := okteto.GetRolloutsClient()
+	if err != nil {
+		return nil, oktetoErrors.ErrNotFound
+	}
+	return rc, nil
+}
+
 func Get(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Interface) (App, error) {
 	d, err := deployments.GetByDev(ctx, dev, namespace, c)
 
@@ -51,7 +66,23 @@ func Get(ctx context.Context, dev *model.Dev, namespace string, c kubernetes.Int
 	sfs, err := statefulsets.GetByDev(ctx, dev, namespace, c)
 	if err != nil {
 		if oktetoErrors.IsNotFound(err) {
-			return nil, ErrApplicationNotFound{Name: dev.Name}
+			rc, rcErr := newRolloutsClient()
+			if rcErr != nil {
+				if oktetoErrors.IsNotFound(rcErr) {
+					return nil, ErrApplicationNotFound{Name: dev.Name}
+				}
+				return nil, rcErr
+			}
+
+			r, rErr := k8srollouts.GetByDev(ctx, dev, namespace, rc)
+			if rErr != nil {
+				if oktetoErrors.IsNotFound(rErr) {
+					return nil, ErrApplicationNotFound{Name: dev.Name}
+				}
+				return nil, rErr
+			}
+
+			return NewRolloutApp(r, rc), nil
 		}
 		return nil, err
 	}

--- a/pkg/k8s/apps/crud_test.go
+++ b/pkg/k8s/apps/crud_test.go
@@ -18,6 +18,9 @@ import (
 	"os"
 	"testing"
 
+	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutsclientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
+	rolloutsfake "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
 	"github.com/okteto/okteto/pkg/constants"
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -41,6 +44,18 @@ func TestMain(m *testing.M) {
 		},
 	}
 	os.Exit(m.Run())
+}
+
+func useRolloutsClient(t *testing.T, client rolloutsclientset.Interface) {
+	t.Helper()
+
+	previous := newRolloutsClient
+	newRolloutsClient = func() (rolloutsclientset.Interface, error) {
+		return client, nil
+	}
+	t.Cleanup(func() {
+		newRolloutsClient = previous
+	})
 }
 
 func TestGetStatefulset(t *testing.T) {
@@ -110,6 +125,51 @@ func TestGetDeployment(t *testing.T) {
 	}
 
 	clientset := fake.NewSimpleClientset(d)
+
+	dev := &model.Dev{
+		Name:  "test",
+		Image: "image",
+		PersistentVolumeInfo: &model.PersistentVolumeInfo{
+			Enabled: true,
+		},
+	}
+	app, err := Get(ctx, dev, "test", clientset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if app.ObjectMeta().Name != "test" {
+		t.Fatal("not retrieved correctly")
+	}
+}
+
+func TestGetRollout(t *testing.T) {
+	ctx := context.Background()
+	r := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: rolloutsv1alpha1.RolloutSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "main",
+							VolumeMounts: []v1.VolumeMount{
+								{
+									MountPath: "/data",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset()
+	rolloutsClient := rolloutsfake.NewSimpleClientset(r)
+	useRolloutsClient(t, rolloutsClient)
 
 	dev := &model.Dev{
 		Name:  "test",
@@ -282,6 +342,13 @@ func TestListDevModeOn(t *testing.T) {
 					Enabled: true,
 				},
 			},
+			"rollout": &model.Dev{
+				Name:  "rollout",
+				Image: "image",
+				PersistentVolumeInfo: &model.PersistentVolumeInfo{
+					Enabled: true,
+				},
+			},
 			"autocreate": &model.Dev{
 				Name:  "autocreate",
 				Image: "image",
@@ -296,6 +363,7 @@ func TestListDevModeOn(t *testing.T) {
 		expectedError error
 		sfs           *appsv1.StatefulSet
 		ds            *appsv1.Deployment
+		rollout       *rolloutsv1alpha1.Rollout
 		name          string
 		expectedList  []string
 	}{
@@ -447,6 +515,28 @@ func TestListDevModeOn(t *testing.T) {
 			expectedList: []string{"dev", "sfs"},
 		},
 		{
+			name: "rollout-is-dev-mode",
+			sfs:  &appsv1.StatefulSet{},
+			ds:   &appsv1.Deployment{},
+			rollout: &rolloutsv1alpha1.Rollout{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rollout",
+					Namespace: "test",
+					Labels: map[string]string{
+						constants.DevLabel: "true",
+					},
+				},
+				Spec: rolloutsv1alpha1.RolloutSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{Name: "main"}},
+						},
+					},
+				},
+			},
+			expectedList: []string{"rollout"},
+		},
+		{
 			name: "err-dev-not-found",
 			sfs: &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -538,6 +628,11 @@ func TestListDevModeOn(t *testing.T) {
 	for _, tt := range tests {
 		ctx := context.Background()
 		clientset := fake.NewSimpleClientset(tt.sfs, tt.ds)
+		rolloutsClient := rolloutsfake.NewSimpleClientset()
+		if tt.rollout != nil {
+			rolloutsClient = rolloutsfake.NewSimpleClientset(tt.rollout)
+		}
+		useRolloutsClient(t, rolloutsClient)
 
 		result := ListDevModeOn(ctx, manifest.Dev, "test", clientset)
 		assert.ElementsMatch(t, tt.expectedList, result)

--- a/pkg/k8s/apps/rollouts.go
+++ b/pkg/k8s/apps/rollouts.go
@@ -30,6 +30,7 @@ import (
 	"github.com/okteto/okteto/pkg/okteto"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -110,7 +111,10 @@ func (i *RolloutApp) DevClone() App {
 
 	delete(clone.Annotations, model.OktetoAutoCreateAnnotation)
 	clone.Spec.Strategy = rolloutsv1alpha1.RolloutStrategy{
-		Canary: &rolloutsv1alpha1.CanaryStrategy{},
+		Canary: &rolloutsv1alpha1.CanaryStrategy{
+			MaxSurge:       ptr.To(intstr.FromInt(0)),
+			MaxUnavailable: ptr.To(intstr.FromInt(1)),
+		},
 	}
 
 	return NewRolloutApp(clone, i.rc)

--- a/pkg/k8s/apps/rollouts.go
+++ b/pkg/k8s/apps/rollouts.go
@@ -1,0 +1,226 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutsclientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/pods"
+	"github.com/okteto/okteto/pkg/k8s/replicasets"
+	k8srollouts "github.com/okteto/okteto/pkg/k8s/rollouts"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/ptr"
+)
+
+type RolloutApp struct {
+	r  *rolloutsv1alpha1.Rollout
+	rc rolloutsclientset.Interface
+}
+
+func NewRolloutApp(r *rolloutsv1alpha1.Rollout, rc rolloutsclientset.Interface) *RolloutApp {
+	return &RolloutApp{r: r, rc: rc}
+}
+
+func (i *RolloutApp) Kind() string {
+	return okteto.Rollout
+}
+
+func (i *RolloutApp) ObjectMeta() metav1.ObjectMeta {
+	if i.r.ObjectMeta.Annotations == nil {
+		i.r.ObjectMeta.Annotations = map[string]string{}
+	}
+	if i.r.ObjectMeta.Labels == nil {
+		i.r.ObjectMeta.Labels = map[string]string{}
+	}
+	return i.r.ObjectMeta
+}
+
+func (i *RolloutApp) Replicas() int32 {
+	if i.r.Spec.Replicas == nil {
+		return 1
+	}
+	return *i.r.Spec.Replicas
+}
+
+func (i *RolloutApp) SetReplicas(n int32) {
+	i.r.Spec.Replicas = ptr.To(n)
+}
+
+func (i *RolloutApp) TemplateObjectMeta() metav1.ObjectMeta {
+	if i.r.Spec.Template.ObjectMeta.Annotations == nil {
+		i.r.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+	}
+	if i.r.Spec.Template.ObjectMeta.Labels == nil {
+		i.r.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
+	return i.r.Spec.Template.ObjectMeta
+}
+
+func (i *RolloutApp) PodSpec() *apiv1.PodSpec {
+	return &i.r.Spec.Template.Spec
+}
+
+func (i *RolloutApp) DevClone() App {
+	clone := &rolloutsv1alpha1.Rollout{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       i.r.TypeMeta.Kind,
+			APIVersion: i.r.TypeMeta.APIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        model.DevCloneName(i.r.Name),
+			Namespace:   i.r.Namespace,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		Spec: *i.r.Spec.DeepCopy(),
+	}
+
+	clone.Spec.WorkloadRef = nil
+	clone.Labels[model.DevCloneLabel] = string(i.r.UID)
+
+	for k, v := range i.r.Labels {
+		clone.Labels[k] = v
+	}
+	for k, v := range i.r.Annotations {
+		clone.Annotations[k] = v
+	}
+
+	delete(clone.Annotations, model.OktetoAutoCreateAnnotation)
+	clone.Spec.Strategy = rolloutsv1alpha1.RolloutStrategy{
+		Canary: &rolloutsv1alpha1.CanaryStrategy{},
+	}
+
+	return NewRolloutApp(clone, i.rc)
+}
+
+func (i *RolloutApp) CheckConditionErrors(dev *model.Dev) error {
+	return k8srollouts.CheckConditionErrors(i.r, dev)
+}
+
+func (i *RolloutApp) GetRunningPod(ctx context.Context, c kubernetes.Interface) (*apiv1.Pod, error) {
+	if strconv.FormatInt(i.r.Generation, 10) != i.r.Status.ObservedGeneration {
+		return nil, oktetoErrors.ErrNotFound
+	}
+
+	rs, err := replicasets.GetReplicaSetByRollout(ctx, i.r, c)
+	if err != nil {
+		return nil, err
+	}
+	return pods.GetPodByReplicaSet(ctx, rs, c)
+}
+
+func (i *RolloutApp) RestoreOriginal() error {
+	manifest := i.r.Annotations[model.RolloutAnnotation]
+	if manifest == "" {
+		return nil
+	}
+	oktetoLog.Info("deprecated devmodeoff behavior")
+	rOrig := &rolloutsv1alpha1.Rollout{}
+	if err := json.Unmarshal([]byte(manifest), rOrig); err != nil {
+		return fmt.Errorf("malformed manifest: %w", err)
+	}
+	i.r = rOrig
+	return nil
+}
+
+func (i *RolloutApp) Refresh(ctx context.Context, _ kubernetes.Interface) error {
+	r, err := k8srollouts.Get(ctx, i.r.Name, i.r.Namespace, i.rc)
+	if err == nil {
+		i.r = r
+	}
+	return err
+}
+
+func (i *RolloutApp) Watch(ctx context.Context, result chan error, _ kubernetes.Interface) {
+	optsWatch := metav1.ListOptions{
+		Watch:         true,
+		FieldSelector: fmt.Sprintf("metadata.name=%s", i.r.Name),
+	}
+
+	watcher, err := i.rc.ArgoprojV1alpha1().Rollouts(i.r.Namespace).Watch(ctx, optsWatch)
+	if err != nil {
+		result <- err
+		return
+	}
+
+	for {
+		select {
+		case e := <-watcher.ResultChan():
+			oktetoLog.Debugf("Received rollout '%s' event: %s", i.r.Name, e)
+			if e.Object == nil {
+				oktetoLog.Debugf("Recreating rollout '%s' watcher", i.r.Name)
+				watcher, err = i.rc.ArgoprojV1alpha1().Rollouts(i.r.Namespace).Watch(ctx, optsWatch)
+				if err != nil {
+					result <- err
+					return
+				}
+				continue
+			}
+			if e.Type == watch.Deleted {
+				result <- oktetoErrors.ErrDeleteToApp
+				return
+			} else if e.Type == watch.Modified {
+				r, ok := e.Object.(*rolloutsv1alpha1.Rollout)
+				if !ok {
+					oktetoLog.Debugf("Failed to parse rollout event: %s", e)
+					continue
+				}
+				if r.Generation != i.r.Generation {
+					result <- oktetoErrors.ErrApplyToApp
+					return
+				}
+			}
+		case err := <-ctx.Done():
+			oktetoLog.Debugf("call to up.applyToApp cancelled: %v", err)
+			return
+		}
+	}
+}
+
+func (i *RolloutApp) Deploy(ctx context.Context, _ kubernetes.Interface) error {
+	r, err := k8srollouts.Deploy(ctx, i.r, i.rc)
+	if err == nil {
+		i.r = r
+	}
+	return err
+}
+
+func (i *RolloutApp) Destroy(ctx context.Context, _ kubernetes.Interface) error {
+	return k8srollouts.Destroy(ctx, i.r.Name, i.r.Namespace, i.rc)
+}
+
+func (i *RolloutApp) PatchAnnotations(ctx context.Context, _ kubernetes.Interface) error {
+	return k8srollouts.PatchAnnotations(ctx, i.r, i.rc)
+}
+
+func (i *RolloutApp) GetDevClone(ctx context.Context, _ kubernetes.Interface) (App, error) {
+	clonedName := model.DevCloneName(i.r.Name)
+	r, err := k8srollouts.Get(ctx, clonedName, i.r.Namespace, i.rc)
+	if err == nil {
+		return NewRolloutApp(r, i.rc), nil
+	}
+	return nil, err
+}

--- a/pkg/k8s/apps/rollouts_test.go
+++ b/pkg/k8s/apps/rollouts_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/okteto/okteto/pkg/model"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -70,4 +71,22 @@ func TestRolloutGetDevCloneWithoutError(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, model.DevCloneName("test"), result.ObjectMeta().Name)
 	require.Equal(t, "test", result.ObjectMeta().Namespace)
+}
+
+func TestRolloutDevCloneUsesZeroSurgeStrategy(t *testing.T) {
+	r := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	app := NewRolloutApp(r, rolloutsfake.NewSimpleClientset())
+	clone, ok := app.DevClone().(*RolloutApp)
+	require.True(t, ok)
+	require.NotNil(t, clone.r.Spec.Strategy.Canary)
+	require.NotNil(t, clone.r.Spec.Strategy.Canary.MaxSurge)
+	require.NotNil(t, clone.r.Spec.Strategy.Canary.MaxUnavailable)
+	require.Equal(t, intstr.FromInt(0), *clone.r.Spec.Strategy.Canary.MaxSurge)
+	require.Equal(t, intstr.FromInt(1), *clone.r.Spec.Strategy.Canary.MaxUnavailable)
 }

--- a/pkg/k8s/apps/rollouts_test.go
+++ b/pkg/k8s/apps/rollouts_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"context"
+	"testing"
+
+	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutsfake "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRolloutGetDevCloneWithError(t *testing.T) {
+	r := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	app := NewRolloutApp(r, rolloutsfake.NewSimpleClientset())
+	c := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	_, err := app.GetDevClone(ctx, c)
+
+	require.Error(t, err)
+}
+
+func TestRolloutGetDevCloneWithoutError(t *testing.T) {
+	r := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+
+	cloned := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      model.DevCloneName("test"),
+			Namespace: "test",
+			Labels: map[string]string{
+				model.DevCloneLabel: "true",
+			},
+		},
+	}
+
+	rc := rolloutsfake.NewSimpleClientset(cloned)
+	app := NewRolloutApp(r, rc)
+	c := fake.NewSimpleClientset()
+	ctx := context.Background()
+
+	result, err := app.GetDevClone(ctx, c)
+
+	require.NoError(t, err)
+	require.Equal(t, model.DevCloneName("test"), result.ObjectMeta().Name)
+	require.Equal(t, "test", result.ObjectMeta().Namespace)
+}

--- a/pkg/k8s/conditions/errors.go
+++ b/pkg/k8s/conditions/errors.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conditions
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// FailedCreateError returns a user-facing error for a failed pod creation message.
+func FailedCreateError(errorMessage string, dev *model.Dev) error {
+	if strings.Contains(errorMessage, "exceeded quota") {
+		oktetoLog.Infof("%s: %s", oktetoErrors.ErrQuota, errorMessage)
+		if strings.Contains(errorMessage, "requested: pods=") {
+			return fmt.Errorf("quota exceeded, you have reached the maximum number of pods per namespace")
+		}
+		if strings.Contains(errorMessage, "requested: requests.storage=") {
+			return fmt.Errorf("quota exceeded, you have reached the maximum storage per namespace")
+		}
+		return oktetoErrors.ErrQuota
+	}
+
+	if IsResourcesRelatedError(errorMessage) {
+		return ResourceLimitError(errorMessage, dev)
+	}
+
+	return fmt.Errorf("%s", errorMessage)
+}
+
+// IsResourcesRelatedError returns true when the message refers to resource limit validation.
+func IsResourcesRelatedError(errorMessage string) bool {
+	return strings.Contains(errorMessage, "maximum cpu usage") || strings.Contains(errorMessage, "maximum memory usage")
+}
+
+// ResourceLimitError formats a resource limit validation error for the user.
+func ResourceLimitError(errorMessage string, dev *model.Dev) error {
+	var errorToReturn string
+	const regexMaxSubstring = 2
+
+	if strings.Contains(errorMessage, "maximum cpu usage") {
+		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
+		maximumCPUPerPodMatchGroups := cpuMaximumRegex.FindStringSubmatch(errorMessage)
+		if len(maximumCPUPerPodMatchGroups) < regexMaxSubstring {
+			errorToReturn += "The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. "
+		} else {
+			var manifestCPU string
+			if limitCPU, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
+				manifestCPU = limitCPU.String()
+			}
+			maximumCPUPerPod := maximumCPUPerPodMatchGroups[1]
+			errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCPU, maximumCPUPerPod)
+		}
+	}
+
+	if strings.Contains(errorMessage, "maximum memory usage") {
+		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
+		maximumMemoryPerPodMatchGroups := memoryMaximumRegex.FindStringSubmatch(errorMessage)
+		if len(maximumMemoryPerPodMatchGroups) < regexMaxSubstring {
+			errorToReturn += "The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod."
+		} else {
+			var manifestMemory string
+			if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
+				manifestMemory = limitMemory.String()
+			}
+			maximumMemoryPerPod := maximumMemoryPerPodMatchGroups[1]
+			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
+		}
+	}
+
+	return fmt.Errorf("%s", strings.TrimSpace(errorToReturn))
+}

--- a/pkg/k8s/deployments/crud.go
+++ b/pkg/k8s/deployments/crud.go
@@ -17,11 +17,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/conditions"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	appsv1 "k8s.io/api/apps/v1"
@@ -145,63 +144,10 @@ func GetByDev(ctx context.Context, dev *model.Dev, namespace string, c kubernete
 func CheckConditionErrors(deployment *appsv1.Deployment, dev *model.Dev) error {
 	for _, c := range deployment.Status.Conditions {
 		if c.Type == appsv1.DeploymentReplicaFailure && c.Reason == "FailedCreate" && c.Status == apiv1.ConditionTrue {
-			if strings.Contains(c.Message, "exceeded quota") {
-				oktetoLog.Infof("%s: %s", oktetoErrors.ErrQuota, c.Message)
-				if strings.Contains(c.Message, "requested: pods=") {
-					return fmt.Errorf("quota exceeded, you have reached the maximum number of pods per namespace")
-				}
-				if strings.Contains(c.Message, "requested: requests.storage=") {
-					return fmt.Errorf("quota exceeded, you have reached the maximum storage per namespace")
-				}
-				return oktetoErrors.ErrQuota
-			} else if isResourcesRelatedError(c.Message) {
-				return getResourceLimitError(c.Message, dev)
-			}
-			return fmt.Errorf("%s", c.Message)
+			return conditions.FailedCreateError(c.Message, dev)
 		}
 	}
 	return nil
-}
-
-func isResourcesRelatedError(errorMessage string) bool {
-	if strings.Contains(errorMessage, "maximum cpu usage") || strings.Contains(errorMessage, "maximum memory usage") {
-		return true
-	}
-	return false
-}
-
-func getResourceLimitError(errorMessage string, dev *model.Dev) error {
-	var errorToReturn string
-	var regexMaxSubstring = 2
-	if strings.Contains(errorMessage, "maximum cpu usage") {
-		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
-		maximumCpuPerPodMatchGroups := cpuMaximumRegex.FindStringSubmatch(errorMessage)
-		if len(maximumCpuPerPodMatchGroups) < regexMaxSubstring {
-			errorToReturn += "The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. "
-		} else {
-			var manifestCpu string
-			if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
-				manifestCpu = limitCpu.String()
-			}
-			maximumCpuPerPod := maximumCpuPerPodMatchGroups[1]
-			errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCpu, maximumCpuPerPod)
-		}
-	}
-	if strings.Contains(errorMessage, "maximum memory usage") {
-		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
-		maximumMemoryPerPodMatchGroups := memoryMaximumRegex.FindStringSubmatch(errorMessage)
-		if len(maximumMemoryPerPodMatchGroups) < regexMaxSubstring {
-			errorToReturn += "The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod."
-		} else {
-			var manifestMemory string
-			if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
-				manifestMemory = limitMemory.String()
-			}
-			maximumMemoryPerPod := maximumMemoryPerPodMatchGroups[1]
-			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
-		}
-	}
-	return fmt.Errorf("%s", strings.TrimSpace(errorToReturn))
 }
 
 // Deploy creates or updates a deployment

--- a/pkg/k8s/replicasets/replicaset.go
+++ b/pkg/k8s/replicasets/replicaset.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/model"
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,5 +41,23 @@ func GetReplicaSetByDeployment(ctx context.Context, d *appsv1.Deployment, c kube
 			}
 		}
 	}
+	return nil, oktetoErrors.ErrNotFound
+}
+
+// GetReplicaSetByRollout given a rollout, returns its current replica set or an error.
+func GetReplicaSetByRollout(ctx context.Context, r *rolloutsv1alpha1.Rollout, c kubernetes.Interface) (*appsv1.ReplicaSet, error) {
+	rsList, err := c.AppsV1().ReplicaSets(r.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get replicasets: %w", err)
+	}
+
+	for i := range rsList.Items {
+		for _, or := range rsList.Items[i].OwnerReferences {
+			if or.UID == r.UID && rsList.Items[i].Labels[rolloutsv1alpha1.DefaultRolloutUniqueLabelKey] == r.Status.CurrentPodHash {
+				return &rsList.Items[i], nil
+			}
+		}
+	}
+
 	return nil, oktetoErrors.ErrNotFound
 }

--- a/pkg/k8s/rollouts/crud.go
+++ b/pkg/k8s/rollouts/crud.go
@@ -107,7 +107,15 @@ func CheckConditionErrors(rollout *rolloutsv1alpha1.Rollout, dev *model.Dev) err
 
 // Deploy creates or updates a rollout.
 func Deploy(ctx context.Context, r *rolloutsv1alpha1.Rollout, c rolloutsclientset.Interface) (*rolloutsv1alpha1.Rollout, error) {
-	r.ResourceVersion = ""
+	if r.ResourceVersion == "" {
+		existing, err := c.ArgoprojV1alpha1().Rollouts(r.Namespace).Get(ctx, r.Name, metav1.GetOptions{})
+		if err == nil {
+			r.ResourceVersion = existing.ResourceVersion
+		} else if !oktetoErrors.IsNotFound(err) {
+			return nil, err
+		}
+	}
+
 	result, err := c.ArgoprojV1alpha1().Rollouts(r.Namespace).Update(ctx, r, metav1.UpdateOptions{})
 	if err == nil {
 		return result, nil
@@ -117,6 +125,7 @@ func Deploy(ctx context.Context, r *rolloutsv1alpha1.Rollout, c rolloutsclientse
 		return nil, err
 	}
 
+	r.ResourceVersion = ""
 	return c.ArgoprojV1alpha1().Rollouts(r.Namespace).Create(ctx, r, metav1.CreateOptions{})
 }
 

--- a/pkg/k8s/rollouts/crud.go
+++ b/pkg/k8s/rollouts/crud.go
@@ -1,0 +1,205 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rollouts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutsclientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/model"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+type patchAnnotations struct {
+	Value map[string]string `json:"value"`
+	Op    string            `json:"op"`
+	Path  string            `json:"path"`
+}
+
+// List returns the list of rollouts.
+func List(ctx context.Context, namespace, labels string, c rolloutsclientset.Interface) ([]rolloutsv1alpha1.Rollout, error) {
+	rList, err := c.ArgoprojV1alpha1().Rollouts(namespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: labels,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return rList.Items, nil
+}
+
+// Get returns a rollout object by name.
+func Get(ctx context.Context, name, namespace string, c rolloutsclientset.Interface) (*rolloutsv1alpha1.Rollout, error) {
+	return c.ArgoprojV1alpha1().Rollouts(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// GetByDev returns a rollout object given a dev struct (by name or by label).
+func GetByDev(ctx context.Context, dev *model.Dev, namespace string, c rolloutsclientset.Interface) (*rolloutsv1alpha1.Rollout, error) {
+	if len(dev.Selector) == 0 {
+		return Get(ctx, dev.Name, namespace, c)
+	}
+
+	rList, err := c.ArgoprojV1alpha1().Rollouts(namespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: dev.LabelsSelector(),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(rList.Items) == 0 {
+		return nil, oktetoErrors.ErrNotFound
+	}
+
+	validRollouts := []*rolloutsv1alpha1.Rollout{}
+	for i := range rList.Items {
+		if rList.Items[i].Labels[model.DevCloneLabel] == "" {
+			validRollouts = append(validRollouts, &rList.Items[i])
+		}
+	}
+
+	if len(validRollouts) == 0 {
+		return nil, oktetoErrors.ErrNotFound
+	}
+	if len(validRollouts) > 1 {
+		return nil, fmt.Errorf("found '%d' rollouts for labels '%s' instead of 1", len(validRollouts), dev.LabelsSelector())
+	}
+	return validRollouts[0], nil
+}
+
+// CheckConditionErrors checks errors in conditions.
+func CheckConditionErrors(rollout *rolloutsv1alpha1.Rollout, dev *model.Dev) error {
+	for _, c := range rollout.Status.Conditions {
+		if c.Type == rolloutsv1alpha1.InvalidSpec && c.Status == apiv1.ConditionTrue {
+			return fmt.Errorf("%s", c.Message)
+		}
+
+		if c.Type == rolloutsv1alpha1.RolloutReplicaFailure && c.Reason == "FailedCreate" && c.Status == apiv1.ConditionTrue {
+			if strings.Contains(c.Message, "exceeded quota") {
+				oktetoLog.Infof("%s: %s", oktetoErrors.ErrQuota, c.Message)
+				if strings.Contains(c.Message, "requested: pods=") {
+					return fmt.Errorf("quota exceeded, you have reached the maximum number of pods per namespace")
+				}
+				if strings.Contains(c.Message, "requested: requests.storage=") {
+					return fmt.Errorf("quota exceeded, you have reached the maximum storage per namespace")
+				}
+				return oktetoErrors.ErrQuota
+			} else if isResourcesRelatedError(c.Message) {
+				return getResourceLimitError(c.Message, dev)
+			}
+			return fmt.Errorf("%s", c.Message)
+		}
+	}
+	return nil
+}
+
+func isResourcesRelatedError(errorMessage string) bool {
+	return strings.Contains(errorMessage, "maximum cpu usage") || strings.Contains(errorMessage, "maximum memory usage")
+}
+
+func getResourceLimitError(errorMessage string, dev *model.Dev) error {
+	var errorToReturn string
+	const regexMaxSubstring = 2
+	if strings.Contains(errorMessage, "maximum cpu usage") {
+		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
+		maximumCpuPerPodMatchGroups := cpuMaximumRegex.FindStringSubmatch(errorMessage)
+		if len(maximumCpuPerPodMatchGroups) < regexMaxSubstring {
+			errorToReturn += "The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. "
+		} else {
+			var manifestCPU string
+			if limitCPU, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
+				manifestCPU = limitCPU.String()
+			}
+			maximumCPUPerPod := maximumCpuPerPodMatchGroups[1]
+			errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCPU, maximumCPUPerPod)
+		}
+	}
+	if strings.Contains(errorMessage, "maximum memory usage") {
+		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
+		maximumMemoryPerPodMatchGroups := memoryMaximumRegex.FindStringSubmatch(errorMessage)
+		if len(maximumMemoryPerPodMatchGroups) < regexMaxSubstring {
+			errorToReturn += "The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod."
+		} else {
+			var manifestMemory string
+			if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
+				manifestMemory = limitMemory.String()
+			}
+			maximumMemoryPerPod := maximumMemoryPerPodMatchGroups[1]
+			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
+		}
+	}
+	return fmt.Errorf("%s", strings.TrimSpace(errorToReturn))
+}
+
+// Deploy creates or updates a rollout.
+func Deploy(ctx context.Context, r *rolloutsv1alpha1.Rollout, c rolloutsclientset.Interface) (*rolloutsv1alpha1.Rollout, error) {
+	r.ResourceVersion = ""
+	result, err := c.ArgoprojV1alpha1().Rollouts(r.Namespace).Update(ctx, r, metav1.UpdateOptions{})
+	if err == nil {
+		return result, nil
+	}
+
+	if !oktetoErrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	return c.ArgoprojV1alpha1().Rollouts(r.Namespace).Create(ctx, r, metav1.CreateOptions{})
+}
+
+// Destroy removes a rollout object given its name and namespace.
+func Destroy(ctx context.Context, name, namespace string, c rolloutsclientset.Interface) error {
+	oktetoLog.Infof("deleting rollout '%s'", name)
+	err := c.ArgoprojV1alpha1().Rollouts(namespace).Delete(ctx, name, metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))})
+	if err != nil {
+		if oktetoErrors.IsNotFound(err) || apierrors.IsMethodNotSupported(err) {
+			return nil
+		}
+		return fmt.Errorf("error deleting argo rollout: %w", err)
+	}
+	oktetoLog.Infof("rollout '%s' deleted", name)
+	return nil
+}
+
+// PatchAnnotations patches the rollout annotations.
+func PatchAnnotations(ctx context.Context, r *rolloutsv1alpha1.Rollout, c rolloutsclientset.Interface) error {
+	payload := []patchAnnotations{
+		{
+			Op:    "replace",
+			Path:  "/metadata/annotations",
+			Value: r.Annotations,
+		},
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if _, err := c.ArgoprojV1alpha1().Rollouts(r.Namespace).Patch(ctx, r.Name, types.JSONPatchType, payloadBytes, metav1.PatchOptions{}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/k8s/rollouts/crud.go
+++ b/pkg/k8s/rollouts/crud.go
@@ -17,12 +17,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strings"
 
 	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
 	rolloutsclientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/conditions"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	apiv1 "k8s.io/api/core/v1"
@@ -100,60 +99,10 @@ func CheckConditionErrors(rollout *rolloutsv1alpha1.Rollout, dev *model.Dev) err
 		}
 
 		if c.Type == rolloutsv1alpha1.RolloutReplicaFailure && c.Reason == "FailedCreate" && c.Status == apiv1.ConditionTrue {
-			if strings.Contains(c.Message, "exceeded quota") {
-				oktetoLog.Infof("%s: %s", oktetoErrors.ErrQuota, c.Message)
-				if strings.Contains(c.Message, "requested: pods=") {
-					return fmt.Errorf("quota exceeded, you have reached the maximum number of pods per namespace")
-				}
-				if strings.Contains(c.Message, "requested: requests.storage=") {
-					return fmt.Errorf("quota exceeded, you have reached the maximum storage per namespace")
-				}
-				return oktetoErrors.ErrQuota
-			} else if isResourcesRelatedError(c.Message) {
-				return getResourceLimitError(c.Message, dev)
-			}
-			return fmt.Errorf("%s", c.Message)
+			return conditions.FailedCreateError(c.Message, dev)
 		}
 	}
 	return nil
-}
-
-func isResourcesRelatedError(errorMessage string) bool {
-	return strings.Contains(errorMessage, "maximum cpu usage") || strings.Contains(errorMessage, "maximum memory usage")
-}
-
-func getResourceLimitError(errorMessage string, dev *model.Dev) error {
-	var errorToReturn string
-	const regexMaxSubstring = 2
-	if strings.Contains(errorMessage, "maximum cpu usage") {
-		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
-		maximumCpuPerPodMatchGroups := cpuMaximumRegex.FindStringSubmatch(errorMessage)
-		if len(maximumCpuPerPodMatchGroups) < regexMaxSubstring {
-			errorToReturn += "The value of resources.limits.cpu in your okteto manifest exceeds the maximum CPU limit per pod. "
-		} else {
-			var manifestCPU string
-			if limitCPU, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
-				manifestCPU = limitCPU.String()
-			}
-			maximumCPUPerPod := maximumCpuPerPodMatchGroups[1]
-			errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCPU, maximumCPUPerPod)
-		}
-	}
-	if strings.Contains(errorMessage, "maximum memory usage") {
-		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
-		maximumMemoryPerPodMatchGroups := memoryMaximumRegex.FindStringSubmatch(errorMessage)
-		if len(maximumMemoryPerPodMatchGroups) < regexMaxSubstring {
-			errorToReturn += "The value of resources.limits.memory in your okteto manifest exceeds the maximum memory limit per pod."
-		} else {
-			var manifestMemory string
-			if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
-				manifestMemory = limitMemory.String()
-			}
-			maximumMemoryPerPod := maximumMemoryPerPodMatchGroups[1]
-			errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
-		}
-	}
-	return fmt.Errorf("%s", strings.TrimSpace(errorToReturn))
 }
 
 // Deploy creates or updates a rollout.

--- a/pkg/k8s/rollouts/crud_test.go
+++ b/pkg/k8s/rollouts/crud_test.go
@@ -136,6 +136,55 @@ func TestDeployAndPatchAnnotations(t *testing.T) {
 	assert.Equal(t, "value", updated.Annotations["after"])
 }
 
+func TestDeployUpdatesExistingRollout(t *testing.T) {
+	ctx := context.Background()
+	existing := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			Namespace:       "test",
+			ResourceVersion: "7",
+			Annotations:     map[string]string{"before": "value"},
+		},
+	}
+
+	client := rolloutsfake.NewSimpleClientset(existing.DeepCopy())
+
+	existing.Annotations["after"] = "value"
+	updated, err := Deploy(ctx, existing, client)
+	assert.NoError(t, err)
+	assert.Equal(t, "value", updated.Annotations["after"])
+
+	reloaded, err := Get(ctx, "test", "test", client)
+	assert.NoError(t, err)
+	assert.Equal(t, "value", reloaded.Annotations["after"])
+}
+
+func TestDeployHydratesResourceVersionBeforeUpdate(t *testing.T) {
+	ctx := context.Background()
+	existing := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			Namespace:       "test",
+			ResourceVersion: "11",
+			Annotations:     map[string]string{"before": "value"},
+		},
+	}
+
+	client := rolloutsfake.NewSimpleClientset(existing.DeepCopy())
+
+	desired := existing.DeepCopy()
+	desired.ResourceVersion = ""
+	desired.Annotations["after"] = "value"
+
+	updated, err := Deploy(ctx, desired, client)
+	assert.NoError(t, err)
+	assert.Equal(t, "11", updated.ResourceVersion)
+
+	reloaded, err := Get(ctx, "test", "test", client)
+	assert.NoError(t, err)
+	assert.Equal(t, "value", reloaded.Annotations["after"])
+}
+
 func TestCheckConditionErrors(t *testing.T) {
 	r := &rolloutsv1alpha1.Rollout{
 		Status: rolloutsv1alpha1.RolloutStatus{

--- a/pkg/k8s/rollouts/crud_test.go
+++ b/pkg/k8s/rollouts/crud_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rollouts
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	rolloutsv1alpha1 "github.com/argoproj/argo-rollouts/pkg/apis/rollouts/v1alpha1"
+	rolloutsfake "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned/fake"
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGetByDev(t *testing.T) {
+	tests := []struct {
+		name          string
+		dev           *model.Dev
+		rollouts      []*rolloutsv1alpha1.Rollout
+		expectedName  string
+		expectedError error
+	}{
+		{
+			name: "get by name",
+			dev:  &model.Dev{Name: "test"},
+			rollouts: []*rolloutsv1alpha1.Rollout{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test"},
+				},
+			},
+			expectedName: "test",
+		},
+		{
+			name: "get by selector ignores dev clone",
+			dev: &model.Dev{
+				Name:     "test",
+				Selector: map[string]string{"app": "test"},
+			},
+			rollouts: []*rolloutsv1alpha1.Rollout{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test",
+						Labels:    map[string]string{"app": "test"},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-okteto",
+						Namespace: "test",
+						Labels: map[string]string{
+							"app":               "test",
+							model.DevCloneLabel: "clone",
+						},
+					},
+				},
+			},
+			expectedName: "test",
+		},
+		{
+			name: "multiple rollouts",
+			dev: &model.Dev{
+				Name:     "test",
+				Selector: map[string]string{"app": "test"},
+			},
+			rollouts: []*rolloutsv1alpha1.Rollout{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-1", Namespace: "test", Labels: map[string]string{"app": "test"}},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-2", Namespace: "test", Labels: map[string]string{"app": "test"}},
+				},
+			},
+			expectedError: fmt.Errorf("found '2' rollouts for labels 'app=test' instead of 1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objects []runtime.Object
+			for _, r := range tt.rollouts {
+				objects = append(objects, r)
+			}
+
+			client := rolloutsfake.NewSimpleClientset(objects...)
+			result, err := GetByDev(context.Background(), tt.dev, "test", client)
+
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedName, result.Name)
+		})
+	}
+}
+
+func TestDeployAndPatchAnnotations(t *testing.T) {
+	ctx := context.Background()
+	r := &rolloutsv1alpha1.Rollout{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Namespace:   "test",
+			Annotations: map[string]string{"before": "value"},
+		},
+	}
+
+	client := rolloutsfake.NewSimpleClientset()
+
+	created, err := Deploy(ctx, r, client)
+	assert.NoError(t, err)
+	assert.Equal(t, "test", created.Name)
+
+	created.Annotations["after"] = "value"
+	err = PatchAnnotations(ctx, created, client)
+	assert.NoError(t, err)
+
+	updated, err := Get(ctx, "test", "test", client)
+	assert.NoError(t, err)
+	assert.Equal(t, "value", updated.Annotations["after"])
+}
+
+func TestCheckConditionErrors(t *testing.T) {
+	r := &rolloutsv1alpha1.Rollout{
+		Status: rolloutsv1alpha1.RolloutStatus{
+			Conditions: []rolloutsv1alpha1.RolloutCondition{
+				{
+					Type:    rolloutsv1alpha1.RolloutReplicaFailure,
+					Reason:  "FailedCreate",
+					Status:  apiv1.ConditionTrue,
+					Message: "exceeded quota: requested: pods=1",
+				},
+			},
+		},
+	}
+
+	err := CheckConditionErrors(r, &model.Dev{})
+	assert.EqualError(t, err, "quota exceeded, you have reached the maximum number of pods per namespace")
+}

--- a/pkg/k8s/statefulsets/crud.go
+++ b/pkg/k8s/statefulsets/crud.go
@@ -17,10 +17,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strings"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/k8s/conditions"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/model"
 	appsv1 "k8s.io/api/apps/v1"
@@ -172,52 +171,10 @@ func IsRunning(ctx context.Context, namespace, svcName string, c kubernetes.Inte
 func CheckConditionErrors(sfs *appsv1.StatefulSet, dev *model.Dev) error {
 	for _, c := range sfs.Status.Conditions {
 		if c.Reason == "FailedCreate" && c.Status == apiv1.ConditionTrue {
-			if strings.Contains(c.Message, "exceeded quota") {
-				oktetoLog.Infof("%s: %s", oktetoErrors.ErrQuota, c.Message)
-				if strings.Contains(c.Message, "requested: pods=") {
-					return fmt.Errorf("quota exceeded, you have reached the maximum number of pods per namespace")
-				}
-				if strings.Contains(c.Message, "requested: requests.storage=") {
-					return fmt.Errorf("quota exceeded, you have reached the maximum storage per namespace")
-				}
-				return oktetoErrors.ErrQuota
-			} else if isResourcesRelatedError(c.Message) {
-				return getResourceLimitError(c.Message, dev)
-			}
-			return fmt.Errorf("%s", c.Message)
+			return conditions.FailedCreateError(c.Message, dev)
 		}
 	}
 	return nil
-}
-
-func isResourcesRelatedError(errorMessage string) bool {
-	if strings.Contains(errorMessage, "maximum cpu usage") || strings.Contains(errorMessage, "maximum memory usage") {
-		return true
-	}
-	return false
-}
-
-func getResourceLimitError(errorMessage string, dev *model.Dev) error {
-	var errorToReturn string
-	if strings.Contains(errorMessage, "maximum cpu usage") {
-		cpuMaximumRegex := regexp.MustCompile(`cpu usage per Pod is (\d*\w*)`)
-		maximumCpuPerPod := cpuMaximumRegex.FindStringSubmatch(errorMessage)[1]
-		var manifestCpu string
-		if limitCpu, ok := dev.Resources.Limits[apiv1.ResourceCPU]; ok {
-			manifestCpu = limitCpu.String()
-		}
-		errorToReturn += fmt.Sprintf("The value of resources.limits.cpu in your okteto manifest (%s) exceeds the maximum CPU limit per pod (%s). ", manifestCpu, maximumCpuPerPod)
-	}
-	if strings.Contains(errorMessage, "maximum memory usage") {
-		memoryMaximumRegex := regexp.MustCompile(`memory usage per Pod is (\d*\w*)`)
-		maximumMemoryPerPod := memoryMaximumRegex.FindStringSubmatch(errorMessage)[1]
-		var manifestMemory string
-		if limitMemory, ok := dev.Resources.Limits[apiv1.ResourceMemory]; ok {
-			manifestMemory = limitMemory.String()
-		}
-		errorToReturn += fmt.Sprintf("The value of resources.limits.memory in your okteto manifest (%s) exceeds the maximum memory limit per pod (%s). ", manifestMemory, maximumMemoryPerPod)
-	}
-	return fmt.Errorf("%s", strings.TrimSpace(errorToReturn))
 }
 
 // PatchAnnotations patches the statefulset annotations

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -42,6 +42,9 @@ const (
 	// DeploymentAnnotation indicates the original deployment manifest  when the development container was activated
 	DeploymentAnnotation = "dev.okteto.com/deployment"
 
+	// RolloutAnnotation indicates the original rollout manifest when the development container was activated
+	RolloutAnnotation = "dev.okteto.com/rollout"
+
 	// StatefulsetAnnotation indicates the original statefulset manifest  when the development container was activated
 	StatefulsetAnnotation = "dev.okteto.com/statefulset"
 

--- a/pkg/okteto/const.go
+++ b/pkg/okteto/const.go
@@ -16,6 +16,8 @@ package okteto
 const (
 	// Deployment k8s deployemnt kind
 	Deployment = "Deployment"
+	// Rollout k8s Argo Rollout kind
+	Rollout = "Rollout"
 	// StatefulSet k8s statefulset kind
 	StatefulSet = "StatefulSet"
 	// Job k8s Job kind

--- a/pkg/okteto/context.go
+++ b/pkg/okteto/context.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	rolloutsclientset "github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	"github.com/okteto/okteto/pkg/config"
 	"github.com/okteto/okteto/pkg/constants"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -456,6 +458,28 @@ func GetDynamicClient() (dynamic.Interface, *rest.Config, error) {
 		return nil, nil, fmt.Errorf("okteto context not initialized")
 	}
 	return getDynamicClient(GetContext().Cfg)
+}
+
+// GetRolloutsClient returns an Argo Rollouts client for the current okteto context
+func GetRolloutsClient() (rolloutsclientset.Interface, *rest.Config, error) {
+	if GetContext().Cfg == nil {
+		return nil, nil, fmt.Errorf("okteto context not initialized")
+	}
+
+	clientConfig := clientcmd.NewDefaultClientConfig(*GetContext().Cfg, nil)
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	config.WarningHandler = rest.NoWarnings{}
+	config.Timeout = GetKubernetesTimeout()
+
+	client, err := rolloutsclientset.NewForConfig(config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, config, nil
 }
 
 // GetDiscoveryClient return a kubernetes discovery client for the current okteto context


### PR DESCRIPTION
## Summary
- add dev-mode support for existing Argo Rollouts alongside Deployments and StatefulSets
- add Rollout app/crud integration, ReplicaSet pod resolution, and autodown coverage
- update tests and module deps for the Argo Rollouts typed client

## Testing
- go test ./...