### PR TITLE
fix(integration): set GITHUB_OUTPUT for namespace action test

### DIFF
--- a/integration/actions/namespace_test.go
+++ b/integration/actions/namespace_test.go
@@ -97,7 +97,15 @@ func executeChangeNamespaceAction(namespace string) error {
 	command := fmt.Sprintf("%s/entrypoint.sh", actionFolder)
 	args := []string{namespace}
 	cmd := exec.Command(command, args...)
-	cmd.Env = os.Environ()
+
+	githubOutputFile, err := os.CreateTemp("", "github-output-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file for GITHUB_OUTPUT: %w", err)
+	}
+	defer os.Remove(githubOutputFile.Name())
+	githubOutputFile.Close()
+
+	cmd.Env = append(os.Environ(), fmt.Sprintf("GITHUB_OUTPUT=%s", githubOutputFile.Name()))
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s %s: %s", command, strings.Join(args, " "), string(o))


### PR DESCRIPTION
## What

Set a temporary file as `GITHUB_OUTPUT` when running the `okteto/namespace` action entrypoint in the integration test.

## Why

The namespace action's `entrypoint.sh` writes its kubeconfig output path to `$GITHUB_OUTPUT` (a GitHub Actions built-in env var). In non-GHA environments like CircleCI, this variable is unset, causing the shell to fail at line 38 with:

```
namespace/entrypoint.sh: 38: cannot create : Directory nonexistent
```

## How

Before executing the command, create a temp file and expose it as `GITHUB_OUTPUT` in the child process environment. The file is cleaned up with `defer os.Remove`.

```
TestNamespaceActionsPipeline — was failing at executeChangeNamespaceAction
```