### PR TITLE
feat(build): add env-variable secret source support

### DIFF
--- a/pkg/build/buildkit/opt.go
+++ b/pkg/build/buildkit/opt.go
@@ -114,7 +114,7 @@ func (b *SolveOptBuilder) Build(ctx context.Context, buildOptions *types.BuildOp
 
 	// inject secrets to buildkit from temp folder
 	if err := b.replaceSecretsSourceEnvWithTempFile(buildOptions); err != nil {
-		return nil, fmt.Errorf("%w: secret should have the format 'id=mysecret,src=/local/secret'", err)
+		return nil, fmt.Errorf("failed to process build secrets: %w", err)
 	}
 
 	var localDirs map[string]string

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -14,6 +14,7 @@
 package build
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -42,8 +43,41 @@ type Info struct {
 	DependsOn        DependsOn         `yaml:"depends_on,omitempty"`
 }
 
+// Secret represents a single build secret — either a file path or an env var name.
+type Secret struct {
+	File string `yaml:"file,omitempty"`
+	Env  string `yaml:"env,omitempty"`
+}
+
+// UnmarshalYAML handles both short (string) and long (struct) forms:
+//
+//	my_secret: /path/to/file        → Secret{File: "/path/to/file"}
+//	my_secret:
+//	  file: /path/to/file           → Secret{File: "/path/to/file"}
+//	my_secret:
+//	  env: MY_ENV_VAR               → Secret{Env: "MY_ENV_VAR"}
+func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var shorthand string
+	if err := unmarshal(&shorthand); err == nil {
+		s.File = shorthand
+		return nil
+	}
+
+	type rawSecret Secret // avoid infinite recursion
+	var raw rawSecret
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	if raw.File != "" && raw.Env != "" {
+		return fmt.Errorf("secret cannot specify both 'file' and 'env'")
+	}
+	s.File = raw.File
+	s.Env = raw.Env
+	return nil
+}
+
 // Secrets represents the secrets to be injected to the build of the image
-type Secrets map[string]string
+type Secrets map[string]Secret
 
 // infoRaw represents the build info for serialization
 type infoRaw struct {
@@ -124,9 +158,13 @@ func (i *Info) expandManifestBuildArgs(previousImageArgs map[string]string) (err
 	return nil
 }
 
-func (i *Info) expandSecrets() (err error) {
-	for k, v := range i.Secrets {
-		val := v
+func (i *Info) expandSecrets() error {
+	for k, s := range i.Secrets {
+		if s.File == "" {
+			// env-based secrets don't need path expansion
+			continue
+		}
+		val := s.File
 		if strings.HasPrefix(val, "~/") {
 			home, err := os.UserHomeDir()
 			if err != nil {
@@ -134,10 +172,12 @@ func (i *Info) expandSecrets() (err error) {
 			}
 			val = filepath.Join(home, val[2:])
 		}
-		i.Secrets[k], err = env.ExpandEnv(val)
+		expanded, err := env.ExpandEnv(val)
 		if err != nil {
 			return err
 		}
+		s.File = expanded
+		i.Secrets[k] = s
 	}
 	return nil
 }

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -14,10 +14,7 @@
 package build
 
 import (
-	"fmt"
 	"net/url"
-	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -42,42 +39,6 @@ type Info struct {
 	ExportCache      cache.ExportCache `yaml:"export_cache,omitempty"`
 	DependsOn        DependsOn         `yaml:"depends_on,omitempty"`
 }
-
-// Secret represents a single build secret — either a file path or an env var name.
-type Secret struct {
-	File string `yaml:"file,omitempty"`
-	Env  string `yaml:"env,omitempty"`
-}
-
-// UnmarshalYAML handles both short (string) and long (struct) forms:
-//
-//	my_secret: /path/to/file        → Secret{File: "/path/to/file"}
-//	my_secret:
-//	  file: /path/to/file           → Secret{File: "/path/to/file"}
-//	my_secret:
-//	  env: MY_ENV_VAR               → Secret{Env: "MY_ENV_VAR"}
-func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var shorthand string
-	if err := unmarshal(&shorthand); err == nil {
-		s.File = shorthand
-		return nil
-	}
-
-	type rawSecret Secret // avoid infinite recursion
-	var raw rawSecret
-	if err := unmarshal(&raw); err != nil {
-		return err
-	}
-	if raw.File != "" && raw.Env != "" {
-		return fmt.Errorf("secret cannot specify both 'file' and 'env'")
-	}
-	s.File = raw.File
-	s.Env = raw.Env
-	return nil
-}
-
-// Secrets represents the secrets to be injected to the build of the image
-type Secrets map[string]Secret
 
 // infoRaw represents the build info for serialization
 type infoRaw struct {
@@ -154,30 +115,6 @@ func (i *Info) expandManifestBuildArgs(previousImageArgs map[string]string) (err
 			return err
 		}
 		i.Args[idx] = arg
-	}
-	return nil
-}
-
-func (i *Info) expandSecrets() error {
-	for k, s := range i.Secrets {
-		if s.File == "" {
-			// env-based secrets don't need path expansion
-			continue
-		}
-		val := s.File
-		if strings.HasPrefix(val, "~/") {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return err
-			}
-			val = filepath.Join(home, val[2:])
-		}
-		expanded, err := env.ExpandEnv(val)
-		if err != nil {
-			return err
-		}
-		s.File = expanded
-		i.Secrets[k] = s
 	}
 	return nil
 }

--- a/pkg/build/info_test.go
+++ b/pkg/build/info_test.go
@@ -342,6 +342,11 @@ secrets:
 			input:       "secrets:\n  token:\n    file: /path\n    env: MY_TOKEN",
 			expectedErr: true,
 		},
+		{
+			name:        "unmarshal secret with unknown keys and no file or env is an error",
+			input:       "secrets:\n  errored:\n    aa: asa",
+			expectedErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/build/info_test.go
+++ b/pkg/build/info_test.go
@@ -194,7 +194,7 @@ func Test_BuildInfoCopy(t *testing.T) {
 			},
 		},
 		Secrets: Secrets{
-			"sec": "test",
+			"sec": Secret{File: "test"},
 		},
 		VolumesToInclude: []VolumeMounts{
 			{
@@ -270,7 +270,7 @@ secrets:
 					"test_depends_on",
 				},
 				Secrets: Secrets{
-					"secretName": "secretValue",
+					"secretName": Secret{File: "secretValue"},
 				},
 			},
 		},
@@ -304,13 +304,42 @@ secrets:
 					"test_depends_on",
 				},
 				Secrets: Secrets{
-					"secretName": "secretValue",
+					"secretName": Secret{File: "secretValue"},
 				},
 			},
 		},
 		{
 			name:        "error unmarshal string nor struct",
 			input:       "- an string value as list",
+			expectedErr: true,
+		},
+		{
+			name: "unmarshal secret long form with file key",
+			input: `
+secrets:
+  cert:
+    file: /path/to/cert`,
+			expected: &Info{
+				Secrets: Secrets{
+					"cert": Secret{File: "/path/to/cert"},
+				},
+			},
+		},
+		{
+			name: "unmarshal secret long form with env key",
+			input: `
+secrets:
+  token:
+    env: MY_TOKEN`,
+			expected: &Info{
+				Secrets: Secrets{
+					"token": Secret{Env: "MY_TOKEN"},
+				},
+			},
+		},
+		{
+			name:        "unmarshal secret with both file and env is an error",
+			input:       "secrets:\n  token:\n    file: /path\n    env: MY_TOKEN",
 			expectedErr: true,
 		},
 	}
@@ -399,38 +428,38 @@ func Test_expandSecrets(t *testing.T) {
 		},
 		{
 			name: "successfully expand home directory",
-			input: &Info{Secrets: map[string]string{
-				"path": "~/secret",
+			input: &Info{Secrets: Secrets{
+				"path": Secret{File: "~/secret"},
 			}},
-			expected: &Info{Secrets: map[string]string{
-				"path": filepath.Clean("/home/testuser/secret"),
+			expected: &Info{Secrets: Secrets{
+				"path": Secret{File: filepath.Clean("/home/testuser/secret")},
 			}},
 		},
 		{
 			name: "only replace initial tilde-slash",
-			input: &Info{Secrets: map[string]string{
-				"path": "~/test/~/secret",
+			input: &Info{Secrets: Secrets{
+				"path": Secret{File: "~/test/~/secret"},
 			}},
-			expected: &Info{Secrets: map[string]string{
-				"path": filepath.Clean("/home/testuser/test/~/secret"),
+			expected: &Info{Secrets: Secrets{
+				"path": Secret{File: filepath.Clean("/home/testuser/test/~/secret")},
 			}},
 		},
 		{
 			name: "no expansion needed",
-			input: &Info{Secrets: map[string]string{
-				"path": "/var/log",
+			input: &Info{Secrets: Secrets{
+				"path": Secret{File: "/var/log"},
 			}},
-			expected: &Info{Secrets: map[string]string{
-				"path": "/var/log",
+			expected: &Info{Secrets: Secrets{
+				"path": Secret{File: "/var/log"},
 			}},
 		},
 		{
 			name: "expand HOME env var",
-			input: &Info{Secrets: map[string]string{
-				"path": filepath.Join(fmt.Sprintf("$%s", homeEnvVar), "secrets"),
+			input: &Info{Secrets: Secrets{
+				"path": Secret{File: filepath.Join(fmt.Sprintf("$%s", homeEnvVar), "secrets")},
 			}},
-			expected: &Info{Secrets: map[string]string{
-				"path": filepath.Clean("/home/testuser/secrets"),
+			expected: &Info{Secrets: Secrets{
+				"path": Secret{File: filepath.Clean("/home/testuser/secrets")},
 			}},
 			setEnvFunc: func(t *testing.T) {
 				t.Setenv("TEST_RANDOM_DIR", "/home/testuser")
@@ -438,31 +467,51 @@ func Test_expandSecrets(t *testing.T) {
 		},
 		{
 			name: "expand unset env var",
-			input: &Info{Secrets: map[string]string{
-				"path": "$TEST_RANDOM_DIR/secrets",
+			input: &Info{Secrets: Secrets{
+				"path": Secret{File: "$TEST_RANDOM_DIR/secrets"},
 			}},
-			expected: &Info{Secrets: map[string]string{
-				"path": "/secrets",
+			expected: &Info{Secrets: Secrets{
+				"path": Secret{File: "/secrets"},
 			}},
 		},
 		{
 			name: "empty - unset env var",
-			input: &Info{Secrets: map[string]string{
-				"path": "$TEST_RANDOM_DIR",
+			input: &Info{Secrets: Secrets{
+				"path": Secret{File: "$TEST_RANDOM_DIR"},
 			}},
-			expected: &Info{Secrets: map[string]string{
-				"path": "",
+			expected: &Info{Secrets: Secrets{
+				"path": Secret{File: ""},
 			}},
 		},
 		{
 			name: "broken env var",
-			input: &Info{Secrets: map[string]string{
-				"path": "${TEST_RANDOM_DIR/secrets",
+			input: &Info{Secrets: Secrets{
+				"path": Secret{File: "${TEST_RANDOM_DIR/secrets"},
 			}},
-			expected: &Info{Secrets: map[string]string{
-				"path": "",
+			expected: &Info{Secrets: Secrets{
+				"path": Secret{File: "${TEST_RANDOM_DIR/secrets"},
 			}},
 			expectedErr: true,
+		},
+		{
+			name: "env secret - no path expansion performed",
+			input: &Info{Secrets: Secrets{
+				"token": Secret{Env: "MY_TOKEN"},
+			}},
+			expected: &Info{Secrets: Secrets{
+				"token": Secret{Env: "MY_TOKEN"},
+			}},
+		},
+		{
+			name: "mixed file and env secrets",
+			input: &Info{Secrets: Secrets{
+				"cert":  Secret{File: "~/certs/cert.pem"},
+				"token": Secret{Env: "MY_TOKEN"},
+			}},
+			expected: &Info{Secrets: Secrets{
+				"cert":  Secret{File: filepath.Clean("/home/testuser/certs/cert.pem")},
+				"token": Secret{Env: "MY_TOKEN"},
+			}},
 		},
 	}
 

--- a/pkg/build/secret.go
+++ b/pkg/build/secret.go
@@ -1,0 +1,86 @@
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/okteto/okteto/pkg/env"
+)
+
+// Secret represents a single build secret — either a file path or an env var name.
+type Secret struct {
+	File string `yaml:"file,omitempty"`
+	Env  string `yaml:"env,omitempty"`
+}
+
+// UnmarshalYAML handles both short (string) and long (struct) forms:
+//
+//	my_secret: /path/to/file        → Secret{File: "/path/to/file"}
+//	my_secret:
+//	  file: /path/to/file           → Secret{File: "/path/to/file"}
+//	my_secret:
+//	  env: MY_ENV_VAR               → Secret{Env: "MY_ENV_VAR"}
+func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var shorthand string
+	if err := unmarshal(&shorthand); err == nil {
+		s.File = shorthand
+		return nil
+	}
+
+	type rawSecret Secret // avoid infinite recursion
+	var raw rawSecret
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	if raw.File != "" && raw.Env != "" {
+		return fmt.Errorf("secret cannot specify both 'file' and 'env'")
+	}
+	if raw.File == "" && raw.Env == "" {
+		return fmt.Errorf("secret must specify either 'file' or 'env'")
+	}
+	s.File = raw.File
+	s.Env = raw.Env
+	return nil
+}
+
+// Secrets represents the secrets to be injected to the build of the image
+type Secrets map[string]Secret
+
+func (i *Info) expandSecrets() error {
+	for k, s := range i.Secrets {
+		if s.File == "" {
+			// env-based secrets don't need path expansion
+			continue
+		}
+		val := s.File
+		if strings.HasPrefix(val, "~/") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+			val = filepath.Join(home, val[2:])
+		}
+		expanded, err := env.ExpandEnv(val)
+		if err != nil {
+			return err
+		}
+		s.File = expanded
+		i.Secrets[k] = s
+	}
+	return nil
+}

--- a/pkg/build/secret.go
+++ b/pkg/build/secret.go
@@ -22,13 +22,31 @@ import (
 	"github.com/okteto/okteto/pkg/env"
 )
 
+const secretFormatHint = `
+
+Secrets in your Okteto manifest must be valid file paths or environment variable names. Use one of these formats:
+
+  # Short form (file path)
+  secrets:
+    my_secret: /path/to/secret/file
+
+  # Explicit file key
+  secrets:
+    my_secret:
+      file: /path/to/secret/file
+
+  # Environment variable as secret value
+  secrets:
+    my_secret:
+      env: MY_ENV_VAR`
+
 // Secret represents a single build secret — either a file path or an env var name.
 type Secret struct {
 	File string `yaml:"file,omitempty"`
 	Env  string `yaml:"env,omitempty"`
 }
 
-// UnmarshalYAML handles both short (string) and long (struct) forms:
+// UnmarshalYAML handles both short (string) and long (map) forms:
 //
 //	my_secret: /path/to/file        → Secret{File: "/path/to/file"}
 //	my_secret:
@@ -42,19 +60,28 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return nil
 	}
 
-	type rawSecret Secret // avoid infinite recursion
-	var raw rawSecret
+	// Decode into a plain map so that unknown keys produce a clean, user-facing
+	// error rather than leaking internal type names (e.g. "build.rawSecret").
+	var raw map[string]string
 	if err := unmarshal(&raw); err != nil {
-		return err
+		return fmt.Errorf("%w%s", err, secretFormatHint)
 	}
-	if raw.File != "" && raw.Env != "" {
-		return fmt.Errorf("secret cannot specify both 'file' and 'env'")
+
+	for k := range raw {
+		if k != "file" && k != "env" {
+			return fmt.Errorf("unknown secret key %q — only 'file' and 'env' are allowed%s", k, secretFormatHint)
+		}
 	}
-	if raw.File == "" && raw.Env == "" {
-		return fmt.Errorf("secret must specify either 'file' or 'env'")
+
+	file, env := raw["file"], raw["env"]
+	if file != "" && env != "" {
+		return fmt.Errorf("secret cannot specify both 'file' and 'env'%s", secretFormatHint)
 	}
-	s.File = raw.File
-	s.Env = raw.Env
+	if file == "" && env == "" {
+		return fmt.Errorf("secret must specify either 'file' or 'env'%s", secretFormatHint)
+	}
+	s.File = file
+	s.Env = env
 	return nil
 }
 

--- a/pkg/cmd/build/build.go
+++ b/pkg/cmd/build/build.go
@@ -369,8 +369,12 @@ func OptsFromBuildInfo(manifest *model.Manifest, svcName string, b *build.Info, 
 		opts.Secrets = o.Secrets
 	}
 	// add to the build the secrets from the manifest build
-	for id, src := range b.Secrets {
-		opts.Secrets = append(opts.Secrets, fmt.Sprintf("id=%s,src=%s", id, src))
+	for id, secret := range b.Secrets {
+		if secret.Env != "" {
+			opts.Secrets = append(opts.Secrets, fmt.Sprintf("id=%s,env=%s", id, secret.Env))
+		} else {
+			opts.Secrets = append(opts.Secrets, fmt.Sprintf("id=%s,src=%s", id, secret.File))
+		}
 	}
 
 	outputMode := oktetoLog.GetOutputFormat()

--- a/pkg/cmd/build/build_test.go
+++ b/pkg/cmd/build/build_test.go
@@ -337,8 +337,8 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 						Value: "value1",
 					},
 				},
-				Secrets: map[string]string{
-					"mysecret": "source",
+				Secrets: build.Secrets{
+					"mysecret": build.Secret{File: "source"},
 				},
 				ExportCache: []string{"export-image"},
 			},
@@ -368,8 +368,8 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 									Value: "value1",
 								},
 							},
-							Secrets: map[string]string{
-								"mysecret": "source",
+							Secrets: build.Secrets{
+								"mysecret": build.Secret{File: "source"},
 							},
 							ExportCache: []string{"export-image"},
 						},
@@ -493,6 +493,36 @@ func Test_OptsFromBuildInfo(t *testing.T) {
 				},
 				Tag:        "okteto.dev/movies-service:okteto",
 				OutputMode: "tty",
+			},
+		},
+		{
+			name:        "env-secret-from-manifest",
+			serviceName: "service",
+			buildInfo: &build.Info{
+				Context: ".",
+				Secrets: build.Secrets{
+					"mytoken": build.Secret{Env: "MY_TOKEN"},
+				},
+			},
+			mr:          mockRegistry{},
+			initialOpts: &types.BuildOptions{OutputMode: "tty"},
+			isOkteto:    false,
+			expected: &types.BuildOptions{
+				Manifest: &model.Manifest{
+					Name: "movies",
+					Build: build.ManifestBuild{
+						"service": {
+							Context: ".",
+							Secrets: build.Secrets{
+								"mytoken": build.Secret{Env: "MY_TOKEN"},
+							},
+						},
+					},
+				},
+				OutputMode: oktetoLog.TTYFormat,
+				Path:       ".",
+				BuildArgs:  []string{},
+				Secrets:    []string{"id=mytoken,env=MY_TOKEN"},
 			},
 		},
 	}

--- a/pkg/model/serializer_test.go
+++ b/pkg/model/serializer_test.go
@@ -2425,8 +2425,8 @@ func TestManifestBuildUnmarshalling(t *testing.T) {
 					},
 					CacheFrom: []string{"cache-image"},
 					Secrets: build.Secrets{
-						"mysecret":    "source",
-						"othersecret": "othersource",
+						"mysecret":    build.Secret{File: "source"},
+						"othersecret": build.Secret{File: "othersource"},
 					},
 				},
 			},


### PR DESCRIPTION
# Proposed changes

Fixes # (issue)

Introduces a structured `Secret` type for build secrets, replacing the previous `map[string]string` representation. This enables secrets to be sourced from either a file path or an environment variable, and emits the correct `id=foo,env=BAR` wire format to BuildKit for env-based secrets.

Previously, secrets could only point to a file path. This change adds a `Secret` struct with `File` and `Env` fields, updates YAML unmarshalling to handle both short-form (string path) and long-form (`file:` / `env:` keys) declarations, validates that exactly one of the two is set, and ensures error messages do not leak internal Go type names.

## How to validate

1. Build a Docker image with a file-based secret to confirm existing behaviour is unchanged:
   ```
   okteto build --secret id=mysecret,src=/path/to/file
   ```
2. Build a Docker image with an env-based secret and confirm BuildKit receives the `env=` format:
   ```
   export MY_TOKEN=supersecret
   okteto build --secret id=mytoken,env=MY_TOKEN
   ```
3. Declare a secret in `okteto.yml` using long form with `env:` and confirm the manifest parses without error:
   ```yaml
   build:
     context: .
     secrets:
       token:
         env: MY_TOKEN
   ```
4. Declare a secret with both `file:` and `env:` and confirm a clear validation error is returned.
5. Run the unit tests for the build package:
   ```
   go test ./pkg/build/...
   ```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines