### PR TITLE
Inject gateway env vars into deploy, test, and destroy

### DIFF
--- a/.oktetoignore
+++ b/.oktetoignore
@@ -35,6 +35,8 @@
 [test.unit]
 *
 !**/*.go
+!tools/go.mod
+!tools/go.sum
 !go.mod
 !go.sum
 !Makefile

--- a/cmd/deploy/remote.go
+++ b/cmd/deploy/remote.go
@@ -150,6 +150,9 @@ func (rd *remoteDeployer) Deploy(ctx context.Context, deployOptions *Options) er
 		UseOktetoDeployIgnoreFile:   true,
 		ContextAbsolutePathOverride: ctxPath,
 	}
+	for k, v := range deployable.GetGatewayEnvironment() {
+		runParams.OktetoCommandSpecificEnvVars[k] = v
+	}
 
 	if err := rd.runner.Run(ctx, &runParams); err != nil {
 		var cmdErr buildkit.CommandErr

--- a/cmd/deploy/remote_test.go
+++ b/cmd/deploy/remote_test.go
@@ -179,6 +179,21 @@ func Test_newRemoteDeployer(t *testing.T) {
 }
 
 func TestDeployRemoteWithCtx(t *testing.T) {
+	originalStore := okteto.CurrentStore
+	defer func() { okteto.CurrentStore = originalStore }()
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Gateway: &okteto.GatewayMetadata{
+					Name:      "dev-gateway",
+					Namespace: "gateway-ns",
+				},
+			},
+		},
+	}
+
 	workdirCtrl := fakefs.NewFakeWorkingDirectoryCtrl("/path/to/manifest")
 	manifest := &model.Manifest{
 		Deploy: &model.DeployInfo{
@@ -217,6 +232,8 @@ func TestDeployRemoteWithCtx(t *testing.T) {
 		},
 		OktetoCommandSpecificEnvVars: map[string]string{
 			"OKTETO_IS_PREVIEW_ENVIRONMENT": "",
+			"OKTETO_DEV_GATEWAY_NAME":       "dev-gateway",
+			"OKTETO_DEV_GATEWAY_NAMESPACE":  "gateway-ns",
 		},
 		Manifest:                    manifest,
 		Command:                     remote.DeployCommand,

--- a/cmd/destroy/remote.go
+++ b/cmd/destroy/remote.go
@@ -151,6 +151,9 @@ func (rd *remoteDestroyCommand) Destroy(ctx context.Context, opts *Options) erro
 		UseOktetoDeployIgnoreFile:   true,
 		ContextAbsolutePathOverride: ctxPath,
 	}
+	for k, v := range deployable.GetGatewayEnvironment() {
+		runParams.OktetoCommandSpecificEnvVars[k] = v
+	}
 
 	// we need to call Run() method using a remote builder. This Builder will have
 	// the same behavior as the V1 builder but with a different output taking into

--- a/cmd/destroy/remote_test.go
+++ b/cmd/destroy/remote_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/okteto/okteto/pkg/externalresource"
 	fakefs "github.com/okteto/okteto/pkg/filesystem/fake"
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -111,6 +112,21 @@ func TestGetCommandFlags(t *testing.T) {
 }
 
 func TestDestroyRemoteWithCtx(t *testing.T) {
+	originalStore := okteto.CurrentStore
+	defer func() { okteto.CurrentStore = originalStore }()
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Gateway: &okteto.GatewayMetadata{
+					Name:      "dev-gateway",
+					Namespace: "gateway-ns",
+				},
+			},
+		},
+	}
+
 	workdirCtrl := fakefs.NewFakeWorkingDirectoryCtrl("/path/to/manifest")
 	manifest := &model.Manifest{
 		Destroy: &model.DestroyInfo{
@@ -142,6 +158,8 @@ func TestDestroyRemoteWithCtx(t *testing.T) {
 		},
 		OktetoCommandSpecificEnvVars: map[string]string{
 			"OKTETO_IS_PREVIEW_ENVIRONMENT": "",
+			"OKTETO_DEV_GATEWAY_NAME":       "dev-gateway",
+			"OKTETO_DEV_GATEWAY_NAMESPACE":  "gateway-ns",
 		},
 		BuildEnvVars:                make(map[string]string),
 		DependenciesEnvVars:         make(map[string]string),

--- a/cmd/test/cmd.go
+++ b/cmd/test/cmd.go
@@ -397,6 +397,9 @@ func doRun(ctx context.Context, servicesToTest []string, options *Options, ioCtr
 			Artifacts:                   test.Artifacts,
 			Hosts:                       test.Hosts,
 		}
+		for k, v := range deployable.GetGatewayEnvironment() {
+			params.OktetoCommandSpecificEnvVars[k] = v
+		}
 		if test.SkipIfNoFileChanges && !options.NoCache {
 			params.CacheInvalidationKey = "const"
 		}

--- a/okteto.yml
+++ b/okteto.yml
@@ -22,7 +22,7 @@ dev:
     autocreate: true
 test:
   unit:
-    image: okteto/golang:1
+    image: okteto/golang-ci:2.9.2
     artifacts:
       - coverage.txt
       - coverage.html

--- a/pkg/deployable/context_test.go
+++ b/pkg/deployable/context_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployable
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/pkg/okteto"
+)
+
+func setFakeOktetoContext(t *testing.T) {
+	t.Helper()
+
+	originalStore := okteto.CurrentStore
+	t.Cleanup(func() {
+		okteto.CurrentStore = originalStore
+	})
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Name:      "test",
+				Namespace: "test",
+				IsOkteto:  true,
+				Gateway:   nil,
+			},
+		},
+	}
+}

--- a/pkg/deployable/deploy.go
+++ b/pkg/deployable/deploy.go
@@ -298,6 +298,7 @@ func (r *DeployRunner) runCommandsSection(ctx context.Context, params DeployPara
 	defer unlinkEnv()
 
 	envStepper := NewEnvStepper(oktetoEnvFile.Name())
+	params.Variables = appendGatewayEnvVars(params.Variables)
 
 	if len(params.Deployable.Commands) != 0 {
 		startTime := time.Now()

--- a/pkg/deployable/deploy_test.go
+++ b/pkg/deployable/deploy_test.go
@@ -114,6 +114,8 @@ func (f *fakeExternalResource) Deploy(ctx context.Context, name, ns string, exte
 }
 
 func TestDeployNotRemovingEnvFile(t *testing.T) {
+	setFakeOktetoContext(t)
+
 	fs := afero.NewMemMapFs()
 
 	_, err := fs.Create(".env")

--- a/pkg/deployable/deploy_test.go
+++ b/pkg/deployable/deploy_test.go
@@ -245,6 +245,10 @@ func TestRunCommandsSectionWithCommands(t *testing.T) {
 			"test": {
 				Namespace: "test",
 				IsOkteto:  true,
+				Gateway: &okteto.GatewayMetadata{
+					Name:      "dev-gateway",
+					Namespace: "gateway-ns",
+				},
 			},
 		},
 		CurrentContext: "test",
@@ -287,6 +291,8 @@ func TestRunCommandsSectionWithCommands(t *testing.T) {
 	expectedVariables := []string{
 		"A=value1",
 		"B=value2",
+		"OKTETO_DEV_GATEWAY_NAME=dev-gateway",
+		"OKTETO_DEV_GATEWAY_NAMESPACE=gateway-ns",
 	}
 	executor.On("Execute", expectedCommand1, expectedVariables).Return(nil).Once()
 	executor.On("Execute", expectedCommand2, expectedVariables).Return(nil).Once()

--- a/pkg/deployable/destroy.go
+++ b/pkg/deployable/destroy.go
@@ -51,6 +51,7 @@ func (dr *DestroyRunner) RunDestroy(ctx context.Context, params DestroyParameter
 			oktetoLog.AddMaskedWord(v)
 		}
 	}
+	params.Variables = appendGatewayEnvVars(params.Variables)
 
 	// Setup helm version based on environment variable
 	if err := setupHelmVersion(); err != nil {

--- a/pkg/deployable/destroy_test.go
+++ b/pkg/deployable/destroy_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,11 +26,13 @@ import (
 type fakeDestroyExecutor struct {
 	err      error
 	executed []model.DeployCommand
+	envs     [][]string
 	cleaned  bool
 }
 
-func (fe *fakeDestroyExecutor) Execute(command model.DeployCommand, _ []string) error {
+func (fe *fakeDestroyExecutor) Execute(command model.DeployCommand, env []string) error {
 	fe.executed = append(fe.executed, command)
+	fe.envs = append(fe.envs, env)
 	if fe.err != nil {
 		return fe.err
 	}
@@ -117,12 +120,28 @@ func TestRunDestroyWithErrorAndForceDestroy(t *testing.T) {
 }
 
 func TestRunDestroyWithoutError(t *testing.T) {
+	originalStore := okteto.CurrentStore
+	defer func() { okteto.CurrentStore = originalStore }()
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Gateway: &okteto.GatewayMetadata{
+					Name:      "dev-gateway",
+					Namespace: "gateway-ns",
+				},
+			},
+		},
+	}
+
 	executor := &fakeDestroyExecutor{}
 	runner := &DestroyRunner{
 		Executor: executor,
 	}
 
 	params := DestroyParameters{
+		Variables: []string{"A=value1"},
 		Deployable: Entity{
 			Commands: []model.DeployCommand{
 				{
@@ -152,6 +171,12 @@ func TestRunDestroyWithoutError(t *testing.T) {
 	}
 	require.NoError(t, err)
 	require.ElementsMatch(t, expectedExecutedCommands, executor.executed)
+	require.Len(t, executor.envs, 2)
+	require.Equal(t, []string{
+		"A=value1",
+		"OKTETO_DEV_GATEWAY_NAME=dev-gateway",
+		"OKTETO_DEV_GATEWAY_NAMESPACE=gateway-ns",
+	}, executor.envs[0])
 }
 
 func TestCleanUp(t *testing.T) {

--- a/pkg/deployable/destroy_test.go
+++ b/pkg/deployable/destroy_test.go
@@ -45,6 +45,8 @@ func (fe *fakeDestroyExecutor) CleanUp(_ error) {
 }
 
 func TestRunDestroyWithError(t *testing.T) {
+	setFakeOktetoContext(t)
+
 	executor := &fakeDestroyExecutor{
 		err: assert.AnError,
 	}
@@ -80,6 +82,8 @@ func TestRunDestroyWithError(t *testing.T) {
 }
 
 func TestRunDestroyWithErrorAndForceDestroy(t *testing.T) {
+	setFakeOktetoContext(t)
+
 	executor := &fakeDestroyExecutor{
 		err: assert.AnError,
 	}

--- a/pkg/deployable/gatewayenv.go
+++ b/pkg/deployable/gatewayenv.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployable
+
+import (
+	"fmt"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+)
+
+// GetGatewayEnvironment returns the gateway metadata exposed as env vars for custom commands.
+func GetGatewayEnvironment() map[string]string {
+	result := make(map[string]string)
+
+	gateway := okteto.GetContext().Gateway
+	if gateway == nil {
+		return result
+	}
+
+	if gateway.Name != "" {
+		result[model.OktetoDevGatewayNameEnvVar] = gateway.Name
+	}
+	if gateway.Namespace != "" {
+		result[model.OktetoDevGatewayNamespaceEnvVar] = gateway.Namespace
+	}
+
+	return result
+}
+
+func appendGatewayEnvVars(envVars []string) []string {
+	gatewayEnv := GetGatewayEnvironment()
+	if value, ok := gatewayEnv[model.OktetoDevGatewayNameEnvVar]; ok {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", model.OktetoDevGatewayNameEnvVar, value))
+	}
+	if value, ok := gatewayEnv[model.OktetoDevGatewayNamespaceEnvVar]; ok {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", model.OktetoDevGatewayNamespaceEnvVar, value))
+	}
+
+	return envVars
+}

--- a/pkg/deployable/gatewayenv_test.go
+++ b/pkg/deployable/gatewayenv_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployable
+
+import (
+	"testing"
+
+	"github.com/okteto/okteto/pkg/model"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGatewayEnvironment(t *testing.T) {
+	originalStore := okteto.CurrentStore
+	defer func() { okteto.CurrentStore = originalStore }()
+
+	tests := []struct {
+		name     string
+		gateway  *okteto.GatewayMetadata
+		expected map[string]string
+	}{
+		{
+			name:     "no gateway configured",
+			gateway:  nil,
+			expected: map[string]string{},
+		},
+		{
+			name: "only gateway name",
+			gateway: &okteto.GatewayMetadata{
+				Name: "dev-gateway",
+			},
+			expected: map[string]string{
+				model.OktetoDevGatewayNameEnvVar: "dev-gateway",
+			},
+		},
+		{
+			name: "only gateway namespace",
+			gateway: &okteto.GatewayMetadata{
+				Namespace: "gateway-ns",
+			},
+			expected: map[string]string{
+				model.OktetoDevGatewayNamespaceEnvVar: "gateway-ns",
+			},
+		},
+		{
+			name: "gateway name and namespace",
+			gateway: &okteto.GatewayMetadata{
+				Name:      "dev-gateway",
+				Namespace: "gateway-ns",
+			},
+			expected: map[string]string{
+				model.OktetoDevGatewayNameEnvVar:      "dev-gateway",
+				model.OktetoDevGatewayNamespaceEnvVar: "gateway-ns",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			okteto.CurrentStore = &okteto.ContextStore{
+				CurrentContext: "test",
+				Contexts: map[string]*okteto.Context{
+					"test": {
+						Gateway: tt.gateway,
+					},
+				},
+			}
+
+			require.Equal(t, tt.expected, GetGatewayEnvironment())
+		})
+	}
+}

--- a/pkg/deployable/test.go
+++ b/pkg/deployable/test.go
@@ -54,6 +54,7 @@ func (dr *TestRunner) RunTest(ctx context.Context, params TestParameters) error 
 			oktetoLog.AddMaskedWord(v)
 		}
 	}
+	params.Variables = appendGatewayEnvVars(params.Variables)
 
 	// Setup helm version based on environment variable
 	if err := setupHelmVersion(); err != nil {

--- a/pkg/deployable/test_test.go
+++ b/pkg/deployable/test_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestTestRunner(t *testing.T) {
+	setFakeOktetoContext(t)
+
 	executor := &fakeExecutor{}
 	runner := TestRunner{
 		Executor: executor,

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -185,6 +185,12 @@ const (
 	// OktetoDomainEnvVar defines the domain the user is using
 	OktetoDomainEnvVar = "OKTETO_DOMAIN"
 
+	// OktetoDevGatewayNameEnvVar defines the configured gateway name for deploy/test/destroy commands
+	OktetoDevGatewayNameEnvVar = "OKTETO_DEV_GATEWAY_NAME"
+
+	// OktetoDevGatewayNamespaceEnvVar defines the configured gateway namespace for deploy/test/destroy commands
+	OktetoDevGatewayNamespaceEnvVar = "OKTETO_DEV_GATEWAY_NAMESPACE"
+
 	// SyncthingVersionEnvVar defines the syncthing version okteto should use
 	SyncthingVersionEnvVar = "OKTETO_SYNCTHING_VERSION"
 

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -217,6 +217,21 @@ func TestExtraHosts(t *testing.T) {
 }
 
 func TestCreateDockerfile(t *testing.T) {
+	originalStore := okteto.CurrentStore
+	defer func() { okteto.CurrentStore = originalStore }()
+
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Gateway: &okteto.GatewayMetadata{
+					Name:      "dev-gateway",
+					Namespace: "gateway-ns",
+				},
+			},
+		},
+	}
+
 	wdCtrl := filesystem.NewFakeWorkingDirectoryCtrl(filepath.Clean("/"))
 	fs := afero.NewMemMapFs()
 	fakeManifest := &model.Manifest{
@@ -347,7 +362,9 @@ COPY --from=runner /etc/.oktetocachekey .oktetocachekey
 					BuildEnvVars:        map[string]string{"OKTETO_BUIL_SVC_IMAGE": "ONE_VALUE", "OKTETO_BUILD_SVC2_IMAGE": "TWO_VALUE"},
 					DependenciesEnvVars: map[string]string{"OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD": "dependency_pass", "OKTETO_DEPENDENCY_DATABASE_VARIABLE_USERNAME": "dependency_user"},
 					OktetoCommandSpecificEnvVars: map[string]string{
-						constants.CIEnvVar: "true",
+						constants.CIEnvVar:                    "true",
+						model.OktetoDevGatewayNameEnvVar:      "dev-gateway",
+						model.OktetoDevGatewayNamespaceEnvVar: "gateway-ns",
 					},
 					DockerfileName:   "Dockerfile.test",
 					Command:          "test",
@@ -402,6 +419,10 @@ ENV OKTETO_BUIL_SVC_IMAGE="ONE_VALUE"
 
 
 ENV CI=true
+
+ENV OKTETO_DEV_GATEWAY_NAME=dev-gateway
+
+ENV OKTETO_DEV_GATEWAY_NAMESPACE=gateway-ns
 
 
 ENV OKTETO_DEPENDENCY_DATABASE_VARIABLE_PASSWORD="dependency_pass"


### PR DESCRIPTION
## Summary
- inject `OKTETO_DEV_GATEWAY_NAME` and `OKTETO_DEV_GATEWAY_NAMESPACE` into custom deploy, test, and destroy command execution
- use the gateway metadata already stored in the active Okteto context instead of re-querying the API
- only expose each variable when the corresponding gateway value is present

## What Changed
- added gateway env var constants in `pkg/model/const.go`
- added a shared helper in `pkg/deployable` to derive gateway env vars from `okteto.GetContext().Gateway`
- injected the gateway env vars into local deploy and destroy command execution
- injected the same gateway env vars into remote deploy, remote destroy, and remote test command environments
- updated tests to cover helper behavior, local command env injection, remote command params, and remote Dockerfile rendering

## Testing
- `GOCACHE=/Users/nachofuertesbernardo/.codex/worktrees/d06e/okteto/.gocache go test ./pkg/remote ./cmd/test ./cmd/deploy ./cmd/destroy ./pkg/deployable`
