### PR TITLE
fix(manifest): return compose error when filename matches compose pattern

### DIFF
--- a/pkg/discovery/compose.go
+++ b/pkg/discovery/compose.go
@@ -47,6 +47,17 @@ var (
 	}
 )
 
+// IsComposeFilename reports whether the base name of path matches a known compose file name.
+func IsComposeFilename(path string) bool {
+	base := filepath.Base(path)
+	for _, parts := range possibleComposeManifests {
+		if parts[len(parts)-1] == base {
+			return true
+		}
+	}
+	return false
+}
+
 // GetComposePath returns a compose file if exists, error otherwise
 func GetComposePath(wd string) (string, error) {
 	for _, possibleStackManifest := range possibleComposeManifests {

--- a/pkg/discovery/compose_test.go
+++ b/pkg/discovery/compose_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetComposePathWhenExists(t *testing.T) {
@@ -81,6 +82,36 @@ func TestGetComposePathWhenExists(t *testing.T) {
 			result, err := GetComposePath(wd)
 			assert.NoError(t, err)
 			assert.Equal(t, filepath.Join(wd, tt.expected), result)
+		})
+	}
+}
+
+func TestIsComposeFilename(t *testing.T) {
+	var tests = []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{name: "docker-compose.yml", path: "docker-compose.yml", expected: true},
+		{name: "docker-compose.yaml", path: "docker-compose.yaml", expected: true},
+		{name: "compose.yml", path: "compose.yml", expected: true},
+		{name: "compose.yaml", path: "compose.yaml", expected: true},
+		{name: "okteto-compose.yml", path: "okteto-compose.yml", expected: true},
+		{name: "okteto-compose.yaml", path: "okteto-compose.yaml", expected: true},
+		{name: "okteto-stack.yml", path: "okteto-stack.yml", expected: true},
+		{name: "okteto-stack.yaml", path: "okteto-stack.yaml", expected: true},
+		{name: "stack.yml", path: "stack.yml", expected: true},
+		{name: "stack.yaml", path: "stack.yaml", expected: true},
+		{name: "full path docker-compose.yml", path: "/some/dir/docker-compose.yml", expected: true},
+		{name: "full path in .okteto dir", path: "/some/.okteto/compose.yml", expected: true},
+		{name: "okteto manifest", path: "okteto.yml", expected: false},
+		{name: "random yaml", path: "my-service.yaml", expected: false},
+		{name: "empty", path: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsComposeFilename(tt.path))
 		})
 	}
 }

--- a/pkg/model/manifest.go
+++ b/pkg/model/manifest.go
@@ -370,6 +370,10 @@ func getManifestFromFile(cwd, manifestPath string, fs afero.Fs) (*Manifest, erro
 
 			// We just log the error in this case to not lose the stackErr. Before that, we are returning it
 			oktetoLog.Infof("there was an error loading compose file(s): %v", stackErr)
+			// if the file has a compose-like name, the compose error is more actionable
+			if discovery.IsComposeFilename(manifestPath) {
+				return nil, stackErr
+			}
 			// if not return original manifest err
 			return nil, err
 		}

--- a/pkg/model/manifest_test.go
+++ b/pkg/model/manifest_test.go
@@ -14,6 +14,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1059,6 +1060,31 @@ sync:
 			}
 		})
 	}
+}
+
+// Test_getManifestFromFile_composeFilenameReturnsComposeError exercises the
+// branch added in pkg/model/manifest.go that returns the compose/stack error
+// (instead of the okteto manifest error) when both parsers fail and the file
+// has a recognised compose filename.
+func Test_getManifestFromFile_composeFilenameReturnsComposeError(t *testing.T) {
+	// "asdasa: asda" is invalid for both the okteto manifest parser and the
+	// compose/stack parser, but it is not an empty file, depends-on error, or
+	// empty-service error, so none of the early-return guards fire.
+	invalidContent := []byte("asdasa: asda")
+
+	dir := t.TempDir()
+	composeFile := filepath.Join(dir, "docker-compose.yml")
+	require.NoError(t, os.WriteFile(composeFile, invalidContent, 0600))
+
+	_, err := getManifestFromFile(dir, composeFile, afero.NewMemMapFs())
+
+	require.Error(t, err)
+	// The returned error must come from the compose/stack parser.
+	require.ErrorContains(t, err, "invalid compose manifest")
+	// It must NOT be the okteto manifest error, which is what would be returned
+	// for a non-compose-named file in the same situation.
+	require.False(t, errors.Is(err, oktetoErrors.ErrInvalidManifest),
+		"expected compose/stack error to be returned, not okteto manifest error")
 }
 
 func TestHasDev(t *testing.T) {


### PR DESCRIPTION
## Summary

When a file with a compose-style name (e.g. `docker-compose.yml`, `compose.yaml`, `okteto-stack.yml`) failed to parse as both an okteto manifest and a compose/stack file, the user received the okteto manifest error — the less relevant of the two. Users pointing at a compose file expect compose errors.

The fix checks whether the filename matches a known compose pattern via a new `discovery.IsComposeFilename` helper and, if so, returns the compose error instead.

## What changed

- **`pkg/discovery/compose.go`** — adds `IsComposeFilename(path string) bool`, which checks the base filename against the existing `possibleComposeManifests` list (the same list used by `GetComposePath`).
- **`pkg/model/manifest.go`** — in `getManifestFromFile`, when both okteto manifest and compose loading fail, returns the compose error when `IsComposeFilename` matches.
- **`pkg/discovery/compose_test.go`** — 15 cases covering all known compose filenames, full paths, `.okteto/` subdirectory paths, and non-compose names.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Sonnet_4.6_(200K)](https://img.shields.io/badge/Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)