### PR TITLE
feat(catalog): add catalog list, deploy, and add commands

### DIFF
--- a/cmd/catalog/add.go
+++ b/cmd/catalog/add.go
@@ -1,0 +1,155 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	contextCMD "github.com/okteto/okteto/cmd/context"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/skratchdot/open-golang/open"
+	"github.com/spf13/cobra"
+)
+
+const adminCatalogPath = "/admin/catalog/new"
+
+// errNotAdmin is returned when a non-admin user runs `okteto catalog add`.
+// The mutations behind the form are admin-only on the backend, so there's no
+// point opening the UI for a user who can't submit it.
+var errNotAdmin = oktetoErrors.UserError{
+	E:    errors.New("adding a Catalog item requires administrator privileges"),
+	Hint: "Ask your Okteto administrator to add the item, or log in with an admin account.",
+}
+
+// browserOpener is injected for testing so we do not spawn a browser in unit tests.
+type browserOpener func(url string) error
+
+// Add returns the `okteto catalog add` cobra command. It opens the Okteto UI on
+// the "new Catalog item" page. Catalog item creation is admin-only, so this
+// command performs a pre-flight admin check before launching the browser.
+func Add(ctx context.Context) *cobra.Command {
+	var k8sContext string
+	cmd := &cobra.Command{
+		Use:   "add",
+		Short: "Open the Okteto UI to add a new Catalog item (admin only)",
+		Long: `Open the Okteto web UI on the "new Catalog item" page.
+
+Catalog items are managed from the Okteto UI and can only be created by Okteto
+administrators. This command checks your admin status and, if authorised,
+launches the browser on the admin page.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := contextCMD.NewContextCommand().Run(ctx, &contextCMD.Options{Context: k8sContext, Show: true}); err != nil {
+				return err
+			}
+			if !okteto.IsOkteto() {
+				return oktetoErrors.ErrContextIsNotOktetoCluster
+			}
+
+			c, err := NewCommand()
+			if err != nil {
+				return err
+			}
+			return c.ExecuteAdd(ctx, open.Start)
+		},
+	}
+	cmd.Flags().StringVarP(&k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	return cmd
+}
+
+// ExecuteAdd runs the admin pre-flight check and opens the browser on the
+// Catalog admin page. Passing the browserOpener in keeps the function unit
+// testable without launching a real browser.
+func (c *Command) ExecuteAdd(ctx context.Context, openBrowser browserOpener) error {
+	if err := ensureAdmin(ctx, c.okClient.User()); err != nil {
+		return err
+	}
+	return runAdd(okteto.GetContext().Name, openBrowser)
+}
+
+// ensureAdmin checks admin status via the Okteto API. A non-admin user is
+// rejected with a clear error. A generic query failure fails closed so auth or
+// configuration issues surface here rather than confusing the user at the UI
+// submission step. The single exception is a very old server that does not
+// expose `super` on the `me` type; in that case we defer to the UI since the
+// backend still enforces authorization on submission.
+func ensureAdmin(ctx context.Context, user types.UserInterface) error {
+	admin, err := user.IsAdmin(ctx)
+	if err != nil {
+		if isSuperFieldMissingErr(err) {
+			oktetoLog.Warning("This Okteto instance does not expose admin status; the Okteto UI will reject the submission if you are not an administrator.")
+			return nil
+		}
+		return fmt.Errorf("could not verify administrator privileges: %w", err)
+	}
+	if !admin {
+		return errNotAdmin
+	}
+	return nil
+}
+
+// isSuperFieldMissingErr reports whether the error indicates the server does
+// not know about the `super` field — the one narrow case where we fall back
+// to the UI's admin gate instead of blocking the user.
+func isSuperFieldMissingErr(err error) bool {
+	return strings.Contains(err.Error(), `Cannot query field "super"`)
+}
+
+// runAdd builds the admin catalog URL from the current context and opens it.
+func runAdd(contextURL string, openBrowser browserOpener) error {
+	target, err := buildAdminCatalogURL(contextURL)
+	if err != nil {
+		return err
+	}
+
+	oktetoLog.Information("Opening the Okteto Catalog in your browser to add a new item")
+	if err := openBrowser(target); err != nil {
+		oktetoLog.Warning("Could not open the browser automatically: %s", err)
+		oktetoLog.Println(fmt.Sprintf("Open this URL manually: %s", target))
+		return nil
+	}
+	oktetoLog.Println(fmt.Sprintf("If the page does not open, visit: %s", target))
+	return nil
+}
+
+// buildAdminCatalogURL appends the admin catalog path to the Okteto context
+// URL. When the context URL has no scheme we prepend "https://" *before*
+// parsing so hosts with ports or sub-paths (e.g. "example.com:8443",
+// "example.com/okteto") round-trip cleanly — letting url.Parse do the splitting.
+func buildAdminCatalogURL(contextURL string) (string, error) {
+	if contextURL == "" {
+		return "", fmt.Errorf("current Okteto Context has no URL")
+	}
+	trimmed := strings.TrimRight(contextURL, "/")
+	if !strings.Contains(trimmed, "://") {
+		trimmed = "https://" + trimmed
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid Okteto Context URL %q: %w", contextURL, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid Okteto Context URL %q: missing host", contextURL)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + adminCatalogPath
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}

--- a/cmd/catalog/add.go
+++ b/cmd/catalog/add.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/catalog/add_test.go
+++ b/cmd/catalog/add_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/catalog/add_test.go
+++ b/cmd/catalog/add_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/okteto/okteto/internal/test/client"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAdminCatalogURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "https URL is preserved",
+			input: "https://cloud.okteto.com",
+			want:  "https://cloud.okteto.com/admin/catalog/new",
+		},
+		{
+			name:  "trailing slash stripped",
+			input: "https://cloud.okteto.com/",
+			want:  "https://cloud.okteto.com/admin/catalog/new",
+		},
+		{
+			name:  "bare host gets https scheme",
+			input: "cloud.okteto.com",
+			want:  "https://cloud.okteto.com/admin/catalog/new",
+		},
+		{
+			name:  "http scheme preserved",
+			input: "http://localhost:8080",
+			want:  "http://localhost:8080/admin/catalog/new",
+		},
+		{
+			name:  "bare host with port",
+			input: "localhost:8080",
+			want:  "https://localhost:8080/admin/catalog/new",
+		},
+		{
+			name:  "bare host with subpath",
+			input: "example.com/okteto",
+			want:  "https://example.com/okteto/admin/catalog/new",
+		},
+		{
+			name:  "existing query and fragment are dropped",
+			input: "https://cloud.okteto.com/?foo=bar#baz",
+			want:  "https://cloud.okteto.com/admin/catalog/new",
+		},
+		{
+			name:    "empty URL rejected",
+			input:   "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildAdminCatalogURL(tc.input)
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRunAdd_InvokesOpenerWithURL(t *testing.T) {
+	var captured string
+	opener := func(target string) error {
+		captured = target
+		return nil
+	}
+	err := runAdd("https://cloud.okteto.com", opener)
+	require.NoError(t, err)
+	assert.Equal(t, "https://cloud.okteto.com/admin/catalog/new", captured)
+}
+
+func TestRunAdd_BrowserFailureDoesNotError(t *testing.T) {
+	opener := func(string) error { return errors.New("no browser") }
+	// We do not want CLI failure to block the user - they just get the URL printed.
+	assert.NoError(t, runAdd("https://cloud.okteto.com", opener))
+}
+
+func TestRunAdd_EmptyContextURLReturnsError(t *testing.T) {
+	opener := func(string) error { return nil }
+	err := runAdd("", opener)
+	require.Error(t, err)
+}
+
+func TestEnsureAdmin_AllowsAdmin(t *testing.T) {
+	user := &client.FakeUserClient{Admin: true}
+	require.NoError(t, ensureAdmin(context.Background(), user))
+}
+
+func TestEnsureAdmin_RejectsNonAdmin(t *testing.T) {
+	user := &client.FakeUserClient{Admin: false}
+	err := ensureAdmin(context.Background(), user)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNotAdmin.E)
+}
+
+func TestEnsureAdmin_GenericAPIFailureFailsClosed(t *testing.T) {
+	user := &client.FakeUserClient{}
+	user.SetIsAdminErr(errors.New("network unreachable"))
+	// Fail-closed on unknown errors so auth/config problems surface here rather
+	// than confusing the user at the UI submission step.
+	err := ensureAdmin(context.Background(), user)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not verify administrator privileges")
+}
+
+func TestEnsureAdmin_OldServerWithoutSuperFieldSoftFails(t *testing.T) {
+	user := &client.FakeUserClient{}
+	user.SetIsAdminErr(errors.New(`graphql: Cannot query field "super" on type "me"`))
+	// Very old servers do not expose `super`; the UI still enforces admin
+	// authorization on submission, so we proceed instead of blocking.
+	assert.NoError(t, ensureAdmin(context.Background(), user))
+}
+
+func TestExecuteAdd_NonAdminDoesNotOpenBrowser(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts:       map[string]*okteto.Context{"test": {Name: "https://cloud.okteto.com"}},
+	}
+	cmd := &Command{
+		okClient: &client.FakeOktetoClient{
+			Users: &client.FakeUserClient{Admin: false},
+		},
+	}
+	var opened bool
+	opener := func(string) error {
+		opened = true
+		return nil
+	}
+	err := cmd.ExecuteAdd(context.Background(), opener)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNotAdmin.E)
+	assert.False(t, opened, "browser must not open when the user is not an admin")
+}
+
+func TestExecuteAdd_AdminOpensBrowser(t *testing.T) {
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts:       map[string]*okteto.Context{"test": {Name: "https://cloud.okteto.com"}},
+	}
+	cmd := &Command{
+		okClient: &client.FakeOktetoClient{
+			Users: &client.FakeUserClient{Admin: true},
+		},
+	}
+	var captured string
+	opener := func(target string) error {
+		captured = target
+		return nil
+	}
+	require.NoError(t, cmd.ExecuteAdd(context.Background(), opener))
+	assert.Equal(t, "https://cloud.okteto.com/admin/catalog/new", captured)
+}
+
+// Compile-time assertion that FakeUserClient still satisfies UserInterface
+// after the addition of IsAdmin, so this test file also guards the contract.
+var _ types.UserInterface = (*client.FakeUserClient)(nil)

--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"context"
+
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// Command groups the shared state for catalog subcommands.
+type Command struct {
+	okClient types.OktetoInterface
+}
+
+// NewCommand builds a Command wired to the real Okteto client.
+func NewCommand() (*Command, error) {
+	c, err := okteto.NewOktetoClient()
+	if err != nil {
+		return nil, err
+	}
+	return &Command{okClient: c}, nil
+}
+
+// Catalog returns the parent `okteto catalog` cobra command.
+func Catalog(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "catalog",
+		Short: "Browse and deploy Okteto Catalog items",
+		Long: `Browse and deploy pre-configured Development Environments from the Okteto Catalog.
+
+Catalog items are templates defined by your administrator. Each item points at a
+git repository, a branch, an Okteto manifest, and optional default variables.
+Deploying a catalog item creates a Development Environment in your current Okteto
+Namespace.`,
+	}
+
+	cmd.AddCommand(List(ctx))
+	cmd.AddCommand(Deploy(ctx))
+	cmd.AddCommand(Add(ctx))
+	return cmd
+}

--- a/cmd/catalog/catalog.go
+++ b/cmd/catalog/catalog.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/catalog/deploy.go
+++ b/cmd/catalog/deploy.go
@@ -1,0 +1,388 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agext/levenshtein"
+	contextCMD "github.com/okteto/okteto/cmd/context"
+	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/analytics"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/okteto/okteto/pkg/validator"
+	"github.com/spf13/cobra"
+)
+
+const (
+	deployTimeoutDefault = 5 * time.Minute
+	varKV                = 2
+	// suggestionMaxDistance caps how tolerant the "did you mean?" suggestion is.
+	// Names within this Levenshtein distance are considered similar enough to suggest.
+	suggestionMaxDistance = 3
+)
+
+// errCatalogItemNotFound is returned when no catalog item matches the requested name.
+var errCatalogItemNotFound = errors.New("catalog item not found")
+
+// errNoCatalogItems is returned when deploy is invoked interactively but the
+// catalog is empty, so there is nothing to pick from.
+var errNoCatalogItems = oktetoErrors.UserError{
+	E:    errors.New("no catalog items are available"),
+	Hint: "Ask your administrator to add a catalog item, or run 'okteto catalog add' to open the Okteto UI.",
+}
+
+type deployFlags struct {
+	name       string
+	namespace  string
+	k8sContext string
+	branch     string
+	file       string
+	variables  []string
+	timeout    time.Duration
+	wait       bool
+}
+
+// Deploy returns the `okteto catalog deploy <name>` cobra command.
+func Deploy(ctx context.Context) *cobra.Command {
+	flags := &deployFlags{}
+	cmd := &cobra.Command{
+		Use:   "deploy <catalog-item>",
+		Short: "Deploy a Development Environment from the Okteto Catalog",
+		Long: `Deploy a Development Environment from an Okteto Catalog item.
+
+The catalog item's repository, branch, manifest path, and default variables are
+used to create the Development Environment in your current Okteto Namespace.
+Use --var KEY=VALUE to override any default variable.`,
+		Args: utils.MaximumNArgsAccepted(1, ""),
+		Example: `Run without arguments to pick an item from an interactive list:
+  okteto catalog deploy
+
+Deploy a catalog item by name into the current namespace:
+  okteto catalog deploy demo-app
+
+Override a variable and deploy into a specific namespace:
+  okteto catalog deploy demo-app -n my-ns --var API_TOKEN=xyz`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			catalogItemName := ""
+			if len(args) > 0 {
+				catalogItemName = args[0]
+			}
+
+			if err := validator.CheckReservedVariablesNameOption(flags.variables); err != nil {
+				return err
+			}
+
+			ctxOptions := &contextCMD.Options{
+				Namespace: flags.namespace,
+				Context:   flags.k8sContext,
+				Show:      true,
+			}
+			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+				return err
+			}
+			if !okteto.IsOkteto() {
+				return oktetoErrors.ErrContextIsNotOktetoCluster
+			}
+
+			c, err := NewCommand()
+			if err != nil {
+				return err
+			}
+			return c.ExecuteDeploy(ctx, catalogItemName, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.name, "name", "", "name of the deployed Development Environment (defaults to the catalog item name)")
+	cmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "namespace to deploy into (defaults to your current Okteto Namespace)")
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&flags.branch, "branch", "b", "", "override the branch configured on the catalog item")
+	cmd.Flags().StringVarP(&flags.file, "file", "f", "", "override the manifest path configured on the catalog item")
+	cmd.Flags().StringArrayVarP(&flags.variables, "var", "v", []string{}, "set a variable to override the catalog item default (can be set more than once, KEY=VALUE)")
+	cmd.Flags().DurationVarP(&flags.timeout, "timeout", "t", deployTimeoutDefault, "how long to wait for the deployment to complete (e.g. 1s, 2m, 3h)")
+	cmd.Flags().BoolVarP(&flags.wait, "wait", "w", true, "wait until the deployment finishes")
+	return cmd
+}
+
+// catalogItemPicker prompts the user to pick a catalog item from a list and
+// returns the chosen item's name. It is an interface so tests can substitute a
+// deterministic picker instead of driving the terminal.
+type catalogItemPicker func(items []types.GitCatalogItem) (string, error)
+
+// ExecuteDeploy resolves the catalog item, merges variables, triggers a deploy,
+// and optionally waits for it to finish while streaming its logs. When
+// catalogItemName is empty the user is prompted to pick one from an interactive
+// list, matching the UX of `okteto namespace use`.
+func (c *Command) ExecuteDeploy(ctx context.Context, catalogItemName string, flags *deployFlags) error {
+	err := c.executeDeploy(ctx, catalogItemName, flags, promptForCatalogItem)
+	analytics.TrackCatalogDeploy(err == nil, len(flags.variables) > 0)
+	return err
+}
+
+func (c *Command) executeDeploy(ctx context.Context, catalogItemName string, flags *deployFlags, pick catalogItemPicker) error {
+	items, err := c.okClient.Catalog().List(ctx)
+	if err != nil {
+		var uErr oktetoErrors.UserError
+		if errors.As(err, &uErr) {
+			return uErr
+		}
+		return fmt.Errorf("failed to list catalog items: %w", err)
+	}
+
+	if catalogItemName == "" {
+		if len(items) == 0 {
+			return errNoCatalogItems
+		}
+		catalogItemName, err = pick(items)
+		if err != nil {
+			return err
+		}
+	}
+
+	item, ok := findCatalogItem(items, catalogItemName)
+	if !ok {
+		return notFoundError(catalogItemName, items)
+	}
+
+	userVars, err := parseVariableOverrides(flags.variables)
+	if err != nil {
+		return err
+	}
+	mergedVars := mergeVariables(item.Variables, userVars)
+
+	opts := types.CatalogDeployOptions{
+		CatalogItemID: item.ID,
+		Name:          firstNonEmpty(flags.name, item.Name),
+		Repository:    item.RepositoryURL,
+		Branch:        firstNonEmpty(flags.branch, item.Branch),
+		Filename:      firstNonEmpty(flags.file, item.ManifestPath),
+		Namespace:     firstNonEmpty(flags.namespace, okteto.GetContext().Namespace),
+		Variables:     mergedVars,
+	}
+
+	oktetoLog.Spinner(fmt.Sprintf("Deploying '%s' from the catalog...", opts.Name))
+	oktetoLog.StartSpinner()
+	defer oktetoLog.StopSpinner()
+
+	resp, err := c.okClient.Catalog().Deploy(ctx, opts)
+	if err != nil {
+		var uErr oktetoErrors.UserError
+		if errors.As(err, &uErr) {
+			return uErr
+		}
+		return fmt.Errorf("failed to deploy catalog item '%s': %w", item.Name, err)
+	}
+
+	if !flags.wait {
+		oktetoLog.StopSpinner()
+		oktetoLog.Success("Development Environment '%s' scheduled for deployment", opts.Name)
+		return nil
+	}
+
+	if err := c.waitUntilRunning(ctx, opts.Name, opts.Namespace, resp.Action, flags.timeout); err != nil {
+		return fmt.Errorf("wait for '%s' to finish failed: %w", opts.Name, err)
+	}
+
+	oktetoLog.StopSpinner()
+	oktetoLog.Success("Development Environment '%s' successfully deployed", opts.Name)
+	return nil
+}
+
+// waitUntilRunning blocks until the deploy action finishes or CTRL+C is hit,
+// concurrently streaming the deploy's logs so the user sees live progress.
+func (c *Command) waitUntilRunning(ctx context.Context, name, namespace string, action *types.Action, timeout time.Duration) error {
+	oktetoLog.Spinner(fmt.Sprintf("Waiting for '%s' to be deployed...", name))
+
+	waitCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+	defer signal.Stop(stop)
+
+	// The channel is buffered for both writers so the losing goroutine never
+	// blocks after the select has resolved.
+	exit := make(chan error, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := c.okClient.Pipeline().WaitForActionProgressing(waitCtx, name, namespace, action.Name, timeout); err != nil {
+			oktetoLog.Infof("waiting for action to progress failed: %v", err)
+			exit <- err
+			return
+		}
+		// Log streaming errors are advisory; they don't signal deploy failure.
+		if err := c.okClient.Stream().PipelineLogs(waitCtx, name, namespace, action.Name, timeout); err != nil {
+			oktetoLog.Warning("deploy logs cannot be streamed due to connectivity issues")
+			oktetoLog.Infof("deploy logs cannot be streamed due to connectivity issues: %v", err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		exit <- c.okClient.Pipeline().WaitForActionToFinish(waitCtx, name, namespace, action.Name, timeout)
+	}()
+
+	select {
+	case <-stop:
+		oktetoLog.Infof("CTRL+C received, starting shutdown sequence")
+		cancel()
+		wg.Wait()
+		return oktetoErrors.ErrIntSig
+	case err := <-exit:
+		cancel()
+		wg.Wait()
+		return err
+	}
+}
+
+// notFoundError builds a user-friendly "not found" error, with a "did you mean?"
+// suggestion when a sufficiently similar catalog item name exists.
+func notFoundError(requested string, items []types.GitCatalogItem) error {
+	suggestion := closestName(requested, items)
+	if suggestion != "" {
+		return fmt.Errorf("%w: %q. Did you mean %q? Run 'okteto catalog list' to see available items",
+			errCatalogItemNotFound, requested, suggestion)
+	}
+	return fmt.Errorf("%w: %q. Run 'okteto catalog list' to see available items",
+		errCatalogItemNotFound, requested)
+}
+
+// closestName returns the item name whose Levenshtein distance from target is
+// smallest, as long as it is within suggestionMaxDistance. An empty string
+// means no suggestion is worth offering.
+func closestName(target string, items []types.GitCatalogItem) string {
+	best := ""
+	bestDist := suggestionMaxDistance + 1
+	for _, it := range items {
+		d := levenshtein.Distance(strings.ToLower(target), strings.ToLower(it.Name), nil)
+		if d < bestDist {
+			bestDist = d
+			best = it.Name
+		}
+	}
+	if bestDist > suggestionMaxDistance {
+		return ""
+	}
+	return best
+}
+
+// findCatalogItem returns the item whose name matches exactly.
+func findCatalogItem(items []types.GitCatalogItem, name string) (types.GitCatalogItem, bool) {
+	for _, it := range items {
+		if it.Name == name {
+			return it, true
+		}
+	}
+	return types.GitCatalogItem{}, false
+}
+
+// parseVariableOverrides converts KEY=VALUE strings into Variables.
+func parseVariableOverrides(raw []string) ([]types.Variable, error) {
+	vars := make([]types.Variable, 0, len(raw))
+	for _, v := range raw {
+		kv := strings.SplitN(v, "=", varKV)
+		if len(kv) != varKV || kv[0] == "" {
+			return nil, fmt.Errorf("invalid variable value %q: must follow KEY=VALUE format", v)
+		}
+		vars = append(vars, types.Variable{Name: kv[0], Value: kv[1]})
+	}
+	return vars, nil
+}
+
+// mergeVariables returns catalog defaults overridden by user values, matching the UI flow.
+func mergeVariables(defaults []types.GitCatalogItemVariable, overrides []types.Variable) []types.Variable {
+	merged := make(map[string]string, len(defaults)+len(overrides))
+	order := make([]string, 0, len(defaults)+len(overrides))
+	for _, d := range defaults {
+		if _, seen := merged[d.Name]; !seen {
+			order = append(order, d.Name)
+		}
+		merged[d.Name] = d.Value
+	}
+	for _, o := range overrides {
+		if _, seen := merged[o.Name]; !seen {
+			order = append(order, o.Name)
+		}
+		merged[o.Name] = o.Value
+	}
+
+	out := make([]types.Variable, 0, len(order))
+	for _, name := range order {
+		out = append(out, types.Variable{Name: name, Value: merged[name]})
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// promptForCatalogItem shows an interactive list of catalog items, returns the
+// name of the one the user picked. Items are sorted alphabetically so repeated
+// runs show them in the same order. Each entry's label includes the repository
+// and branch so the user can tell similar items apart at a glance.
+func promptForCatalogItem(items []types.GitCatalogItem) (string, error) {
+	sorted := make([]types.GitCatalogItem, len(items))
+	copy(sorted, items)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	options := make([]utils.SelectorItem, 0, len(sorted))
+	for _, it := range sorted {
+		options = append(options, utils.SelectorItem{
+			Name:   it.Name,
+			Label:  formatPickerLabel(it),
+			Enable: true,
+		})
+	}
+
+	selector := utils.NewOktetoSelector("Select the catalog item to deploy:", "Catalog Item")
+	chosen, err := selector.AskForOptionsOkteto(options, -1)
+	if err != nil {
+		return "", err
+	}
+	return chosen, nil
+}
+
+// formatPickerLabel renders a catalog item as "<name> — <repo>@<branch>" so the
+// selector shows enough context to disambiguate similarly-named items.
+func formatPickerLabel(it types.GitCatalogItem) string {
+	branch := it.Branch
+	if branch == "" {
+		branch = "default"
+	}
+	if it.RepositoryURL == "" {
+		return it.Name
+	}
+	return fmt.Sprintf("%s — %s@%s", it.Name, it.RepositoryURL, branch)
+}

--- a/cmd/catalog/deploy.go
+++ b/cmd/catalog/deploy.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/catalog/deploy_test.go
+++ b/cmd/catalog/deploy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/catalog/deploy_test.go
+++ b/cmd/catalog/deploy_test.go
@@ -1,0 +1,425 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/okteto/okteto/internal/test/client"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVariableOverrides(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    []types.Variable
+		wantErr bool
+	}{
+		{
+			name:  "empty slice",
+			input: nil,
+			want:  []types.Variable{},
+		},
+		{
+			name:  "single valid pair",
+			input: []string{"FOO=bar"},
+			want:  []types.Variable{{Name: "FOO", Value: "bar"}},
+		},
+		{
+			name:  "value containing equals preserved",
+			input: []string{"TOKEN=abc=def"},
+			want:  []types.Variable{{Name: "TOKEN", Value: "abc=def"}},
+		},
+		{
+			name:  "empty value allowed",
+			input: []string{"EMPTY="},
+			want:  []types.Variable{{Name: "EMPTY", Value: ""}},
+		},
+		{
+			name:    "missing equals rejected",
+			input:   []string{"NOTPAIR"},
+			wantErr: true,
+		},
+		{
+			name:    "empty key rejected",
+			input:   []string{"=value"},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseVariableOverrides(tc.input)
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMergeVariables_OverridesReplaceDefaults(t *testing.T) {
+	defaults := []types.GitCatalogItemVariable{
+		{Name: "FOO", Value: "default-foo"},
+		{Name: "BAR", Value: "default-bar"},
+	}
+	overrides := []types.Variable{
+		{Name: "FOO", Value: "user-foo"},
+		{Name: "BAZ", Value: "user-baz"},
+	}
+	merged := mergeVariables(defaults, overrides)
+	require.Len(t, merged, 3)
+	byName := map[string]string{}
+	for _, v := range merged {
+		byName[v.Name] = v.Value
+	}
+	assert.Equal(t, "user-foo", byName["FOO"])
+	assert.Equal(t, "default-bar", byName["BAR"])
+	assert.Equal(t, "user-baz", byName["BAZ"])
+}
+
+func TestMergeVariables_PreservesDefaultOrder(t *testing.T) {
+	defaults := []types.GitCatalogItemVariable{
+		{Name: "A"}, {Name: "B"}, {Name: "C"},
+	}
+	merged := mergeVariables(defaults, nil)
+	require.Len(t, merged, 3)
+	assert.Equal(t, "A", merged[0].Name)
+	assert.Equal(t, "B", merged[1].Name)
+	assert.Equal(t, "C", merged[2].Name)
+}
+
+func TestMergeVariables_EmptyInputs(t *testing.T) {
+	merged := mergeVariables(nil, nil)
+	assert.Empty(t, merged)
+}
+
+func TestMergeVariables_RepeatedOverrideKeyKeepsLast(t *testing.T) {
+	// Documents `--var FOO=a --var FOO=b` semantics: the last override wins
+	// and the variable is only emitted once.
+	overrides := []types.Variable{
+		{Name: "FOO", Value: "first"},
+		{Name: "FOO", Value: "second"},
+	}
+	merged := mergeVariables(nil, overrides)
+	require.Len(t, merged, 1)
+	assert.Equal(t, "FOO", merged[0].Name)
+	assert.Equal(t, "second", merged[0].Value)
+}
+
+func TestFindCatalogItem(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{ID: "1", Name: "alpha"},
+		{ID: "2", Name: "beta"},
+	}
+	tests := []struct {
+		name     string
+		lookup   string
+		wantID   string
+		wantFind bool
+	}{
+		{name: "exact match", lookup: "alpha", wantID: "1", wantFind: true},
+		{name: "second entry", lookup: "beta", wantID: "2", wantFind: true},
+		{name: "no match", lookup: "gamma", wantFind: false},
+		{name: "empty name", lookup: "", wantFind: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := findCatalogItem(items, tc.lookup)
+			assert.Equal(t, tc.wantFind, ok)
+			assert.Equal(t, tc.wantID, got.ID)
+		})
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		inputs []string
+		want   string
+	}{
+		{name: "first wins", inputs: []string{"a", "b"}, want: "a"},
+		{name: "skips empty", inputs: []string{"", "b"}, want: "b"},
+		{name: "all empty", inputs: []string{"", ""}, want: ""},
+		{name: "no args", inputs: nil, want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, firstNonEmpty(tc.inputs...))
+		})
+	}
+}
+
+func TestClosestName_SuggestsCloseMatch(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{Name: "demo-app"},
+		{Name: "movies"},
+		{Name: "api"},
+	}
+	assert.Equal(t, "demo-app", closestName("dem-app", items))
+}
+
+func TestClosestName_CaseInsensitive(t *testing.T) {
+	items := []types.GitCatalogItem{{Name: "MyApp"}}
+	assert.Equal(t, "MyApp", closestName("myapp", items))
+}
+
+func TestClosestName_NoSuggestionWhenTooFar(t *testing.T) {
+	items := []types.GitCatalogItem{{Name: "demo-app"}}
+	assert.Empty(t, closestName("totally-unrelated-name", items))
+}
+
+func TestClosestName_EmptyItems(t *testing.T) {
+	assert.Empty(t, closestName("anything", nil))
+}
+
+func TestNotFoundError_IncludesSuggestionWhenClose(t *testing.T) {
+	items := []types.GitCatalogItem{{Name: "demo-app"}}
+	err := notFoundError("demoapp", items)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errCatalogItemNotFound)
+	assert.Contains(t, err.Error(), `Did you mean "demo-app"?`)
+}
+
+func TestNotFoundError_OmitsSuggestionWhenFar(t *testing.T) {
+	items := []types.GitCatalogItem{{Name: "demo-app"}}
+	err := notFoundError("not-a-match-at-all", items)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "Did you mean")
+}
+
+// deployTestFixture assembles a Command backed by fake clients so ExecuteDeploy
+// can be tested without hitting the network.
+type deployTestFixture struct {
+	catalogResp  *client.FakeCatalogResponse
+	pipelineResp *client.FakePipelineResponses
+	streamResp   *client.FakeStreamResponse
+	cmd          *Command
+}
+
+func newDeployTestFixture(t *testing.T, items []types.GitCatalogItem) *deployTestFixture {
+	t.Helper()
+	okteto.CurrentStore = &okteto.ContextStore{
+		CurrentContext: "test",
+		Contexts: map[string]*okteto.Context{
+			"test": {Name: "test", Namespace: "my-ns"},
+		},
+	}
+	catalogResp := &client.FakeCatalogResponse{
+		CatalogItems: items,
+		DeployResp: &types.GitDeployResponse{
+			Action:    &types.Action{ID: "action-id", Name: "cli", Status: "progressing"},
+			GitDeploy: &types.GitDeploy{ID: "deploy-id", Name: "demo", Status: "progressing"},
+		},
+	}
+	pipelineResp := &client.FakePipelineResponses{}
+	streamResp := &client.FakeStreamResponse{}
+	return &deployTestFixture{
+		catalogResp:  catalogResp,
+		pipelineResp: pipelineResp,
+		streamResp:   streamResp,
+		cmd: &Command{
+			okClient: &client.FakeOktetoClient{
+				CatalogClient:  client.NewFakeCatalogClient(catalogResp),
+				PipelineClient: client.NewFakePipelineClient(pipelineResp),
+				StreamClient:   client.NewFakeStreamClient(streamResp),
+			},
+		},
+	}
+}
+
+func TestExecuteDeploy_AppliesCatalogDefaultsAndOverrides(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{
+			ID:            "item-1",
+			Name:          "demo",
+			RepositoryURL: "https://github.com/okteto/movies",
+			Branch:        "main",
+			ManifestPath:  "okteto.yml",
+			Variables: []types.GitCatalogItemVariable{
+				{Name: "API_TOKEN", Value: "default-token"},
+				{Name: "REGION", Value: "eu-west-1"},
+			},
+		},
+	}
+	fx := newDeployTestFixture(t, items)
+
+	flags := &deployFlags{
+		variables: []string{"API_TOKEN=override"},
+		timeout:   time.Second,
+		wait:      false,
+	}
+	err := fx.cmd.ExecuteDeploy(context.Background(), "demo", flags)
+	require.NoError(t, err)
+
+	opts := fx.catalogResp.LastDeployOpts
+	assert.Equal(t, "item-1", opts.CatalogItemID)
+	assert.Equal(t, "demo", opts.Name)
+	assert.Equal(t, "https://github.com/okteto/movies", opts.Repository)
+	assert.Equal(t, "main", opts.Branch)
+	assert.Equal(t, "okteto.yml", opts.Filename)
+	assert.Equal(t, "my-ns", opts.Namespace)
+
+	byName := map[string]string{}
+	for _, v := range opts.Variables {
+		byName[v.Name] = v.Value
+	}
+	assert.Equal(t, "override", byName["API_TOKEN"])
+	assert.Equal(t, "eu-west-1", byName["REGION"])
+}
+
+func TestExecuteDeploy_FlagOverridesWinOverCatalogFields(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{ID: "item-1", Name: "demo", RepositoryURL: "repo", Branch: "main", ManifestPath: "okteto.yml"},
+	}
+	fx := newDeployTestFixture(t, items)
+
+	flags := &deployFlags{
+		name:      "custom-name",
+		namespace: "other-ns",
+		branch:    "feature/x",
+		file:      "custom/okteto.yml",
+		wait:      false,
+	}
+	require.NoError(t, fx.cmd.ExecuteDeploy(context.Background(), "demo", flags))
+
+	opts := fx.catalogResp.LastDeployOpts
+	assert.Equal(t, "custom-name", opts.Name)
+	assert.Equal(t, "other-ns", opts.Namespace)
+	assert.Equal(t, "feature/x", opts.Branch)
+	assert.Equal(t, "custom/okteto.yml", opts.Filename)
+}
+
+func TestExecuteDeploy_NotFoundSuggestsSimilar(t *testing.T) {
+	items := []types.GitCatalogItem{{ID: "item-1", Name: "demo-app"}}
+	fx := newDeployTestFixture(t, items)
+
+	err := fx.cmd.ExecuteDeploy(context.Background(), "demoapp", &deployFlags{wait: false})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errCatalogItemNotFound)
+	assert.Contains(t, err.Error(), `Did you mean "demo-app"?`)
+}
+
+func TestExecuteDeploy_PropagatesListError(t *testing.T) {
+	fx := newDeployTestFixture(t, nil)
+	fx.catalogResp.ErrList = errors.New("boom")
+
+	err := fx.cmd.ExecuteDeploy(context.Background(), "demo", &deployFlags{wait: false})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestExecuteDeploy_PropagatesDeployError(t *testing.T) {
+	items := []types.GitCatalogItem{{ID: "item-1", Name: "demo", RepositoryURL: "repo"}}
+	fx := newDeployTestFixture(t, items)
+	fx.catalogResp.ErrDeploy = errors.New("deploy boom")
+
+	err := fx.cmd.ExecuteDeploy(context.Background(), "demo", &deployFlags{wait: false})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deploy boom")
+}
+
+func TestExecuteDeploy_WaitPathSucceeds(t *testing.T) {
+	items := []types.GitCatalogItem{{ID: "item-1", Name: "demo", RepositoryURL: "repo"}}
+	fx := newDeployTestFixture(t, items)
+
+	err := fx.cmd.ExecuteDeploy(context.Background(), "demo", &deployFlags{wait: true, timeout: time.Second})
+	require.NoError(t, err)
+}
+
+func TestExecuteDeploy_WaitPathSurfacesActionError(t *testing.T) {
+	items := []types.GitCatalogItem{{ID: "item-1", Name: "demo", RepositoryURL: "repo"}}
+	fx := newDeployTestFixture(t, items)
+	fx.pipelineResp.WaitErr = errors.New("action failed")
+
+	err := fx.cmd.ExecuteDeploy(context.Background(), "demo", &deployFlags{wait: true, timeout: time.Second})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "action failed")
+}
+
+func TestExecuteDeploy_PromptsWhenNameOmitted(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{ID: "item-1", Name: "alpha", RepositoryURL: "repo-a"},
+		{ID: "item-2", Name: "beta", RepositoryURL: "repo-b"},
+	}
+	fx := newDeployTestFixture(t, items)
+
+	var received []types.GitCatalogItem
+	picker := func(list []types.GitCatalogItem) (string, error) {
+		received = list
+		return "beta", nil
+	}
+	err := fx.cmd.executeDeploy(context.Background(), "", &deployFlags{wait: false}, picker)
+	require.NoError(t, err)
+
+	assert.Len(t, received, 2)
+	assert.Equal(t, "item-2", fx.catalogResp.LastDeployOpts.CatalogItemID)
+	assert.Equal(t, "beta", fx.catalogResp.LastDeployOpts.Name)
+}
+
+func TestExecuteDeploy_PickerCancelSurfacesError(t *testing.T) {
+	items := []types.GitCatalogItem{{ID: "item-1", Name: "alpha"}}
+	fx := newDeployTestFixture(t, items)
+
+	cancelled := errors.New("user cancelled")
+	picker := func([]types.GitCatalogItem) (string, error) { return "", cancelled }
+
+	err := fx.cmd.executeDeploy(context.Background(), "", &deployFlags{wait: false}, picker)
+	require.ErrorIs(t, err, cancelled)
+}
+
+func TestExecuteDeploy_EmptyCatalogReturnsUserError(t *testing.T) {
+	fx := newDeployTestFixture(t, nil)
+	picker := func([]types.GitCatalogItem) (string, error) {
+		t.Fatal("picker should not be called when the catalog is empty")
+		return "", nil
+	}
+
+	err := fx.cmd.executeDeploy(context.Background(), "", &deployFlags{wait: false}, picker)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoCatalogItems.E)
+}
+
+func TestFormatPickerLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		in   types.GitCatalogItem
+		want string
+	}{
+		{
+			name: "full label",
+			in:   types.GitCatalogItem{Name: "demo", RepositoryURL: "https://github.com/okteto/movies", Branch: "main"},
+			want: "demo — https://github.com/okteto/movies@main",
+		},
+		{
+			name: "no branch defaults to 'default'",
+			in:   types.GitCatalogItem{Name: "demo", RepositoryURL: "repo"},
+			want: "demo — repo@default",
+		},
+		{
+			name: "no repo shows just the name",
+			in:   types.GitCatalogItem{Name: "demo"},
+			want: "demo",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatPickerLabel(tc.in))
+		})
+	}
+}

--- a/cmd/catalog/list.go
+++ b/cmd/catalog/list.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/cmd/catalog/list.go
+++ b/cmd/catalog/list.go
@@ -1,0 +1,172 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	contextCMD "github.com/okteto/okteto/cmd/context"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// errInvalidListOutput is returned when the -o flag is set to an unsupported value.
+var errInvalidListOutput = fmt.Errorf("output format is not accepted. Value must be one of: ['json', 'yaml']")
+
+type listFlags struct {
+	output     string
+	k8sContext string
+}
+
+// catalogListOutput is the view model for a single catalog item in list output.
+type catalogListOutput struct {
+	Name          string   `json:"name" yaml:"name"`
+	RepositoryURL string   `json:"repositoryUrl" yaml:"repositoryUrl"`
+	Branch        string   `json:"branch" yaml:"branch"`
+	ManifestPath  string   `json:"manifestPath" yaml:"manifestPath"`
+	Variables     []string `json:"variables" yaml:"variables"`
+	ReadOnly      bool     `json:"readOnly" yaml:"readOnly"`
+}
+
+// List returns the `okteto catalog list` cobra command.
+func List(ctx context.Context) *cobra.Command {
+	flags := &listFlags{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the available Okteto Catalog items",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateListOutput(flags.output); err != nil {
+				return err
+			}
+
+			ctxOptions := &contextCMD.Options{Context: flags.k8sContext}
+			if flags.output == "" {
+				ctxOptions.Show = true
+			}
+			if err := contextCMD.NewContextCommand().Run(ctx, ctxOptions); err != nil {
+				return err
+			}
+			if !okteto.IsOkteto() {
+				return oktetoErrors.ErrContextIsNotOktetoCluster
+			}
+
+			c, err := NewCommand()
+			if err != nil {
+				return err
+			}
+			items, err := c.okClient.Catalog().List(ctx)
+			if err != nil {
+				var uErr oktetoErrors.UserError
+				if errors.As(err, &uErr) {
+					return uErr
+				}
+				return fmt.Errorf("failed to list catalog items: %w", err)
+			}
+			return displayCatalogItems(os.Stdout, items, flags.output)
+		},
+	}
+
+	cmd.Flags().StringVarP(&flags.k8sContext, "context", "c", "", "overwrite the current Okteto Context")
+	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "output format. One of: ['json', 'yaml']")
+	return cmd
+}
+
+// displayCatalogItems renders the catalog items in the requested format.
+func displayCatalogItems(w io.Writer, items []types.GitCatalogItem, format string) error {
+	view := toCatalogListOutput(items)
+	switch format {
+	case "json":
+		if len(view) == 0 {
+			fmt.Fprintln(w, "[]")
+			return nil
+		}
+		bytes, err := json.MarshalIndent(view, "", " ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(w, string(bytes))
+	case "yaml":
+		bytes, err := yaml.Marshal(view)
+		if err != nil {
+			return err
+		}
+		fmt.Fprint(w, string(bytes))
+	default:
+		if len(view) == 0 {
+			fmt.Fprintln(w, "There are no catalog items available")
+			return nil
+		}
+		tw := tabwriter.NewWriter(w, 1, 1, 2, ' ', 0)
+		fmt.Fprint(tw, "Name\tRepository\tBranch\tManifest\tRead-Only\n")
+		for _, item := range view {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%v\n",
+				item.Name,
+				item.RepositoryURL,
+				valueOrDash(item.Branch),
+				valueOrDash(item.ManifestPath),
+				item.ReadOnly,
+			)
+		}
+		return tw.Flush()
+	}
+	return nil
+}
+
+// toCatalogListOutput maps API types into stable display structs, sorted by name
+// so output is deterministic across runs.
+func toCatalogListOutput(items []types.GitCatalogItem) []catalogListOutput {
+	out := make([]catalogListOutput, 0, len(items))
+	for _, it := range items {
+		vars := make([]string, 0, len(it.Variables))
+		for _, v := range it.Variables {
+			vars = append(vars, v.Name)
+		}
+		out = append(out, catalogListOutput{
+			Name:          it.Name,
+			RepositoryURL: it.RepositoryURL,
+			Branch:        it.Branch,
+			ManifestPath:  it.ManifestPath,
+			Variables:     vars,
+			ReadOnly:      it.ReadOnly,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func valueOrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func validateListOutput(output string) error {
+	switch output {
+	case "", "json", "yaml":
+		return nil
+	default:
+		return errInvalidListOutput
+	}
+}

--- a/cmd/catalog/list_test.go
+++ b/cmd/catalog/list_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package catalog
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateListOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty is valid", input: "", wantErr: false},
+		{name: "json is valid", input: "json", wantErr: false},
+		{name: "yaml is valid", input: "yaml", wantErr: false},
+		{name: "other is invalid", input: "xml", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateListOutput(tc.input)
+			assert.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}
+
+func TestToCatalogListOutput_SortsByName(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{Name: "zeta"},
+		{Name: "alpha"},
+		{Name: "beta"},
+	}
+	out := toCatalogListOutput(items)
+	require.Len(t, out, 3)
+	assert.Equal(t, "alpha", out[0].Name)
+	assert.Equal(t, "beta", out[1].Name)
+	assert.Equal(t, "zeta", out[2].Name)
+}
+
+func TestToCatalogListOutput_ExtractsVariableNames(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{
+			Name: "demo",
+			Variables: []types.GitCatalogItemVariable{
+				{Name: "FOO", Value: "bar"},
+				{Name: "BAZ", Value: "qux"},
+			},
+		},
+	}
+	out := toCatalogListOutput(items)
+	require.Len(t, out, 1)
+	assert.ElementsMatch(t, []string{"FOO", "BAZ"}, out[0].Variables)
+}
+
+func TestDisplayCatalogItems_TableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, displayCatalogItems(&buf, nil, ""))
+	assert.Contains(t, buf.String(), "There are no catalog items available")
+}
+
+func TestDisplayCatalogItems_TableWithItems(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{
+			Name:          "demo",
+			RepositoryURL: "https://github.com/okteto/movies",
+			Branch:        "main",
+			ManifestPath:  "okteto.yml",
+			ReadOnly:      true,
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, displayCatalogItems(&buf, items, ""))
+	out := buf.String()
+	assert.Contains(t, out, "Name")
+	assert.Contains(t, out, "demo")
+	assert.Contains(t, out, "https://github.com/okteto/movies")
+	assert.Contains(t, out, "main")
+	assert.Contains(t, out, "okteto.yml")
+	assert.Contains(t, out, "true")
+}
+
+func TestDisplayCatalogItems_JSONEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, displayCatalogItems(&buf, nil, "json"))
+	assert.Contains(t, buf.String(), "[]")
+}
+
+func TestDisplayCatalogItems_JSONWithItems(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{Name: "demo", RepositoryURL: "repo", Branch: "main"},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, displayCatalogItems(&buf, items, "json"))
+	out := buf.String()
+	assert.Contains(t, out, `"name": "demo"`)
+	assert.Contains(t, out, `"repositoryUrl": "repo"`)
+}
+
+func TestDisplayCatalogItems_YAML(t *testing.T) {
+	items := []types.GitCatalogItem{
+		{Name: "demo", RepositoryURL: "repo"},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, displayCatalogItems(&buf, items, "yaml"))
+	out := buf.String()
+	assert.Contains(t, out, "name: demo")
+	assert.Contains(t, out, "repositoryUrl: repo")
+}
+
+func TestValueOrDash(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "non-empty returned as-is", in: "foo", want: "foo"},
+		{name: "empty becomes dash", in: "", want: "-"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, valueOrDash(tc.in))
+		})
+	}
+}

--- a/cmd/catalog/list_test.go
+++ b/cmd/catalog/list_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/test/client/catalog.go
+++ b/internal/test/client/catalog.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/internal/test/client/catalog.go
+++ b/internal/test/client/catalog.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	"github.com/okteto/okteto/pkg/types"
+)
+
+// FakeCatalogResponse holds the canned responses returned by FakeCatalogClient.
+type FakeCatalogResponse struct {
+	ErrList   error
+	ErrDeploy error
+
+	CatalogItems []types.GitCatalogItem
+	DeployResp   *types.GitDeployResponse
+
+	// LastDeployOpts captures the opts passed to the last Deploy call so tests can assert on them.
+	LastDeployOpts types.CatalogDeployOptions
+}
+
+// FakeCatalogClient mocks the CatalogInterface for tests.
+type FakeCatalogClient struct {
+	response *FakeCatalogResponse
+}
+
+// NewFakeCatalogClient returns a FakeCatalogClient backed by the given response.
+func NewFakeCatalogClient(response *FakeCatalogResponse) *FakeCatalogClient {
+	if response == nil {
+		response = &FakeCatalogResponse{}
+	}
+	return &FakeCatalogClient{response: response}
+}
+
+// List returns the configured catalog items.
+func (c *FakeCatalogClient) List(_ context.Context) ([]types.GitCatalogItem, error) {
+	return c.response.CatalogItems, c.response.ErrList
+}
+
+// Deploy records the opts and returns the canned deploy response.
+func (c *FakeCatalogClient) Deploy(_ context.Context, opts types.CatalogDeployOptions) (*types.GitDeployResponse, error) {
+	c.response.LastDeployOpts = opts
+	return c.response.DeployResp, c.response.ErrDeploy
+}

--- a/internal/test/client/okteto_client.go
+++ b/internal/test/client/okteto_client.go
@@ -41,6 +41,7 @@ type FakeOktetoClient struct {
 	StreamClient    types.StreamInterface
 	KubetokenClient types.KubetokenInterface
 	BuildkitClient  types.BuildkitInterface
+	CatalogClient   types.CatalogInterface
 }
 
 func NewFakeOktetoClient() *FakeOktetoClient {
@@ -80,4 +81,9 @@ func (c *FakeOktetoClient) Kubetoken() types.KubetokenInterface {
 // Buildkit retrieves the Buildkit client
 func (c *FakeOktetoClient) Buildkit() types.BuildkitInterface {
 	return c.BuildkitClient
+}
+
+// Catalog retrieves the Catalog client
+func (c *FakeOktetoClient) Catalog() types.CatalogInterface {
+	return c.CatalogClient
 }

--- a/internal/test/client/user.go
+++ b/internal/test/client/user.go
@@ -24,10 +24,12 @@ import (
 // FakeUserClient is used to mock the userClient interface
 type FakeUserClient struct {
 	errGetPlatformVariables error
+	errIsAdmin              error
 	userCtx                 *types.UserContext
 	platformVariables       []env.Var
 	err                     []error
 	ClusterMetadata         types.ClusterMetadata
+	Admin                   bool
 }
 
 func NewFakeUsersClient(user *types.User, err ...error) *FakeUserClient {
@@ -78,4 +80,17 @@ func (*FakeUserClient) GetExecutionEnv(_ context.Context) (map[string]string, er
 
 func (*FakeUserClient) GetKnownHostsConfig(_ context.Context) (types.KnownHostsConfig, error) {
 	return types.KnownHostsConfig{}, nil
+}
+
+// IsAdmin returns the configured admin flag or error.
+func (c *FakeUserClient) IsAdmin(_ context.Context) (bool, error) {
+	if c.errIsAdmin != nil {
+		return false, c.errIsAdmin
+	}
+	return c.Admin, nil
+}
+
+// SetIsAdminErr lets tests force IsAdmin to return a specific error.
+func (c *FakeUserClient) SetIsAdminErr(err error) {
+	c.errIsAdmin = err
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/okteto/okteto/cmd"
 	"github.com/okteto/okteto/cmd/build"
+	"github.com/okteto/okteto/cmd/catalog"
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/deploy"
 	"github.com/okteto/okteto/cmd/destroy"
@@ -179,6 +180,7 @@ func main() {
 	root.AddCommand(cmd.Validate(fs))
 
 	root.AddCommand(pipeline.Pipeline(ctx))
+	root.AddCommand(catalog.Catalog(ctx))
 
 	err = root.Execute()
 

--- a/pkg/analytics/track.go
+++ b/pkg/analytics/track.go
@@ -50,6 +50,7 @@ const (
 	namespaceDeleteEvent          = "DeleteNamespace"
 	previewDeployEvent            = "DeployPreview"
 	previewDestroyEvent           = "DestroyPreview"
+	catalogDeployEvent            = "DeployCatalog"
 	execEvent                     = "Exec"
 	signupEvent                   = "Signup"
 	contextEvent                  = "Context"
@@ -106,6 +107,16 @@ func TrackPreviewDeploy(success bool, scope string) {
 // TrackPreviewDestroy sends a tracking event to mixpanel when the deletes a preview environment
 func TrackPreviewDestroy(success bool) {
 	track(previewDestroyEvent, success, nil)
+}
+
+// TrackCatalogDeploy sends a tracking event to mixpanel when the user deploys a
+// Development Environment from the Catalog. Reports whether variables were
+// overridden so we can tell at a glance how often the catalog is used as-is.
+func TrackCatalogDeploy(success, withVariableOverrides bool) {
+	props := map[string]interface{}{
+		"withVariableOverrides": withVariableOverrides,
+	}
+	track(catalogDeployEvent, success, props)
 }
 
 // TrackExecMetadata is the metadata added to execEvent

--- a/pkg/okteto/catalog.go
+++ b/pkg/okteto/catalog.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/okteto/catalog.go
+++ b/pkg/okteto/catalog.go
@@ -1,0 +1,176 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package okteto
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/okteto/okteto/pkg/config"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	oktetoLog "github.com/okteto/okteto/pkg/log"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/shurcooL/graphql"
+)
+
+// ErrCatalogNotSupported is returned when the Okteto backend does not expose
+// the catalog feature (older servers).
+var ErrCatalogNotSupported = oktetoErrors.UserError{
+	E:    errors.New("the catalog feature is not available on this Okteto instance"),
+	Hint: "Please upgrade Okteto or contact your system administrator for more information.",
+}
+
+const catalogItemIDArgUnknown = `Unknown argument "catalogItemId" on field "deployGitRepository"`
+
+type catalogClient struct {
+	client graphqlClientInterface
+}
+
+func newCatalogClient(client graphqlClientInterface) *catalogClient {
+	return &catalogClient{client: client}
+}
+
+type getGitCatalogItemsQuery struct {
+	Response []gitCatalogItem `graphql:"getGitCatalogItems"`
+}
+
+type gitCatalogItem struct {
+	Id            graphql.String
+	Name          graphql.String
+	RepositoryUrl graphql.String
+	Branch        graphql.String
+	ManifestPath  graphql.String
+	ReadOnly      graphql.Boolean
+	Variables     []gitCatalogItemVariable
+}
+
+type gitCatalogItemVariable struct {
+	Name  graphql.String
+	Value graphql.String
+}
+
+type deployCatalogItemMutation struct {
+	Response deployCatalogItemResponse `graphql:"deployGitRepository(name: $name, repository: $repository, space: $space, branch: $branch, variables: $variables, filename: $filename, catalogItemId: $catalogItemId, dependencies: $dependencies, source: $source)"`
+}
+
+type deployCatalogItemResponse struct {
+	Action    actionStruct
+	GitDeploy gitDeployInfoWithRepoInfo
+}
+
+// List returns the catalog items visible to the current user.
+func (c *catalogClient) List(ctx context.Context) ([]types.GitCatalogItem, error) {
+	oktetoLog.Infof("listing catalog items")
+	var q getGitCatalogItemsQuery
+	if err := query(ctx, &q, nil, c.client); err != nil {
+		if isCatalogUnsupportedErr(err) {
+			return nil, ErrCatalogNotSupported
+		}
+		return nil, fmt.Errorf("failed to list catalog items: %w", err)
+	}
+
+	items := make([]types.GitCatalogItem, 0, len(q.Response))
+	for _, it := range q.Response {
+		vars := make([]types.GitCatalogItemVariable, 0, len(it.Variables))
+		for _, v := range it.Variables {
+			vars = append(vars, types.GitCatalogItemVariable{
+				Name:  string(v.Name),
+				Value: string(v.Value),
+			})
+		}
+		items = append(items, types.GitCatalogItem{
+			ID:            string(it.Id),
+			Name:          string(it.Name),
+			RepositoryURL: string(it.RepositoryUrl),
+			Branch:        string(it.Branch),
+			ManifestPath:  string(it.ManifestPath),
+			ReadOnly:      bool(it.ReadOnly),
+			Variables:     vars,
+		})
+	}
+	return items, nil
+}
+
+// Deploy launches a catalog item into the given namespace.
+// The deploy links back to the originating catalog item via catalogItemId so
+// the UI can show a back-reference on the resulting dev environment.
+func (c *catalogClient) Deploy(ctx context.Context, opts types.CatalogDeployOptions) (*types.GitDeployResponse, error) {
+	oktetoLog.Infof("deploying catalog item '%s' into namespace '%s'", opts.Name, opts.Namespace)
+
+	vars := c.buildDeployVariables(opts)
+	mutation := &deployCatalogItemMutation{}
+	if err := mutate(ctx, mutation, vars, c.client); err != nil {
+		if strings.Contains(err.Error(), catalogItemIDArgUnknown) {
+			return nil, ErrCatalogNotSupported
+		}
+		return nil, fmt.Errorf("failed to deploy catalog item: %w", err)
+	}
+
+	return &types.GitDeployResponse{
+		Action: &types.Action{
+			ID:     string(mutation.Response.Action.Id),
+			Name:   string(mutation.Response.Action.Name),
+			Status: string(mutation.Response.Action.Status),
+		},
+		GitDeploy: &types.GitDeploy{
+			ID:         string(mutation.Response.GitDeploy.Id),
+			Name:       string(mutation.Response.GitDeploy.Name),
+			Repository: string(mutation.Response.GitDeploy.Repository),
+			Status:     string(mutation.Response.GitDeploy.Status),
+		},
+	}, nil
+}
+
+func (c *catalogClient) buildDeployVariables(opts types.CatalogDeployOptions) map[string]interface{} {
+	inputVars := make([]InputVariable, 0, len(opts.Variables)+1)
+	hasOrigin := false
+	for _, v := range opts.Variables {
+		inputVars = append(inputVars, InputVariable{
+			Name:  graphql.String(v.Name),
+			Value: graphql.String(v.Value),
+		})
+		if v.Name == "OKTETO_ORIGIN" {
+			hasOrigin = true
+		}
+	}
+	if !hasOrigin {
+		inputVars = append(inputVars, InputVariable{
+			Name:  graphql.String("OKTETO_ORIGIN"),
+			Value: graphql.String(config.GetDeployOrigin()),
+		})
+	}
+
+	return map[string]interface{}{
+		"name":          graphql.String(opts.Name),
+		"repository":    graphql.String(opts.Repository),
+		"space":         graphql.String(opts.Namespace),
+		"branch":        graphql.String(opts.Branch),
+		"variables":     inputVars,
+		"filename":      graphql.String(opts.Filename),
+		"catalogItemId": graphql.String(opts.CatalogItemID),
+		"dependencies":  graphql.Boolean(opts.RedeployDependencies),
+		"source":        graphql.String("cli"),
+	}
+}
+
+// isCatalogUnsupportedErr returns true when the server does not know about the
+// getGitCatalogItems query, which means the catalog feature is not available
+// on this Okteto instance. We anchor on the exact prefix emitted by the GraphQL
+// library so we don't misclassify unrelated server errors that happen to echo
+// the query name.
+func isCatalogUnsupportedErr(err error) bool {
+	return strings.Contains(err.Error(), `Cannot query field "getGitCatalogItems"`)
+}

--- a/pkg/okteto/catalog_test.go
+++ b/pkg/okteto/catalog_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package okteto
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
+	"github.com/okteto/okteto/pkg/types"
+	"github.com/shurcooL/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogClient_List_Success(t *testing.T) {
+	t.Helper()
+	fake := &fakeGraphQLClient{
+		queryResult: &getGitCatalogItemsQuery{
+			Response: []gitCatalogItem{
+				{
+					Id:            "id-1",
+					Name:          "demo",
+					RepositoryUrl: "https://github.com/okteto/movies",
+					Branch:        "main",
+					ManifestPath:  "okteto.yml",
+					ReadOnly:      false,
+					Variables: []gitCatalogItemVariable{
+						{Name: "TOKEN", Value: "abc"},
+					},
+				},
+			},
+		},
+	}
+	c := newCatalogClient(fake)
+
+	items, err := c.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, types.GitCatalogItem{
+		ID:            "id-1",
+		Name:          "demo",
+		RepositoryURL: "https://github.com/okteto/movies",
+		Branch:        "main",
+		ManifestPath:  "okteto.yml",
+		ReadOnly:      false,
+		Variables:     []types.GitCatalogItemVariable{{Name: "TOKEN", Value: "abc"}},
+	}, items[0])
+}
+
+func TestCatalogClient_List_EmptyResponse(t *testing.T) {
+	t.Helper()
+	c := newCatalogClient(&fakeGraphQLClient{})
+
+	items, err := c.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestCatalogClient_List_UnsupportedServer(t *testing.T) {
+	t.Helper()
+	c := newCatalogClient(&fakeGraphQLClient{
+		err: errors.New(`graphql: Cannot query field "getGitCatalogItems" on type "Query"`),
+	})
+
+	_, err := c.List(context.Background())
+	require.Error(t, err)
+	var userErr oktetoErrors.UserError
+	require.ErrorAs(t, err, &userErr)
+	assert.Equal(t, ErrCatalogNotSupported, err)
+}
+
+func TestCatalogClient_List_GenericError(t *testing.T) {
+	t.Helper()
+	c := newCatalogClient(&fakeGraphQLClient{
+		err: errors.New("boom"),
+	})
+
+	_, err := c.List(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list catalog items")
+}
+
+func TestCatalogClient_Deploy_Success(t *testing.T) {
+	t.Helper()
+	fake := &fakeGraphQLClient{
+		mutationResult: &deployCatalogItemMutation{
+			Response: deployCatalogItemResponse{
+				Action: actionStruct{
+					Id:     graphql.String("action-id"),
+					Name:   graphql.String("cli"),
+					Status: graphql.String("progressing"),
+				},
+				GitDeploy: gitDeployInfoWithRepoInfo{
+					Id:     graphql.String("deploy-id"),
+					Name:   graphql.String("demo"),
+					Status: graphql.String("progressing"),
+				},
+			},
+		},
+	}
+	c := newCatalogClient(fake)
+
+	resp, err := c.Deploy(context.Background(), types.CatalogDeployOptions{
+		CatalogItemID: "id-1",
+		Name:          "demo",
+		Repository:    "https://github.com/okteto/movies",
+		Branch:        "main",
+		Filename:      "okteto.yml",
+		Namespace:     "ns",
+		Variables:     []types.Variable{{Name: "TOKEN", Value: "abc"}},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "deploy-id", resp.GitDeploy.ID)
+	assert.Equal(t, "action-id", resp.Action.ID)
+}
+
+func TestCatalogClient_Deploy_UnsupportedServer(t *testing.T) {
+	t.Helper()
+	c := newCatalogClient(&fakeGraphQLClient{
+		err: errors.New(`graphql: Unknown argument "catalogItemId" on field "deployGitRepository" of type "Mutation"`),
+	})
+
+	_, err := c.Deploy(context.Background(), types.CatalogDeployOptions{Name: "demo", Namespace: "ns"})
+	require.Error(t, err)
+	assert.Equal(t, ErrCatalogNotSupported, err)
+}
+
+func TestBuildDeployVariables_InjectsOriginWhenMissing(t *testing.T) {
+	t.Helper()
+	c := newCatalogClient(&fakeGraphQLClient{})
+
+	vars := c.buildDeployVariables(types.CatalogDeployOptions{
+		Name:       "demo",
+		Repository: "repo",
+		Namespace:  "ns",
+		Variables:  []types.Variable{{Name: "FOO", Value: "bar"}},
+	})
+
+	inputs, ok := vars["variables"].([]InputVariable)
+	require.True(t, ok)
+	names := make([]string, 0, len(inputs))
+	for _, v := range inputs {
+		names = append(names, string(v.Name))
+	}
+	assert.Contains(t, names, "FOO")
+	assert.Contains(t, names, "OKTETO_ORIGIN")
+}
+
+func TestBuildDeployVariables_PreservesUserOrigin(t *testing.T) {
+	t.Helper()
+	c := newCatalogClient(&fakeGraphQLClient{})
+
+	vars := c.buildDeployVariables(types.CatalogDeployOptions{
+		Name:       "demo",
+		Repository: "repo",
+		Namespace:  "ns",
+		Variables:  []types.Variable{{Name: "OKTETO_ORIGIN", Value: "from-user"}},
+	})
+
+	inputs, ok := vars["variables"].([]InputVariable)
+	require.True(t, ok)
+	require.Len(t, inputs, 1)
+	assert.Equal(t, "OKTETO_ORIGIN", string(inputs[0].Name))
+	assert.Equal(t, "from-user", string(inputs[0].Value))
+}

--- a/pkg/okteto/catalog_test.go
+++ b/pkg/okteto/catalog_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/okteto/client.go
+++ b/pkg/okteto/client.go
@@ -47,6 +47,7 @@ type Client struct {
 	kubetoken types.KubetokenInterface
 	endpoint  types.EndpointClientInterface
 	buildkit  types.BuildkitInterface
+	catalog   types.CatalogInterface
 }
 
 type ClientProvider struct{}
@@ -322,6 +323,7 @@ func newOktetoClientFromGraphqlClient(url string, httpClient *http.Client) (*Cli
 	c.kubetoken = newKubeTokenClient(httpClient)
 	c.endpoint = newEndpointClient(c.client)
 	c.buildkit = newBuildkitClient(c.client)
+	c.catalog = newCatalogClient(c.client)
 	return c, nil
 }
 
@@ -498,6 +500,11 @@ func (c *Client) Endpoint() types.EndpointClientInterface {
 // Buildkit retrieves the Buildkit client
 func (c *Client) Buildkit() types.BuildkitInterface {
 	return c.buildkit
+}
+
+// Catalog retrieves the Catalog client
+func (c *Client) Catalog() types.CatalogInterface {
+	return c.catalog
 }
 
 func SetInsecureSkipTLSVerifyPolicy(isInsecure bool) {

--- a/pkg/okteto/secrets.go
+++ b/pkg/okteto/secrets.go
@@ -343,6 +343,25 @@ func (c *userClient) GetExecutionEnv(ctx context.Context) (map[string]string, er
 	return result, nil
 }
 
+// isAdminQuery selects only the `super` flag from the current `user` so we can
+// cheaply check whether the logged-in user has admin privileges.
+type isAdminQuery struct {
+	User struct {
+		Super graphql.Boolean
+	} `graphql:"user"`
+}
+
+// IsAdmin returns true when the current user has administrator privileges on
+// the Okteto instance. This mirrors the backend's `u.Super` check used to
+// authorize admin-only mutations.
+func (c *userClient) IsAdmin(ctx context.Context) (bool, error) {
+	var q isAdminQuery
+	if err := query(ctx, &q, nil, c.client); err != nil {
+		return false, err
+	}
+	return bool(q.User.Super), nil
+}
+
 // GetKnownHostsConfig returns the known hosts configuration from Okteto API
 func (c *userClient) GetKnownHostsConfig(ctx context.Context) (types.KnownHostsConfig, error) {
 	var queryStruct getKnownHostsConfigQuery

--- a/pkg/types/catalog.go
+++ b/pkg/types/catalog.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Okteto Authors
+// Copyright 2026 The Okteto Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/pkg/types/catalog.go
+++ b/pkg/types/catalog.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// GitCatalogItem represents a catalog item configured by an Okteto admin.
+// Admins define these in the Okteto UI as pre-configured dev environment
+// templates so developers can deploy them without extra setup.
+type GitCatalogItem struct {
+	ID            string                   `json:"id" yaml:"id"`
+	Name          string                   `json:"name" yaml:"name"`
+	RepositoryURL string                   `json:"repositoryUrl" yaml:"repositoryUrl"`
+	Branch        string                   `json:"branch" yaml:"branch"`
+	ManifestPath  string                   `json:"manifestPath" yaml:"manifestPath"`
+	Variables     []GitCatalogItemVariable `json:"variables" yaml:"variables"`
+	ReadOnly      bool                     `json:"readOnly" yaml:"readOnly"`
+}
+
+// GitCatalogItemVariable is a default variable configured on a catalog item.
+type GitCatalogItemVariable struct {
+	Name  string `json:"name" yaml:"name"`
+	Value string `json:"value" yaml:"value"`
+}
+
+// CatalogDeployOptions holds the parameters for deploying a catalog item.
+type CatalogDeployOptions struct {
+	CatalogItemID        string
+	Name                 string
+	Repository           string
+	Branch               string
+	Filename             string
+	Namespace            string
+	Variables            []Variable
+	RedeployDependencies bool
+}

--- a/pkg/types/interface.go
+++ b/pkg/types/interface.go
@@ -30,6 +30,7 @@ type OktetoInterface interface {
 	Stream() StreamInterface
 	Kubetoken() KubetokenInterface
 	Buildkit() BuildkitInterface
+	Catalog() CatalogInterface
 }
 
 // UserInterface represents the client that connects to the user functions
@@ -41,6 +42,7 @@ type UserInterface interface {
 	GetRegistryCredentials(ctx context.Context, host string) (dockertypes.AuthConfig, error)
 	GetExecutionEnv(ctx context.Context) (map[string]string, error)
 	GetKnownHostsConfig(ctx context.Context) (KnownHostsConfig, error)
+	IsAdmin(ctx context.Context) (bool, error)
 }
 
 // NamespaceInterface represents the client that connects to the namespace functions
@@ -100,4 +102,10 @@ type EndpointClientInterface interface {
 // BuildkitInterface represents the buildkit client
 type BuildkitInterface interface {
 	GetLeastLoadedBuildKitPod(ctx context.Context, buildRequestID string) (*BuildKitPodResponse, error)
+}
+
+// CatalogInterface represents the client that connects to the catalog functions
+type CatalogInterface interface {
+	List(ctx context.Context) ([]GitCatalogItem, error)
+	Deploy(ctx context.Context, opts CatalogDeployOptions) (*GitDeployResponse, error)
 }


### PR DESCRIPTION
# Proposed changes

Fixes # (issue)

Adds a new top-level `okteto catalog` command that lets users browse and launch admin-configured Catalog dev-environment templates directly from the terminal, without needing to switch to the Okteto web UI.

The command ships with three subcommands that mirror the existing patterns used by `cmd/preview` and `cmd/pipeline`:

- **`okteto catalog list`** — lists available Catalog items. Supports `-o table` (default), `-o json`, and `-o yaml` output formats.
- **`okteto catalog deploy [name]`** — deploys a Catalog item. When invoked without a name, opens an interactive arrow-key picker. Supports `--var KEY=VALUE` overrides (merged with item defaults), streams deployment logs while waiting, and prints "did you mean?" suggestions on typos.
- **`okteto catalog add`** — admin-gated command that opens the Okteto UI at `/admin/catalog/new`. Returns a clear error for non-admin users.

### What's in the diff

- New `cmd/catalog/` package with `list`, `deploy`, and `add` subcommands wired into the root command tree.
- `OktetoInterface` extended with a `Catalog()` accessor; `UserInterface` extended with `IsAdmin(ctx)`. Both are internal interfaces with no external implementers.
- New Mixpanel analytics event `DeployCatalog` carrying a `withVariableOverrides` boolean property.
- Follows existing CLI conventions for output formatting, interactive prompts, variable override merging, and log streaming.

### Follow-ups

- No integration test under `integration/catalog/` — requires a live cluster with Catalog items configured; will be added in a follow-up PR.
- User-facing docs live in a separate repository and will be updated there.
- PostHog analytics not included since the CLI has no PostHog integration yet; all commands use Mixpanel.

## How to validate

1. Build the CLI: `make build`
1. List available Catalog items in table and JSON formats: `./bin/okteto catalog list` and `./bin/okteto catalog list -o json`
1. Deploy a Catalog item interactively (arrow-key picker) and by name with a variable override: `./bin/okteto catalog deploy` then `./bin/okteto catalog deploy <item-name> --var KEY=VALUE`
1. Verify the "did you mean?" suggestion by passing a typo: `./bin/okteto catalog deploy <typo-of-real-item>`
1. As an admin, run `./bin/okteto catalog add` and confirm the browser opens to `/admin/catalog/new`; as a non-admin, confirm the command returns a clear permission error.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines