### PR TITLE
ci: log trivy version before image scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,6 +509,7 @@ jobs:
       - run: *docker-login
       - run: *github-packages-login
       - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG" "linux/amd64,linux/arm64"
+      - run: trivy --version
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress ghcr.io/okteto/okteto:$CIRCLE_TAG
 
   push-image-dev:
@@ -519,6 +520,7 @@ jobs:
       - run: *docker-login
       - run: *github-packages-login
       - run: ./scripts/ci/push-image.sh "$CIRCLE_TAG",dev "linux/amd64,linux/arm64"
+      - run: trivy --version
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress ghcr.io/okteto/okteto:dev
 
   push-image-master:
@@ -529,6 +531,7 @@ jobs:
       - run: *docker-login
       - run: *github-packages-login
       - run: ./scripts/ci/push-image.sh "master" "linux/amd64,linux/arm64"
+      - run: trivy --version
       - run: trivy image --db-repository public.ecr.aws/aquasecurity/trivy-db:2 --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db:1 --no-progress ghcr.io/okteto/okteto:master
 
   upload-static-job:


### PR DESCRIPTION
When a Trivy scan failed or produced unexpected results, there was no way to know which Trivy version ran. Each of the 3 push-image jobs now runs `trivy --version` immediately before the scan, making the version visible in CI logs for audit and debugging.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Sonnet_4.6_(200K)](https://img.shields.io/badge/Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)