### PR TITLE
[codex] add compose enable service links option

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -149,6 +149,7 @@ func translateDeployment(svcName string, s *model.Stack, divert Divert) *appsv1.
 	podSpec := apiv1.PodSpec{
 		TerminationGracePeriodSeconds: ptr.To(svc.StopGracePeriod),
 		NodeSelector:                  svc.NodeSelector,
+		EnableServiceLinks:            svc.EnableServiceLinks,
 		Containers: []apiv1.Container{
 			{
 				Name:            svcName,
@@ -228,6 +229,7 @@ func translateStatefulSet(svcName string, s *model.Stack, divert Divert) *appsv1
 		InitContainers:                initContainers,
 		Affinity:                      translateAffinity(svc),
 		NodeSelector:                  svc.NodeSelector,
+		EnableServiceLinks:            svc.EnableServiceLinks,
 		Volumes:                       translateVolumes(svc),
 		Containers: []apiv1.Container{
 			{
@@ -289,6 +291,7 @@ func translateJob(svcName string, s *model.Stack, divert Divert) *batchv1.Job {
 		InitContainers:                initContainers,
 		Affinity:                      translateAffinity(svc),
 		NodeSelector:                  svc.NodeSelector,
+		EnableServiceLinks:            svc.EnableServiceLinks,
 		Containers: []apiv1.Container{
 			{
 				Name:            svcName,

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -90,11 +90,12 @@ func Test_translateDeployment(t *testing.T) {
 					"node1": "value1",
 					"node2": "value2",
 				},
-				Image:           "image",
-				Replicas:        3,
-				StopGracePeriod: 20,
-				Entrypoint:      model.Entrypoint{Values: []string{"command1", "command2"}},
-				Command:         model.Command{Values: []string{"args1", "args2"}},
+				Image:              "image",
+				Replicas:           3,
+				StopGracePeriod:    20,
+				EnableServiceLinks: ptr.To(false),
+				Entrypoint:         model.Entrypoint{Values: []string{"command1", "command2"}},
+				Command:            model.Command{Values: []string{"args1", "args2"}},
 				Environment: []env.Var{
 					{
 						Name:  "env1",
@@ -132,6 +133,8 @@ func Test_translateDeployment(t *testing.T) {
 		"node2": "value2",
 	}
 	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
+	require.NotNil(t, result.Spec.Template.Spec.EnableServiceLinks)
+	assert.False(t, *result.Spec.Template.Spec.EnableServiceLinks)
 
 	if *result.Spec.Replicas != 3 {
 		t.Errorf("Wrong deployment spec.replicas: '%d'", *result.Spec.Replicas)
@@ -203,11 +206,12 @@ func Test_translateStatefulSet(t *testing.T) {
 					"node1": "value1",
 					"node2": "value2",
 				},
-				Image:           "image",
-				Replicas:        3,
-				StopGracePeriod: 20,
-				Entrypoint:      model.Entrypoint{Values: []string{"command1", "command2"}},
-				Command:         model.Command{Values: []string{"args1", "args2"}},
+				Image:              "image",
+				Replicas:           3,
+				StopGracePeriod:    20,
+				EnableServiceLinks: ptr.To(false),
+				Entrypoint:         model.Entrypoint{Values: []string{"command1", "command2"}},
+				Command:            model.Command{Values: []string{"args1", "args2"}},
 				Environment: []env.Var{
 					{
 						Name:  "env1",
@@ -261,6 +265,8 @@ func Test_translateStatefulSet(t *testing.T) {
 		"node2": "value2",
 	}
 	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
+	require.NotNil(t, result.Spec.Template.Spec.EnableServiceLinks)
+	assert.False(t, *result.Spec.Template.Spec.EnableServiceLinks)
 	if *result.Spec.Replicas != 3 {
 		t.Errorf("Wrong statefulset spec.replicas: '%d'", *result.Spec.Replicas)
 	}
@@ -410,11 +416,12 @@ func Test_translateJobWithoutVolumes(t *testing.T) {
 					"node1": "value1",
 					"node2": "value2",
 				},
-				Image:           "image",
-				StopGracePeriod: 20,
-				Replicas:        3,
-				Entrypoint:      model.Entrypoint{Values: []string{"command1", "command2"}},
-				Command:         model.Command{Values: []string{"args1", "args2"}},
+				Image:              "image",
+				StopGracePeriod:    20,
+				Replicas:           3,
+				EnableServiceLinks: ptr.To(false),
+				Entrypoint:         model.Entrypoint{Values: []string{"command1", "command2"}},
+				Command:            model.Command{Values: []string{"args1", "args2"}},
 				Environment: []env.Var{
 					{
 						Name:  "env1",
@@ -468,6 +475,8 @@ func Test_translateJobWithoutVolumes(t *testing.T) {
 		"node2": "value2",
 	}
 	assert.Equal(t, result.Spec.Template.Spec.NodeSelector, nodeSelector)
+	require.NotNil(t, result.Spec.Template.Spec.EnableServiceLinks)
+	assert.False(t, *result.Spec.Template.Spec.EnableServiceLinks)
 	if *result.Spec.Completions != 3 {
 		t.Errorf("Wrong job spec.completions: '%d'", *result.Spec.Completions)
 	}

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -212,7 +212,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.Probes":                      {"liveness", "readiness", "startup"},
 				"model.ResourceRequirements":        {"limits", "requests"},
 				"model.SecurityContext":             {"runAsUser", "runAsGroup", "fsGroup", "capabilities", "runAsNonRoot", "allowPrivilegeEscalation", "readOnlyRootFilesystem"},
-				"model.Service":                     {"healthcheck", "labels", "resources", "x-node-selector", "user", "depends_on", "build", "workdir", "image", "restart", "environment", "ports", "volumes", "cap_add", "cap_drop", "env_file", "command", "annotations", "entrypoint", "stop_grace_period", "replicas", "max_attempts", "public", "endpoint_mode"},
+				"model.Service":                     {"healthcheck", "labels", "resources", "x-node-selector", "x-enable-service-links", "user", "depends_on", "build", "workdir", "image", "restart", "environment", "ports", "volumes", "cap_add", "cap_drop", "env_file", "command", "annotations", "entrypoint", "stop_grace_period", "replicas", "max_attempts", "public", "endpoint_mode"},
 				"model.ServiceResources":            {"cpu", "memory", "storage"},
 				"model.Stack":                       {"volumes", "services", "endpoints", "name", "namespace", "context"},
 				"model.StackResources":              {"limits", "requests"},

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -96,16 +96,17 @@ const (
 
 // Service represents an okteto stack service
 type Service struct {
-	Healtcheck    *HealthCheck          `yaml:"healthcheck,omitempty"`
-	Labels        Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Resources     *StackResources       `yaml:"resources,omitempty"` // For okteto stack only
-	NodeSelector  Selector              `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
-	User          *StackSecurityContext `yaml:"user,omitempty"`
-	DependsOn     DependsOn             `yaml:"depends_on,omitempty"`
-	Build         *build.Info           `yaml:"build,omitempty"`
-	Workdir       string                `yaml:"workdir,omitempty"`
-	Image         string                `yaml:"image,omitempty"`
-	RestartPolicy apiv1.RestartPolicy   `yaml:"restart,omitempty"`
+	Healtcheck         *HealthCheck          `yaml:"healthcheck,omitempty"`
+	Labels             Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Resources          *StackResources       `yaml:"resources,omitempty"` // For okteto stack only
+	NodeSelector       Selector              `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
+	EnableServiceLinks *bool                 `json:"x-enable-service-links,omitempty" yaml:"x-enable-service-links,omitempty"`
+	User               *StackSecurityContext `yaml:"user,omitempty"`
+	DependsOn          DependsOn             `yaml:"depends_on,omitempty"`
+	Build              *build.Info           `yaml:"build,omitempty"`
+	Workdir            string                `yaml:"workdir,omitempty"`
+	Image              string                `yaml:"image,omitempty"`
+	RestartPolicy      apiv1.RestartPolicy   `yaml:"restart,omitempty"`
 
 	Environment     env.Environment      `yaml:"environment,omitempty"`
 	Ports           []Port               `yaml:"ports,omitempty"`

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -93,6 +93,7 @@ type ServiceRaw struct {
 	Labels                   Labels                 `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations              Annotations            `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	NodeSelector             Selector               `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
+	EnableServiceLinks       *bool                  `json:"x-enable-service-links,omitempty" yaml:"x-enable-service-links,omitempty"`
 	ReadOnly                 *WarningType           `yaml:"read_only,omitempty"`
 	PullPolicy               *WarningType           `yaml:"pull_policy,omitempty"`
 	ContainerName            *WarningType           `yaml:"container_name,omitempty"`
@@ -436,6 +437,7 @@ func (serviceRaw *ServiceRaw) toService(svcName string, stack *Stack, topLevelSe
 	}
 
 	svc.NodeSelector = serviceRaw.NodeSelector
+	svc.EnableServiceLinks = serviceRaw.EnableServiceLinks
 
 	if svc.Labels == nil {
 		svc.Labels = make(Labels)

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -480,6 +480,37 @@ func Test_NodeSelectorUnmarshalling(t *testing.T) {
 	}
 }
 
+func TestEnableServiceLinksUnmarshalling(t *testing.T) {
+	tests := []struct {
+		expected *bool
+		name     string
+		manifest []byte
+	}{
+		{
+			name:     "not set",
+			manifest: []byte("services:\n  app:\n    image: okteto/vote:1"),
+			expected: nil,
+		},
+		{
+			name:     "disabled",
+			manifest: []byte("services:\n  app:\n    image: okteto/vote:1\n    x-enable-service-links: false"),
+			expected: ptr.To(false),
+		},
+		{
+			name:     "enabled",
+			manifest: []byte("services:\n  app:\n    image: okteto/vote:1\n    x-enable-service-links: true"),
+			expected: ptr.To(true),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := ReadStack(tt.manifest, true)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, s.Services["app"].EnableServiceLinks)
+		})
+	}
+}
+
 func TestComposeBuildSectionUnmarshalling(t *testing.T) {
 	tests := []struct {
 		expected *composeBuildInfo


### PR DESCRIPTION
## Summary

Adds a per-service Docker Compose extension, `x-enable-service-links`, that maps to Kubernetes `PodSpec.EnableServiceLinks` on generated compose workloads.

## Details

- Parses `x-enable-service-links` as an optional boolean on compose services, preserving the difference between omitted and explicitly set values.
- Applies the value to Deployment, StatefulSet, and Job pod specs generated from compose services.
- Adds unit coverage for unmarshalling omitted/true/false values and for propagating `false` into generated pod specs.

## Validation

- `go test ./pkg/model ./pkg/cmd/stack`
- `go test ./pkg/model -run TestEnableServiceLinksUnmarshalling -v`
- `go test ./pkg/cmd/stack -run 'Test_translate(Deployment|StatefulSet|JobWithoutVolumes)$' -v`
- `git diff --check`