### PR TITLE
feat(analytics): normalize repo_url before hashing in image_build event

### DIFF
--- a/pkg/analytics/hasher.go
+++ b/pkg/analytics/hasher.go
@@ -16,9 +16,30 @@ package analytics
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"net/url"
+	"strings"
 )
 
 func hashString(s string) string {
 	hash := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(hash[:])
+}
+
+// normalizeRepoURL normalizes a git repo URL before hashing:
+// converts SSH git@ format to HTTPS, forces https scheme,
+// strips a trailing .git suffix and trailing slashes, and lowercases the result.
+func normalizeRepoURL(rawURL string) string {
+	if strings.HasPrefix(rawURL, "git@") {
+		rawURL = "https://" + strings.Replace(strings.TrimPrefix(rawURL, "git@"), ":", "/", 1)
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return strings.ToLower(rawURL)
+	}
+
+	u.Scheme = "https"
+	u.Path = strings.TrimRight(strings.TrimSuffix(strings.TrimRight(u.Path, "/"), ".git"), "/")
+
+	return strings.ToLower(u.String())
 }

--- a/pkg/analytics/hasher.go
+++ b/pkg/analytics/hasher.go
@@ -16,8 +16,9 @@ package analytics
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"net/url"
 	"strings"
+
+	giturls "github.com/chainguard-dev/git-urls"
 )
 
 func hashString(s string) string {
@@ -26,19 +27,18 @@ func hashString(s string) string {
 }
 
 // normalizeRepoURL normalizes a git repo URL before hashing:
-// converts SSH git@ format to HTTPS, forces https scheme,
-// strips a trailing .git suffix and trailing slashes, and lowercases the result.
+// parses all git URL formats (https, ssh://, git@), forces https scheme,
+// strips credentials, query params, fragments, trailing .git suffix, and lowercases the result.
 func normalizeRepoURL(rawURL string) string {
-	if strings.HasPrefix(rawURL, "git@") {
-		rawURL = "https://" + strings.Replace(strings.TrimPrefix(rawURL, "git@"), ":", "/", 1)
-	}
-
-	u, err := url.Parse(rawURL)
+	u, err := giturls.Parse(rawURL)
 	if err != nil || u.Host == "" {
 		return strings.ToLower(rawURL)
 	}
 
 	u.Scheme = "https"
+	u.User = nil
+	u.RawQuery = ""
+	u.Fragment = ""
 	u.Path = strings.TrimRight(strings.TrimSuffix(strings.TrimRight(u.Path, "/"), ".git"), "/")
 
 	return strings.ToLower(u.String())

--- a/pkg/analytics/hasher_test.go
+++ b/pkg/analytics/hasher_test.go
@@ -23,3 +23,68 @@ func Test_hashString(t *testing.T) {
 	input := "test-string"
 	require.Equal(t, hashString(input), "ffe65f1d98fafedea3514adc956c8ada5980c6c5d2552fd61f48401aefd5c00e")
 }
+
+func Test_normalizeRepoURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "already normalized https",
+			input:    "https://github.com/org/repo",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "http converted to https",
+			input:    "http://github.com/org/repo",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "trailing .git removed",
+			input:    "https://github.com/org/repo.git",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "http with .git",
+			input:    "http://github.com/org/repo.git",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "ssh git@ converted to https",
+			input:    "git@github.com:org/repo.git",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "ssh git@ without .git",
+			input:    "git@github.com:org/repo",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "uppercased url lowercased",
+			input:    "https://GitHub.COM/Org/Repo",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "mixed case with .git",
+			input:    "HTTPS://GitHub.com/Org/Repo.git",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "trailing slash removed",
+			input:    "https://github.com/org/repo/",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "trailing slash and .git removed",
+			input:    "https://github.com/org/repo.git/",
+			expected: "https://github.com/org/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, normalizeRepoURL(tt.input))
+		})
+	}
+}

--- a/pkg/analytics/hasher_test.go
+++ b/pkg/analytics/hasher_test.go
@@ -80,6 +80,71 @@ func Test_normalizeRepoURL(t *testing.T) {
 			input:    "https://github.com/org/repo.git/",
 			expected: "https://github.com/org/repo",
 		},
+		{
+			name:     "credentials stripped from https url",
+			input:    "https://user:password@github.com/org/repo",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "query params stripped",
+			input:    "https://github.com/org/repo?token=secret&ref=main",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "fragment stripped",
+			input:    "https://github.com/org/repo#readme",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "ssh:// scheme converted to https",
+			input:    "ssh://git@github.com/org/repo.git",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "credentials and query params stripped together",
+			input:    "https://user:token@github.com/org/repo.git?ref=main#section",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "gitlab subgroup ssh",
+			input:    "git@gitlab.com:group/subgroup/repo.git",
+			expected: "https://gitlab.com/group/subgroup/repo",
+		},
+		{
+			name:     "gitlab subgroup https",
+			input:    "https://gitlab.com/group/subgroup/repo.git",
+			expected: "https://gitlab.com/group/subgroup/repo",
+		},
+		{
+			name:     "gitlab deep nesting",
+			input:    "git@gitlab.com:a/b/c/d/repo.git",
+			expected: "https://gitlab.com/a/b/c/d/repo",
+		},
+		{
+			name:     "bitbucket ssh",
+			input:    "git@bitbucket.org:workspace/repo.git",
+			expected: "https://bitbucket.org/workspace/repo",
+		},
+		{
+			name:     "bitbucket https",
+			input:    "https://bitbucket.org/workspace/repo.git",
+			expected: "https://bitbucket.org/workspace/repo",
+		},
+		{
+			name:     "git:// protocol converted to https",
+			input:    "git://github.com/org/repo.git",
+			expected: "https://github.com/org/repo",
+		},
+		{
+			name:     "git:// protocol gitlab subgroup",
+			input:    "git://gitlab.com/group/subgroup/repo.git",
+			expected: "https://gitlab.com/group/subgroup/repo",
+		},
+		{
+			name:     "file:// local path returned as-is lowercased",
+			input:    "file:///path/to/repo",
+			expected: "file:///path/to/repo",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/analytics/imagebuild.go
+++ b/pkg/analytics/imagebuild.go
@@ -65,7 +65,7 @@ func (m *ImageBuildMetadata) toMixpanelProps() map[string]any {
 		props["name"] = hashString(m.Name)
 	}
 	if m.RepoURL != "" {
-		props["repoURL"] = hashString(m.RepoURL)
+		props["repoURL"] = hashString(normalizeRepoURL(m.RepoURL))
 	}
 
 	return props
@@ -98,7 +98,7 @@ func (m *ImageBuildMetadata) toPostHogProps() map[string]any {
 		props["connection_type"] = m.ConnectionType
 	}
 	if m.RepoURL != "" {
-		props["repo_url"] = hashString(m.RepoURL)
+		props["repo_url"] = hashString(normalizeRepoURL(m.RepoURL))
 	}
 	if !m.Success && m.ErrorReason != "" {
 		props["error_reason"] = m.ErrorReason

--- a/pkg/analytics/imagebuild_test.go
+++ b/pkg/analytics/imagebuild_test.go
@@ -70,7 +70,7 @@ func Test_ImageBuildMetadata_toMixpanelProps(t *testing.T) {
 
 	expectedProps := map[string]interface{}{
 		"name":                            "665653223b1e8bfa2d462b3adb06d49f8984052e5df03d7fd2365293a102fce8",
-		"repoURL":                         "82eec095b1cc767833c5e4b5d7b02a6df10c0f284127c7e840e1f460b1896067",
+		"repoURL":                         "e405794625b21c12a1254f8f1c464e8f46c26f5a5a3b8843231f81d86ee1c3c1",
 		"cacheHit":                        true,
 		"cacheHitDurationSeconds":         float64(5),
 		"waitForBuildkitAvailable":        float64(12),


### PR DESCRIPTION
## Proposed changes

Ensures that semantically equivalent git repo URLs always produce the same hash in the `image_build` analytics event (PostHog and Mixpanel).

The same repository can appear in several forms:
- `https://github.com/org/repo`
- `https://github.com/org/repo.git`
- `https://github.com/org/repo/`
- `http://github.com/org/repo.git`
- `git@github.com:org/repo.git`
- `HTTPS://GitHub.com/Org/Repo.git`

Without normalization each form produces a different SHA-256 hash, causing dashboards to count them as distinct repos and inflating unique-repo metrics.

**`normalizeRepoURL`** (added to `pkg/analytics/hasher.go`) applies in order:
1. Converts SSH `git@host:path` → `https://host/path`
2. Forces scheme to `https`
3. Strips trailing slashes
4. Strips trailing `.git` suffix
5. Strips trailing slashes again (handles `repo.git/`)
6. Lowercases the entire result

Both `toMixpanelProps` and `toPostHogProps` in `imagebuild.go` now call `normalizeRepoURL(m.RepoURL)` before `hashString`.

## How to validate

```bash
go test ./pkg/analytics/... -v -run 'Test_normalizeRepoURL|Test_ImageBuildMetadata'
make lint
```

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines