### PR TITLE
feat(buildkit): make readiness health-check timeout configurable (DEV-1426)

### DIFF
--- a/pkg/build/buildkit/connector/incluster.go
+++ b/pkg/build/buildkit/connector/incluster.go
@@ -46,7 +46,6 @@ type InClusterConnector struct {
 	oktetoClient types.OktetoInterface
 	ioCtrl       *io.Controller
 	maxWaitTime  time.Duration
-	waiter       *Waiter
 
 	// Connection state
 	podIP string
@@ -65,7 +64,6 @@ func NewInClusterConnector(ctx context.Context, okCtx InClusterOktetoContextInte
 
 	sessionID := uuid.New().String()
 	maxWaitTime := env.LoadTimeOrDefault(buildkitQueueWaitTimeoutEnvVar, defaultMaxWaitTimePortForward)
-	waiter := NewBuildkitClientReadinessWaiter(ioCtrl)
 
 	ic := &InClusterConnector{
 		sessionID:    sessionID,
@@ -73,7 +71,6 @@ func NewInClusterConnector(ctx context.Context, okCtx InClusterOktetoContextInte
 		oktetoClient: oktetoClient,
 		ioCtrl:       ioCtrl,
 		maxWaitTime:  maxWaitTime,
-		waiter:       waiter,
 		metrics:      NewConnectorMetrics(analytics.ConnectorTypeInCluster, sessionID, tracker),
 	}
 

--- a/pkg/build/buildkit/connector/incluster.go
+++ b/pkg/build/buildkit/connector/incluster.go
@@ -65,7 +65,7 @@ func NewInClusterConnector(ctx context.Context, okCtx InClusterOktetoContextInte
 
 	sessionID := uuid.New().String()
 	maxWaitTime := env.LoadTimeOrDefault(buildkitQueueWaitTimeoutEnvVar, defaultMaxWaitTimePortForward)
-	waiter := NewBuildkitClientWaiterWithConfig(ioCtrl, 4*time.Second, 1*time.Second)
+	waiter := NewBuildkitClientReadinessWaiter(ioCtrl)
 
 	ic := &InClusterConnector{
 		sessionID:    sessionID,

--- a/pkg/build/buildkit/connector/portforward.go
+++ b/pkg/build/buildkit/connector/portforward.go
@@ -112,8 +112,7 @@ func NewPortForwarder(ctx context.Context, okCtx PortForwarderOktetoContextInter
 	}
 
 	maxWaitTime := env.LoadTimeOrDefault(buildkitQueueWaitTimeoutEnvVar, defaultMaxWaitTimePortForward)
-	// Configure waiter for 3 attempts: 1s retry interval * 4 = 4s max wait time
-	waiter := NewBuildkitClientWaiterWithConfig(ioCtrl, 4*time.Second, 1*time.Second)
+	waiter := NewBuildkitClientReadinessWaiter(ioCtrl)
 
 	pf := &PortForwarder{
 		sessionID:    sessionID,

--- a/pkg/build/buildkit/connector/wait.go
+++ b/pkg/build/buildkit/connector/wait.go
@@ -37,7 +37,7 @@ const (
 	retryBuildkitIntervalEnvVar = "OKTETO_BUILDKIT_RETRY_INTERVAL"
 
 	// defaultReadinessTimeout is the default budget for the buildkit readiness health-check
-	// (the Info() call) used by the port-forward and in-cluster connectors.
+	// (the Info() call) used by the port-forward connector.
 	defaultReadinessTimeout = 6 * time.Second
 
 	// readinessRetryInterval is the interval between buildkit readiness health-check attempts.
@@ -82,7 +82,7 @@ func NewBuildkitClientWaiter(logger *io.Controller) *Waiter {
 }
 
 // NewBuildkitClientReadinessWaiter creates a waiter for the buildkit readiness health-check
-// used by the port-forward and in-cluster connectors. The timeout budget is configurable via
+// used by the port-forward connector. The timeout budget is configurable via
 // readinessTimeoutEnvVar and defaults to defaultReadinessTimeout.
 func NewBuildkitClientReadinessWaiter(logger *io.Controller) *Waiter {
 	return &Waiter{

--- a/pkg/build/buildkit/connector/wait.go
+++ b/pkg/build/buildkit/connector/wait.go
@@ -35,6 +35,16 @@ const (
 
 	// retryBuildkitTimeEnvVar is the environment variable to set the retry time for buildkit
 	retryBuildkitIntervalEnvVar = "OKTETO_BUILDKIT_RETRY_INTERVAL"
+
+	// defaultReadinessTimeout is the default budget for the buildkit readiness health-check
+	// (the Info() call) used by the port-forward and in-cluster connectors.
+	defaultReadinessTimeout = 6 * time.Second
+
+	// readinessRetryInterval is the interval between buildkit readiness health-check attempts.
+	readinessRetryInterval = 1 * time.Second
+
+	// readinessTimeoutEnvVar overrides defaultReadinessTimeout for the readiness health-check.
+	readinessTimeoutEnvVar = "OKTETO_BUILDKIT_READINESS_TIMEOUT"
 )
 
 // sleeper defines an interface for sleeping
@@ -71,11 +81,13 @@ func NewBuildkitClientWaiter(logger *io.Controller) *Waiter {
 	}
 }
 
-// NewBuildkitClientWaiterWithConfig creates a new buildkitWaiter with custom configuration
-func NewBuildkitClientWaiterWithConfig(logger *io.Controller, maxWaitTime, retryInterval time.Duration) *Waiter {
+// NewBuildkitClientReadinessWaiter creates a waiter for the buildkit readiness health-check
+// used by the port-forward and in-cluster connectors. The timeout budget is configurable via
+// readinessTimeoutEnvVar and defaults to defaultReadinessTimeout.
+func NewBuildkitClientReadinessWaiter(logger *io.Controller) *Waiter {
 	return &Waiter{
-		maxWaitTime:   maxWaitTime,
-		retryInterval: retryInterval,
+		maxWaitTime:   env.LoadTimeOrDefault(readinessTimeoutEnvVar, defaultReadinessTimeout),
+		retryInterval: readinessRetryInterval,
 		sleeper:       &DefaultSleeper{},
 		logger:        logger,
 	}

--- a/pkg/build/buildkit/connector/wait.go
+++ b/pkg/build/buildkit/connector/wait.go
@@ -85,8 +85,16 @@ func NewBuildkitClientWaiter(logger *io.Controller) *Waiter {
 // used by the port-forward connector. The timeout budget is configurable via
 // readinessTimeoutEnvVar and defaults to defaultReadinessTimeout.
 func NewBuildkitClientReadinessWaiter(logger *io.Controller) *Waiter {
+	maxWaitTime := env.LoadTimeOrDefault(readinessTimeoutEnvVar, defaultReadinessTimeout)
+	// A non-positive timeout would make the readiness check fail immediately, so treat it
+	// as invalid and fall back to the default.
+	if maxWaitTime <= 0 {
+		logger.Infof("'%s' must be a positive duration, falling back to %v\n", readinessTimeoutEnvVar, defaultReadinessTimeout)
+		maxWaitTime = defaultReadinessTimeout
+	}
+
 	return &Waiter{
-		maxWaitTime:   env.LoadTimeOrDefault(readinessTimeoutEnvVar, defaultReadinessTimeout),
+		maxWaitTime:   maxWaitTime,
 		retryInterval: readinessRetryInterval,
 		sleeper:       &DefaultSleeper{},
 		logger:        logger,

--- a/pkg/build/buildkit/connector/wait_test.go
+++ b/pkg/build/buildkit/connector/wait_test.go
@@ -178,6 +178,16 @@ func TestNewBuildkitClientReadinessWaiter(t *testing.T) {
 			envValue:            "notaduration",
 			expectedMaxWaitTime: defaultReadinessTimeout,
 		},
+		{
+			name:                "ZeroValueFallsBackToDefault",
+			envValue:            "0s",
+			expectedMaxWaitTime: defaultReadinessTimeout,
+		},
+		{
+			name:                "NegativeValueFallsBackToDefault",
+			envValue:            "-1s",
+			expectedMaxWaitTime: defaultReadinessTimeout,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/build/buildkit/connector/wait_test.go
+++ b/pkg/build/buildkit/connector/wait_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockSleeper is a mock implementation of the sleeper interface.
@@ -152,6 +153,45 @@ func TestNewBuildkitClientWaiter(t *testing.T) {
 			assert.Equal(t, tt.expectedRetryTime, bw.retryInterval)
 			assert.IsType(t, &DefaultSleeper{}, bw.sleeper)
 			assert.Equal(t, logger, bw.logger)
+		})
+	}
+}
+
+func TestNewBuildkitClientReadinessWaiter(t *testing.T) {
+	tests := []struct {
+		name                string
+		envValue            string
+		expectedMaxWaitTime time.Duration
+	}{
+		{
+			name:                "DefaultValue",
+			envValue:            "",
+			expectedMaxWaitTime: defaultReadinessTimeout,
+		},
+		{
+			name:                "CustomValue",
+			envValue:            "30s",
+			expectedMaxWaitTime: 30 * time.Second,
+		},
+		{
+			name:                "InvalidValueFallsBackToDefault",
+			envValue:            "notaduration",
+			expectedMaxWaitTime: defaultReadinessTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setting an empty value is equivalent to the variable being unset for LoadTimeOrDefault.
+			t.Setenv(readinessTimeoutEnvVar, tt.envValue)
+
+			logger := io.NewIOController()
+			bw := NewBuildkitClientReadinessWaiter(logger)
+
+			require.Equal(t, tt.expectedMaxWaitTime, bw.maxWaitTime)
+			require.Equal(t, readinessRetryInterval, bw.retryInterval)
+			require.IsType(t, &DefaultSleeper{}, bw.sleeper)
+			require.Equal(t, logger, bw.logger)
 		})
 	}
 }


### PR DESCRIPTION
# Proposed changes

Jira: **DEV-1426**

The BuildKit readiness health-check (the `Info()` call) in the **port-forward connector** had a hardcoded **4s** budget, shared across all retry attempts. Over slow or lossy transports — e.g. an AWS Client VPN tunnel nested under the SPDY port-forward — the TLS handshake inside `Info()` could not complete in time, so the CLI failed immediately with `context deadline exceeded` while `kubectl` (which has no such aggressive deadline) rode it out.

This PR makes that timeout **configurable** and bumps the default:

- New env var **`OKTETO_BUILDKIT_READINESS_TIMEOUT`** (parsed as a Go duration, e.g. `30s`).
- Default raised **4s → 6s**.
- Introduces `NewBuildkitClientReadinessWaiter` as the single source of truth for the port-forward connector, removing the duplicated `4*time.Second` literals and the stale "3 attempts" comment.
- Removes the **unused `waiter` field** from `InClusterConnector` — it was dead code (`WaitUntilIsReady` is a no-op; the in-cluster connector verifies readiness inline in `Start()`/`verifyConnection()`).

Scope is intentionally limited to the timeout value; the retry interval stays fixed at 1s. The env var affects the port-forward connector only — the in-cluster connector continues to verify readiness inline with its existing 5s check.

## How to validate

1. Build the CLI: `make build` (or `go build ./...`).
2. Run a build that uses the port-forward connector (`okteto build ...`). With no env var set, the readiness health-check now allows up to 6s instead of 4s.
3. Override it: `OKTETO_BUILDKIT_READINESS_TIMEOUT=30s okteto build ...` and confirm the connector waits up to 30s before failing. An invalid value (e.g. `notaduration`) logs a warning and falls back to the 6s default.
4. Unit tests: `go test ./pkg/build/buildkit/connector/...` — see `TestNewBuildkitClientReadinessWaiter` (default / custom / invalid-fallback cases).

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
