### PR TITLE
Fix "okteto destroy --all" hanging on sleeping namespaces

### DIFF
--- a/cmd/destroy/all.go
+++ b/cmd/destroy/all.go
@@ -145,7 +145,10 @@ func (lda *localDestroyAllCommand) waitForNamespaceDestroyAllToComplete(ctx cont
 			}
 
 			switch status {
-			case "Active":
+			case "Active", constants.NamespaceStatusSleeping:
+				// The backend sets the namespace back to its previous status when destroy all
+				// succeeds: "Active" for active namespaces and "Sleeping" for namespaces that were
+				// already sleeping (e.g. emptied by the garbage collector). Both are success states.
 				// If we haven't been in DestroyingAll state for at least destroyingAllTickerDuration, wait before checking resources.
 				if !hasBeenDestroyingAll && time.Since(destroyingAllTicker) < destroyingAllTickerDuration {
 					jobNotFoundAfterXSeconds = true

--- a/integration/commands/deploy.go
+++ b/integration/commands/deploy.go
@@ -50,6 +50,7 @@ type DestroyOptions struct {
 	Token        string
 	Name         string
 	IsRemote     bool
+	All          bool
 }
 
 // GetOktetoDeployCmdOutput runs an okteto deploy command
@@ -109,6 +110,18 @@ func RunOktetoDestroyAndGetOutput(oktetoPath string, destroyOptions *DestroyOpti
 	return string(o), nil
 }
 
+// RunOktetoDestroyAll runs an okteto destroy --all command
+func RunOktetoDestroyAll(oktetoPath string, destroyOptions *DestroyOptions) error {
+	log.Printf("okteto destroy --all %s", oktetoPath)
+	cmd := getDestroyCmd(oktetoPath, destroyOptions)
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("okteto destroy --all failed: %s - %w", string(o), err)
+	}
+	log.Printf("okteto destroy --all success")
+	return nil
+}
+
 // RunOktetoDestroyRemote runs an okteto destroy command in remote
 func RunOktetoDestroyRemote(oktetoPath string, destroyOptions *DestroyOptions) error {
 	log.Printf("okteto destroy %s", oktetoPath)
@@ -139,6 +152,9 @@ func getDestroyCmd(oktetoPath string, destroyOptions *DestroyOptions) *exec.Cmd 
 	}
 	if destroyOptions.IsRemote {
 		cmd.Args = append(cmd.Args, "--remote")
+	}
+	if destroyOptions.All {
+		cmd.Args = append(cmd.Args, "--all")
 	}
 	cmd.Env = os.Environ()
 	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {

--- a/integration/commands/namespace.go
+++ b/integration/commands/namespace.go
@@ -61,6 +61,28 @@ func RunOktetoCreateNamespace(oktetoPath string, namespaceOpts *NamespaceOptions
 	return nil
 }
 
+// RunOktetoNamespaceSleep runs okteto namespace sleep
+func RunOktetoNamespaceSleep(oktetoPath string, namespaceOpts *NamespaceOptions) error {
+	log.Printf("okteto namespace sleep %s", namespaceOpts.Namespace)
+	sleepCMD := exec.Command(oktetoPath, "namespace", "sleep", namespaceOpts.Namespace)
+
+	sleepCMD.Env = os.Environ()
+	if v := os.Getenv(model.OktetoURLEnvVar); v != "" {
+		sleepCMD.Env = append(sleepCMD.Env, fmt.Sprintf("%s=%s", model.OktetoURLEnvVar, v))
+	}
+	if namespaceOpts.Token != "" {
+		sleepCMD.Env = append(sleepCMD.Env, fmt.Sprintf("%s=%s", model.OktetoTokenEnvVar, namespaceOpts.Token))
+	}
+	if namespaceOpts.OktetoHome != "" {
+		sleepCMD.Env = append(sleepCMD.Env, fmt.Sprintf("%s=%s", constants.OktetoHomeEnvVar, namespaceOpts.OktetoHome))
+	}
+	o, err := sleepCMD.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("okteto namespace sleep failed: %s - %w", string(o), err)
+	}
+	return nil
+}
+
 // RunOktetoDeleteNamespace runs okteto namespace delete
 func RunOktetoDeleteNamespace(oktetoPath string, namespaceOpts *NamespaceOptions) error {
 	log.Printf("okteto namespace delete %s", namespaceOpts.Namespace)

--- a/integration/k8s-client.go
+++ b/integration/k8s-client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,32 @@ func UpdateStatefulset(ctx context.Context, ns string, sfs *appsv1.StatefulSet, 
 // GetConfigmap returns a configmap given name and namespace
 func GetConfigmap(ctx context.Context, ns, name string, client kubernetes.Interface) (*corev1.ConfigMap, error) {
 	return client.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+}
+
+// GetNamespace returns a namespace given its name
+func GetNamespace(ctx context.Context, name string, client kubernetes.Interface) (*corev1.Namespace, error) {
+	return client.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+}
+
+// WaitForNamespaceStatus polls the namespace until its status label matches the expected value or the timeout is reached
+func WaitForNamespaceStatus(ctx context.Context, name, status string, client kubernetes.Interface, timeout time.Duration) error {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	to := time.After(timeout)
+	for {
+		select {
+		case <-to:
+			return fmt.Errorf("namespace %q didn't reach status %q after %s", name, status, timeout)
+		case <-ticker.C:
+			ns, err := client.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if ns.Labels[constants.NamespaceStatusLabel] == status {
+				return nil
+			}
+		}
+	}
 }
 
 // GetDeploymentList returns all deployments given a namespace

--- a/integration/okteto/destroy_all_test.go
+++ b/integration/okteto/destroy_all_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+// +build integration
+
+// Copyright 2023 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package okteto
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/okteto/okteto/integration"
+	"github.com/okteto/okteto/integration/commands"
+	"github.com/okteto/okteto/pkg/constants"
+	"github.com/okteto/okteto/pkg/k8s/kubeconfig"
+	"github.com/okteto/okteto/pkg/okteto"
+	"github.com/stretchr/testify/require"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	// statusActive is the namespace status label value for an active namespace.
+	// It is a bare literal because the CLI does not expose a constant for it.
+	statusActive = "Active"
+
+	destroyAllDevEnvName = "destroyall"
+
+	destroyAllK8sManifest = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-destroy-all
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: e2e-destroy-all
+  template:
+    metadata:
+      labels:
+        app: e2e-destroy-all
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: test
+        image: nginx:alpine
+`
+
+	destroyAllOktetoManifest = `deploy:
+- kubectl apply -f k8s.yml
+`
+)
+
+// TestDestroyAllPreservesNamespaceStatus verifies that `okteto destroy --all`:
+//   - completes and leaves the namespace "Active" when it was active before the command, and
+//   - completes and keeps the namespace "Sleeping" when it was sleeping before the command.
+//
+// The sleeping case is a regression test: the backend now restores the namespace to its
+// previous status after destroy all (Active or Sleeping). Previously the CLI wait loop only
+// understood "Active", so destroying a sleeping namespace hung until the 5-minute timeout.
+func TestDestroyAllPreservesNamespaceStatus(t *testing.T) {
+	integration.SkipIfNotOktetoCluster(t)
+	t.Parallel()
+
+	oktetoPath, err := integration.GetOktetoPath()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, createDestroyAllManifests(dir))
+
+	testNamespace := integration.GetTestNamespace(t.Name())
+	namespaceOpts := &commands.NamespaceOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+	}
+	require.NoError(t, commands.RunOktetoCreateNamespace(oktetoPath, namespaceOpts))
+	t.Cleanup(func() {
+		require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
+	})
+	require.NoError(t, commands.RunOktetoKubeconfig(oktetoPath, &commands.KubeconfigOpts{
+		OktetoHome: dir,
+	}))
+
+	c, _, err := okteto.NewK8sClientProvider().Provide(kubeconfig.Get([]string{filepath.Join(dir, ".kube", "config")}))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	devEnvConfigMap := fmt.Sprintf("okteto-git-%s", destroyAllDevEnvName)
+
+	deployOptions := &commands.DeployOptions{
+		Workdir:    dir,
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		Name:       destroyAllDevEnvName,
+	}
+	destroyAllOptions := &commands.DestroyOptions{
+		Namespace:  testNamespace,
+		OktetoHome: dir,
+		Token:      token,
+		All:        true,
+	}
+
+	// 1) Active namespace: deploy a dev environment, then destroy all.
+	// The namespace must end up clean and remain Active.
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+	_, err = integration.GetConfigmap(ctx, testNamespace, devEnvConfigMap, c)
+	require.NoError(t, err)
+
+	require.NoError(t, commands.RunOktetoDestroyAll(oktetoPath, destroyAllOptions))
+
+	_, err = integration.GetConfigmap(ctx, testNamespace, devEnvConfigMap, c)
+	require.True(t, k8sErrors.IsNotFound(err), "dev environment configmap should be destroyed")
+	ns, err := integration.GetNamespace(ctx, testNamespace, c)
+	require.NoError(t, err)
+	require.Equal(t, statusActive, ns.Labels[constants.NamespaceStatusLabel], "namespace should remain Active")
+
+	// 2) Sleeping namespace: deploy again, put the namespace to sleep, then destroy all.
+	// The namespace must end up clean and remain Sleeping (the regression scenario).
+	require.NoError(t, commands.RunOktetoDeploy(oktetoPath, deployOptions))
+	_, err = integration.GetConfigmap(ctx, testNamespace, devEnvConfigMap, c)
+	require.NoError(t, err)
+
+	require.NoError(t, commands.RunOktetoNamespaceSleep(oktetoPath, namespaceOpts))
+	require.NoError(t, integration.WaitForNamespaceStatus(ctx, testNamespace, constants.NamespaceStatusSleeping, c, 2*time.Minute))
+
+	require.NoError(t, commands.RunOktetoDestroyAll(oktetoPath, destroyAllOptions))
+
+	_, err = integration.GetConfigmap(ctx, testNamespace, devEnvConfigMap, c)
+	require.True(t, k8sErrors.IsNotFound(err), "dev environment configmap should be destroyed")
+	ns, err = integration.GetNamespace(ctx, testNamespace, c)
+	require.NoError(t, err)
+	require.Equal(t, constants.NamespaceStatusSleeping, ns.Labels[constants.NamespaceStatusLabel], "namespace should remain Sleeping")
+}
+
+func createDestroyAllManifests(dir string) error {
+	if err := os.WriteFile(filepath.Join(dir, "k8s.yml"), []byte(destroyAllK8sManifest), 0600); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "okteto.yml"), []byte(destroyAllOktetoManifest), 0600); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
`okteto destroy --all` would succeed in-cluster but the CLI never returned — it spun until the 5-minute timeout and then reported a false deploy didn't finish error. This happened on namespaces in Sleeping status.

Backend PR okteto/app#9902 changed destroy-all to restore a namespace to its previous status on success — Active for active namespaces, Sleeping for sleeping ones — instead of always Active. The CLI wait loop in cmd/destroy/all.go only recognized Active, DestroyingAll, and DestroyAllFailed, so a final Sleeping status fell through the switch and the loop polled until timeout.

Added an integration test (integration/okteto/destroy_all_test.go) that deploys a sample dev environment and runs destroy --all twice:
- on an active namespace → completes, namespace cleaned, status stays Active
- on a sleeping namespace → completes, namespace cleaned, status stays Sleeping (regression guard)