### PR TITLE
feat(deploy): allow overriding redeploy detection via OKTETO_IS_REDEPLOY

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -395,7 +395,7 @@ func (dc *Command) Run(ctx context.Context, deployOptions *Options) error {
 		return err
 	}
 
-	dc.isRedeploy = pipeline.IsDeployed(ctx, deployOptions.Name, deployOptions.Namespace, c)
+	dc.isRedeploy = resolveIsRedeploy(ctx, deployOptions.Name, deployOptions.Namespace, c)
 
 	dc.isWithinPreview = analytics.IsWithinPreview(ctx, func(ctx context.Context, ns string) error {
 		okClient, err := okteto.NewOktetoClient()
@@ -773,6 +773,14 @@ func deployRepoURL(manifestPath string) string {
 		oktetoLog.Infof("failed to get repo URL for analytics: %s", err)
 	}
 	return repoURL
+}
+
+// resolveIsRedeploy determines whether this deploy is a redeploy of an existing development
+func resolveIsRedeploy(ctx context.Context, name, namespace string, c kubernetes.Interface) bool {
+	if _, ok := os.LookupEnv(constants.OktetoIsRedeployEnvVar); ok {
+		return env.LoadBoolean(constants.OktetoIsRedeployEnvVar)
+	}
+	return pipeline.IsDeployed(ctx, name, namespace, c)
 }
 
 // deployDependencies deploy the dependencies in the manifest

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -47,7 +47,9 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd/api"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -1477,4 +1479,89 @@ func TestCalculateManifestPathToBeStored(t *testing.T) {
 
 func boolPointer(v bool) *bool {
 	return &v
+}
+
+func Test_resolveIsRedeploy_EnvVarTakesPrecedence(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test"
+	name := "movies"
+
+	// A configmap in "deployed" status is present so IsDeployed would return true. The env var must
+	// take precedence over it, proving the fallback is not used when the variable is set.
+	deployedCfg := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipeline.TranslatePipelineName(name),
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"status": pipeline.DeployedStatus,
+		},
+	}
+
+	var tests = []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "env var true",
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "env var false overrides deployed configmap",
+			envValue: "false",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(constants.OktetoIsRedeployEnvVar, tt.envValue)
+			c := fake.NewSimpleClientset(deployedCfg)
+			result := resolveIsRedeploy(ctx, name, namespace, c)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_resolveIsRedeploy_FallbackToConfigmap(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test"
+	name := "movies"
+
+	deployedCfg := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pipeline.TranslatePipelineName(name),
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"status": pipeline.DeployedStatus,
+		},
+	}
+
+	var tests = []struct {
+		name     string
+		objects  []runtime.Object
+		expected bool
+	}{
+		{
+			name:     "no configmap - first deploy",
+			objects:  nil,
+			expected: false,
+		},
+		{
+			name:     "deployed configmap - redeploy",
+			objects:  []runtime.Object{deployedCfg},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fake.NewSimpleClientset(tt.objects...)
+			result := resolveIsRedeploy(ctx, name, namespace, c)
+			require.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -152,6 +152,9 @@ const (
 	// OktetoIsPreviewEnvVar Env variable containing a boolean indicating if the environment is a preview environment
 	OktetoIsPreviewEnvVar = "OKTETO_IS_PREVIEW_ENVIRONMENT"
 
+	// OktetoIsRedeployEnvVar Env variable containing a boolean set by the installer indicating if the deploy is a redeploy of an existing development environment
+	OktetoIsRedeployEnvVar = "OKTETO_IS_REDEPLOY"
+
 	// CIEnvVar Env variable defines if the environment is a CI environment
 	CIEnvVar = "CI"
 


### PR DESCRIPTION
# Proposed changes

Introduce the `OKTETO_IS_REDEPLOY` environment variable so the installer can explicitly signal whether a deploy is a redeploy of an existing development environment.

Until now, `okteto deploy` inferred the redeploy state solely by inspecting the pipeline configmap via `pipeline.IsDeployed`. This inference is not always reliable in installer-driven flows. With this change, when `OKTETO_IS_REDEPLOY` is set, its boolean value takes precedence; otherwise the command falls back to the existing configmap-based detection, preserving current behavior.

## How to validate

1. Deploy an environment for the first time without the variable set and confirm it is detected as a **first deploy** (`isRedeploy=false`).
1. Set `OKTETO_IS_REDEPLOY=true` and run `okteto deploy` on the same environment; confirm it is treated as a **redeploy** regardless of configmap state.
1. Set `OKTETO_IS_REDEPLOY=false` on an already-deployed environment (with a `deployed` configmap present) and confirm it is treated as a **first deploy**, proving the env var overrides the fallback.

## CLI Quality Reminders 🔧

- No regressions: default behavior is unchanged when the variable is unset (falls back to `pipeline.IsDeployed`).
- Automated tests added covering both precedence and fallback paths.
- Developer Experience: no new logs or performance impact; a single `os.LookupEnv` check.