### PR TITLE
chore(analytics): remove redundant is_within_preview from deploy_preview_triggered

### DIFF
--- a/cmd/preview/deploy.go
+++ b/cmd/preview/deploy.go
@@ -120,11 +120,7 @@ func (pw *Command) ExecuteDeployPreview(ctx context.Context, opts *DeployOptions
 			ParentWorkflowID: os.Getenv(constants.OktetoParentWorkflowIDEnvVar),
 			RepoURL:          opts.repository,
 			Preview:          opts.name,
-			IsWithinPreview: analytics.IsWithinPreview(ctx, func(ctx context.Context, ns string) error {
-				_, err := pw.okClient.Previews().Get(ctx, ns)
-				return err
-			}),
-			IsRedeploy: !oktetoErrors.IsNotFound(getErr),
+			IsRedeploy:       !oktetoErrors.IsNotFound(getErr),
 		})
 	}
 

--- a/pkg/analytics/posthog.go
+++ b/pkg/analytics/posthog.go
@@ -252,7 +252,6 @@ func (b *posthogBackend) TrackDeployPreviewTriggered(ctx context.Context, m Depl
 	userID := okteto.GetContext().UserID
 	props := commonPostHogProperties()
 	props["workflow_id"] = m.WorkflowID
-	props["is_within_preview"] = m.IsWithinPreview
 	props["is_redeploy"] = m.IsRedeploy
 	if m.ParentWorkflowID != "" {
 		props["parent_workflow_id"] = m.ParentWorkflowID

--- a/pkg/analytics/posthog_test.go
+++ b/pkg/analytics/posthog_test.go
@@ -667,7 +667,6 @@ func TestPostHogBackend_TrackDeployPreviewTriggered_HappyPath(t *testing.T) {
 		ParentWorkflowID: "wf-parent-2",
 		RepoURL:          "https://github.com/org/repo",
 		Preview:          "my-preview",
-		IsWithinPreview:  false,
 		IsRedeploy:       true,
 	}
 	b.TrackDeployPreviewTriggered(context.Background(), m)
@@ -679,7 +678,6 @@ func TestPostHogBackend_TrackDeployPreviewTriggered_HappyPath(t *testing.T) {
 	require.Equal(t, "user-123", event.DistinctId)
 	require.Equal(t, "wf-parent-2", event.Properties["parent_workflow_id"])
 	require.Equal(t, "bdb72e6e68b80f9ed3bbdb0ad1d2f8b4fac8ade379eb82182de40a3357a2d3b3", event.Properties["repo_url"])
-	require.Equal(t, false, event.Properties["is_within_preview"])
 	require.Equal(t, true, event.Properties["is_redeploy"])
 	require.Equal(t, "preview-uid-xyz", event.Properties["preview"])
 	require.NotEmpty(t, event.Properties["cli_version"])

--- a/pkg/analytics/preview_triggered.go
+++ b/pkg/analytics/preview_triggered.go
@@ -22,7 +22,6 @@ type DeployPreviewTriggeredMetadata struct {
 	RepoURL          string
 	Preview          string
 	UIElement        string
-	IsWithinPreview  bool
 	IsRedeploy       bool
 }
 


### PR DESCRIPTION
## Summary

- The `deploy_preview_triggered` PostHog event is always scoped to a preview (it is enqueued with `withPreview(m.Preview)`), so `is_within_preview` carried no signal for this event.
- Removed the `IsWithinPreview` field from `DeployPreviewTriggeredMetadata`, stopped populating it in `TrackDeployPreviewTriggered`, and dropped its assignment in `cmd/preview/deploy.go`.
- `DeployPipelineTriggeredMetadata` / `deploy` events keep `is_within_preview` unchanged, since it remains meaningful there.

## Test plan

- [x] `go build ./cmd/preview/... ./pkg/analytics/...`
- [x] `go test ./pkg/analytics/ ./cmd/preview/...`
- [x] `gofmt` and `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)