### PR TITLE
feat(analytics): add wake_triggered PostHog event

### DIFF
--- a/cmd/namespace/namespace.go
+++ b/cmd/namespace/namespace.go
@@ -18,11 +18,17 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/okteto"
 	"github.com/okteto/okteto/pkg/types"
 	"github.com/spf13/cobra"
 )
+
+// wakeAnalyticsTracker tracks the wake_triggered event.
+type wakeAnalyticsTracker interface {
+	TrackWakeTriggered(ctx context.Context, m analytics.WakeTriggeredMetadata)
+}
 
 // Command has all the namespaces subcommands
 type Command struct {
@@ -58,7 +64,7 @@ func NewCommandStateless(c *okteto.Client, ioCtrl *io.Controller) *Command {
 }
 
 // Namespace fetch credentials for a cluster namespace
-func Namespace(ctx context.Context, k8sLogger *io.K8sLogger, ioCtrl *io.Controller) *cobra.Command {
+func Namespace(ctx context.Context, k8sLogger *io.K8sLogger, ioCtrl *io.Controller, at wakeAnalyticsTracker) *cobra.Command {
 	options := &UseOptions{}
 	cmd := &cobra.Command{
 		Use:     "namespace",
@@ -74,6 +80,6 @@ func Namespace(ctx context.Context, k8sLogger *io.K8sLogger, ioCtrl *io.Controll
 	cmd.AddCommand(Create(ctx, ioCtrl))
 	cmd.AddCommand(Delete(ctx, k8sLogger, ioCtrl))
 	cmd.AddCommand(Sleep(ctx, ioCtrl))
-	cmd.AddCommand(Wake(ctx, ioCtrl))
+	cmd.AddCommand(Wake(ctx, ioCtrl, at))
 	return cmd
 }

--- a/cmd/namespace/namespace_test.go
+++ b/cmd/namespace/namespace_test.go
@@ -14,9 +14,12 @@
 package namespace
 
 import (
+	"context"
+
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/internal/test"
 	"github.com/okteto/okteto/internal/test/client"
+	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/k8s/ingresses"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/okteto/okteto/pkg/types"
@@ -24,6 +27,14 @@ import (
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
+
+type fakeWakeAnalyticsTracker struct {
+	calls []analytics.WakeTriggeredMetadata
+}
+
+func (f *fakeWakeAnalyticsTracker) TrackWakeTriggered(_ context.Context, m analytics.WakeTriggeredMetadata) {
+	f.calls = append(f.calls, m)
+}
 
 type fakeK8sProvider struct {
 	k8sClient kubernetes.Interface

--- a/cmd/namespace/wake.go
+++ b/cmd/namespace/wake.go
@@ -19,6 +19,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/analytics"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/log/io"
@@ -26,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func Wake(ctx context.Context, ioCtrl *io.Controller) *cobra.Command {
+func Wake(ctx context.Context, ioCtrl *io.Controller, at wakeAnalyticsTracker) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "wake <name>",
 		Short: "Wakes an Okteto Namespace. By default, it wakes the default namespace in the Okteto Context",
@@ -48,14 +49,14 @@ func Wake(ctx context.Context, ioCtrl *io.Controller) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = nsCmd.ExecuteWakeNamespace(ctx, nsToWake)
+			err = nsCmd.ExecuteWakeNamespace(ctx, nsToWake, at)
 			return err
 		},
 	}
 	return cmd
 }
 
-func (nc *Command) ExecuteWakeNamespace(ctx context.Context, namespace string) error {
+func (nc *Command) ExecuteWakeNamespace(ctx context.Context, namespace string, at wakeAnalyticsTracker) error {
 	// Spinner to be loaded before waking a namespace
 	oktetoLog.Spinner(fmt.Sprintf("Waking %s namespace", namespace))
 	oktetoLog.StartSpinner()
@@ -65,6 +66,11 @@ func (nc *Command) ExecuteWakeNamespace(ctx context.Context, namespace string) e
 	if err := nc.okClient.Namespaces().Wake(ctx, namespace); err != nil {
 		return fmt.Errorf("%w: %w", errFailedWakeNamespace, err)
 	}
+
+	at.TrackWakeTriggered(ctx, analytics.WakeTriggeredMetadata{
+		Namespace: namespace,
+		IsPreview: false,
+	})
 
 	oktetoLog.Success("Namespace '%s' is awake now", namespace)
 	return nil

--- a/cmd/namespace/wake_test.go
+++ b/cmd/namespace/wake_test.go
@@ -46,6 +46,7 @@ func Test_WakeNamespace(t *testing.T) {
 		// toWakeNs the namespace to wake
 		toWakeNs                        string
 		initialNamespacesAtOktetoClient []types.Namespace
+		expectTracked                   bool
 	}{
 		{
 			name:                            "wakes existing ns, the current one",
@@ -57,6 +58,7 @@ func Test_WakeNamespace(t *testing.T) {
 				StreamClient: client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 			},
 			fakeK8sClient: fake.NewSimpleClientset(),
+			expectTracked: true,
 		},
 		{
 			name:                            "wakes existing ns, not the current one",
@@ -68,6 +70,7 @@ func Test_WakeNamespace(t *testing.T) {
 				StreamClient: client.NewFakeStreamClient(&client.FakeStreamResponse{}),
 			},
 			fakeK8sClient: fake.NewSimpleClientset(),
+			expectTracked: true,
 		},
 		{
 			name:                            "wakes a non existing ns",
@@ -80,6 +83,7 @@ func Test_WakeNamespace(t *testing.T) {
 			},
 			fakeK8sClient: fake.NewSimpleClientset(),
 			err:           errFailedWakeNamespace,
+			expectTracked: false,
 		},
 	}
 
@@ -98,12 +102,21 @@ func Test_WakeNamespace(t *testing.T) {
 				},
 				CurrentContext: "test-context",
 			}
+			tracker := &fakeWakeAnalyticsTracker{}
 			nsFakeCommand := NewFakeNamespaceCommand(tt.fakeOkClient, tt.fakeK8sClient, usr)
-			err := nsFakeCommand.ExecuteWakeNamespace(ctx, tt.toWakeNs)
+			err := nsFakeCommand.ExecuteWakeNamespace(ctx, tt.toWakeNs, tracker)
 			if tt.err != nil {
 				assert.ErrorIs(t, err, tt.err)
 			} else {
 				assert.NoError(t, err)
+			}
+
+			if tt.expectTracked {
+				assert.Len(t, tracker.calls, 1)
+				assert.Equal(t, tt.toWakeNs, tracker.calls[0].Namespace)
+				assert.False(t, tracker.calls[0].IsPreview)
+			} else {
+				assert.Empty(t, tracker.calls)
 			}
 		})
 	}

--- a/cmd/preview/preview.go
+++ b/cmd/preview/preview.go
@@ -24,6 +24,7 @@ import (
 
 type previewAnalyticsTracker interface {
 	TrackDeployPreviewTriggered(ctx context.Context, m analytics.DeployPreviewTriggeredMetadata)
+	TrackWakeTriggered(ctx context.Context, m analytics.WakeTriggeredMetadata)
 }
 
 type Command struct {

--- a/cmd/preview/wake.go
+++ b/cmd/preview/wake.go
@@ -19,6 +19,7 @@ import (
 
 	contextCMD "github.com/okteto/okteto/cmd/context"
 	"github.com/okteto/okteto/cmd/utils"
+	"github.com/okteto/okteto/pkg/analytics"
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	oktetoLog "github.com/okteto/okteto/pkg/log"
 	"github.com/okteto/okteto/pkg/okteto"
@@ -64,6 +65,11 @@ func (pr *Command) ExecuteWakePreview(ctx context.Context, preview string) error
 	if err := pr.okClient.Namespaces().Wake(ctx, preview); err != nil {
 		return fmt.Errorf("%w: %w", errFailedWakePreview, err)
 	}
+
+	pr.analyticsTracker.TrackWakeTriggered(ctx, analytics.WakeTriggeredMetadata{
+		Namespace: preview,
+		IsPreview: true,
+	})
 
 	oktetoLog.Success("Preview environment '%s' is awake now", preview)
 	return nil

--- a/cmd/preview/wake_test.go
+++ b/cmd/preview/wake_test.go
@@ -1,0 +1,83 @@
+// Copyright 2023-2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preview
+
+import (
+	"context"
+	"testing"
+
+	"github.com/okteto/okteto/internal/test/client"
+	"github.com/okteto/okteto/pkg/analytics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeWakePreviewTracker struct {
+	wakeCalls []analytics.WakeTriggeredMetadata
+}
+
+func (*fakeWakePreviewTracker) TrackDeployPreviewTriggered(_ context.Context, _ analytics.DeployPreviewTriggeredMetadata) {
+}
+
+func (f *fakeWakePreviewTracker) TrackWakeTriggered(_ context.Context, m analytics.WakeTriggeredMetadata) {
+	f.wakeCalls = append(f.wakeCalls, m)
+}
+
+func Test_ExecuteWakePreview(t *testing.T) {
+	tests := []struct {
+		wakeErr       error
+		name          string
+		expectTracked bool
+	}{
+		{
+			name:          "wake succeeds, tracks is_preview true",
+			wakeErr:       nil,
+			expectTracked: true,
+		},
+		{
+			name:          "wake fails, does not track",
+			wakeErr:       assert.AnError,
+			expectTracked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tracker := &fakeWakePreviewTracker{}
+			prCmd := &Command{
+				okClient: &client.FakeOktetoClient{
+					Namespace: client.NewFakeNamespaceClient(nil, tt.wakeErr),
+				},
+				analyticsTracker: tracker,
+			}
+
+			err := prCmd.ExecuteWakePreview(ctx, "my-preview")
+
+			if tt.wakeErr != nil {
+				require.ErrorIs(t, err, errFailedWakePreview)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.expectTracked {
+				require.Len(t, tracker.wakeCalls, 1)
+				require.Equal(t, "my-preview", tracker.wakeCalls[0].Namespace)
+				require.True(t, tracker.wakeCalls[0].IsPreview)
+			} else {
+				require.Empty(t, tracker.wakeCalls)
+			}
+		})
+	}
+}

--- a/cmd/up/autodown_test.go
+++ b/cmd/up/autodown_test.go
@@ -28,6 +28,7 @@ import (
 
 type mockAnalyticsTracker struct {
 	mock.Mock
+	wakeCalls []analytics.WakeTriggeredMetadata
 }
 
 func (m *mockAnalyticsTracker) TrackEvent(event string, properties map[string]interface{}) {
@@ -63,6 +64,10 @@ func (m *mockAnalyticsTracker) TrackBuildkitConnection(meta *analytics.BuildkitC
 }
 
 func (m *mockAnalyticsTracker) TrackDeployPipelineTriggered(_ context.Context, _ analytics.DeployPipelineTriggeredMetadata) {
+}
+
+func (m *mockAnalyticsTracker) TrackWakeTriggered(_ context.Context, meta analytics.WakeTriggeredMetadata) {
+	m.wakeCalls = append(m.wakeCalls, meta)
 }
 
 func (m *mockAnalyticsTracker) TrackUpStarted(service, namespace, repoURL, workflowID string) {

--- a/cmd/up/types.go
+++ b/cmd/up/types.go
@@ -50,6 +50,7 @@ type analyticsTrackerInterface interface {
 	TrackDeployStarted(analytics.DeployStartedMetadata)
 	TrackDeploy(analytics.DeployMetadata)
 	TrackDeployPipelineTriggered(ctx context.Context, m analytics.DeployPipelineTriggeredMetadata)
+	TrackWakeTriggered(ctx context.Context, m analytics.WakeTriggeredMetadata)
 	TrackUp(*analytics.UpMetricsMetadata)
 	TrackUpStarted(service, namespace, repoURL, workflowID string)
 	TrackDown(bool)

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -309,7 +309,7 @@ okteto up api -- echo this is a test
 						oktetoLog.Infof("failed to create okteto client: '%s'", err.Error())
 						return
 					}
-					if err := wakeNamespaceIfApplies(ctx, up.Namespace, k8sClient, okClient); err != nil {
+					if err := wakeNamespaceIfApplies(ctx, up.Namespace, k8sClient, okClient, at); err != nil {
 						// If there is an error waking up namespace, we don't want to fail the up command
 						oktetoLog.Infof("failed to wake up the namespace: %s", err.Error())
 					}
@@ -849,8 +849,13 @@ func printDisplayContext(up *upContext) {
 	oktetoLog.Println()
 }
 
+// wakeAnalyticsTracker tracks the wake_triggered event.
+type wakeAnalyticsTracker interface {
+	TrackWakeTriggered(ctx context.Context, m analytics.WakeTriggeredMetadata)
+}
+
 // wakeNamespaceIfApplies wakes the namespace if it is sleeping
-func wakeNamespaceIfApplies(ctx context.Context, ns string, k8sClient kubernetes.Interface, okClient types.OktetoInterface) error {
+func wakeNamespaceIfApplies(ctx context.Context, ns string, k8sClient kubernetes.Interface, okClient types.OktetoInterface, at wakeAnalyticsTracker) error {
 	n, err := k8sClient.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -862,7 +867,19 @@ func wakeNamespaceIfApplies(ctx context.Context, ns string, k8sClient kubernetes
 	}
 
 	oktetoLog.Information("Namespace '%s' is sleeping, waking it up...", ns)
-	return okClient.Namespaces().Wake(ctx, ns)
+	if err := okClient.Namespaces().Wake(ctx, ns); err != nil {
+		return err
+	}
+
+	at.TrackWakeTriggered(ctx, analytics.WakeTriggeredMetadata{
+		Namespace: ns,
+		IsPreview: analytics.IsWithinPreview(ctx, func(ctx context.Context, ns string) error {
+			_, err := okClient.Previews().Get(ctx, ns)
+			return err
+		}),
+	})
+
+	return nil
 }
 
 // tokenUpgrader updates the token of the config when the token is outdated

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -318,9 +318,10 @@ func TestEnvVarIsNotAddedWhenHasBuiltInOktetoEnvVarsFormat(t *testing.T) {
 
 func TestWakeNamespaceIfAppliesWithoutErrors(t *testing.T) {
 	tests := []struct {
-		name              string
-		ns                v1.Namespace
-		expectedWakeCalls int
+		name               string
+		ns                 v1.Namespace
+		expectedWakeCalls  int
+		expectedTrackCalls int
 	}{
 		{
 			name: "wake namespace if it is not sleeping",
@@ -332,7 +333,8 @@ func TestWakeNamespaceIfAppliesWithoutErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedWakeCalls: 0,
+			expectedWakeCalls:  0,
+			expectedTrackCalls: 0,
 		},
 		{
 			name: "wake namespace if it is sleeping",
@@ -344,10 +346,19 @@ func TestWakeNamespaceIfAppliesWithoutErrors(t *testing.T) {
 					},
 				},
 			},
-			expectedWakeCalls: 1,
+			expectedWakeCalls:  1,
+			expectedTrackCalls: 1,
 		},
 	}
 	ctx := context.Background()
+	okteto.CurrentStore = &okteto.ContextStore{
+		Contexts: map[string]*okteto.Context{
+			"test": {
+				Namespace: "test",
+			},
+		},
+		CurrentContext: "test",
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -355,12 +366,19 @@ func TestWakeNamespaceIfAppliesWithoutErrors(t *testing.T) {
 			nsClient := client.NewFakeNamespaceClient([]types.Namespace{}, nil)
 			oktetoClient := &client.FakeOktetoClient{
 				Namespace: nsClient,
+				Preview:   client.NewFakePreviewClient(&client.FakePreviewResponse{ErrGetPreview: assert.AnError}),
 			}
+			tracker := &mockAnalyticsTracker{}
 
-			err := wakeNamespaceIfApplies(ctx, tt.ns.Name, k8sClient, oktetoClient)
+			err := wakeNamespaceIfApplies(ctx, tt.ns.Name, k8sClient, oktetoClient, tracker)
 
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedWakeCalls, nsClient.WakeCalls)
+			require.Len(t, tracker.wakeCalls, tt.expectedTrackCalls)
+			if tt.expectedTrackCalls > 0 {
+				require.Equal(t, tt.ns.Name, tracker.wakeCalls[0].Namespace)
+				require.False(t, tracker.wakeCalls[0].IsPreview)
+			}
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func main() {
 
 	root.AddCommand(build.Build(ctx, ioController, at, insights, k8sLogger))
 
-	root.AddCommand(namespace.Namespace(ctx, k8sLogger, ioController))
+	root.AddCommand(namespace.Namespace(ctx, k8sLogger, ioController, at))
 	root.AddCommand(up.Up(at, insights, ioController, k8sLogger, fs))
 	root.AddCommand(cmd.Down(at, k8sLogger, fs))
 	root.AddCommand(cmd.Status(fs))

--- a/pkg/analytics/mixpanel_backend.go
+++ b/pkg/analytics/mixpanel_backend.go
@@ -35,6 +35,9 @@ func (b *mixpanelBackend) TrackDeployPipelineTriggered(_ context.Context, _ Depl
 func (b *mixpanelBackend) TrackDeployPreviewTriggered(_ context.Context, _ DeployPreviewTriggeredMetadata) {
 }
 
+func (b *mixpanelBackend) TrackWakeTriggered(_ context.Context, _ WakeTriggeredMetadata) {
+}
+
 func (b *mixpanelBackend) TrackUp(_ *UpMetricsMetadata) {}
 
 func (b *mixpanelBackend) TrackUpStarted(_, _, _, _ string) {}

--- a/pkg/analytics/posthog.go
+++ b/pkg/analytics/posthog.go
@@ -42,6 +42,7 @@ const (
 	posthogDeployPreviewTriggeredEvent  = "deploy_preview_triggered"
 	posthogUpEvent                      = "up"
 	posthogUpStartedEvent               = "up_started"
+	posthogWakeTriggeredEvent           = "wake_triggered"
 )
 
 // posthogEnqueuer is a narrow interface over posthog.Client that only exposes
@@ -261,6 +262,18 @@ func (b *posthogBackend) TrackDeployPreviewTriggered(ctx context.Context, m Depl
 		props["repo_url"] = hashString(normalizeRepoURL(m.RepoURL))
 	}
 	b.enqueue(ctx, userID, posthogDeployPreviewTriggeredEvent, props, b.withPreview(m.Preview))
+}
+
+// TrackWakeTriggered sends a wake_triggered event to PostHog.
+func (b *posthogBackend) TrackWakeTriggered(ctx context.Context, m WakeTriggeredMetadata) {
+	if b.client == nil || !analyticsEnabled() {
+		return
+	}
+
+	userID := okteto.GetContext().UserID
+	props := commonPostHogProperties()
+	props["is_preview"] = m.IsPreview
+	b.enqueue(ctx, userID, posthogWakeTriggeredEvent, props, b.withNamespace(m.Namespace))
 }
 
 // IsWithinPreview reports whether the current CLI context is inside a preview

--- a/pkg/analytics/posthog_test.go
+++ b/pkg/analytics/posthog_test.go
@@ -1094,3 +1094,51 @@ func TestPostHogBackend_TrackDeployStarted_HappyPath(t *testing.T) {
 	require.Equal(t, "ACME Corp", ev.Properties["customer_name"])
 	require.Equal(t, "cli", ev.Properties["measurement_source"])
 }
+
+func TestPostHogBackend_TrackWakeTriggered_NilClient(t *testing.T) {
+	b := &posthogBackend{client: nil}
+	require.NotPanics(t, func() {
+		b.TrackWakeTriggered(context.Background(), WakeTriggeredMetadata{Namespace: "dev-ns"})
+	})
+}
+
+func TestPostHogBackend_TrackWakeTriggered_AnalyticsDisabled(t *testing.T) {
+	teardown := setupPostHogContext(t, false /* disabled */)
+	defer teardown()
+
+	mock := &mockPostHogClient{}
+	b := &posthogBackend{client: mock}
+	b.TrackWakeTriggered(context.Background(), WakeTriggeredMetadata{Namespace: "dev-ns"})
+
+	require.Empty(t, mock.captured, "Enqueue must not be called when analytics is disabled")
+}
+
+func TestPostHogBackend_TrackWakeTriggered_HappyPath(t *testing.T) {
+	teardown := setupPostHogContext(t, true)
+	defer teardown()
+
+	mock := &mockPostHogClient{}
+	b := &posthogBackend{
+		client:     mock,
+		nsResolver: &mockNamespaceUIDResolver{uid: "ns-uid-wake"},
+	}
+	b.TrackWakeTriggered(context.Background(), WakeTriggeredMetadata{
+		Namespace: "dev-ns",
+		IsPreview: true,
+	})
+	b.wg.Wait()
+
+	require.Len(t, mock.captured, 1)
+	ev := mock.captured[0]
+	require.Equal(t, posthogWakeTriggeredEvent, ev.Event)
+	require.Equal(t, "user-123", ev.DistinctId)
+	require.Equal(t, "ns-uid-wake", ev.Properties["namespace"])
+	require.Equal(t, true, ev.Properties["is_preview"])
+	require.NotContains(t, ev.Properties, "workflow_id")
+	require.NotContains(t, ev.Properties, "ui_element")
+
+	// Common props
+	require.Equal(t, "ACME Corp", ev.Properties["customer_name"])
+	require.Equal(t, "cli", ev.Properties["measurement_source"])
+	require.Equal(t, "user-123", ev.Properties["user_id"])
+}

--- a/pkg/analytics/tracker.go
+++ b/pkg/analytics/tracker.go
@@ -21,6 +21,7 @@ type analyticsBackend interface {
 	TrackImageBuild(ctx context.Context, meta *ImageBuildMetadata)
 	TrackDeployPipelineTriggered(ctx context.Context, m DeployPipelineTriggeredMetadata)
 	TrackDeployPreviewTriggered(ctx context.Context, m DeployPreviewTriggeredMetadata)
+	TrackWakeTriggered(ctx context.Context, m WakeTriggeredMetadata)
 	TrackUp(meta *UpMetricsMetadata)
 	TrackUpStarted(service, namespace, repoURL, workflowID string)
 	TrackDeployStarted(meta DeployStartedMetadata)

--- a/pkg/analytics/tracker_test.go
+++ b/pkg/analytics/tracker_test.go
@@ -41,6 +41,9 @@ func (m *mockAnalyticsBackend) TrackDeployPipelineTriggered(_ context.Context, _
 func (m *mockAnalyticsBackend) TrackDeployPreviewTriggered(_ context.Context, _ DeployPreviewTriggeredMetadata) {
 }
 
+func (m *mockAnalyticsBackend) TrackWakeTriggered(_ context.Context, _ WakeTriggeredMetadata) {
+}
+
 func (m *mockAnalyticsBackend) TrackUp(meta *UpMetricsMetadata) {
 	if m.trackUpFn != nil {
 		m.trackUpFn(meta)

--- a/pkg/analytics/wake_triggered.go
+++ b/pkg/analytics/wake_triggered.go
@@ -1,0 +1,29 @@
+// Copyright 2023-2025 The Okteto Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analytics
+
+import "context"
+
+// WakeTriggeredMetadata contains the metadata of a wake_triggered event
+type WakeTriggeredMetadata struct {
+	Namespace string
+	IsPreview bool
+}
+
+// TrackWakeTriggered sends a wake_triggered event to all registered backends.
+func (a *Tracker) TrackWakeTriggered(ctx context.Context, m WakeTriggeredMetadata) {
+	for _, b := range a.backends {
+		b.TrackWakeTriggered(ctx, m)
+	}
+}


### PR DESCRIPTION
# Proposed changes

Jira: [DEV-1435](https://okteto.atlassian.net/browse/DEV-1435)

Adds a new `wake_triggered` PostHog analytics event, emitted whenever a namespace or preview environment is woken through the GraphQL `Wake` mutation. The event is fired from the three call sites that trigger a wake, and only when the wake actually succeeds:

- `okteto namespace wake` (explicit)
- `okteto preview wake` (explicit)
- the implicit wake performed by `okteto up` on a sleeping namespace

The event carries two event-specific properties: `namespace` (resolved to its Kubernetes UID via the existing `withNamespace` enricher) and `is_preview`. All common properties (`customer_name`, `cluster_id`, `cluster_url`, `cluster_version`, `user_id`, `measurement_source`, `trigger_source`, `is_agent`, `agent_type`, `machine_id`, etc.) are attached automatically by `commonPostHogProperties()`, so they are not set per event. `workflow_id` and `ui_element` from the product spec are intentionally omitted (`workflow_id` is not generated yet; `ui_element` is UI-only).

`is_preview` is `true` for preview wakes, computed via `analytics.IsWithinPreview` for the implicit `up` wake (matching the `deploy` command), and `false` for namespace wakes.

Following the existing two-backend pattern, the event is implemented on the PostHog backend and is a no-op on the legacy Mixpanel backend.

## How to validate

1. Build the CLI: `make build`.
1. Put a namespace to sleep and wake it with debug logging, confirming no `failed to send posthog analytics` error appears: `./bin/okteto namespace sleep <ns>` then `./bin/okteto --log-level=debug namespace wake <ns>`.
1. Wake a preview and confirm the event is emitted with `is_preview=true`: `./bin/okteto --log-level=debug preview wake <preview>`.
1. Run `./bin/okteto up` on a sleeping namespace and confirm the implicit wake emits the event.
1. Run the unit tests: `go test ./pkg/analytics/... ./cmd/namespace/... ./cmd/preview/... ./cmd/up/...`.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

[DEV-1435]: https://okteto.atlassian.net/browse/DEV-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ