### PR TITLE
Stabilize flaky integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ jobs:
             # This command exports a variable to use the CLI built in the commit, so the test runs against the branch code
             $env:OKTETO_CLI_IMAGE="okteto.global/cli-e2e:$env:CIRCLE_SHA1"
             & "$($HOME)\project\artifacts\bin\okteto.exe" context use $env:OKTETO_CONTEXT --token $env:OKTETO_API_INTEGRATION_TOKEN
-            go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
+            go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 30m
 
   e2e-okteto-test-windows:
     executor:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ integration-build:
 
 .PHONY: integration-deploy
 integration-deploy:
-	go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 20m
+	go test github.com/okteto/okteto/integration/deploy -tags="integration" --count=1 -v -timeout 30m
 
 .PHONY: integration-okteto
 integration-okteto:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ integration:
 
 .PHONY: integration-actions
 integration-actions:
-	go test github.com/okteto/okteto/integration/actions -tags="actions" --count=1 -v -timeout 10m
+	go test github.com/okteto/okteto/integration/actions -tags="actions" --count=1 -v -timeout 15m
 
 .PHONY: integration-build
 integration-build:

--- a/integration/commands/dev.go
+++ b/integration/commands/dev.go
@@ -197,7 +197,12 @@ func RunOktetoDown(oktetoPath string, downOpts *DownOptions) error {
 func HasUpCommandFinished(pid int) bool {
 	var err error
 	ticker := time.NewTicker(1 * time.Second)
-	to := time.NewTicker(15 * time.Second)
+	// After `okteto down` deactivates the dev container, the `up` process
+	// self-exits once it observes the deactivation, which can take up to a
+	// minute under CI load.
+	to := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	defer to.Stop()
 	for {
 		select {
 		case <-to.C:

--- a/integration/okteto/dependencies_test.go
+++ b/integration/okteto/dependencies_test.go
@@ -31,11 +31,11 @@ import (
 
 const manifestWithDependencies = `
 deploy:
-  - echo "dependency variable ${OKTETO_DEPENDENCY_POSTGRESQL_VARIABLE_TEST_VARIABLE}"
+  - echo "dependency variable ${OKTETO_DEPENDENCY_E2E_VARIABLE_TEST_VARIABLE}"
 dependencies:
-  postgresql:
-    repository: https://github.com/okteto/movies
-    branch: cli-e2e
+  e2e:
+    repository: https://github.com/okteto/e2e-dependency
+    branch: main
     wait: true
     variables:
       TEST_VARIABLE: test-value
@@ -45,11 +45,11 @@ const remoteManifestWithDependencies = `
 deploy:
   remote: true
   commands:
-    - echo "dependency variable ${OKTETO_DEPENDENCY_POSTGRESQL_VARIABLE_TEST_VARIABLE}"
+    - echo "dependency variable ${OKTETO_DEPENDENCY_E2E_VARIABLE_TEST_VARIABLE}"
 dependencies:
-  postgresql:
-    repository: https://github.com/okteto/movies
-    branch: cli-e2e
+  e2e:
+    repository: https://github.com/okteto/e2e-dependency
+    branch: main
     wait: true
     variables:
       TEST_VARIABLE: test-value
@@ -100,7 +100,7 @@ func TestDependencies(t *testing.T) {
 	expectedOutputCommand := "dependency variable test-value"
 	require.Contains(t, strings.ToLower(string(output)), expectedOutputCommand)
 
-	contentURL := fmt.Sprintf("https://movies-%s.%s", testNamespace, appsSubdomain)
+	contentURL := fmt.Sprintf("https://e2e-dependency-%s.%s", testNamespace, appsSubdomain)
 	require.NotEmpty(t, integration.GetContentFromURL(contentURL, timeout))
 	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }
@@ -138,7 +138,7 @@ func TestDependenciesOnRemote(t *testing.T) {
 	expectedOutputCommand := "dependency variable test-value"
 	require.Contains(t, strings.ToLower(string(output)), expectedOutputCommand)
 
-	contentURL := fmt.Sprintf("https://movies-%s.%s", testNamespace, appsSubdomain)
+	contentURL := fmt.Sprintf("https://e2e-dependency-%s.%s", testNamespace, appsSubdomain)
 	require.NotEmpty(t, integration.GetContentFromURL(contentURL, timeout))
 	require.NoError(t, commands.RunOktetoDeleteNamespace(oktetoPath, namespaceOpts))
 }

--- a/integration/up/deployment_test.go
+++ b/integration/up/deployment_test.go
@@ -65,8 +65,24 @@ dev:
     workdir: /usr/src/app
     sync:
     - .:/usr/src/app
+`
+	// deploymentManifestV2Reset is dedicated to TestUpResetFlag. It uses its
+	// own local forward port so it does not collide with the other tests that
+	// run in parallel and also forward a local port (each up test must own a
+	// unique local port).
+	deploymentManifestV2Reset = `
+dev:
+  e2etest:
+    image: python:alpine
+    command:
+    - sh
+    - -c
+    - "echo -n $VAR > var.html && python -m http.server 8080"
+    workdir: /usr/src/app
+    sync:
+    - .:/usr/src/app
     forward:
-    - 8084:8080
+    - 8087:8080
 `
 
 	k8sManifestTemplate = `
@@ -313,7 +329,7 @@ func TestUpResetFlag(t *testing.T) {
 	log.Printf("original 'index.html' content: %s", testNamespace)
 
 	require.NoError(t, writeFile(filepath.Join(dir, "deployment.yml"), k8sManifestTemplate))
-	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), deploymentManifestV2Exec))
+	require.NoError(t, writeFile(filepath.Join(dir, "okteto.yml"), deploymentManifestV2Reset))
 	require.NoError(t, writeFile(filepath.Join(dir, ".stignore"), stignoreContent))
 
 	kubectlOpts := &commands.KubectlOptions{
@@ -344,7 +360,7 @@ func TestUpResetFlag(t *testing.T) {
 	upResult, err := commands.RunOktetoUp(oktetoPath, upOptions)
 	require.NoError(t, err)
 
-	indexLocalEndpoint := "http://localhost:8084/index.html"
+	indexLocalEndpoint := "http://localhost:8087/index.html"
 	require.Equal(t, testNamespace, integration.GetContentFromURL(indexLocalEndpoint, timeout))
 
 	updatedContent := fmt.Sprintf("%s-before-reset", testNamespace)

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -919,7 +919,13 @@ func (s *Syncthing) HardTerminate() error {
 
 		cmdline, err := p.Cmdline()
 		if err != nil {
-			return err
+			// reading a process command line can fail transiently (e.g. the
+			// process is exiting, or "cannot read process PEB" on Windows).
+			// This is best-effort cleanup, so skip processes we cannot inspect.
+			if err != io.EOF {
+				oktetoLog.Infof("error getting command line for process %d: %s", p.Pid, err.Error())
+			}
+			continue
 		}
 
 		oktetoLog.Infof("checking syncthing home '%s' with command '%s'", s.Home, cmdline)


### PR DESCRIPTION
This PR groups a set of independent fixes for flaky integration tests. Each commit is a single, self-contained change, so they can be reviewed (or reverted) one by one.

## Changes

- `test: bump deploy integration timeout to 30m` — The deploy suite was hitting its 20m `go test` timeout under CI load (all tests passed, but the run was killed mid-suite). Raised to 30m.
- `test: bump actions integration timeout to 15m` — The actions suite (serial, ~10 min of tests) occasionally exceeded its 10m timeout under load. Raised to 15m.
- `test: deconflict local port 8084 between parallel up tests` — `TestUpDeploymentV2` and `TestUpResetFlag` both run in parallel and forwarded the same local port 8084, so whichever started second failed with port is already allocated. Gave `TestUpResetFlag` its own port (8087) and dropped the unused forward from the serial `TestExec`.
- `test: wait up to 60s for okteto up to exit after down` — After `okteto down`, the up process self-exits once it observes the deactivation, which can take longer than the previous 15s budget under load, causing `okteto up didn't exit after down`. Bumped the wait to 60s.
- `fix: skip unreadable processes when terminating syncthing` — On Windows, HardTerminate iterates all processes and reading a command line can fail with cannot read process PEB, which aborted the whole dev-container activation. Now it skips processes it can't inspect (best-effort cleanup) instead of failing.
- `test: use lightweight repo for dependency e2e tests` — `TestDependencies/TestDependenciesOnRemote` used okteto/movies, whose deploy includes a mongodb/bitnami app that intermittently failed to become healthy on the cluster (deployed with errors). Switched the dependency to okteto/e2e-dependency, which deploys a single nginx endpoint reliably.