### PR TITLE
fix(build): prevent deadlock on buildkit port forward failure

### DIFF
--- a/pkg/build/buildkit/connector/portforward.go
+++ b/pkg/build/buildkit/connector/portforward.go
@@ -303,23 +303,36 @@ func (pf *PortForwarder) establishPortForward() error {
 		return fmt.Errorf("failed to create port forwarder: %w", err)
 	}
 
+	// Bind this attempt's error channel: pf.errChan is reassigned on every retry, and a
+	// late failure from this goroutine must never leak into a newer attempt's channel.
+	errChan := pf.errChan
 	go func() {
 		if err := forwarder.ForwardPorts(); err != nil {
-			pf.ioCtrl.Logger().Infof("port forward to buildkit finished with error: %s", err)
-			// Only send error to channel if it's a port conflict (address already in use)
-			// so we can retry with a different port
-			if containsAddressInUse(err) {
-				pf.errChan <- fmt.Errorf("port %d is already in use. Please check if another process is using it.", pf.localPort)
-				return
-			}
-			pf.mu.Lock()
-			pf.podName = ""
-			pf.mu.Unlock()
-			pf.Stop()
+			pf.handlePortForwardError(err, errChan)
 		}
 	}()
 
 	return nil
+}
+
+// handlePortForwardError reports a ForwardPorts failure and cleans up the connection state.
+// The error must be sent to errChan before acquiring pf.mu: Start() holds the lock while
+// blocked in waitUntilPortForwardIsReady, so locking first would deadlock the whole process.
+// errChan must be the channel of the attempt that failed, not read from pf.errChan, which
+// may already belong to a newer attempt.
+func (pf *PortForwarder) handlePortForwardError(err error, errChan chan<- error) {
+	pf.ioCtrl.Logger().Infof("port forward to buildkit finished with error: %s", err)
+	if containsAddressInUse(err) {
+		errChan <- fmt.Errorf("port %d is already in use. Please check if another process is using it.", pf.localPort)
+		return
+	}
+	// errChan is buffered, so this never blocks even if nobody is waiting anymore
+	// (e.g. the connection dropped after the port forward was ready)
+	errChan <- err
+	pf.mu.Lock()
+	pf.podName = ""
+	pf.mu.Unlock()
+	pf.Stop()
 }
 
 // waitUntilReady waits for the port forward to be ready or context to be cancelled
@@ -335,7 +348,9 @@ func (pf *PortForwarder) waitUntilPortForwardIsReady(ctx context.Context) error 
 		pf.ioCtrl.Logger().Infof("port forward failed: %s", err)
 		return fmt.Errorf("port forward failed: %w", err)
 	case <-ctx.Done():
-		pf.Stop()
+		// Calling Stop() here would self-deadlock: Start() already holds pf.mu and the
+		// mutex is not reentrant. Close stopChan directly to terminate the forwarder.
+		close(pf.stopChan)
 		pf.metrics.SetErrReason("ContextCancelledWhileWaitingForPortForward")
 		return fmt.Errorf("context cancelled while waiting for port forward: %w", ctx.Err())
 	}

--- a/pkg/build/buildkit/connector/portforward.go
+++ b/pkg/build/buildkit/connector/portforward.go
@@ -158,7 +158,7 @@ const buildkitPort = 1234
 func newPortForwardCreationUserError() oktetoErrors.UserError {
 	return oktetoErrors.UserError{
 		E:    errors.New("port forward creation to BuildKit has failed"),
-		Hint: "Run the command again with the '--log-level=debug' flag to get more information about the failure",
+		Hint: "Run the command again with the '--log-level=info' flag to get more information about the failure",
 	}
 }
 

--- a/pkg/build/buildkit/connector/portforward.go
+++ b/pkg/build/buildkit/connector/portforward.go
@@ -151,6 +151,17 @@ func NewPortForwarder(ctx context.Context, okCtx PortForwarderOktetoContextInter
 // buildkitPort is the port where buildkit listens inside the pod
 const buildkitPort = 1234
 
+// newPortForwardCreationUserError returns the user-facing error for a port forward
+// failure. It deliberately hides the raw cause, which must have been written to the
+// logs by the caller, so the console shows an intuitive message instead of a low-level
+// kubernetes connection error.
+func newPortForwardCreationUserError() oktetoErrors.UserError {
+	return oktetoErrors.UserError{
+		E:    errors.New("port forward creation to BuildKit has failed"),
+		Hint: "Run the command again with the '--log-level=debug' flag to get more information about the failure",
+	}
+}
+
 // Start establishes the port forward connection to the buildkit pod.
 // If already active, it reuses the existing connection.
 // If not active, it gets the least loaded pod and establishes a new connection.
@@ -177,7 +188,7 @@ func (pf *PortForwarder) Start(ctx context.Context) error {
 		pf.ioCtrl.Logger().Infof("failed to establish port forward: %s", err)
 		pf.metrics.SetErrReason("PortForwardCreation")
 		pf.metrics.TrackFailure()
-		return err
+		return newPortForwardCreationUserError()
 	}
 
 	if err := pf.waitUntilPortForwardIsReady(ctx); err != nil {
@@ -323,7 +334,10 @@ func (pf *PortForwarder) establishPortForward() error {
 func (pf *PortForwarder) handlePortForwardError(err error, errChan chan<- error) {
 	pf.ioCtrl.Logger().Infof("port forward to buildkit finished with error: %s", err)
 	if containsAddressInUse(err) {
-		errChan <- fmt.Errorf("port %d is already in use. Please check if another process is using it.", pf.localPort)
+		errChan <- oktetoErrors.UserError{
+			E:    fmt.Errorf("port %d is already in use", pf.localPort),
+			Hint: "Check which process is using the port or free it and try again",
+		}
 		return
 	}
 	// errChan is buffered, so this never blocks even if nobody is waiting anymore
@@ -346,7 +360,12 @@ func (pf *PortForwarder) waitUntilPortForwardIsReady(ctx context.Context) error 
 		return nil
 	case err := <-pf.errChan:
 		pf.ioCtrl.Logger().Infof("port forward failed: %s", err)
-		return fmt.Errorf("port forward failed: %w", err)
+		// known failures already carry a user-facing message and hint
+		var userErr oktetoErrors.UserError
+		if errors.As(err, &userErr) {
+			return userErr
+		}
+		return newPortForwardCreationUserError()
 	case <-ctx.Done():
 		// Calling Stop() here would self-deadlock: Start() already holds pf.mu and the
 		// mutex is not reentrant. Close stopChan directly to terminate the forwarder.
@@ -413,7 +432,7 @@ func containsAddressInUse(err error) bool {
 func (pf *PortForwarder) WaitUntilIsReady(ctx context.Context) error {
 	if !pf.isActive {
 		if err := pf.Start(ctx); err != nil {
-			return fmt.Errorf("failed to start port forward: %w", err)
+			return err
 		}
 	}
 	return pf.waiter.WaitUntilIsUp(ctx, pf.GetBuildkitClient)

--- a/pkg/build/buildkit/connector/portforward_test.go
+++ b/pkg/build/buildkit/connector/portforward_test.go
@@ -145,7 +145,7 @@ func TestPortForwarder_WaitUntilReady_UnblockedByPortForwardFailure(t *testing.T
 	require.NotContains(t, err.Error(), "connection timed out", "raw cause must only go to the logs")
 	var userErr oktetoErrors.UserError
 	require.ErrorAs(t, err, &userErr)
-	require.Contains(t, userErr.Hint, "--log-level=debug")
+	require.Contains(t, userErr.Hint, "--log-level=info")
 	require.Eventually(t, func() bool {
 		pf.mu.Lock()
 		defer pf.mu.Unlock()

--- a/pkg/build/buildkit/connector/portforward_test.go
+++ b/pkg/build/buildkit/connector/portforward_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/okteto/okteto/pkg/analytics"
+	oktetoErrors "github.com/okteto/okteto/pkg/errors"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/stretchr/testify/require"
 )
@@ -140,7 +141,11 @@ func TestPortForwarder_WaitUntilReady_UnblockedByPortForwardFailure(t *testing.T
 		return pf.waitUntilPortForwardIsReady(context.Background())
 	})
 
-	require.ErrorContains(t, err, "connection timed out")
+	require.EqualError(t, err, "port forward creation to BuildKit has failed")
+	require.NotContains(t, err.Error(), "connection timed out", "raw cause must only go to the logs")
+	var userErr oktetoErrors.UserError
+	require.ErrorAs(t, err, &userErr)
+	require.Contains(t, userErr.Hint, "--log-level=debug")
 	require.Eventually(t, func() bool {
 		pf.mu.Lock()
 		defer pf.mu.Unlock()
@@ -193,7 +198,30 @@ func TestPortForwarder_HandlePortForwardError_AddressInUse(t *testing.T) {
 
 	err := <-pf.errChan
 	require.ErrorContains(t, err, "port 8080 is already in use")
+	var userErr oktetoErrors.UserError
+	require.ErrorAs(t, err, &userErr)
+	require.NotEmpty(t, userErr.Hint)
 	require.Equal(t, "buildkit-0", pf.podName, "pod assignment should be kept for a local port conflict")
+}
+
+func TestPortForwarder_WaitUntilReady_KeepsAddressInUseMessage(t *testing.T) {
+	pf := &PortForwarder{
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		errChan:   make(chan error, 1),
+		podName:   "buildkit-0",
+		localPort: 8080,
+		ioCtrl:    io.NewIOController(),
+		metrics:   NewConnectorMetrics(analytics.ConnectorTypePortForward, "test-session", fakeConnectionTracker{}),
+	}
+	pf.handlePortForwardError(errors.New("unable to listen on any of the requested ports"), pf.errChan)
+
+	err := pf.waitUntilPortForwardIsReady(context.Background())
+
+	require.EqualError(t, err, "port 8080 is already in use", "specific message must not be replaced by the generic one")
+	var userErr oktetoErrors.UserError
+	require.ErrorAs(t, err, &userErr)
+	require.Contains(t, userErr.Hint, "Check which process is using the port")
 }
 
 func TestPortForwarder_HandlePortForwardError_StaleAttemptDoesNotLeakIntoNewChannel(t *testing.T) {

--- a/pkg/build/buildkit/connector/portforward_test.go
+++ b/pkg/build/buildkit/connector/portforward_test.go
@@ -14,11 +14,31 @@
 package connector
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/okteto/okteto/pkg/analytics"
 	"github.com/okteto/okteto/pkg/log/io"
 	"github.com/stretchr/testify/require"
 )
+
+// runWithDeadlockGuard runs fn on a separate goroutine and fails the test if it does not
+// return within a timeout, which would indicate the process-wide deadlock this package
+// used to hit when the port forward failed while Start() was holding the mutex.
+func runWithDeadlockGuard(t *testing.T, fn func() error) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(3 * time.Second):
+		t.Fatal("deadlock: function did not return")
+		return nil
+	}
+}
 
 func TestPortForwarder_Stop(t *testing.T) {
 	tests := []struct {
@@ -97,6 +117,105 @@ func TestPortForwarder_Stop_MultipleCallsSafe(t *testing.T) {
 	require.NotPanics(t, func() {
 		pf.Stop()
 	})
+}
+
+func TestPortForwarder_WaitUntilReady_UnblockedByPortForwardFailure(t *testing.T) {
+	pf := &PortForwarder{
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		errChan:   make(chan error, 1),
+		podName:   "buildkit-0",
+		localPort: 8080,
+		ioCtrl:    io.NewIOController(),
+		metrics:   NewConnectorMetrics(analytics.ConnectorTypePortForward, "test-session", fakeConnectionTracker{}),
+	}
+
+	forwardErr := errors.New("error upgrading connection: connect: connection timed out")
+	go pf.handlePortForwardError(forwardErr, pf.errChan)
+
+	err := runWithDeadlockGuard(t, func() error {
+		// Start() holds the mutex while waiting for the port forward to become ready
+		pf.mu.Lock()
+		defer pf.mu.Unlock()
+		return pf.waitUntilPortForwardIsReady(context.Background())
+	})
+
+	require.ErrorContains(t, err, "connection timed out")
+	require.Eventually(t, func() bool {
+		pf.mu.Lock()
+		defer pf.mu.Unlock()
+		return pf.podName == ""
+	}, 3*time.Second, 10*time.Millisecond, "podName should be reset by the failure handler")
+}
+
+func TestPortForwarder_WaitUntilReady_ContextCancelledWhileHoldingLock(t *testing.T) {
+	pf := &PortForwarder{
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		errChan:   make(chan error, 1),
+		podName:   "buildkit-0",
+		localPort: 8080,
+		ioCtrl:    io.NewIOController(),
+		metrics:   NewConnectorMetrics(analytics.ConnectorTypePortForward, "test-session", fakeConnectionTracker{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := runWithDeadlockGuard(t, func() error {
+		// Start() holds the mutex while waiting for the port forward to become ready
+		pf.mu.Lock()
+		defer pf.mu.Unlock()
+		return pf.waitUntilPortForwardIsReady(ctx)
+	})
+
+	require.ErrorContains(t, err, "context cancelled while waiting for port forward")
+	select {
+	case _, ok := <-pf.stopChan:
+		require.False(t, ok, "stopChan should be closed to terminate the forwarder")
+	default:
+		t.Error("stopChan should be closed but is still open")
+	}
+	require.False(t, pf.isActive, "port forward never became ready")
+	require.Nil(t, pf.buildkitClient, "no client should be cached for a cancelled start")
+	// the runner defers connector.Stop(); it must be safe after a cancelled Start
+	require.NotPanics(t, pf.Stop)
+}
+
+func TestPortForwarder_HandlePortForwardError_AddressInUse(t *testing.T) {
+	pf := &PortForwarder{
+		errChan:   make(chan error, 1),
+		podName:   "buildkit-0",
+		localPort: 8080,
+		ioCtrl:    io.NewIOController(),
+	}
+
+	pf.handlePortForwardError(errors.New("unable to listen on any of the requested ports"), pf.errChan)
+
+	err := <-pf.errChan
+	require.ErrorContains(t, err, "port 8080 is already in use")
+	require.Equal(t, "buildkit-0", pf.podName, "pod assignment should be kept for a local port conflict")
+}
+
+func TestPortForwarder_HandlePortForwardError_StaleAttemptDoesNotLeakIntoNewChannel(t *testing.T) {
+	pf := &PortForwarder{
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		errChan:   make(chan error, 1),
+		podName:   "buildkit-0",
+		localPort: 8080,
+		ioCtrl:    io.NewIOController(),
+	}
+	staleAttemptChan := pf.errChan
+
+	// a retry re-establishes the port forward, replacing the connection channels
+	pf.errChan = make(chan error, 1)
+
+	// the old attempt's forwarder fails late, after the retry already started
+	pf.handlePortForwardError(errors.New("lost connection to pod"), staleAttemptChan)
+
+	require.Len(t, staleAttemptChan, 1, "error should land in the failed attempt's channel")
+	require.Empty(t, pf.errChan, "new attempt's channel must not receive stale errors")
+	require.Empty(t, pf.podName, "pod should be released so the retry can be reassigned")
 }
 
 func TestPortForwarder_GetWaiter(t *testing.T) {

--- a/pkg/build/buildkit/connector/portforward_test.go
+++ b/pkg/build/buildkit/connector/portforward_test.go
@@ -31,7 +31,14 @@ import (
 func runWithDeadlockGuard(t *testing.T, fn func() error) error {
 	t.Helper()
 	done := make(chan error, 1)
-	go func() { done <- fn() }()
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				done <- errors.New("panic in guarded function")
+			}
+		}()
+		done <- fn()
+	}()
 	select {
 	case err := <-done:
 		return err

--- a/pkg/build/buildkit/runner.go
+++ b/pkg/build/buildkit/runner.go
@@ -180,7 +180,7 @@ func (r *Runner) Run(ctx context.Context, buildOptions *types.BuildOptions, outp
 		}
 		if err := r.connector.Start(ctx); err != nil {
 			r.logger.Logger().Infof("failed to start buildkit connector: %s", err)
-			return fmt.Errorf("could not start buildkit connector: %w", err)
+			return err
 		}
 
 		// if buildkit is not available for 10 minutes, we should fail


### PR DESCRIPTION
# Proposed changes

Fixes DEV-1441

A customer reported the CLI crashing with `fatal error: all goroutines are asleep - deadlock!` right after the log line `port forward to buildkit finished with error: error upgrading connection: ... connect: connection timed out`.

**Root cause (deadlock)**: in `pkg/build/buildkit/connector/portforward.go`, when `ForwardPorts()` failed with any error other than "address already in use", the forwarder goroutine tried to acquire `pf.mu` — but `Start()` holds that lock while blocked in `waitUntilPortForwardIsReady` waiting on channels that only the forwarder goroutine could signal. All goroutines asleep → Go runtime fatal crash.

**Fixes**:

- Always send the `ForwardPorts()` error to the buffered `errChan` *before* touching `pf.mu`, so the waiter in `Start()` returns a proper error instead of deadlocking the process.
- Bind each attempt's `errChan` at goroutine spawn time, so a late failure from an old attempt can't leak a stale error into a newer attempt's channel (the channel is reassigned on every retry).
- The `ctx.Done()` branch now closes `stopChan` directly instead of calling `Stop()`, which would self-deadlock on the non-reentrant mutex (and was previously a no-op that leaked the forwarder goroutine).

**Error UX (second commit)**: the raw kubernetes error is no longer surfaced on the console. Users now see a `UserError`: `port forward creation to BuildKit has failed` with the hint `Run the command again with the '--log-level=info' flag to get more information about the failure`. The raw cause is still written to the logs at info level. The actionable `port N is already in use` message is preserved (now a `UserError` with its own hint). Redundant wrapping prefixes (`failed to start port forward`, `could not start buildkit connector`) were dropped.

**Tests**: regression tests in `portforward_test.go` with a deadlock guard (the test fails if the wait never returns), a stale-attempt channel isolation test, and an address-in-use passthrough test. Verified with `go test -race`, `golangci-lint` (0 issues), and a full `go build`.

## How to validate

1. Reproduce the bug with a pre-fix CLI: on a cluster where the connection to the BuildKit pod times out (e.g. block outbound traffic to the pod's port-forward upgrade endpoint, or point the context at a cluster whose BuildKit node is unreachable), run `okteto build .` and observe the CLI crash with `fatal error: all goroutines are asleep - deadlock!` right after `port forward to buildkit finished with error: ... connection timed out` in the debug log.
1. Build this branch (`make build`) and run the same `okteto build .` — the CLI no longer crashes; it exits cleanly with `port forward creation to BuildKit has failed` and the hint to re-run with `--log-level=info`. Run `okteto build . --log-level=info` and confirm the raw kubernetes error is still visible in the logs.
1. Reproduce the port-conflict path: occupy the local port used for the BuildKit port forward (e.g. `nc -l <port>`), run `okteto build .`, and confirm the `port <N> is already in use` user error with its hint is still shown.
1. Run the regression tests: `go test -race ./pkg/build/buildkit/connector/...` — includes a deadlock guard that fails if the wait never returns.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
