### PR TITLE
Assign SSH port right before opening it to reduce conflict window with other processes competing for ports

### DIFF
--- a/cmd/up/forwards.go
+++ b/cmd/up/forwards.go
@@ -90,6 +90,11 @@ func (up *upContext) sshForwards(ctx context.Context) error {
 		return err
 	}
 
+	// assign the SSH tunnel port right before creating the forward, to minimize
+	// the window between choosing a free port and binding it. If it is already
+	// assigned (user-pinned or a previous connection), the same port is reused.
+	up.Dev.AssignRemotePort()
+
 	oktetoLog.Infof("starting SSH port forwards")
 	f := forwardk8s.NewPortForwardManager(ctx, up.Dev.Interface, restConfig, k8sClient, up.Namespace)
 	if err := f.Add(forward.Forward{Local: up.Dev.RemotePort, Remote: up.Dev.SSHServerPort}); err != nil {
@@ -109,14 +114,14 @@ func (up *upContext) sshForwards(ctx context.Context) error {
 		return err
 	}
 
-	if err := ssh.AddEntry(up.Dev.Name, up.Dev.Interface, up.Dev.RemotePort); err != nil {
-		oktetoLog.Infof("failed to add entry to your SSH config file: %s", err)
-		return fmt.Errorf("failed to add entry to your SSH config file")
-	}
-
 	err = up.Forwarder.Start(up.Pod.Name, up.Namespace)
 	if err != nil {
 		return err
+	}
+
+	if err := ssh.AddEntry(up.Dev.Name, up.Dev.Interface, up.Dev.RemotePort); err != nil {
+		oktetoLog.Infof("failed to add entry to your SSH config file: %s", err)
+		return fmt.Errorf("failed to add entry to your SSH config file")
 	}
 
 	if isNeededGlobalForwarder(up.Manifest.GlobalForward) {

--- a/pkg/model/dev.go
+++ b/pkg/model/dev.go
@@ -693,19 +693,30 @@ func (dev *Dev) validateSecurityContext() error {
 	return nil
 }
 
-// LoadRemote configures remote execution
-func (dev *Dev) LoadRemote(pubKeyPath string) {
-	if dev.RemotePort == 0 {
-		p, err := GetAvailablePort(dev.Interface)
-		if err != nil {
-			oktetoLog.Infof("failed to get random port for SSH connection: %s", err)
-			p = oktetoDefaultSSHServerPort
-		}
-
-		dev.RemotePort = p
-		oktetoLog.Infof("remote port not set, using %d", dev.RemotePort)
+// AssignRemotePort assigns a free local port for the SSH tunnel when one is not
+// already set. It is meant to be called right before the tunnel is opened, to
+// minimize the window between choosing a free port and binding it. A port
+// already set (user-pinned via the manifest 'remote' field or the --remote
+// flag, or assigned by a previous connection) is kept, so the same port is
+// reused across reconnections.
+func (dev *Dev) AssignRemotePort() {
+	if dev.RemotePort != 0 {
+		return
 	}
 
+	p, err := GetAvailablePort(dev.Interface)
+	if err != nil {
+		oktetoLog.Infof("failed to get random port for SSH connection: %s", err)
+		p = oktetoDefaultSSHServerPort
+	}
+
+	dev.RemotePort = p
+	oktetoLog.Infof("remote port not set, using %d", dev.RemotePort)
+}
+
+// LoadRemote configures remote execution. The local SSH port is assigned
+// separately (see AssignRemotePort) right before the tunnel is opened.
+func (dev *Dev) LoadRemote(pubKeyPath string) {
 	p := Secret{
 		LocalPath:  pubKeyPath,
 		RemotePath: authorizedKeysPath,

--- a/pkg/model/dev_test.go
+++ b/pkg/model/dev_test.go
@@ -634,8 +634,15 @@ func Test_Reverse(t *testing.T) {
 
 	dev.LoadRemote("/tmp/key.pub")
 
+	// a dev with reverse forwards runs in remote mode; the local SSH port is
+	// assigned separately (right before opening the tunnel) via AssignRemotePort
+	if !dev.RemoteModeEnabled() {
+		t.Error("remote mode was not automatically enabled")
+	}
+
+	dev.AssignRemotePort()
 	if dev.RemotePort == 0 {
-		t.Error("remote port was not automatically enabled")
+		t.Error("remote port was not assigned")
 	}
 
 	if dev.Reverse[0].Local != 8080 {


### PR DESCRIPTION
`okteto up` picks its dynamic ports (SSH tunnel + syncthing forwards) with a select-then-bind pattern that has a TOCTOU gap: another process can grab the port between choosing it and binding it. Under parallel load (e.g. e2e) this flakes as local "port N is already in-use".

Changes:
- Wrap dynamic-port collisions in a new transient `errDynamicPortInUse`; the existing `activate()` retry loop then reruns with freshly allocated ports.
- Split `LoadRemote`: the SSH pubkey secret stays early (needed for pod translation); the SSH port is now assigned in sshForwards, right before binding, so it's re-picked on each retry.
