### PR TITLE
feat(compose): allow disabling kubernetes service links per service

### DIFF
--- a/pkg/cmd/stack/translate.go
+++ b/pkg/cmd/stack/translate.go
@@ -158,6 +158,7 @@ func translateDeployment(svcName string, s *model.Stack, divert Divert) *appsv1.
 	podSpec := apiv1.PodSpec{
 		TerminationGracePeriodSeconds: ptr.To(svc.StopGracePeriod),
 		NodeSelector:                  svc.NodeSelector,
+		EnableServiceLinks:            svc.EnableServiceLinks,
 		Containers: []apiv1.Container{
 			{
 				Name:            svcName,
@@ -243,6 +244,7 @@ func translateStatefulSet(svcName string, s *model.Stack, divert Divert) *appsv1
 		InitContainers:                initContainers,
 		Affinity:                      translateAffinity(svc),
 		NodeSelector:                  svc.NodeSelector,
+		EnableServiceLinks:            svc.EnableServiceLinks,
 		Volumes:                       translateVolumes(svc),
 		Containers: []apiv1.Container{
 			{
@@ -304,6 +306,7 @@ func translateJob(svcName string, s *model.Stack, divert Divert) *batchv1.Job {
 		InitContainers:                initContainers,
 		Affinity:                      translateAffinity(svc),
 		NodeSelector:                  svc.NodeSelector,
+		EnableServiceLinks:            svc.EnableServiceLinks,
 		Containers: []apiv1.Container{
 			{
 				Name:            svcName,

--- a/pkg/cmd/stack/translate_test.go
+++ b/pkg/cmd/stack/translate_test.go
@@ -2285,3 +2285,93 @@ func Test_translateJob_withoutIdentityToken(t *testing.T) {
 	require.False(t, hasIdentityTokenVolume(t, result.Spec.Template.Spec.Volumes))
 	require.False(t, hasIdentityTokenVolumeMount(t, result.Spec.Template.Spec.Containers[0].VolumeMounts))
 }
+
+func Test_translateDeployment_enableServiceLinks(t *testing.T) {
+	tests := []struct {
+		enableServiceLinks *bool
+		name               string
+	}{
+		{name: "unset", enableServiceLinks: nil},
+		{name: "disabled", enableServiceLinks: ptr.To(false)},
+		{name: "enabled", enableServiceLinks: ptr.To(true)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &model.Stack{
+				Name: "stackName",
+				Services: map[string]*model.Service{
+					"svcName": {
+						Image:              "image",
+						Replicas:           1,
+						EnableServiceLinks: tt.enableServiceLinks,
+					},
+				},
+			}
+
+			result := translateDeployment("svcName", s, nil)
+
+			require.Equal(t, tt.enableServiceLinks, result.Spec.Template.Spec.EnableServiceLinks)
+		})
+	}
+}
+
+func Test_translateStatefulSet_enableServiceLinks(t *testing.T) {
+	tests := []struct {
+		enableServiceLinks *bool
+		name               string
+	}{
+		{name: "unset", enableServiceLinks: nil},
+		{name: "disabled", enableServiceLinks: ptr.To(false)},
+		{name: "enabled", enableServiceLinks: ptr.To(true)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &model.Stack{
+				Name: "stackName",
+				Services: map[string]*model.Service{
+					"svcName": {
+						Image:              "image",
+						Replicas:           1,
+						EnableServiceLinks: tt.enableServiceLinks,
+					},
+				},
+			}
+
+			result := translateStatefulSet("svcName", s, nil)
+
+			require.Equal(t, tt.enableServiceLinks, result.Spec.Template.Spec.EnableServiceLinks)
+		})
+	}
+}
+
+func Test_translateJob_enableServiceLinks(t *testing.T) {
+	tests := []struct {
+		enableServiceLinks *bool
+		name               string
+	}{
+		{name: "unset", enableServiceLinks: nil},
+		{name: "disabled", enableServiceLinks: ptr.To(false)},
+		{name: "enabled", enableServiceLinks: ptr.To(true)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &model.Stack{
+				Name: "stackName",
+				Services: map[string]*model.Service{
+					"svcName": {
+						Image:              "image",
+						Replicas:           1,
+						RestartPolicy:      apiv1.RestartPolicyNever,
+						BackOffLimit:       5,
+						EnableServiceLinks: tt.enableServiceLinks,
+					},
+				},
+			}
+			require.True(t, s.Services["svcName"].IsJob())
+
+			result := translateJob("svcName", s, nil)
+
+			require.Equal(t, tt.enableServiceLinks, result.Spec.Template.Spec.EnableServiceLinks)
+		})
+	}
+}

--- a/pkg/model/schema_test.go
+++ b/pkg/model/schema_test.go
@@ -212,7 +212,7 @@ func Test_getStructKeys(t *testing.T) {
 				"model.Probes":                      {"liveness", "readiness", "startup"},
 				"model.ResourceRequirements":        {"limits", "requests"},
 				"model.SecurityContext":             {"runAsUser", "runAsGroup", "fsGroup", "capabilities", "runAsNonRoot", "allowPrivilegeEscalation", "readOnlyRootFilesystem"},
-				"model.Service":                     {"healthcheck", "labels", "resources", "x-node-selector", "user", "depends_on", "build", "x-okteto-identity-token", "workdir", "image", "restart", "environment", "ports", "volumes", "cap_add", "cap_drop", "env_file", "command", "annotations", "entrypoint", "stop_grace_period", "replicas", "max_attempts", "public", "endpoint_mode"},
+				"model.Service":                     {"healthcheck", "labels", "resources", "x-node-selector", "x-enable-service-links", "user", "depends_on", "build", "x-okteto-identity-token", "workdir", "image", "restart", "environment", "ports", "volumes", "cap_add", "cap_drop", "env_file", "command", "annotations", "entrypoint", "stop_grace_period", "replicas", "max_attempts", "public", "endpoint_mode"},
 				"model.ServiceIdentityToken":        {"expiration_seconds", "audience", "mount_path"},
 				"model.ServiceResources":            {"cpu", "memory", "storage"},
 				"model.Stack":                       {"volumes", "services", "endpoints", "name", "namespace", "context"},

--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -96,17 +96,18 @@ const (
 
 // Service represents an okteto stack service
 type Service struct {
-	Healtcheck    *HealthCheck          `yaml:"healthcheck,omitempty"`
-	Labels        Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
-	Resources     *StackResources       `yaml:"resources,omitempty"` // For okteto stack only
-	NodeSelector  Selector              `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
-	User          *StackSecurityContext `yaml:"user,omitempty"`
-	DependsOn     DependsOn             `yaml:"depends_on,omitempty"`
-	Build         *build.Info           `yaml:"build,omitempty"`
-	IdentityToken *ServiceIdentityToken `json:"x-okteto-identity-token,omitempty" yaml:"x-okteto-identity-token,omitempty"`
-	Workdir       string                `yaml:"workdir,omitempty"`
-	Image         string                `yaml:"image,omitempty"`
-	RestartPolicy apiv1.RestartPolicy   `yaml:"restart,omitempty"`
+	Healtcheck         *HealthCheck          `yaml:"healthcheck,omitempty"`
+	Labels             Labels                `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Resources          *StackResources       `yaml:"resources,omitempty"` // For okteto stack only
+	NodeSelector       Selector              `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
+	EnableServiceLinks *bool                 `json:"x-enable-service-links,omitempty" yaml:"x-enable-service-links,omitempty"`
+	User               *StackSecurityContext `yaml:"user,omitempty"`
+	DependsOn          DependsOn             `yaml:"depends_on,omitempty"`
+	Build              *build.Info           `yaml:"build,omitempty"`
+	IdentityToken      *ServiceIdentityToken `json:"x-okteto-identity-token,omitempty" yaml:"x-okteto-identity-token,omitempty"`
+	Workdir            string                `yaml:"workdir,omitempty"`
+	Image              string                `yaml:"image,omitempty"`
+	RestartPolicy      apiv1.RestartPolicy   `yaml:"restart,omitempty"`
 
 	Environment     env.Environment      `yaml:"environment,omitempty"`
 	Ports           []Port               `yaml:"ports,omitempty"`

--- a/pkg/model/stack_serializer.go
+++ b/pkg/model/stack_serializer.go
@@ -95,6 +95,7 @@ type ServiceRaw struct {
 	Labels                   Labels                 `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations              Annotations            `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	NodeSelector             Selector               `json:"x-node-selector,omitempty" yaml:"x-node-selector,omitempty"`
+	EnableServiceLinks       *bool                  `json:"x-enable-service-links,omitempty" yaml:"x-enable-service-links,omitempty"`
 	ReadOnly                 *WarningType           `yaml:"read_only,omitempty"`
 	PullPolicy               *WarningType           `yaml:"pull_policy,omitempty"`
 	ContainerName            *WarningType           `yaml:"container_name,omitempty"`
@@ -438,6 +439,8 @@ func (serviceRaw *ServiceRaw) toService(svcName string, stack *Stack, topLevelSe
 	}
 
 	svc.NodeSelector = serviceRaw.NodeSelector
+
+	svc.EnableServiceLinks = serviceRaw.EnableServiceLinks
 
 	if serviceRaw.IdentityToken != nil {
 		if err := validateIdentityToken(serviceRaw.IdentityToken); err != nil {

--- a/pkg/model/stack_serializer_test.go
+++ b/pkg/model/stack_serializer_test.go
@@ -480,6 +480,50 @@ func Test_NodeSelectorUnmarshalling(t *testing.T) {
 	}
 }
 
+func Test_EnableServiceLinksUnmarshalling(t *testing.T) {
+	tests := []struct {
+		expected      *bool
+		name          string
+		manifest      []byte
+		expectedError bool
+	}{
+		{
+			name:     "not set defaults to nil",
+			manifest: []byte("services:\n  app:\n    image: okteto/vote:1"),
+			expected: nil,
+		},
+		{
+			name:     "explicitly disabled",
+			manifest: []byte("services:\n  app:\n    image: okteto/vote:1\n    x-enable-service-links: false"),
+			expected: ptr.To(false),
+		},
+		{
+			name:     "explicitly enabled",
+			manifest: []byte("services:\n  app:\n    image: okteto/vote:1\n    x-enable-service-links: true"),
+			expected: ptr.To(true),
+		},
+		{
+			name:          "invalid value",
+			manifest:      []byte("services:\n  app:\n    image: okteto/vote:1\n    x-enable-service-links: notabool"),
+			expectedError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := ReadStack(tt.manifest, true)
+			if err != nil && !tt.expectedError {
+				t.Fatal(err)
+			} else if err == nil && tt.expectedError {
+				t.Fatal("error not thrown")
+			}
+
+			if !tt.expectedError {
+				assert.Equal(t, tt.expected, s.Services["app"].EnableServiceLinks)
+			}
+		})
+	}
+}
+
 func TestComposeBuildSectionUnmarshalling(t *testing.T) {
 	tests := []struct {
 		expected *composeBuildInfo


### PR DESCRIPTION
# Proposed changes

Fixes PROD-495

When deploying services through an Okteto compose file, Kubernetes injects environment variables into every pod in the namespace for each service it discovers (`<SERVICE>_PORT`, `<SERVICE>_SERVICE_HOST`, and related variants), with port values expressed as URIs (e.g. `tcp://10.x.x.x:8125`). This injection happens by default and could not be controlled from the compose spec, so applications expecting a plain integer port — or an unset value — under those variable names could break silently or fail validation.

Kubernetes manifests and Helm can suppress this with `enableServiceLinks: false` on the pod spec, but there was no compose equivalent. This PR exposes it as the optional `x-enable-service-links` field at the service level, bringing compose deployments to parity with native manifests.

- New optional `*bool` field `EnableServiceLinks` on the compose service, parsed from `x-enable-service-links` (follows the existing okteto extension convention, e.g. `x-node-selector`).
- Wired through all three pod-spec builders: Deployment, StatefulSet and Job.
- Left unset by default (`nil`), preserving the current Kubernetes behavior — this is purely opt-in and does not affect existing compose files.

## How to validate

1. Deploy a compose file with a "noisy" service (that generates the env vars) and a consumer that does **not** set the flag; confirm Kubernetes injects the `NOISY_*` variables into the consumer pod (`kubectl exec deploy/consumer -- env | grep -i NOISY` returns the URI-formatted values). This reproduces the original problem.
1. Add `x-enable-service-links: false` to the consumer service and redeploy. Verify the flag reaches the pod spec: `kubectl get deploy consumer -o jsonpath='{.spec.template.spec.enableServiceLinks}'` prints `false`.
1. Confirm the injection is gone: `kubectl exec deploy/consumer -- env | grep -i NOISY` returns nothing (only the standard `KUBERNETES_*` / okteto vars remain).

<details>
<summary>Manual e2e evidence</summary>

**Without the flag** — variables injected:
```
$ kubectl exec deploy/consumer -- env | grep -i NOISY
NOISY_SERVICE_PORT=8125
NOISY_SERVICE_HOST=10.153.250.41
NOISY_PORT=tcp://10.153.250.41:8125
NOISY_PORT_8125_TCP=tcp://10.153.250.41:8125
... (13 vars total)
```

**With `x-enable-service-links: false`** — flag set, no injection:
```
$ kubectl get deploy consumer -o jsonpath='{.spec.template.spec.enableServiceLinks}'
false
$ kubectl exec deploy/consumer -- env | grep -i NOISY
(no output)
```
</details>

Automated tests added:
- `Test_EnableServiceLinksUnmarshalling` (parsing: unset→nil / true / false / invalid).
- `Test_translateDeployment_enableServiceLinks`, `Test_translateStatefulSet_enableServiceLinks`, `Test_translateJob_enableServiceLinks` (pod-spec propagation across all three workload types, all three pointer states).
- Updated `Test_getStructKeys` for the new `model.Service` field.

## CLI Quality Reminders 🔧

- No regression: field is opt-in and nil by default, so existing compose deployments are unchanged.
- `make lint` clean on the affected packages; unit tests pass; manual e2e validated against a live cluster (evidence above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)