### PR TITLE
fix(compose): propagate x-enable-service-links across merged compose files

### DIFF
--- a/pkg/model/stack.go
+++ b/pkg/model/stack.go
@@ -792,6 +792,9 @@ func (stack *Stack) mergeServices(otherStack *Stack) *Stack {
 		if len(svc.NodeSelector) > 0 {
 			resultSvc.NodeSelector = svc.NodeSelector
 		}
+		if svc.EnableServiceLinks != nil {
+			resultSvc.EnableServiceLinks = svc.EnableServiceLinks
+		}
 		if svc.IdentityToken != nil {
 			resultSvc.IdentityToken = svc.IdentityToken
 		}

--- a/pkg/model/stack_test.go
+++ b/pkg/model/stack_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -911,6 +912,78 @@ func TestStack_MergeIdentityToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := tt.stack.Merge(tt.otherStack)
 			require.Equal(t, tt.expected, result.Services["app"].IdentityToken)
+		})
+	}
+}
+
+func TestStack_MergeEnableServiceLinks(t *testing.T) {
+	tests := []struct {
+		stack      *Stack
+		otherStack *Stack
+		expected   *bool
+		name       string
+	}{
+		{
+			name: "override sets enable service links when base has none",
+			stack: &Stack{
+				Services: map[string]*Service{
+					"app": {
+						Image: "okteto",
+					},
+				},
+			},
+			otherStack: &Stack{
+				Services: map[string]*Service{
+					"app": {
+						EnableServiceLinks: ptr.To(false),
+					},
+				},
+			},
+			expected: ptr.To(false),
+		},
+		{
+			name: "override replaces existing enable service links",
+			stack: &Stack{
+				Services: map[string]*Service{
+					"app": {
+						Image:              "okteto",
+						EnableServiceLinks: ptr.To(true),
+					},
+				},
+			},
+			otherStack: &Stack{
+				Services: map[string]*Service{
+					"app": {
+						EnableServiceLinks: ptr.To(false),
+					},
+				},
+			},
+			expected: ptr.To(false),
+		},
+		{
+			name: "override without enable service links keeps base value",
+			stack: &Stack{
+				Services: map[string]*Service{
+					"app": {
+						Image:              "okteto",
+						EnableServiceLinks: ptr.To(false),
+					},
+				},
+			},
+			otherStack: &Stack{
+				Services: map[string]*Service{
+					"app": {
+						Image: "okteto-dev",
+					},
+				},
+			},
+			expected: ptr.To(false),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.stack.Merge(tt.otherStack)
+			require.Equal(t, tt.expected, result.Services["app"].EnableServiceLinks)
 		})
 	}
 }


### PR DESCRIPTION
Follow-up of #5093.

Tickets: DEV-1449, PROD-495

## What
`mergeServices` overlays service fields one-by-one but never copied `EnableServiceLinks`, so a value set only in a merged file (an override or a second `-f`) was silently dropped. Copied it alongside `NodeSelector`, nil-guarded like `IdentityToken` so an override that omits the key keeps the base value while an explicit `true`/`false` wins.

## Repro
`compose.yaml`
```yaml
services:
  foo:
    image: nginx
    ports: [80]
```
`compose.override.yaml`
```yaml
services:
  foo:
    x-enable-service-links: false
```
```bash
okteto deploy   # auto-merges the override
kubectl get deploy foo -o jsonpath='{.spec.template.spec.enableServiceLinks}'; echo
```

| | output |
|---|---|
| before | *(empty)* → links stay **on**, override dropped |
| after  | `false` → override respected |

Control: put the field directly in `compose.yaml` (no override) → prints `false` even before the fix, isolating the bug to the merge path.

## Test
`TestStack_MergeEnableServiceLinks` covers base-only, override-replaces-base, and override-omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
