### PR TITLE
ci: bump okteto/golang-ci image to 2.10.1 in okteto.yml

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -22,7 +22,7 @@ dev:
     autocreate: true
 test:
   unit:
-    image: okteto/golang-ci:2.10.0@sha256:760a2299c5c362f9cda71944bffcae1e5d0c87dbda26b228112364709040ccf8
+    image: okteto/golang-ci:2.10.1@sha256:3279c526fdce2272b60979dff352e1e672bf2f8d3035797d96365c619f9c87ab
     artifacts:
       - coverage.txt
       - coverage.html


### PR DESCRIPTION
Bumps the `test.unit.image` in `okteto.yml` from `okteto/golang-ci:2.10.0` to `2.10.1` (+ digest), aligning it with the `.circleci/config.yml` executor already updated in #5098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115oxUS8nc47FefwJEt3Bdi

---
_Generated by [Claude Code](https://claude.ai/code/session_0115oxUS8nc47FefwJEt3Bdi)_