### PR TITLE
ci: build the dev container from the branch image in e2e-gateway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,8 +282,13 @@ jobs:
           name: Run gateway integration tests
           command: |
             export OKTETO_PATH=$(pwd)/artifacts/bin/okteto-Linux-x86_64
+            export OKTETO_CLI_IMAGE=okteto.global/cli-e2e:${CIRCLE_SHA1}
+            echo "OKTETO_CLI_IMAGE=$OKTETO_CLI_IMAGE"
             $(pwd)/artifacts/bin/okteto-Linux-x86_64 context use $OKTETO_CONTEXT --token ${OKTETO_API_INTEGRATION_TOKEN}
             make integration-gateway
+          environment:
+            OKTETO_SKIP_CLEANUP: "true"
+
 
   test-e2e-setup:
     executor: golang-ci


### PR DESCRIPTION
The e2e-gateway job did not export OKTETO_CLI_IMAGE, so config.GetCliImage() fell back to <repo>:master for the okteto-bin init container. The dev pod therefore ran the syncthing shipped in master while the local CLI ran the one built from the commit under test, and okteto up hung in 'synchronizing' until needsDatabaseReset() tripped.

Mirrors the e2e-up job, which already sets both variables.
