### PR TITLE
fix: dial SSH tunnel with explicit host instead of :port

### DIFF
--- a/cmd/up/forwards.go
+++ b/cmd/up/forwards.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	oktetoErrors "github.com/okteto/okteto/pkg/errors"
@@ -101,7 +102,10 @@ func (up *upContext) sshForwards(ctx context.Context) error {
 		return err
 	}
 
-	up.Forwarder = ssh.NewForwardManager(ctx, fmt.Sprintf(":%d", up.Dev.RemotePort), up.Dev.Interface, "0.0.0.0", f, up.Namespace)
+	// Use an explicit host. Dialing ":port" targets 0.0.0.0 and breaks SSH
+	// handshakes on some platforms (e.g. macOS with a VPN default route).
+	sshAddr := net.JoinHostPort(up.Dev.Interface, fmt.Sprintf("%d", up.Dev.RemotePort))
+	up.Forwarder = ssh.NewForwardManager(ctx, sshAddr, up.Dev.Interface, "0.0.0.0", f, up.Namespace)
 	if err := up.Forwarder.Add(forward.Forward{Local: up.Sy.RemotePort, Remote: syncthing.ClusterPort}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

`okteto up` failed establishing the local SSH tunnel on macOS (especially with VPN) because the SSH pool dialed an empty-host address (`:PORT`). In Go, `net.Dial("tcp", ":port")` targets `0.0.0.0`, which is a listen wildcard rather than a safe dial destination and can break the TCP data path during the SSH handshake.

Fix: build the dial address with `net.JoinHostPort(up.Dev.Interface, port)`, matching other SSH dial sites such as `pkg/ssh/exec.go`.

```go
// before
ssh.NewForwardManager(ctx, fmt.Sprintf(":%d", up.Dev.RemotePort), ...)

// after
sshAddr := net.JoinHostPort(up.Dev.Interface, fmt.Sprintf("%d", up.Dev.RemotePort))
ssh.NewForwardManager(ctx, sshAddr, ...)
```

Fixes #5114

## Test plan

- [x] `go test ./pkg/ssh/ ./cmd/up/`
- [x] `go vet ./pkg/ssh/ ./cmd/up/`
- [ ] Manually: on macOS with VPN connected, run `okteto up` (classic and hybrid) and confirm SSH pool starts with `localhost:<port>` and handshake succeeds