### PR TITLE
chore(deps): upgrade Helm to 4.2.4 and Helm 3 to 3.21.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Base image versions - Centralized version control for easier updates
 # Kubernetes tools (kubectl, Helm 3, Helm 4, kustomize)
 ARG KUBECTL_VERSION=1.35.7
-ARG HELM3_VERSION=3.21.3
-ARG HELM4_VERSION=4.2.3
+ARG HELM3_VERSION=3.21.4
+ARG HELM4_VERSION=4.2.4
 ARG KUSTOMIZE_VERSION=5.8.1
 # Okteto components
 ARG SYNCTHING_VERSION=2.1.2


### PR DESCRIPTION
# Proposed changes

Bumps the Helm binaries shipped in the `okteto/okteto` image:

- `HELM4_VERSION`: 4.2.3 → 4.2.4
- `HELM3_VERSION`: 3.21.3 → 3.21.4

**Helm 4.2.4** is the first release that contains [helm/helm#32088](https://github.com/helm/helm/pull/32088) ("Fix missing conflict retry with server-side apply"). That missing retry is what produced the `Operation cannot be fulfilled on resourcequotas … the object has been modified` failures we hit when Helm 4 was enabled in our integration environment ([helm/helm#31783](https://github.com/helm/helm/issues/31783)), which is why the Helm 4 rollout was paused after CLI 3.16. Picking up 4.2.4 unblocks resuming that testing via the `OKTETO_HELM_4_ENABLED` admin variable.

Verified the fix is in the release and not in the one we ship today: commit `2c979a17` appears in `v4.2.3...v4.2.4`.

**Helm 3.21.4** is a patch release with no behavior changes — one bug fix (`Files.Lines` panicked on an empty file) and vulnerability remediation in Helm's own Go dependencies (GO-2026-5932 via the `provenance` migration to `ProtonMail/go-crypto`, GO-2026-5158 otel, GO-2026-6061 grpc, GO-2026-5970 x/text). Included here because `helm3` is the default `helm` today and the image is Trivy-scanned in CI. Note the provenance change touches signature verification (`helm verify` / `--verify`) — happy to split it into its own PR if reviewers would rather keep this one scoped to Helm 4.

No Okteto code changes; the chart still has to bump `OKTETO_CLI_VERSION` before our instances pick this up.

## How to validate

1. Build the image from this branch: `docker build -t okteto-helm-check .`
2. Confirm both binaries report the new versions:
   `docker run --rm okteto-helm-check helm4 version` → `v4.2.4`
   `docker run --rm okteto-helm-check helm3 version` → `v3.21.4`
   `docker run --rm okteto-helm-check helm version` → `v3.21.4` (Helm 3 is still the default `helm`)
3. Once merged, in an environment running `ghcr.io/okteto/okteto:master`, set the admin variable `OKTETO_HELM_4_ENABLED=true` and deploy a dev environment repeatedly (the init container copies `helm4` over `helm`). The resourcequota SSA conflict should no longer appear.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
