### PR TITLE
test: reproduce go-git worktreeConfig failure on repos with worktrees

### DIFF
--- a/pkg/repository/git_test.go
+++ b/pkg/repository/git_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsClean(t *testing.T) {
@@ -579,4 +580,28 @@ func Test_gitRepoController_sanitiseURL(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// TestFindTopLevelGitRepoFromPath_worktreeConfig reproduces the failure seen
+// when running okteto from a repository that uses git worktrees. Such
+// repositories set the "extensions.worktreeConfig" option in their git config,
+// and go-git must be able to open them without erroring out with
+// "core.repositoryformatversion does not support extension: worktreeconfig".
+func TestFindTopLevelGitRepoFromPath_worktreeConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+
+	// Simulate a repository that uses git worktrees, which sets the
+	// worktreeConfig extension in the repository's git config.
+	cfgPath := filepath.Join(dir, ".git", "config")
+	cfg, err := os.ReadFile(cfgPath)
+	require.NoError(t, err)
+	cfg = append(cfg, []byte("[extensions]\n\tworktreeconfig = true\n")...)
+	require.NoError(t, os.WriteFile(cfgPath, cfg, 0600))
+
+	repo, err := FindTopLevelGitRepoFromPath(dir)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
 }


### PR DESCRIPTION
# Proposed changes

Adds a **failing (red) regression test** that reproduces the bug hit when running `okteto pipeline deploy` / `okteto preview deploy` from a repository that uses **git worktrees**:

```
x  Pipeline deploy failed: could not set default values for options: could not get repository url:
   failed to analyze git repo: core.repositoryformatversion does not support extension: worktreeconfig
```

## Root cause

Repositories that use git worktrees set the `extensions.worktreeConfig` option in their git config. `FindTopLevelGitRepoFromPath` (`pkg/repository/git.go`) opens the repo via go-git's `PlainOpenWithOptions`, and **go-git `v5.19.2`** (current on `master`) rejects that extension while `core.repositoryformatversion = 0`, so opening the repo fails. This path is shared by both `pipeline deploy` and `preview deploy` (through `GetRepositoryURL`).

The existing tests in `git_test.go` mock the repository (`fakeRepository`), so they never exercise the real `PlainOpen` and the bug went uncaught.

## What this PR does

- Adds `TestFindTopLevelGitRepoFromPath_worktreeConfig`, a hermetic unit test (no `git` binary, no network) that `PlainInit`s a repo in a temp dir, injects `[extensions] worktreeconfig = true` into `.git/config`, and asserts the repo opens without error.

> ⚠️ This test is **intentionally red** on `master` with go-git `v5.19.2`. It encodes the desired behavior and turns green once the go-git dependency is fixed.

## Related fixes

The two open PRs that fix the underlying go-git issue (by opposite routes) turn this test green:

- #5142 — `revert: downgrade github.com/go-git/go-git/v5 to v5.16.5` (v5.16.5 does not have the strict worktreeConfig check).
- #5141 — `chore(deps): upgrade go-git from v5 to v6` (v6 handles `worktreeConfig` correctly).

## How to validate

1. `go test ./pkg/repository/ -run TestFindTopLevelGitRepoFromPath_worktreeConfig -v` on `master` → **fails** with `core.repositoryformatversion does not support extension: worktreeconfig`.
1. Merge/checkout either #5142 or #5141 → the same test **passes**.

## CLI Quality Reminders 🔧

For both authors and reviewers:

- Scrutinize for potential regressions
- Ensure key automated tests are in place
- Build the CLI and test using the validation steps
- Assess Developer Experience impact (log messages, performances, etc)
- If too broad, consider breaking into smaller PRs
- Adhere to our [code style](https://github.com/okteto/okteto/blob/master/docs/code-style.md) and [code review](https://github.com/okteto/okteto/blob/master/docs/code-review.md) guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
